### PR TITLE
fix(release): push release refs atomically

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -287,9 +287,10 @@ jobs:
         run: |
           set -euo pipefail
 
-          git push origin HEAD:main
-          git push origin HEAD:dev
-          git push origin "$TAG"
+          git push --atomic origin \
+            "HEAD:refs/heads/main" \
+            "HEAD:refs/heads/dev" \
+            "refs/tags/$TAG:refs/tags/$TAG"
 
 
       - name: Create GitHub release

--- a/scripts/prepare-release.py
+++ b/scripts/prepare-release.py
@@ -285,8 +285,7 @@ def print_summary(version: str, tag: str, mpp: Path | None, sha: str | None) -> 
     print("  git add CHANGELOG.md README.md gradle.properties patches-bundle.json patches-list.json")
     print("  git commit -m \"Prepare patch bundle release <N>\"")
     print("  git tag -a <tag> -m <tag>")
-    print("  git push origin main")
-    print("  git push origin <tag>")
+    print("  git push --atomic origin HEAD:refs/heads/main HEAD:refs/heads/dev refs/tags/<tag>:refs/tags/<tag>")
     print("  gh release create <tag> patches/build/libs/<asset> --title <tag> --notes-file <notes-file>")
     print("  make verify-remote VERSION=<version> TAG=<tag>")
 

--- a/scripts/publish-release.py
+++ b/scripts/publish-release.py
@@ -334,16 +334,20 @@ def create_tag(tag: str, *, dry_run: bool) -> None:
 
 
 def push_refs(remote: str, branch: str, mirror_branches: list[str], tag: str, *, dry_run: bool) -> None:
-    refs = [branch, *mirror_branches]
+    refs = list(dict.fromkeys([branch, *mirror_branches]))
+    command = [
+        "git",
+        "push",
+        "--atomic",
+        remote,
+        *(f"HEAD:refs/heads/{ref}" for ref in refs),
+        f"refs/tags/{tag}:refs/tags/{tag}",
+    ]
     if dry_run:
-        for ref in refs:
-            print(f"DRY RUN: would push HEAD:{ref}")
-        print(f"DRY RUN: would push tag {tag}")
+        print("DRY RUN: would run", " ".join(command))
         return
 
-    for ref in refs:
-        run(["git", "push", remote, f"HEAD:{ref}"])
-    run(["git", "push", remote, tag])
+    run(command)
 
 
 def create_github_release(args: argparse.Namespace, asset_path: Path, signature_path: Path) -> None:

--- a/tests/release/test_publish_release_helpers.py
+++ b/tests/release/test_publish_release_helpers.py
@@ -7,6 +7,16 @@ from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[2]
 SCRIPT = ROOT / "scripts" / "publish-release.py"
+WORKFLOW = ROOT / ".github" / "workflows" / "release.yml"
+PREPARE = ROOT / "scripts" / "prepare-release.py"
+
+EXPECTED_METADATA_FILES = (
+    "CHANGELOG.md",
+    "README.md",
+    "gradle.properties",
+    "patches-bundle.json",
+    "patches-list.json",
+)
 
 
 def load_module():
@@ -44,6 +54,65 @@ def test_dirty_file_classification():
     assert mod.unexpected_changed_files(files) == ["scripts/publish-release.py"]
 
 
+def test_release_metadata_contract_is_aligned():
+    mod = load_module()
+    workflow = WORKFLOW.read_text(encoding="utf-8")
+    prepare = PREPARE.read_text(encoding="utf-8")
+    metadata = " ".join(EXPECTED_METADATA_FILES)
+
+    assert mod.ALLOWED_PREPARED_METADATA_FILES == set(EXPECTED_METADATA_FILES)
+    assert f"git diff --check -- {metadata}" in workflow
+    assert f"git add {metadata}" in workflow
+    assert f"git --no-pager diff -- {metadata}" in workflow
+    assert f"git --no-pager diff -- {metadata}" in prepare
+    assert f"git add {metadata}" in prepare
+    assert (
+        "grep -Ev '^(CHANGELOG\\.md|README\\.md|gradle\\.properties|"
+        "patches-bundle\\.json|patches-list\\.json)$'"
+    ) in workflow
+
+
+def test_push_refs_is_one_atomic_transaction():
+    mod = load_module()
+    calls = []
+    mod.run = lambda command: calls.append(command)
+
+    mod.push_refs(
+        "origin",
+        "main",
+        ["dev", "main"],
+        "morphe-patches-83",
+        dry_run=False,
+    )
+
+    assert calls == [[
+        "git",
+        "push",
+        "--atomic",
+        "origin",
+        "HEAD:refs/heads/main",
+        "HEAD:refs/heads/dev",
+        "refs/tags/morphe-patches-83:refs/tags/morphe-patches-83",
+    ]]
+
+
+def test_workflow_and_manual_hint_use_atomic_release_push():
+    workflow = WORKFLOW.read_text(encoding="utf-8")
+    prepare = PREPARE.read_text(encoding="utf-8")
+
+    assert "git push --atomic origin" in workflow
+    assert '"HEAD:refs/heads/main"' in workflow
+    assert '"HEAD:refs/heads/dev"' in workflow
+    assert '"refs/tags/$TAG:refs/tags/$TAG"' in workflow
+    assert "git push origin HEAD:main" not in workflow
+    assert "git push origin HEAD:dev" not in workflow
+    assert "git push origin \"$TAG\"" not in workflow
+    assert (
+        "git push --atomic origin HEAD:refs/heads/main HEAD:refs/heads/dev "
+        "refs/tags/<tag>:refs/tags/<tag>"
+    ) in prepare
+
+
 def test_readme_current_release_table_parser():
     mod = load_module()
     readme = """# Repo
@@ -72,4 +141,7 @@ Release `1.4.46` was earlier.
 if __name__ == "__main__":
     test_default_asset_path_and_name()
     test_dirty_file_classification()
+    test_release_metadata_contract_is_aligned()
+    test_push_refs_is_one_atomic_transaction()
+    test_workflow_and_manual_hint_use_atomic_release_push()
     test_readme_current_release_table_parser()


### PR DESCRIPTION
## Summary

- Push `main`, `dev`, and the release tag in one atomic Git transaction.
- Align the standalone publisher and release guidance with the canonical transaction.
- Add regression coverage for metadata-contract drift and atomic ref publishing.

## Root cause

The workflow pushed the release branches and tag sequentially, allowing a partial release state if one push failed.

The metadata allowlist was also duplicated without a test covering the actual workflow contract.

## Validation

- `./tools/check-semantic-release-contract.sh`
- `python3 tests/release/test_publish_release_helpers.py`
- `python3 tests/release/test_releasectl_mutations.py`
- Python compilation and `git diff --check`
