### PR TITLE
fix(ci): install ripgrep for search contract

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -146,6 +146,15 @@ jobs:
           distribution: 'temurin'
           java-version: '17'
 
+      - name: Install ripgrep
+        shell: bash
+        run: |
+          if ! command -v rg >/dev/null 2>&1; then
+            sudo apt-get update
+            sudo apt-get install --yes ripgrep
+          fi
+          rg --version
+
       - name: Verify Boost Search dedup contract
         run: ./tools/check-boost-search-dedup-contract.sh
 


### PR DESCRIPTION
## Summary

- installs `ripgrep` before running the Search routing contract
- keeps the existing routing assertions unchanged
- unblocks the Morphe 1.4.90 release workflow

## Validation

- `./tools/check-boost-search-route-contract.sh`
- `./tools/check-boost-search-dedup-contract.sh`
- `git diff --check`

No Android runtime behavior or release metadata is changed.