### PR TITLE
feat(boost): support custom Synccit endpoint

### DIFF
--- a/patches/src/main/kotlin/app/morphe/patches/reddit/customclients/boostforreddit/fix/synccit/CustomSynccitUrlPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/reddit/customclients/boostforreddit/fix/synccit/CustomSynccitUrlPatch.kt
@@ -1,0 +1,75 @@
+package app.morphe.patches.reddit.customclients.boostforreddit.fix.synccit
+
+import app.morphe.patcher.extensions.InstructionExtensions.getInstruction
+import app.morphe.patcher.extensions.InstructionExtensions.replaceInstruction
+import app.morphe.patcher.patch.bytecodePatch
+import app.morphe.patcher.patch.stringOption
+import app.morphe.patches.reddit.customclients.boostforreddit.BoostCompatible
+import com.android.tools.smali.dexlib2.iface.instruction.OneRegisterInstruction
+
+@Suppress("unused")
+val customSynccitUrlPatch = bytecodePatch(
+    name = "Custom Synccit URL",
+    description =
+        "Allows Boost to use a custom self-hosted Synccit API endpoint.",
+    default = true,
+) {
+    compatibleWith(*BoostCompatible)
+
+    val synccitUrlOption = stringOption(
+        "synccit-url",
+        LEGACY_SYNCCIT_API_URL,
+        null,
+        "Synccit API URL",
+        "Full HTTP or HTTPS URL to a Synccit-compatible API endpoint, including api.php.",
+        false,
+        validator = { value ->
+            value != null &&
+                value.length in 10..2048 &&
+                (
+                    value.startsWith("https://") ||
+                        value.startsWith("http://")
+                ) &&
+                '"' !in value &&
+                '\n' !in value &&
+                '\r' !in value &&
+                ' ' !in value
+        },
+    )
+
+    execute {
+        val replacement =
+            synccitUrlOption.value
+                ?: throw Exception("Missing synccit-url option")
+
+        val fingerprints = listOf(
+            "update" to synccitUpdateFingerprint,
+            "add" to synccitAddFingerprint,
+            "authenticate" to synccitAuthenticateFingerprint,
+            "read" to synccitReadFingerprint,
+        )
+
+        fingerprints.forEach { (operation, fingerprint) ->
+            val matches = fingerprint.stringMatches
+
+            if (matches.size != 1) {
+                throw Exception(
+                    "Expected one Synccit URL in $operation, found ${matches.size}",
+                )
+            }
+
+            val match = matches.single()
+            val method = fingerprint.method
+
+            val register =
+                method
+                    .getInstruction<OneRegisterInstruction>(match.index)
+                    .registerA
+
+            method.replaceInstruction(
+                match.index,
+                "const-string v$register, \"$replacement\"",
+            )
+        }
+    }
+}

--- a/patches/src/main/kotlin/app/morphe/patches/reddit/customclients/boostforreddit/fix/synccit/Fingerprints.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/reddit/customclients/boostforreddit/fix/synccit/Fingerprints.kt
@@ -1,0 +1,62 @@
+package app.morphe.patches.reddit.customclients.boostforreddit.fix.synccit
+
+import app.morphe.patcher.Fingerprint
+
+internal const val LEGACY_SYNCCIT_API_URL =
+    "https://api.synccit.com/api.php"
+
+private const val SYNCCIT_CLIENT_CLASS = "Lzd/a;"
+
+internal val synccitUpdateFingerprint = Fingerprint(
+    returnType = "V",
+    parameters = listOf(
+        "Lcom/rubenmayayo/reddit/models/synccit/LinkModel;",
+    ),
+    strings = listOf(LEGACY_SYNCCIT_API_URL),
+    custom = { method, classDef ->
+        classDef.type == SYNCCIT_CLIENT_CLASS &&
+            method.name == "d"
+    },
+)
+
+internal val synccitAddFingerprint = Fingerprint(
+    returnType =
+        "Lcom/rubenmayayo/reddit/models/synccit/AddModel;",
+    parameters = listOf(
+        "Ljava/lang/String;",
+        "Ljava/lang/String;",
+        "Ljava/lang/String;",
+    ),
+    strings = listOf(LEGACY_SYNCCIT_API_URL),
+    custom = { method, classDef ->
+        classDef.type == SYNCCIT_CLIENT_CLASS &&
+            method.name == "a"
+    },
+)
+
+internal val synccitAuthenticateFingerprint = Fingerprint(
+    returnType =
+        "Lcom/rubenmayayo/reddit/models/synccit/AddModel;",
+    parameters = listOf(
+        "Ljava/lang/String;",
+        "Ljava/lang/String;",
+        "Ljava/lang/String;",
+    ),
+    strings = listOf(LEGACY_SYNCCIT_API_URL),
+    custom = { method, classDef ->
+        classDef.type == SYNCCIT_CLIENT_CLASS &&
+            method.name == "b"
+    },
+)
+
+internal val synccitReadFingerprint = Fingerprint(
+    returnType = "Ljava/util/List;",
+    parameters = listOf(
+        "Ljava/util/List;",
+    ),
+    strings = listOf(LEGACY_SYNCCIT_API_URL),
+    custom = { method, classDef ->
+        classDef.type == SYNCCIT_CLIENT_CLASS &&
+            method.name == "c"
+    },
+)


### PR DESCRIPTION
## Summary

Adds a configurable Synccit API endpoint for Boost.

The new **Custom Synccit URL** patch provides a `synccit-url` option and replaces the hardcoded Synccit endpoint in all four request paths:

- update read state
- read synchronized state
- create account/device
- authenticate device

Closes #41 after real-server validation.

## Validation

- Kotlin compilation passed
- Android MPP build passed
- Static candidate gate passed
- Bytecode safety gate passed
- All four executable URL references were replaced
- Legacy endpoint references in executable smali: `0`
- Custom endpoint references in executable smali: `4`
- Boost DEV successfully sent both `mode=update` and `mode=read` requests to a configured local mock endpoint
- No DEV application crash

## Remaining validation

Interoperability should still be confirmed against an actual self-hosted Synccit-compatible server before merging and releasing.
