### PR TITLE
docs: modernize contribution workflow

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,44 +1,57 @@
 name: ⭐ Feature request
-description: Create a detailed request for a new feature.
+description: Suggest an improvement or a new Morphe patch.
 title: "feat: "
 labels: ["Feature request"]
 body:
   - type: markdown
     attributes:
       value: |
-        # Patcheddit feature request
+        # Morphe feature request
 
-        Before creating a new feature request, please keep the following in mind:
+        Before creating a new feature request:
 
-        - **Do not submit a duplicate feature request**: Search for existing feature requests [here](https://github.com/wchill/patcheddit/issues?q=label%3A%22Feature+request%22).
-        - **Review the contribution guidelines**: Make sure your feature request adheres to it. You can find the guidelines [here](https://github.com/wchill/patcheddit/blob/main/CONTRIBUTING.md).
-  - type: textarea
+        - **Search for duplicates**: Check existing feature requests [here](https://github.com/brealorg/breal-morphe-patches/issues?q=label%3A%22Feature+request%22).
+        - **Review the contribution guidelines**: Read them [here](https://github.com/brealorg/breal-morphe-patches/blob/main/CONTRIBUTING.md).
+        - Describe a concrete problem or use case. Requests are evaluated against project scope, maintenance cost, and available testing.
+  - type: dropdown
+    id: affected-area
     attributes:
-      label: Feature description
-      description: |
-        - Describe your feature in detail
-        - Add images, videos, links, examples, references, etc. if possible
-  - type: textarea
-    attributes:
-      label: Motivation
-      description: |
-        A strong motivation is necessary for a feature request to be considered.
-
-        - Why should this feature be implemented? 
-        - What is the explicit use case?
-        - What are the benefits?
-        - What makes this feature important?
+      label: Affected app or area
+      description: Where should the proposed change apply?
+      options:
+        - Boost for Reddit
+        - Imgur
+        - Another supported app
+        - Patch bundle or repository tooling
     validations:
       required: true
+  - type: textarea
+    id: feature-description
+    attributes:
+      label: Feature description
+      description: Describe the requested behavior. Add images, videos, links, examples, or references when useful.
+    validations:
+      required: true
+  - type: textarea
+    id: motivation
+    attributes:
+      label: Motivation and use case
+      description: Explain the problem this solves, who benefits, and why the existing behavior is insufficient.
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives or workarounds
+      description: Describe any current workaround or alternative you have tried.
   - type: checkboxes
     id: acknowledgements
     attributes:
       label: Acknowledgements
-      description: Your feature request will be closed if you don't follow the checklist below.
       options:
-        - label: I have checked all open and closed feature requests and this is not a duplicate
+        - label: I have checked all open and closed feature requests and this is not a duplicate.
           required: true
-        - label: I have chosen an appropriate title.
+        - label: I understand that requests are evaluated against project scope, maintenance cost, and available testing.
           required: true
         - label: All requested information has been provided properly.
           required: true

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,23 @@
+## Summary
+
+Describe what changed and why.
+
+## Related issue
+
+Closes #
+
+## Validation
+
+- [ ] The branch is based on the latest `main`.
+- [ ] Relevant build, static, and verifier checks pass, or are marked not applicable below.
+- [ ] Boost behavior changes were tested in the DEV package (`com.rubenmayayo.reddit.dev`) without overwriting normal Boost.
+- [ ] Runtime evidence is included for user-visible behavior, or missing validation is stated explicitly.
+- [ ] Documentation, markers, and release metadata were updated when applicable.
+
+## Evidence
+
+List the tested app/Android versions, reproduction steps, result, and relevant screenshots, video, logs, or markers.
+
+## Risks and notes
+
+Describe known limitations, compatibility risks, rollback considerations, or follow-up work.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,30 +1,39 @@
-# 👋 Contribution guidelines
+# Contribution guidelines
 
-This document describes how to contribute to Morphe Patches template.
+Thanks for helping improve the Breal Morphe patch bundle. This is an unofficial community project focused on practical, maintainable patches for tested app versions.
 
-## 📖 Resources to help you get started
+## Before starting
 
-* [Issues](https://github.com/wchill/patcheddit/issues) are where we keep track of bugs and feature requests
+- Search the [open and closed issues](https://github.com/brealorg/breal-morphe-patches/issues) for existing work.
+- Open an issue before starting a behavior change, compatibility fix, or larger contribution so scope and testing can be discussed.
+- Small documentation and repository-maintenance corrections may be submitted directly as a pull request.
+- Keep each pull request focused on one issue or one closely related change.
 
-## 🙏 Submitting a feature request
+## Reporting bugs and requesting features
 
-Features can be requested by opening an issue using the
-[Feature request issue template](https://github.com/wchill/patcheddit/issues/new?labels=Feature+request&template=feature_request.yml&title=feat%3A+).
+Use the repository's [issue chooser](https://github.com/brealorg/breal-morphe-patches/issues/new/choose) and select the appropriate form. Include the requested environment details, reproduction steps, links, screenshots, or logs when available.
 
-## 🐞 Submitting a bug report
+## Development workflow
 
-If you encounter a bug while using Patcheddit, open an issue using the
-[Bug report issue template](https://github.com/wchill/patcheddit/issues/new?labels=Bug+report&template=bug_report.yml&title=bug%3A+).
+1. Fork the repository and create a work branch from the latest `main`.
+2. Make the smallest change that fully addresses the agreed scope.
+3. Run the relevant build, static checks, and repository verifier scripts.
+4. For Boost behavior changes, build, install, and test the DEV package (`com.rubenmayayo.reddit.dev`). Do not overwrite normal Boost during development.
+5. Capture concise runtime evidence for user-visible behavior, such as steps, result, screenshots, video, logs, or stable markers.
+6. Open a pull request against `main` and link the related issue.
 
-## 📝 How to contribute
+If you cannot perform runtime validation, state that clearly in the pull request so the missing validation is visible.
 
-1. Before contributing, it is recommended to open an issue to discuss your change
-with the maintainers of Patcheddit.
-2. Development happens on the `dev` branch. Fork the repository and create your branch from `dev`
-3. Commit your changes
-4. Submit a pull request to the `dev` branch of the repository and reference issues
-that your pull request closes in the description of your pull request
-5. Our team will review your pull request and provide feedback. Once your pull request is approved,
-it will be merged into the `dev` branch and will be included in the next release of Patcheddit.
+## Pull request expectations
 
-❤️ Thank you for considering contributing to Patcheddit
+A pull request should explain:
+
+- what changed and why;
+- which app versions and Android versions are affected;
+- which build and runtime checks were performed;
+- any known risks, limitations, or follow-up work;
+- whether documentation, release metadata, or verification tooling also needs updating.
+
+User-visible fixes are not considered fully delivered until they are released and verified through the normal installation path when applicable.
+
+Contributions are reviewed for project scope, maintainability, licensing, and available testing. Submission does not guarantee inclusion in the patch bundle.


### PR DESCRIPTION
Modernizes the feature request form, replaces the inherited Patcheddit contribution instructions, and adds a DEV-first pull request template.