### PR TITLE
fix(tools): resolve canonical Android MPP

### DIFF
--- a/tests/tools/test_boost_mpp_workflow.py
+++ b/tests/tools/test_boost_mpp_workflow.py
@@ -1,0 +1,90 @@
+import shutil
+import subprocess
+import tempfile
+import unittest
+import zipfile
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+class BoostMppResolverTests(unittest.TestCase):
+    def make_repo(self, version: str = "9.9.9") -> Path:
+        temp = Path(tempfile.mkdtemp(prefix="boost-mpp-test-"))
+        self.addCleanup(shutil.rmtree, temp)
+        (temp / "tools").mkdir()
+        (temp / "patches" / "build" / "libs").mkdir(parents=True)
+        (temp / "gradle.properties").write_text(
+            f"version = {version}\n", encoding="utf-8"
+        )
+        for name in ("boost-resolve-mpp.sh", "check-mpp-release-asset.sh"):
+            target = temp / "tools" / name
+            shutil.copy2(ROOT / "tools" / name, target)
+            target.chmod(0o755)
+        return temp
+
+    @staticmethod
+    def write_mpp(path: Path, *, android: bool) -> None:
+        with zipfile.ZipFile(path, "w") as archive:
+            if android:
+                archive.writestr("classes.dex", b"dex\n")
+            archive.writestr("extensions/boostforreddit.mpe", b"extension")
+
+    def test_resolves_exact_version_and_ignores_newer_documentation_archives(self) -> None:
+        repo = self.make_repo()
+        expected = repo / "patches" / "build" / "libs" / "patches-9.9.9.mpp"
+        self.write_mpp(expected, android=True)
+        self.write_mpp(expected.with_name("patches-9.9.9-javadoc.mpp"), android=False)
+
+        completed = subprocess.run(
+            [repo / "tools" / "boost-resolve-mpp.sh"],
+            cwd=repo,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            check=False,
+        )
+
+        self.assertEqual(completed.returncode, 0, completed.stderr)
+        self.assertEqual(completed.stdout.strip(), str(expected))
+
+    def test_rejects_assemble_mpp_without_android_dex(self) -> None:
+        repo = self.make_repo()
+        mpp = repo / "patches" / "build" / "libs" / "patches-9.9.9.mpp"
+        self.write_mpp(mpp, android=False)
+
+        completed = subprocess.run(
+            [repo / "tools" / "boost-resolve-mpp.sh"],
+            cwd=repo,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            check=False,
+        )
+
+        self.assertEqual(completed.returncode, 1)
+        self.assertIn("missing required MPP entries: classes.dex", completed.stderr)
+        self.assertIn(":patches:buildAndroid", completed.stderr)
+
+
+class BoostMppWorkflowContractTests(unittest.TestCase):
+    def test_dev_runtime_builds_android_mpp_and_uses_resolver(self) -> None:
+        text = (ROOT / "tools" / "boost-dev-issue-runtime.sh").read_text(
+            encoding="utf-8"
+        )
+        self.assertIn(":patches:buildAndroid", text)
+        self.assertIn("tools/boost-resolve-mpp.sh", text)
+        self.assertNotIn("-name 'patches-*.mpp'", text)
+
+    def test_dev_from_mpp_checks_structure_before_candidate_build(self) -> None:
+        text = (ROOT / "tools" / "boost-dev-from-mpp.sh").read_text(
+            encoding="utf-8"
+        )
+        check = text.index('tools/check-mpp-release-asset.sh "$MPP"')
+        build = text.index("===== build patched normal candidate =====")
+        self.assertLess(check, build)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/boost-dev-from-mpp.sh
+++ b/tools/boost-dev-from-mpp.sh
@@ -162,6 +162,7 @@ git rev-parse --show-toplevel >/dev/null 2>&1 || mark_fail "not inside git repo"
 
 [ -s "$BASE_APK" ] || mark_fail "base APK missing: $BASE_APK"
 [ -s "$MPP" ] || mark_fail "MPP missing: $MPP"
+[ -x tools/check-mpp-release-asset.sh ] || mark_fail "MPP structure checker missing or not executable"
 
 if [ "$FAIL" -eq 0 ]; then
   sha256sum "$BASE_APK" | tee "$OUT_DIR/base-apk.sha256"
@@ -186,8 +187,9 @@ if [ "$FAIL" -eq 0 ]; then
   fi
 
   unzip -t "$MPP" >/dev/null || mark_fail "MPP zip test failed"
-  unzip -l "$MPP" | tee "$OUT_DIR/mpp-list.txt" | grep -E 'classes.dex|extensions/boostforreddit.mpe' \
-    || mark_fail "MPP missing classes.dex or boost extension"
+  unzip -l "$MPP" | tee "$OUT_DIR/mpp-list.txt"
+  tools/check-mpp-release-asset.sh "$MPP" \
+    || mark_fail "MPP is not a canonical Android bundle; run :patches:buildAndroid"
 fi
 
 echo

--- a/tools/boost-dev-inline-preview-source-toggle-runtime.sh
+++ b/tools/boost-dev-inline-preview-source-toggle-runtime.sh
@@ -26,7 +26,7 @@ Usage:
   tools/boost-dev-inline-preview-source-toggle-runtime.sh [options]
 
 Options:
-  --mpp PATH                 MPP to test. Default: newest patches/build/libs/patches-*.mpp
+  --mpp PATH                 MPP to test. Default: canonical current-version Android MPP
   --serial SERIAL            adb serial to use
   --adb-endpoint HOST:PORT   run adb connect HOST:PORT, then use resulting device
   --name NAME                artifact name suffix
@@ -125,15 +125,7 @@ cd "$ROOT" || {
 }
 
 if [ -z "$MPP" ]; then
-  MPP="$(
-    find patches/build/libs \
-      -maxdepth 1 \
-      -type f \
-      -name 'patches-*.mpp' \
-      -printf '%T@ %p\n' 2>/dev/null |
-      sort -nr |
-      awk 'NR == 1 {$1=""; sub(/^ /, ""); print}'
-  )"
+  MPP="$(tools/boost-resolve-mpp.sh)" || mark_fail "canonical Android MPP resolve failed"
 fi
 
 echo

--- a/tools/boost-dev-issue-runtime.sh
+++ b/tools/boost-dev-issue-runtime.sh
@@ -83,16 +83,18 @@ echo "===== build/select MPP ====="
 if [ -z "$MPP" ]; then
   ./gradlew :patches:buildAndroid --no-daemon || mark_fail "buildAndroid failed"
   if [ -n "$VERSION" ]; then
-    MPP="patches/build/libs/patches-${VERSION}.mpp"
+    MPP="$(tools/boost-resolve-mpp.sh --version "$VERSION")" \
+      || mark_fail "canonical Android MPP resolve failed"
   else
-    MPP="$(find patches/build/libs -maxdepth 1 -type f -name 'patches-*.mpp' -printf '%T@ %p\n' | sort -nr | awk 'NR==1{print $2}')"
+    MPP="$(tools/boost-resolve-mpp.sh)" \
+      || mark_fail "canonical Android MPP resolve failed"
   fi
 fi
 
 [ -f "$MPP" ] || mark_fail "MPP not found: $MPP"
 echo "MPP=$MPP"
 sha256sum "$MPP" || true
-unzip -l "$MPP" | grep -E 'classes.dex|extensions/boostforreddit.mpe' || mark_fail "MPP missing required entries"
+tools/check-mpp-release-asset.sh "$MPP" || mark_fail "MPP missing required Android entries"
 
 echo
 echo "===== build/install DEV clone ====="

--- a/tools/boost-resolve-mpp.sh
+++ b/tools/boost-resolve-mpp.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+VERSION=""
+
+usage() {
+  cat <<'EOF'
+Usage:
+  tools/boost-resolve-mpp.sh [--version VERSION]
+
+Resolve the canonical Android MPP for the current repository version.
+The selected archive must contain both classes.dex and the Boost extension.
+EOF
+}
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --version)
+      VERSION="${2:-}"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "FAIL: unknown argument: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+if [ -z "$VERSION" ]; then
+  VERSION="$(
+    sed -nE 's/^[[:space:]]*version[[:space:]]*=[[:space:]]*([^[:space:]]+).*/\1/p' \
+      "$ROOT/gradle.properties" |
+      head -1
+  )"
+fi
+
+if [ -z "$VERSION" ]; then
+  echo "FAIL: could not resolve project version from gradle.properties" >&2
+  exit 1
+fi
+
+MPP="$ROOT/patches/build/libs/patches-${VERSION}.mpp"
+
+if [ ! -s "$MPP" ]; then
+  echo "FAIL: canonical Android MPP missing: $MPP" >&2
+  echo "Run: ./gradlew :patches:buildAndroid --no-daemon" >&2
+  exit 1
+fi
+
+if ! "$ROOT/tools/check-mpp-release-asset.sh" "$MPP" >&2; then
+  echo "FAIL: $MPP is not a canonical Android MPP" >&2
+  echo "Run: ./gradlew :patches:buildAndroid --no-daemon" >&2
+  exit 1
+fi
+
+printf '%s\n' "$MPP"

--- a/tools/release-feed-smoke.sh
+++ b/tools/release-feed-smoke.sh
@@ -15,12 +15,10 @@ git diff --exit-code -- patches-list.json
 
 ./gradlew :patches:buildAndroid --no-daemon
 
-MPP="$(find patches/build/libs -maxdepth 1 -name '*.mpp' ! -name '*sources*' ! -name '*javadoc*' | sort | tail -1)"
+MPP="$(tools/boost-resolve-mpp.sh --version "$VERSION")"
 echo "MPP=$MPP"
 
 test -n "$MPP"
 test -f "$MPP"
 
-unzip -l "$MPP" | tee /tmp/morphe-mpp-list.txt
-grep -q 'classes.dex' /tmp/morphe-mpp-list.txt
-grep -q 'extensions/boostforreddit.mpe' /tmp/morphe-mpp-list.txt
+tools/check-mpp-release-asset.sh "$MPP"


### PR DESCRIPTION
## Summary

- Resolve the exact current-version Android MPP
- Reject bundles missing `classes.dex` or the Boost extension
- Reuse the resolver across DEV and release tooling
- Add regression tests for bundle selection and validation

## Root cause

Filename and modification-time heuristics could select a documentation or assemble-produced MPP without the Android dex payload.

## Validation

- Shell syntax checks passed
- 4 unit tests passed
- Android MPP build passed
- Release-feed smoke and MPP structure checks passed