### PR TITLE
fix(boost): standardize bottom navigation FAB clearance

### DIFF
--- a/patches-list.json
+++ b/patches-list.json
@@ -632,32 +632,6 @@
       "options": []
     },
     {
-      "name": "Fix Boost Home floating action menu overlap",
-      "description": "Raises the Home floating action menu above the bottom navigation without changing Comments or split-screen layouts.",
-      "default": true,
-      "dependencies": [],
-      "compatiblePackages": [
-        {
-          "packageName": "com.rubenmayayo.reddit",
-          "name": "Boost for Reddit",
-          "description": null,
-          "apkFileType": "APK_REQUIRED",
-          "appIconColor": "#FF4500",
-          "signatures": null,
-          "targets": [
-            {
-              "version": "1.12.12",
-              "versionCodes": null,
-              "isExperimental": false,
-              "minSdk": 21,
-              "description": null
-            }
-          ]
-        }
-      ],
-      "options": []
-    },
-    {
       "name": "Fix Boost YouTube playback fallback",
       "description": "Opens the original YouTube link externally when Boost's legacy embedded YouTube player is unavailable.",
       "default": true,
@@ -2560,6 +2534,32 @@
       "dependencies": [
         "BytecodePatch"
       ],
+      "compatiblePackages": [
+        {
+          "packageName": "com.rubenmayayo.reddit",
+          "name": "Boost for Reddit",
+          "description": null,
+          "apkFileType": "APK_REQUIRED",
+          "appIconColor": "#FF4500",
+          "signatures": null,
+          "targets": [
+            {
+              "version": "1.12.12",
+              "versionCodes": null,
+              "isExperimental": false,
+              "minSdk": 21,
+              "description": null
+            }
+          ]
+        }
+      ],
+      "options": []
+    },
+    {
+      "name": "Standardize Boost bottom-navigation FAB clearance",
+      "description": "Keeps Home/Subreddit, Random, Inbox and Profile FABs 16 dp above the canonical bottom navigation.",
+      "default": true,
+      "dependencies": [],
       "compatiblePackages": [
         {
           "packageName": "com.rubenmayayo.reddit",

--- a/patches/src/main/kotlin/app/morphe/patches/reddit/customclients/boostforreddit/fix/homefab/FixHomeFloatingActionMenuOverlapPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/reddit/customclients/boostforreddit/fix/homefab/FixHomeFloatingActionMenuOverlapPatch.kt
@@ -2,70 +2,184 @@ package app.morphe.patches.reddit.customclients.boostforreddit.fix.homefab
 
 import app.morphe.patcher.patch.resourcePatch
 import app.morphe.patches.reddit.customclients.boostforreddit.BoostCompatible
+import org.w3c.dom.Document
 import org.w3c.dom.Element
 
-private const val HOME_CONTENT_LAYOUT =
+private const val MAIN_CONTENT_LAYOUT =
     "res/layout/content_main.xml"
 
-private const val SUBREDDIT_FAB_LAYOUT =
-    "@layout/fab_subreddit"
+private const val INBOX_LAYOUT =
+    "res/layout/activity_inbox.xml"
 
-private const val HOME_FAB_BOTTOM_MARGIN =
+private const val USER_LAYOUT =
+    "res/layout/activity_user.xml"
+
+private const val MATERIAL_FAB =
+    "com.google.android.material.floatingactionbutton.FloatingActionButton"
+
+private const val INCLUDED_FAB_BOTTOM_MARGIN =
+    "56.0dp"
+
+private const val DIRECT_FAB_BOTTOM_MARGIN =
     "72.0dp"
+
+private const val FAB_SIDE_MARGIN =
+    "@dimen/fab_margin"
+
+private data class IncludedFab(
+    val layout: String,
+    val gravity: String,
+)
+
+private val MAIN_INCLUDED_FABS =
+    listOf(
+        IncludedFab(
+            layout = "@layout/fab_subreddit",
+            gravity = "end|bottom",
+        ),
+        IncludedFab(
+            layout = "@layout/fab_random",
+            gravity = "center|bottom",
+        ),
+    )
+
+private val DIRECT_FAB_IDS =
+    setOf(
+        "@id/fab",
+        "@id/fab_submit",
+    )
+
+private fun Document.raiseIncludedFabs(
+    layoutName: String,
+    targets: List<IncludedFab>,
+) {
+    val includeNodes = getElementsByTagName("include")
+    val includes =
+        (0 until includeNodes.length)
+            .mapNotNull { includeNodes.item(it) as? Element }
+
+    targets.forEach { target ->
+        val matches =
+            includes.filter {
+                it.getAttribute("layout") == target.layout
+            }
+
+        require(matches.size == 1) {
+            "Expected one ${target.layout} include in $layoutName, " +
+                "found ${matches.size}"
+        }
+
+        matches.single().apply {
+            /*
+             * The Main host contributes one native 16dp FAB separation layer.
+             * A 56dp include margin therefore produces the same visual 16dp
+             * clearance as the direct 72dp Inbox/Profile geometry.
+             */
+            setAttribute(
+                "android:layout_width",
+                "wrap_content",
+            )
+            setAttribute(
+                "android:layout_height",
+                "wrap_content",
+            )
+            setAttribute(
+                "android:layout_gravity",
+                target.gravity,
+            )
+            setAttribute(
+                "android:layout_marginBottom",
+                INCLUDED_FAB_BOTTOM_MARGIN,
+            )
+        }
+    }
+}
+
+private fun Document.raiseDirectFabs(
+    layoutName: String,
+) {
+    val fabNodes = getElementsByTagName(MATERIAL_FAB)
+    val matches =
+        (0 until fabNodes.length)
+            .mapNotNull { fabNodes.item(it) as? Element }
+            .filter {
+                it.getAttribute("android:id") in DIRECT_FAB_IDS
+            }
+
+    require(matches.size == DIRECT_FAB_IDS.size) {
+        "Expected ${DIRECT_FAB_IDS.size} navigation FABs in $layoutName, " +
+            "found ${matches.size}"
+    }
+
+    require(
+        matches.map {
+            it.getAttribute("android:id")
+        }.toSet() == DIRECT_FAB_IDS
+    ) {
+        "Unexpected navigation FAB ids in $layoutName"
+    }
+
+    matches.forEach { fab ->
+        require(
+            fab.getAttribute("android:layout_margin") ==
+                FAB_SIDE_MARGIN
+        ) {
+            "Unexpected native FAB margin for " +
+                "${fab.getAttribute("android:id")} in $layoutName"
+        }
+
+        /*
+         * MarginLayoutParams gives the generic layout_margin precedence over
+         * the directional margins. Expand it before overriding the bottom
+         * margin so the 72dp navigation clearance survives inflation.
+         */
+        fab.removeAttribute(
+            "android:layout_margin",
+        )
+        listOf(
+            "android:layout_marginLeft",
+            "android:layout_marginTop",
+            "android:layout_marginRight",
+            "android:layout_marginStart",
+            "android:layout_marginEnd",
+        ).forEach { marginAttribute ->
+            fab.setAttribute(
+                marginAttribute,
+                FAB_SIDE_MARGIN,
+            )
+        }
+
+        fab.setAttribute(
+            "android:layout_marginBottom",
+            DIRECT_FAB_BOTTOM_MARGIN,
+        )
+    }
+}
 
 @Suppress("unused")
 val fixBoostHomeFloatingActionMenuOverlapPatch = resourcePatch(
-    name = "Fix Boost Home floating action menu overlap",
+    name = "Standardize Boost bottom-navigation FAB clearance",
     description =
-        "Raises the Home floating action menu above the bottom navigation " +
-            "without changing Comments or split-screen layouts.",
+        "Keeps Home/Subreddit, Random, Inbox and Profile FABs " +
+            "16 dp above the canonical bottom navigation.",
     default = true,
 ) {
     compatibleWith(*BoostCompatible)
 
     execute {
-        document(HOME_CONTENT_LAYOUT).use { document ->
-            val includeNodes = document.getElementsByTagName("include")
+        document(MAIN_CONTENT_LAYOUT).use { document ->
+            document.raiseIncludedFabs(
+                layoutName = MAIN_CONTENT_LAYOUT,
+                targets = MAIN_INCLUDED_FABS,
+            )
+        }
 
-            val matches =
-                (0 until includeNodes.length)
-                    .mapNotNull { includeNodes.item(it) as? Element }
-                    .filter {
-                        it.getAttribute("layout") ==
-                            SUBREDDIT_FAB_LAYOUT
-                    }
+        document(INBOX_LAYOUT).use { document ->
+            document.raiseDirectFabs(INBOX_LAYOUT)
+        }
 
-            require(matches.size == 1) {
-                "Expected one fab_subreddit include in content_main.xml, " +
-                    "found ${matches.size}"
-            }
-
-            matches.single().apply {
-                /*
-                 * Native bottom-navigation height: 56dp.
-                 * Standard Boost FAB separation: 16dp.
-                 * Total required Home offset: 72dp.
-                 *
-                 * Width and height are specified on the include so Android
-                 * applies the overridden layout parameters reliably.
-                 */
-                setAttribute(
-                    "android:layout_width",
-                    "wrap_content",
-                )
-                setAttribute(
-                    "android:layout_height",
-                    "wrap_content",
-                )
-                setAttribute(
-                    "android:layout_gravity",
-                    "end|bottom",
-                )
-                setAttribute(
-                    "android:layout_marginBottom",
-                    HOME_FAB_BOTTOM_MARGIN,
-                )
-            }
+        document(USER_LAYOUT).use { document ->
+            document.raiseDirectFabs(USER_LAYOUT)
         }
     }
 }


### PR DESCRIPTION
Closes #67

## Summary

- Standardizes Home/Subreddit, Inbox, and Profile FAB geometry above the locked five-button navigation.
- Produces 16 dp visual clearance above the 56 dp navigation surface.
- Uses 56 dp raw offset for included Home/Random menus and 72 dp for direct Inbox/Profile FABs.
- Expands Inbox/Profile’s generic margin so the bottom override survives layout inflation.
- Excludes the legacy Subscriptions layout because the canonical destination has no visible FAB.

## Root cause

Home and Inbox/Profile use different FAB parent geometry, so one raw XML offset did not produce the same visual position. Inbox/Profile also had a generic margin that overrode the specific bottom margin.

## Validation

- `./gradlew :patches:buildAndroid`: PASS
- Static gate: 14 PASS, 0 FAIL
- Bytecode safety gate: PASS
- DEV resource geometry gate: PASS
- Installed and launched `com.rubenmayayo.reddit.dev` on Pixel 6 without fatal logs
- Home, Inbox, and Profile manually confirmed aligned
- DEV APK SHA-256: `12a47fe8efb7774c3a5348ab39a5ccb1c57eb7d8f0937da42d7c6158d313bdae`

Normal Boost was not installed or modified.
