### PR TITLE
fix(boost): prevent duplicate Search discovery rows

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -146,6 +146,9 @@ jobs:
           distribution: 'temurin'
           java-version: '17'
 
+      - name: Verify Boost Search dedup contract
+        run: ./tools/check-boost-search-dedup-contract.sh
+
       - name: Cache Gradle
         uses: gradle/actions/setup-gradle@v6
         with:

--- a/extensions/boostforreddit/src/main/java/app/morphe/extension/boostforreddit/search/SearchExploreRows.java
+++ b/extensions/boostforreddit/src/main/java/app/morphe/extension/boostforreddit/search/SearchExploreRows.java
@@ -17,7 +17,6 @@ import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.WeakHashMap;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -26,7 +25,7 @@ import java.util.concurrent.TimeUnit;
 
 public final class SearchExploreRows {
     private static final String TAG = "MorpheSearchExplore";
-    private static final String MARKER = "MORPHE_SEARCH_EXPLORE_V5M_ACTIVE_SUBREDDITS_REDDIT_LABELS";
+    private static final String MARKER = "MORPHE_SEARCH_EXPLORE_ISSUE61_DEDUP_V2_IDENTITY_GATE";
 
     private static final String CACHE_PREFS = "morphe_search_active_subreddits_v5l";
     private static final String CACHE_VALUE = "active_rows";
@@ -37,7 +36,7 @@ public final class SearchExploreRows {
     private static final int FINAL_LIMIT = 10;
     private static final Object LOCK = new Object();
 
-    private static final WeakHashMap<ArrayList, List<Object>> INSERTED_BY_ROWS = new WeakHashMap<>();
+    private static final SearchInsertedRowsTracker<Activity> INSERTED_ROWS = new SearchInsertedRowsTracker<>();
     private static List<Object> cachedRows;
     private static List<CacheEntry> cachedEntries;
     private static boolean inFlight;
@@ -95,7 +94,7 @@ public final class SearchExploreRows {
         boolean shouldFetch = false;
 
         synchronized (LOCK) {
-            removeInsertedLocked(rows);
+            removeInsertedLocked(activity, rows);
 
             List<Object> instantRows = null;
             String instantMode = null;
@@ -121,7 +120,7 @@ public final class SearchExploreRows {
                 inserted.add(makeHeader("Active subreddits"));
                 inserted.addAll(instantRows);
                 rows.addAll(inserted);
-                INSERTED_BY_ROWS.put(rows, inserted);
+                INSERTED_ROWS.record(activity, inserted);
                 log("mode=" + instantMode + " rows=" + instantRows.size() + " CACHE_HIT=true");
 
                 if (!inFlight) {
@@ -132,7 +131,7 @@ public final class SearchExploreRows {
                 List<Object> inserted = new ArrayList<Object>();
                 inserted.add(makeHeader("Loading active subreddits"));
                 rows.addAll(inserted);
-                INSERTED_BY_ROWS.put(rows, inserted);
+                INSERTED_ROWS.record(activity, inserted);
                 log("mode=loading_active CACHE_HIT=false");
 
                 if (!inFlight) {
@@ -184,7 +183,7 @@ public final class SearchExploreRows {
                         }
 
                         synchronized (LOCK) {
-                            removeInsertedLocked(rows);
+                            removeInsertedLocked(activity, rows);
 
                             List<Object> inserted = new ArrayList<Object>();
                             if (finalResult.rows != null && !finalResult.rows.isEmpty()) {
@@ -199,7 +198,7 @@ public final class SearchExploreRows {
 
                             if (!inserted.isEmpty()) {
                                 rows.addAll(inserted);
-                                INSERTED_BY_ROWS.put(rows, inserted);
+                                INSERTED_ROWS.record(activity, inserted);
                             }
                         }
 
@@ -1357,11 +1356,12 @@ public final class SearchExploreRows {
         return item == null ? "null" : item.getClass().getName();
     }
 
-    private static void removeInsertedLocked(ArrayList rows) {
-        List<Object> previous = INSERTED_BY_ROWS.remove(rows);
-        if (previous != null && !previous.isEmpty()) {
-            rows.removeAll(previous);
-        }
+    private static void removeInsertedLocked(Activity activity, ArrayList rows) {
+        SearchInsertedRowsTracker.RemovalStats removal = INSERTED_ROWS.remove(activity, rows);
+        log("dedup_remove previous=" + removal.previous
+            + " matchedBefore=" + removal.matchedBefore
+            + " removedOwned=" + removal.removedOwned
+            + " remainingOwned=" + removal.remainingOwned);
     }
 
     private static boolean isSearchTextEmpty(Activity activity) {

--- a/extensions/boostforreddit/src/main/java/app/morphe/extension/boostforreddit/search/SearchInsertedRowsTracker.java
+++ b/extensions/boostforreddit/src/main/java/app/morphe/extension/boostforreddit/search/SearchInsertedRowsTracker.java
@@ -1,0 +1,82 @@
+package app.morphe.extension.boostforreddit.search;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.WeakHashMap;
+
+/** Tracks Search rows by a stable owner and removes only rows owned by Morphe. */
+final class SearchInsertedRowsTracker<K> {
+    private final WeakHashMap<K, List<Object>> insertedByOwner = new WeakHashMap<>();
+
+    void record(K owner, List<?> inserted) {
+        if (owner == null) {
+            throw new NullPointerException("owner");
+        }
+
+        if (inserted == null || inserted.isEmpty()) {
+            insertedByOwner.remove(owner);
+            return;
+        }
+
+        ArrayList<Object> snapshot = new ArrayList<Object>(inserted.size());
+        snapshot.addAll(inserted);
+        insertedByOwner.put(owner, snapshot);
+    }
+
+    RemovalStats remove(K owner, List<?> rows) {
+        List<Object> previous = insertedByOwner.remove(owner);
+        if (previous == null || previous.isEmpty()) {
+            return RemovalStats.EMPTY;
+        }
+
+        int matchedBefore = countOwnedRowsByIdentity(rows, previous);
+        int removedOwned = removeOwnedRowsByIdentity(rows, previous);
+        int remainingOwned = countOwnedRowsByIdentity(rows, previous);
+        return new RemovalStats(previous.size(), matchedBefore, removedOwned, remainingOwned);
+    }
+
+    private static int countOwnedRowsByIdentity(List<?> rows, List<?> owned) {
+        int matches = 0;
+        for (int rowIndex = 0; rowIndex < rows.size(); rowIndex++) {
+            Object row = rows.get(rowIndex);
+            for (int ownedIndex = 0; ownedIndex < owned.size(); ownedIndex++) {
+                if (row == owned.get(ownedIndex)) {
+                    matches++;
+                    break;
+                }
+            }
+        }
+        return matches;
+    }
+
+    private static int removeOwnedRowsByIdentity(List<?> rows, List<?> owned) {
+        int removed = 0;
+        for (int rowIndex = rows.size() - 1; rowIndex >= 0; rowIndex--) {
+            Object row = rows.get(rowIndex);
+            for (int ownedIndex = 0; ownedIndex < owned.size(); ownedIndex++) {
+                if (row == owned.get(ownedIndex)) {
+                    rows.remove(rowIndex);
+                    removed++;
+                    break;
+                }
+            }
+        }
+        return removed;
+    }
+
+    static final class RemovalStats {
+        static final RemovalStats EMPTY = new RemovalStats(0, 0, 0, 0);
+
+        final int previous;
+        final int matchedBefore;
+        final int removedOwned;
+        final int remainingOwned;
+
+        RemovalStats(int previous, int matchedBefore, int removedOwned, int remainingOwned) {
+            this.previous = previous;
+            this.matchedBefore = matchedBefore;
+            this.removedOwned = removedOwned;
+            this.remainingOwned = remainingOwned;
+        }
+    }
+}

--- a/tools/check-boost-search-dedup-contract.sh
+++ b/tools/check-boost-search-dedup-contract.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+PRODUCTION="$ROOT/extensions/boostforreddit/src/main/java/app/morphe/extension/boostforreddit/search/SearchInsertedRowsTracker.java"
+SEARCH_ROWS="$ROOT/extensions/boostforreddit/src/main/java/app/morphe/extension/boostforreddit/search/SearchExploreRows.java"
+TEST="$ROOT/tools/tests/boost-search/SearchInsertedRowsTrackerContractTest.java"
+TMP="$(mktemp -d "${TMPDIR:-/tmp}/morphe-issue61-contract.XXXXXX")"
+trap 'rm -rf -- "$TMP"' EXIT
+
+test -f "$PRODUCTION"
+test -f "$SEARCH_ROWS"
+test -f "$TEST"
+
+grep -F 'SearchInsertedRowsTracker<Activity>' "$SEARCH_ROWS" >/dev/null
+grep -F 'INSERTED_ROWS.record(activity, inserted)' "$SEARCH_ROWS" >/dev/null
+grep -F 'INSERTED_ROWS.remove(activity, rows)' "$SEARCH_ROWS" >/dev/null
+if grep -F 'INSERTED_BY_ACTIVITY' "$SEARCH_ROWS" >/dev/null; then
+    echo 'FAIL: legacy activity map remains in SearchExploreRows' >&2
+    exit 1
+fi
+
+JAVAC_BIN="${JAVAC:-}"
+if [ -z "$JAVAC_BIN" ] && command -v javac >/dev/null 2>&1; then
+    JAVAC_BIN="$(command -v javac)"
+fi
+if [ -z "$JAVAC_BIN" ] && [ -n "${JAVA_HOME:-}" ] && [ -x "$JAVA_HOME/bin/javac" ]; then
+    JAVAC_BIN="$JAVA_HOME/bin/javac"
+fi
+if [ -z "$JAVAC_BIN" ]; then
+    echo 'FAIL: javac not found; run with a JDK 17 environment' >&2
+    exit 1
+fi
+
+mkdir -p "$TMP/classes"
+"$JAVAC_BIN" -Werror -Xlint:all -d "$TMP/classes" "$PRODUCTION" "$TEST"
+java -ea -cp "$TMP/classes" \
+    app.morphe.extension.boostforreddit.search.SearchInsertedRowsTrackerContractTest

--- a/tools/tests/boost-search/SearchInsertedRowsTrackerContractTest.java
+++ b/tools/tests/boost-search/SearchInsertedRowsTrackerContractTest.java
@@ -1,0 +1,185 @@
+package app.morphe.extension.boostforreddit.search;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.WeakHashMap;
+
+public final class SearchInsertedRowsTrackerContractTest {
+    private static final int STRESS_CYCLES = 10000;
+
+    private SearchInsertedRowsTrackerContractTest() {
+    }
+
+    public static void main(String[] args) {
+        reproduceLegacyMutableListKeyFailure();
+        preserveEqualButUnownedRows();
+        isolateOwners();
+        stressStableOwnerAcrossMutableRows();
+
+        System.out.println("LEGACY_MUTABLE_LIST_KEY=REPRODUCED");
+        System.out.println("IDENTITY_EQUAL_ROW=PASS");
+        System.out.println("OWNER_ISOLATION=PASS");
+        System.out.println("STRESS_CYCLES=" + STRESS_CYCLES);
+        System.out.println("RESULT=MORPHE_ISSUE61_SEARCH_DEDUP_CONTRACT_OK");
+    }
+
+    private static void reproduceLegacyMutableListKeyFailure() {
+        WeakHashMap<ArrayList<Object>, List<Object>> legacy = new WeakHashMap<>();
+        ArrayList<Object> rows = new ArrayList<Object>();
+        rows.add(new HashRow(1));
+        legacy.put(rows, Collections.<Object>singletonList(new Object()));
+
+        boolean lookupLost = false;
+        for (int index = 2; index < 1024; index++) {
+            rows.add(new HashRow(index));
+            if (legacy.get(rows) == null) {
+                lookupLost = true;
+                break;
+            }
+        }
+
+        require(lookupLost, "legacy mutable ArrayList key unexpectedly remained addressable");
+    }
+
+    private static void preserveEqualButUnownedRows() {
+        SearchInsertedRowsTracker<Object> tracker = new SearchInsertedRowsTracker<>();
+        Object owner = new Object();
+        EqualRow owned = new EqualRow("same");
+        EqualRow foreign = new EqualRow("same");
+        ArrayList<Object> rows = new ArrayList<Object>(Arrays.<Object>asList(owned, foreign));
+
+        tracker.record(owner, Collections.<Object>singletonList(owned));
+        SearchInsertedRowsTracker.RemovalStats stats = tracker.remove(owner, rows);
+
+        requireStats(stats, 1, 1, 1, 0, "equal-row identity removal");
+        require(rows.size() == 1 && rows.get(0) == foreign,
+            "value-equal foreign row was removed");
+    }
+
+    private static void isolateOwners() {
+        SearchInsertedRowsTracker<Object> tracker = new SearchInsertedRowsTracker<>();
+        Object ownerA = new Object();
+        Object ownerB = new Object();
+        Object rowA = new Object();
+        Object rowB = new Object();
+        ArrayList<Object> rows = new ArrayList<Object>(Arrays.asList(rowA, rowB));
+
+        tracker.record(ownerA, Collections.singletonList(rowA));
+        tracker.record(ownerB, Collections.singletonList(rowB));
+
+        requireStats(tracker.remove(ownerA, rows), 1, 1, 1, 0, "owner A");
+        require(rows.size() == 1 && rows.get(0) == rowB, "owner A removed owner B row");
+        requireStats(tracker.remove(ownerB, rows), 1, 1, 1, 0, "owner B");
+        require(rows.isEmpty(), "owner B row remained");
+    }
+
+    private static void stressStableOwnerAcrossMutableRows() {
+        SearchInsertedRowsTracker<Object> tracker = new SearchInsertedRowsTracker<>();
+        Object activityOwner = new Object();
+        ArrayList<Object> rows = new ArrayList<Object>();
+        EqualRow nativeEqualRow = new EqualRow("header");
+        rows.add(nativeEqualRow);
+
+        for (int cycle = 0; cycle < STRESS_CYCLES; cycle++) {
+            ArrayList<Object> inserted = new ArrayList<Object>();
+            inserted.add(new EqualRow("header"));
+            for (int row = 0; row < 10; row++) {
+                inserted.add(new EqualRow("community-" + cycle + "-" + row));
+            }
+
+            rows.addAll(inserted);
+            tracker.record(activityOwner, inserted);
+
+            Object goTo = new Object();
+            Object random = new Object();
+            rows.add(0, goTo);
+            rows.add(random);
+            Collections.rotate(rows, (cycle % 5) + 1);
+
+            SearchInsertedRowsTracker.RemovalStats stats = tracker.remove(activityOwner, rows);
+            requireStats(stats, 11, 11, 11, 0, "cycle " + cycle);
+            require(!containsAnyIdentity(rows, inserted), "owned row remained in cycle " + cycle);
+            require(containsIdentity(rows, nativeEqualRow),
+                "value-equal native row was removed in cycle " + cycle);
+
+            rows.remove(goTo);
+            rows.remove(random);
+            require(rows.size() == 1 && rows.get(0) == nativeEqualRow,
+                "non-owned row contract drifted in cycle " + cycle);
+        }
+    }
+
+    private static boolean containsAnyIdentity(List<?> rows, List<?> candidates) {
+        for (Object candidate : candidates) {
+            if (containsIdentity(rows, candidate)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static boolean containsIdentity(List<?> rows, Object candidate) {
+        for (Object row : rows) {
+            if (row == candidate) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static void requireStats(
+        SearchInsertedRowsTracker.RemovalStats stats,
+        int previous,
+        int matchedBefore,
+        int removedOwned,
+        int remainingOwned,
+        String context
+    ) {
+        require(stats.previous == previous, context + ": previous=" + stats.previous);
+        require(stats.matchedBefore == matchedBefore,
+            context + ": matchedBefore=" + stats.matchedBefore);
+        require(stats.removedOwned == removedOwned,
+            context + ": removedOwned=" + stats.removedOwned);
+        require(stats.remainingOwned == remainingOwned,
+            context + ": remainingOwned=" + stats.remainingOwned);
+    }
+
+    private static void require(boolean condition, String message) {
+        if (!condition) {
+            throw new AssertionError(message);
+        }
+    }
+
+    private static final class HashRow {
+        private final int hash;
+
+        HashRow(int hash) {
+            this.hash = hash;
+        }
+
+        @Override
+        public int hashCode() {
+            return hash;
+        }
+    }
+
+    private static final class EqualRow {
+        private final String value;
+
+        EqualRow(String value) {
+            this.value = value;
+        }
+
+        @Override
+        public boolean equals(Object other) {
+            return other instanceof EqualRow && value.equals(((EqualRow) other).value);
+        }
+
+        @Override
+        public int hashCode() {
+            return value.hashCode();
+        }
+    }
+}


### PR DESCRIPTION
Related to #61.

## What changed

- Track Morphe-injected Search rows by the stable Search activity rather than by Boost's mutable `ArrayList`.
- Remove only the exact row object identities owned by Morphe before applying refreshed data.
- Add a permanent host-side regression contract and run it in the release workflow.

## Root cause

Boost mutates the Search `ArrayList` after Morphe inserts cached rows. Using that mutable list as a `WeakHashMap` key changed its hash and made the cached rows unreachable during the asynchronous refresh, so the fresh section was appended below the stale section.

## Validation

- Legacy mutable-list-key failure reproduced deterministically.
- Identity removal and owner isolation passed.
- 10,000 mutation/cache-refresh cycles passed.
- `:patches:buildAndroid` passed after rebasing onto patch bundle 1.4.86.
- Final isolated `com.rubenmayayo.reddit.dev.issue61` install passed with the expected marker and target SDK 35.
- Manual warm-cache smoke test showed exactly one Active subreddits section.

The issue remains open for reporter confirmation after release.
