### PR TITLE
fix(boost): preserve search context and routing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -149,6 +149,9 @@ jobs:
       - name: Verify Boost Search dedup contract
         run: ./tools/check-boost-search-dedup-contract.sh
 
+      - name: Verify Boost Search routing contract
+        run: ./tools/check-boost-search-route-contract.sh
+
       - name: Cache Gradle
         uses: gradle/actions/setup-gradle@v6
         with:

--- a/extensions/boostforreddit/src/main/java/app/morphe/extension/boostforreddit/utils/BoostSearchBottomNavigation.java
+++ b/extensions/boostforreddit/src/main/java/app/morphe/extension/boostforreddit/utils/BoostSearchBottomNavigation.java
@@ -15,12 +15,15 @@ import android.view.Gravity;
 import android.view.Window;
 import android.view.WindowInsets;
 import android.view.WindowInsetsController;
+import android.view.WindowManager;
 import android.view.View;
 import android.view.ViewGroup;
+import android.view.inputmethod.InputMethodManager;
 import android.widget.Toast;
 import android.widget.FrameLayout;
 import android.util.Log;
 
+import java.lang.reflect.Field;
 import java.lang.reflect.InvocationHandler;
 import java.lang.reflect.Method;
 import java.lang.reflect.Proxy;
@@ -47,6 +50,12 @@ public final class BoostSearchBottomNavigation {
             "MORPHE_BOOST_VISIBLE_BOTTOM_NAV_FALLBACK_V751";
     private static volatile String SEARCH_ROUTE_MARKER =
             "MORPHE_BOOST_SEARCH_BACK_STACK_V1_PRESERVE_CALLER";
+    private static final String SEARCH_CONTEXT_MARKER =
+            "MORPHE_BOOST_SEARCH_CONTEXT_ISSUE94_SUBREDDIT_T1_V2";
+    private static final String SEARCH_SCOPE_HINT_MARKER =
+            "MORPHE_BOOST_SEARCH_SCOPE_HINT_ISSUE94_POST_ONCREATE_V2";
+    private static final String SEARCH_RESELECT_MARKER =
+            "MORPHE_BOOST_SEARCH_RESELECT_ISSUE86_V1";
     private static volatile String UNIFIED_MATERIAL_MARKER =
             "MORPHE_BOOST_UNIFIED_MATERIAL_BOTTOM_NAV_V771";
     private static final String CANONICAL_NAV_BASE_MARKER =
@@ -154,6 +163,8 @@ public final class BoostSearchBottomNavigation {
             return;
         }
 
+        scheduleSearchScopeHint(activity);
+
         int fallbackIndex = GO_TO_ACTIVITY.equals(
                 activity.getClass().getName()
         ) ? 2 : 1;
@@ -167,6 +178,96 @@ public final class BoostSearchBottomNavigation {
             INSTALLED.put(
                     activity,
                     Boolean.TRUE
+            );
+        }
+    }
+
+    private static void scheduleSearchScopeHint(
+            final Activity activity
+    ) {
+        if (
+                activity == null
+                        || !SEARCH_ACTIVITY.equals(
+                                activity.getClass().getName()
+                        )
+        ) {
+            return;
+        }
+
+        View decor = activity
+                .getWindow()
+                .getDecorView();
+
+        decor.post(new Runnable() {
+            @Override
+            public void run() {
+                applySearchScopeHint(activity);
+            }
+        });
+    }
+
+    private static void applySearchScopeHint(
+            Activity activity
+    ) {
+        if (
+                activity == null
+                        || !SEARCH_ACTIVITY.equals(
+                                activity.getClass().getName()
+                        )
+        ) {
+            return;
+        }
+
+        try {
+            Intent intent = activity.getIntent();
+            if (intent == null) return;
+
+            Object subscription =
+                    intent.getParcelableExtra("subscription");
+            if (subscription == null) return;
+
+            Field subredditField = findField(
+                    subscription.getClass(),
+                    "b"
+            );
+            if (subredditField == null) return;
+
+            subredditField.setAccessible(true);
+            Object rawSubreddit =
+                    subredditField.get(subscription);
+            if (!(rawSubreddit instanceof String)) return;
+
+            String subreddit =
+                    ((String) rawSubreddit).trim();
+            if (subreddit.length() == 0) return;
+
+            Field inputField = findField(
+                    activity.getClass(),
+                    "searchEditText"
+            );
+            if (inputField == null) return;
+
+            inputField.setAccessible(true);
+            Object input = inputField.get(activity);
+            if (!(input instanceof android.widget.TextView)) return;
+
+            ((android.widget.TextView) input).setHint(
+                    "Search in r/" + subreddit
+            );
+
+            Log.i(
+                    TAG,
+                    "search scope hint applied marker="
+                            + SEARCH_SCOPE_HINT_MARKER
+                            + " subreddit="
+                            + subreddit
+            );
+        } catch (Throwable error) {
+            Log.w(
+                    TAG,
+                    "search scope hint failed marker="
+                            + SEARCH_SCOPE_HINT_MARKER,
+                    error
             );
         }
     }
@@ -3767,6 +3868,14 @@ public final class BoostSearchBottomNavigation {
         int inboxId = resourceId(activity, "item_inbox", "id");
         int profileId = resourceId(activity, "item_profile", "id");
 
+        if (
+                selectedId == searchId
+                        && SEARCH_ACTIVITY.equals(
+                                activity.getClass().getName()
+                        )
+        ) {
+            return focusSearchInput(activity);
+        }
 
         int currentItemId =
                 selectedItemIdForActivity(activity, -1);
@@ -3777,15 +3886,7 @@ public final class BoostSearchBottomNavigation {
         ) {
             return true;
         }
-if (selectedId == searchId) {
-            if (
-                    SEARCH_ACTIVITY.equals(
-                            activity.getClass().getName()
-                    )
-            ) {
-                return true;
-            }
-
+        if (selectedId == searchId) {
             return completeStaticTabTransition(
                     activity,
                     openSearch(activity)
@@ -3822,16 +3923,51 @@ if (selectedId == searchId) {
     private static boolean openSearch(
             Activity activity
     ) {
+        if (activity == null) {
+            return false;
+        }
+
+        if (
+                SEARCH_ACTIVITY.equals(
+                        activity.getClass().getName()
+                )
+        ) {
+            return focusSearchInput(activity);
+        }
+
+        if (SUBREDDIT_ACTIVITY.equals(activity.getClass().getName())) {
         try {
-            if (
-                    activity == null
-                            || SEARCH_ACTIVITY.equals(
-                                    activity.getClass().getName()
-                            )
-            ) {
+            Method nativeSearch = findMethod(
+                    activity.getClass(),
+                    "T1"
+            );
+
+            if (nativeSearch != null) {
+                nativeSearch.setAccessible(true);
+                nativeSearch.invoke(activity);
+
+                Log.i(
+                        TAG,
+                        "native search route marker="
+                                + SEARCH_CONTEXT_MARKER
+                                + " from="
+                                + activity.getClass().getName()
+                );
                 return true;
             }
+        } catch (Throwable error) {
+            Log.w(
+                    TAG,
+                    "native search route failed marker="
+                            + SEARCH_CONTEXT_MARKER
+                            + " from="
+                            + activity.getClass().getName(),
+                    error
+            );
+        }
+        }
 
+        try {
             Class<?> destination = Class.forName(
                     SEARCH_ACTIVITY,
                     false,
@@ -3877,6 +4013,71 @@ if (selectedId == searchId) {
                                             .getClass()
                                             .getName()
                             ),
+                    error
+            );
+            return false;
+        }
+    }
+
+    private static boolean focusSearchInput(
+            final Activity activity
+    ) {
+        if (activity == null) {
+            return false;
+        }
+
+        try {
+            Field field = findField(
+                    activity.getClass(),
+                    "searchEditText"
+            );
+
+            if (field == null) {
+                throw new NoSuchFieldException("searchEditText");
+            }
+
+            field.setAccessible(true);
+            Object value = field.get(activity);
+
+            if (!(value instanceof View)) {
+                throw new IllegalStateException(
+                        "searchEditText is not a View"
+                );
+            }
+
+            final View searchInput = (View) value;
+            searchInput.requestFocus();
+            activity.getWindow().setSoftInputMode(
+                    WindowManager.LayoutParams
+                            .SOFT_INPUT_STATE_ALWAYS_VISIBLE
+            );
+            searchInput.post(new Runnable() {
+                @Override
+                public void run() {
+                    Object service = activity.getSystemService(
+                            Context.INPUT_METHOD_SERVICE
+                    );
+
+                    if (service instanceof InputMethodManager) {
+                        ((InputMethodManager) service).showSoftInput(
+                                searchInput,
+                                InputMethodManager.SHOW_IMPLICIT
+                        );
+                    }
+                }
+            });
+
+            Log.i(
+                    TAG,
+                    "search reselect focused marker="
+                            + SEARCH_RESELECT_MARKER
+            );
+            return true;
+        } catch (Throwable error) {
+            Log.e(
+                    TAG,
+                    "search reselect failed marker="
+                            + SEARCH_RESELECT_MARKER,
                     error
             );
             return false;
@@ -4151,6 +4352,23 @@ if (selectedId == searchId) {
                         parameterTypes
                 );
             } catch (NoSuchMethodException ignored) {
+                current = current.getSuperclass();
+            }
+        }
+
+        return null;
+    }
+
+    private static Field findField(
+            Class<?> type,
+            String name
+    ) {
+        Class<?> current = type;
+
+        while (current != null) {
+            try {
+                return current.getDeclaredField(name);
+            } catch (NoSuchFieldException ignored) {
                 current = current.getSuperclass();
             }
         }

--- a/extensions/boostforreddit/src/main/java/app/morphe/extension/boostforreddit/utils/BoostSearchBottomNavigation.java
+++ b/extensions/boostforreddit/src/main/java/app/morphe/extension/boostforreddit/utils/BoostSearchBottomNavigation.java
@@ -3936,35 +3936,35 @@ public final class BoostSearchBottomNavigation {
         }
 
         if (SUBREDDIT_ACTIVITY.equals(activity.getClass().getName())) {
-        try {
-            Method nativeSearch = findMethod(
-                    activity.getClass(),
-                    "T1"
-            );
+            try {
+                Method nativeSearch = findMethod(
+                        activity.getClass(),
+                        "T1"
+                );
 
-            if (nativeSearch != null) {
-                nativeSearch.setAccessible(true);
-                nativeSearch.invoke(activity);
+                if (nativeSearch != null) {
+                    nativeSearch.setAccessible(true);
+                    nativeSearch.invoke(activity);
 
-                Log.i(
+                    Log.i(
+                            TAG,
+                            "native search route marker="
+                                    + SEARCH_CONTEXT_MARKER
+                                    + " from="
+                                    + activity.getClass().getName()
+                    );
+                    return true;
+                }
+            } catch (Throwable error) {
+                Log.w(
                         TAG,
-                        "native search route marker="
+                        "native search route failed marker="
                                 + SEARCH_CONTEXT_MARKER
                                 + " from="
-                                + activity.getClass().getName()
+                                + activity.getClass().getName(),
+                        error
                 );
-                return true;
             }
-        } catch (Throwable error) {
-            Log.w(
-                    TAG,
-                    "native search route failed marker="
-                            + SEARCH_CONTEXT_MARKER
-                            + " from="
-                            + activity.getClass().getName(),
-                    error
-            );
-        }
         }
 
         try {

--- a/tools/check-boost-search-route-contract.sh
+++ b/tools/check-boost-search-route-contract.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SOURCE='extensions/boostforreddit/src/main/java/app/morphe/extension/boostforreddit/utils/BoostSearchBottomNavigation.java'
+
+test -f "$SOURCE"
+
+rg -q -F 'MORPHE_BOOST_SEARCH_CONTEXT_ISSUE94_SUBREDDIT_T1_V2' "$SOURCE"
+rg -q -F 'MORPHE_BOOST_SEARCH_SCOPE_HINT_ISSUE94_POST_ONCREATE_V2' "$SOURCE"
+rg -q -F 'MORPHE_BOOST_SEARCH_RESELECT_ISSUE86_V1' "$SOURCE"
+rg -q -F 'nativeSearch.invoke(activity);' "$SOURCE"
+rg -q -F 'if (SUBREDDIT_ACTIVITY.equals(activity.getClass().getName())) {' "$SOURCE"
+rg -q -F 'return focusSearchInput(activity);' "$SOURCE"
+rg -q -F 'scheduleSearchScopeHint(activity);' "$SOURCE"
+rg -q -F 'decor.post(new Runnable() {' "$SOURCE"
+rg -q -F 'intent.getParcelableExtra("subscription");' "$SOURCE"
+rg -q -U 'findField\(\s*subscription\.getClass\(\),\s*"b"\s*\)' "$SOURCE"
+rg -q -U 'setHint\(\s*"Search in r/" \+ subreddit\s*\)' "$SOURCE"
+
+SCOPE_HINT_LINE="$(rg -n -m1 -F 'scheduleSearchScopeHint(activity);' "$SOURCE" | cut -d: -f1)"
+NAV_INSTALL_LINE="$(rg -n -m1 -F 'standardizeMaterialNavigation(' "$SOURCE" | cut -d: -f1)"
+RESELECT_LINE="$(rg -n -m1 -F 'return focusSearchInput(activity);' "$SOURCE" | cut -d: -f1)"
+SELECTION_GUARD_LINE="$(rg -n -m1 -F 'currentItemId != 0' "$SOURCE" | cut -d: -f1)"
+NATIVE_LINE="$(rg -n -m1 -F 'nativeSearch.invoke(activity);' "$SOURCE" | cut -d: -f1)"
+NATIVE_SCOPE_LINE="$(rg -n -m1 -F 'if (SUBREDDIT_ACTIVITY.equals(activity.getClass().getName())) {' "$SOURCE" | cut -d: -f1)"
+FALLBACK_LINE="$(rg -n -m1 -F 'Class<?> destination = Class.forName(' "$SOURCE" | cut -d: -f1)"
+
+test "$SCOPE_HINT_LINE" -lt "$NAV_INSTALL_LINE"
+test "$RESELECT_LINE" -lt "$SELECTION_GUARD_LINE"
+test "$NATIVE_SCOPE_LINE" -lt "$NATIVE_LINE"
+test "$NATIVE_LINE" -lt "$FALLBACK_LINE"
+
+echo 'SCOPE_HINT_SCHEDULED_BEFORE_NAV_INSTALL=PASS'
+echo 'RESELECT_BEFORE_SELECTION_GUARD=PASS'
+echo 'NATIVE_T1_SCOPED_TO_SUBREDDIT=PASS'
+echo 'NATIVE_T1_BEFORE_GLOBAL_FALLBACK=PASS'
+echo 'RESULT=MORPHE_SEARCH_ROUTE_CONTRACT_OK'


### PR DESCRIPTION
## Summary

Addresses #94 and #86 for Boost Search navigation.

- preserves native subreddit Search context
- scopes the obfuscated `T1()` route to `SubredditActivity`
- restores global Search from Home, Inbox, Profile, and Subscriptions
- shows `Search in r/<subreddit>` after native Search setup
- opens the keyboard when the selected Search destination is tapped again
- adds a permanent Search routing contract to the release workflow

## Root cause

The direct Search route discarded Boost's `SubscriptionViewModel`. The initial context fix also treated reflection of `T1()` as successful navigation on activities where that method did not open Search.

## Validation

- `./tools/check-boost-search-route-contract.sh`
- `./tools/check-boost-search-dedup-contract.sh`
- `./gradlew :patches:buildAndroid`
- `git diff --check`
- Home, Inbox, Profile, and Subscriptions → global Search: PASS
- subreddit → `Search in r/<subreddit>`: PASS
- selected Search → keyboard: PASS
- Back-stack: PASS
- no fatal exception observed

DEV APK SHA-256:

`6c58e0f8500076367e76ceacd19cf0d285e10b30528fb896e4a9a14cf113ae2d`

## Scope

#95, the asynchronous “Active subreddits” section jump, is separate and intentionally excluded. Normal Boost was not installed or modified.
