### PR TITLE
docs: collect environment details in bug reports

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -10,9 +10,44 @@ body:
 
         Before creating a new bug report, please keep the following in mind:
 
-        - **Do not submit a duplicate bug report**: Search for existing bug reports [here](https://github.com/wchill/patcheddit/issues?q=label%3A%22Bug+report%22).
-        - **Review the contribution guidelines**: Make sure your bug report adheres to it. You can find the guidelines [here](https://github.com/wchill/patcheddit/blob/main/CONTRIBUTING.md).
+        - **Do not submit a duplicate bug report**: Search for existing bug reports [here](https://github.com/brealorg/breal-morphe-patches/issues?q=label%3A%22Bug+report%22).
+        - **Review the contribution guidelines**: Make sure your bug report adheres to them. You can find the guidelines [here](https://github.com/brealorg/breal-morphe-patches/blob/main/CONTRIBUTING.md).
         - **Release verification policy**: User-visible fixes stay open until the fix is released and verified through Morphe Manager / normal Boost when applicable.
+  - type: input
+    id: patch-version
+    attributes:
+      label: Morphe patch version
+      description: Enter the installed Morphe patch bundle version.
+      placeholder: "For example: 1.4.81"
+    validations:
+      required: true
+  - type: dropdown
+    id: installation-type
+    attributes:
+      label: Installation type
+      description: How was this copy of Boost installed?
+      options:
+        - Morphe Manager / normal Boost
+        - Boost DEV test build
+        - Other / manual installation
+    validations:
+      required: true
+  - type: input
+    id: android-version
+    attributes:
+      label: Android version
+      description: Include beta or preview information when applicable.
+      placeholder: "For example: Android 16 or Android 17 Beta"
+    validations:
+      required: true
+  - type: input
+    id: device-model
+    attributes:
+      label: Device model
+      description: Enter the manufacturer and model.
+      placeholder: "For example: Google Pixel 6"
+    validations:
+      required: true
   - type: textarea
     attributes:
       label: Bug description
@@ -41,6 +76,8 @@ body:
       label: Acknowledgements
       description: Your bug report will be closed if you don't follow the checklist below.
       options:
+        - label: I have checked whether this issue still occurs with the latest available Morphe patch version.
+          required: true
         - label: I have checked all open and closed bug reports and this is not a duplicate.
           required: true
         - label: I have chosen an appropriate title.


### PR DESCRIPTION
Adds required patch version, installation type, Android version, and device model fields to bug reports. Also fixes the outdated Patcheddit links.