### PR TITLE
fix(boost): complete search focus and stable refresh

### DIFF
--- a/extensions/boostforreddit/src/main/java/app/morphe/extension/boostforreddit/search/SearchExploreRows.java
+++ b/extensions/boostforreddit/src/main/java/app/morphe/extension/boostforreddit/search/SearchExploreRows.java
@@ -26,6 +26,8 @@ import java.util.concurrent.TimeUnit;
 public final class SearchExploreRows {
     private static final String TAG = "MorpheSearchExplore";
     private static final String MARKER = "MORPHE_SEARCH_EXPLORE_ISSUE61_DEDUP_V2_IDENTITY_GATE";
+    private static final String SECTION_STABILITY_MARKER =
+            "MORPHE_SEARCH_EXPLORE_ISSUE95_STABLE_ANCHOR_V1";
 
     private static final String CACHE_PREFS = "morphe_search_active_subreddits_v5l";
     private static final String CACHE_VALUE = "active_rows";
@@ -119,8 +121,7 @@ public final class SearchExploreRows {
                 List<Object> inserted = new ArrayList<Object>();
                 inserted.add(makeHeader("Active subreddits"));
                 inserted.addAll(instantRows);
-                rows.addAll(inserted);
-                INSERTED_ROWS.record(activity, inserted);
+                insertOwnedLocked(activity, rows, inserted);
                 log("mode=" + instantMode + " rows=" + instantRows.size() + " CACHE_HIT=true");
 
                 if (!inFlight) {
@@ -130,8 +131,7 @@ public final class SearchExploreRows {
             } else {
                 List<Object> inserted = new ArrayList<Object>();
                 inserted.add(makeHeader("Loading active subreddits"));
-                rows.addAll(inserted);
-                INSERTED_ROWS.record(activity, inserted);
+                insertOwnedLocked(activity, rows, inserted);
                 log("mode=loading_active CACHE_HIT=false");
 
                 if (!inFlight) {
@@ -197,8 +197,7 @@ public final class SearchExploreRows {
                             }
 
                             if (!inserted.isEmpty()) {
-                                rows.addAll(inserted);
-                                INSERTED_ROWS.record(activity, inserted);
+                                insertOwnedLocked(activity, rows, inserted);
                             }
                         }
 
@@ -1354,6 +1353,23 @@ public final class SearchExploreRows {
 
     private static String typeName(Object item) {
         return item == null ? "null" : item.getClass().getName();
+    }
+
+    private static void insertOwnedLocked(
+            Activity activity,
+            ArrayList rows,
+            List<Object> inserted
+    ) {
+        int insertionIndex =
+                INSERTED_ROWS.insertionIndex(activity, rows);
+
+        rows.addAll(insertionIndex, inserted);
+        INSERTED_ROWS.record(activity, inserted);
+
+        log(SECTION_STABILITY_MARKER
+                + " insertionIndex=" + insertionIndex
+                + " inserted=" + inserted.size()
+                + " total=" + rows.size());
     }
 
     private static void removeInsertedLocked(Activity activity, ArrayList rows) {

--- a/extensions/boostforreddit/src/main/java/app/morphe/extension/boostforreddit/search/SearchInsertedRowsTracker.java
+++ b/extensions/boostforreddit/src/main/java/app/morphe/extension/boostforreddit/search/SearchInsertedRowsTracker.java
@@ -7,6 +7,7 @@ import java.util.WeakHashMap;
 /** Tracks Search rows by a stable owner and removes only rows owned by Morphe. */
 final class SearchInsertedRowsTracker<K> {
     private final WeakHashMap<K, List<Object>> insertedByOwner = new WeakHashMap<>();
+    private final WeakHashMap<K, Integer> insertionIndexByOwner = new WeakHashMap<>();
 
     void record(K owner, List<?> inserted) {
         if (owner == null) {
@@ -21,6 +22,30 @@ final class SearchInsertedRowsTracker<K> {
         ArrayList<Object> snapshot = new ArrayList<Object>(inserted.size());
         snapshot.addAll(inserted);
         insertedByOwner.put(owner, snapshot);
+    }
+
+    int insertionIndex(K owner, List<?> rows) {
+        if (owner == null) {
+            throw new NullPointerException("owner");
+        }
+        if (rows == null) {
+            throw new NullPointerException("rows");
+        }
+
+        Integer recorded = insertionIndexByOwner.get(owner);
+        int resolved = recorded == null
+            ? rows.size()
+            : recorded.intValue();
+
+        if (resolved < 0) {
+            resolved = 0;
+        }
+        if (resolved > rows.size()) {
+            resolved = rows.size();
+        }
+
+        insertionIndexByOwner.put(owner, Integer.valueOf(resolved));
+        return resolved;
     }
 
     RemovalStats remove(K owner, List<?> rows) {

--- a/extensions/boostforreddit/src/main/java/app/morphe/extension/boostforreddit/utils/BoostSearchBottomNavigation.java
+++ b/extensions/boostforreddit/src/main/java/app/morphe/extension/boostforreddit/utils/BoostSearchBottomNavigation.java
@@ -54,6 +54,8 @@ public final class BoostSearchBottomNavigation {
             "MORPHE_BOOST_SEARCH_CONTEXT_ISSUE94_SUBREDDIT_T1_V2";
     private static final String SEARCH_SCOPE_HINT_MARKER =
             "MORPHE_BOOST_SEARCH_SCOPE_HINT_ISSUE94_POST_ONCREATE_V2";
+    private static final String SEARCH_INITIAL_FOCUS_MARKER =
+            "MORPHE_BOOST_SEARCH_INITIAL_FOCUS_V1";
     private static final String SEARCH_RESELECT_MARKER =
             "MORPHE_BOOST_SEARCH_RESELECT_ISSUE86_V1";
     private static volatile String UNIFIED_MATERIAL_MARKER =
@@ -124,6 +126,9 @@ public final class BoostSearchBottomNavigation {
     private static final String DECOR_UNDERLAY_TAG =
             "morphe_boost_bottom_navigation_decor_underlay";
     private static final String TAG = "MorpheSearchNav";
+    private static final int SEARCH_INITIAL_FOCUS_RETRY_LIMIT = 24;
+    private static final long SEARCH_INITIAL_FOCUS_RETRY_DELAY_MS =
+            75L;
 
     private static final String SEARCH_ACTIVITY =
             "com.rubenmayayo.reddit.ui.search.SearchGenericActivity";
@@ -164,6 +169,7 @@ public final class BoostSearchBottomNavigation {
         }
 
         scheduleSearchScopeHint(activity);
+        scheduleInitialSearchInputFocus(activity);
 
         int fallbackIndex = GO_TO_ACTIVITY.equals(
                 activity.getClass().getName()
@@ -180,6 +186,77 @@ public final class BoostSearchBottomNavigation {
                     Boolean.TRUE
             );
         }
+    }
+
+    private static void scheduleInitialSearchInputFocus(
+            final Activity activity
+    ) {
+        if (
+                activity == null
+                        || !SEARCH_ACTIVITY.equals(
+                                activity.getClass().getName()
+                        )
+        ) {
+            return;
+        }
+
+        final View decor = activity
+                .getWindow()
+                .getDecorView();
+
+        decor.post(new Runnable() {
+            private int attempts;
+
+            @Override
+            public void run() {
+                attempts++;
+
+                if (activity.isFinishing() || activity.isDestroyed()) {
+                    return;
+                }
+
+                if (!activity.hasWindowFocus()) {
+                    if (attempts < SEARCH_INITIAL_FOCUS_RETRY_LIMIT) {
+                        decor.postDelayed(
+                                this,
+                                SEARCH_INITIAL_FOCUS_RETRY_DELAY_MS
+                        );
+                    } else {
+                        Log.w(
+                                TAG,
+                                "search initial focus exhausted marker="
+                                        + SEARCH_INITIAL_FOCUS_MARKER
+                                        + " attempts="
+                                        + attempts
+                        );
+                    }
+                    return;
+                }
+
+                boolean focused = focusSearchInput(activity);
+
+                Log.i(
+                        TAG,
+                        "search initial focus marker="
+                                + SEARCH_INITIAL_FOCUS_MARKER
+                                + " focused="
+                                + focused
+                                + " attempts="
+                                + attempts
+                );
+
+                if (
+                        !focused
+                                && attempts
+                                < SEARCH_INITIAL_FOCUS_RETRY_LIMIT
+                ) {
+                    decor.postDelayed(
+                            this,
+                            SEARCH_INITIAL_FOCUS_RETRY_DELAY_MS
+                    );
+                }
+            }
+        });
     }
 
     private static void scheduleSearchScopeHint(

--- a/tools/check-boost-search-dedup-contract.sh
+++ b/tools/check-boost-search-dedup-contract.sh
@@ -15,6 +15,17 @@ test -f "$TEST"
 grep -F 'SearchInsertedRowsTracker<Activity>' "$SEARCH_ROWS" >/dev/null
 grep -F 'INSERTED_ROWS.record(activity, inserted)' "$SEARCH_ROWS" >/dev/null
 grep -F 'INSERTED_ROWS.remove(activity, rows)' "$SEARCH_ROWS" >/dev/null
+grep -F 'MORPHE_SEARCH_EXPLORE_ISSUE95_STABLE_ANCHOR_V1' \
+    "$SEARCH_ROWS" >/dev/null
+grep -F 'INSERTED_ROWS.insertionIndex(activity, rows)' \
+    "$SEARCH_ROWS" >/dev/null
+grep -F 'rows.addAll(insertionIndex, inserted)' \
+    "$SEARCH_ROWS" >/dev/null
+if grep -F 'rows.addAll(inserted)' "$SEARCH_ROWS" >/dev/null; then
+    echo 'FAIL: Search refresh still appends owned rows without anchor' >&2
+    exit 1
+fi
+
 if grep -F 'INSERTED_BY_ACTIVITY' "$SEARCH_ROWS" >/dev/null; then
     echo 'FAIL: legacy activity map remains in SearchExploreRows' >&2
     exit 1

--- a/tools/check-boost-search-route-contract.sh
+++ b/tools/check-boost-search-route-contract.sh
@@ -7,7 +7,9 @@ test -f "$SOURCE"
 
 rg -q -F 'MORPHE_BOOST_SEARCH_CONTEXT_ISSUE94_SUBREDDIT_T1_V2' "$SOURCE"
 rg -q -F 'MORPHE_BOOST_SEARCH_SCOPE_HINT_ISSUE94_POST_ONCREATE_V2' "$SOURCE"
+rg -q -F 'MORPHE_BOOST_SEARCH_INITIAL_FOCUS_V1' "$SOURCE"
 rg -q -F 'MORPHE_BOOST_SEARCH_RESELECT_ISSUE86_V1' "$SOURCE"
+rg -q -F 'scheduleInitialSearchInputFocus(activity);' "$SOURCE"
 rg -q -F 'nativeSearch.invoke(activity);' "$SOURCE"
 rg -q -F 'if (SUBREDDIT_ACTIVITY.equals(activity.getClass().getName())) {' "$SOURCE"
 rg -q -F 'return focusSearchInput(activity);' "$SOURCE"
@@ -16,8 +18,11 @@ rg -q -F 'decor.post(new Runnable() {' "$SOURCE"
 rg -q -F 'intent.getParcelableExtra("subscription");' "$SOURCE"
 rg -q -U 'findField\(\s*subscription\.getClass\(\),\s*"b"\s*\)' "$SOURCE"
 rg -q -U 'setHint\(\s*"Search in r/" \+ subreddit\s*\)' "$SOURCE"
+rg -q -F 'activity.hasWindowFocus()' "$SOURCE"
+rg -q -F 'SEARCH_INITIAL_FOCUS_RETRY_DELAY_MS' "$SOURCE"
 
 SCOPE_HINT_LINE="$(rg -n -m1 -F 'scheduleSearchScopeHint(activity);' "$SOURCE" | cut -d: -f1)"
+INITIAL_FOCUS_LINE="$(rg -n -m1 -F 'scheduleInitialSearchInputFocus(activity);' "$SOURCE" | cut -d: -f1)"
 NAV_INSTALL_LINE="$(rg -n -m1 -F 'standardizeMaterialNavigation(' "$SOURCE" | cut -d: -f1)"
 RESELECT_LINE="$(rg -n -m1 -F 'return focusSearchInput(activity);' "$SOURCE" | cut -d: -f1)"
 SELECTION_GUARD_LINE="$(rg -n -m1 -F 'currentItemId != 0' "$SOURCE" | cut -d: -f1)"
@@ -26,11 +31,13 @@ NATIVE_SCOPE_LINE="$(rg -n -m1 -F 'if (SUBREDDIT_ACTIVITY.equals(activity.getCla
 FALLBACK_LINE="$(rg -n -m1 -F 'Class<?> destination = Class.forName(' "$SOURCE" | cut -d: -f1)"
 
 test "$SCOPE_HINT_LINE" -lt "$NAV_INSTALL_LINE"
+test "$INITIAL_FOCUS_LINE" -lt "$NAV_INSTALL_LINE"
 test "$RESELECT_LINE" -lt "$SELECTION_GUARD_LINE"
 test "$NATIVE_SCOPE_LINE" -lt "$NATIVE_LINE"
 test "$NATIVE_LINE" -lt "$FALLBACK_LINE"
 
 echo 'SCOPE_HINT_SCHEDULED_BEFORE_NAV_INSTALL=PASS'
+echo 'INITIAL_FOCUS_SCHEDULED_BEFORE_NAV_INSTALL=PASS'
 echo 'RESELECT_BEFORE_SELECTION_GUARD=PASS'
 echo 'NATIVE_T1_SCOPED_TO_SUBREDDIT=PASS'
 echo 'NATIVE_T1_BEFORE_GLOBAL_FALLBACK=PASS'

--- a/tools/tests/boost-search/SearchInsertedRowsTrackerContractTest.java
+++ b/tools/tests/boost-search/SearchInsertedRowsTrackerContractTest.java
@@ -16,11 +16,14 @@ public final class SearchInsertedRowsTrackerContractTest {
         reproduceLegacyMutableListKeyFailure();
         preserveEqualButUnownedRows();
         isolateOwners();
+        preserveStableSectionAnchorAcrossRefresh();
         stressStableOwnerAcrossMutableRows();
 
         System.out.println("LEGACY_MUTABLE_LIST_KEY=REPRODUCED");
         System.out.println("IDENTITY_EQUAL_ROW=PASS");
         System.out.println("OWNER_ISOLATION=PASS");
+        System.out.println("SECTION_ANCHOR=PASS");
+        System.out.println("RESULT=MORPHE_ISSUE95_SEARCH_SECTION_STABILITY_CONTRACT_OK");
         System.out.println("STRESS_CYCLES=" + STRESS_CYCLES);
         System.out.println("RESULT=MORPHE_ISSUE61_SEARCH_DEDUP_CONTRACT_OK");
     }
@@ -73,6 +76,57 @@ public final class SearchInsertedRowsTrackerContractTest {
         require(rows.size() == 1 && rows.get(0) == rowB, "owner A removed owner B row");
         requireStats(tracker.remove(ownerB, rows), 1, 1, 1, 0, "owner B");
         require(rows.isEmpty(), "owner B row remained");
+    }
+
+    private static void preserveStableSectionAnchorAcrossRefresh() {
+        SearchInsertedRowsTracker<Object> tracker =
+            new SearchInsertedRowsTracker<>();
+        Object owner = new Object();
+        Object nativeBeforeA = new Object();
+        Object nativeBeforeB = new Object();
+        Object nativeAfterA = new Object();
+        Object nativeAfterB = new Object();
+        Object firstHeader = new Object();
+        Object firstRow = new Object();
+        Object refreshedHeader = new Object();
+        Object refreshedRow = new Object();
+
+        ArrayList<Object> rows = new ArrayList<Object>(
+            Arrays.asList(nativeBeforeA, nativeBeforeB)
+        );
+
+        int initialAnchor = tracker.insertionIndex(owner, rows);
+        require(initialAnchor == 2, "initial anchor=" + initialAnchor);
+
+        List<Object> firstOwned = Arrays.asList(firstHeader, firstRow);
+        rows.addAll(initialAnchor, firstOwned);
+        tracker.record(owner, firstOwned);
+
+        rows.add(nativeAfterA);
+        rows.add(nativeAfterB);
+
+        requireStats(
+            tracker.remove(owner, rows),
+            2, 2, 2, 0,
+            "stable anchor refresh"
+        );
+
+        int refreshAnchor = tracker.insertionIndex(owner, rows);
+        require(refreshAnchor == initialAnchor,
+            "refresh anchor moved from " + initialAnchor + " to " + refreshAnchor);
+
+        List<Object> refreshedOwned =
+            Arrays.asList(refreshedHeader, refreshedRow);
+        rows.addAll(refreshAnchor, refreshedOwned);
+        tracker.record(owner, refreshedOwned);
+
+        require(rows.size() == 6, "unexpected refreshed row count=" + rows.size());
+        require(rows.get(0) == nativeBeforeA, "native before A moved");
+        require(rows.get(1) == nativeBeforeB, "native before B moved");
+        require(rows.get(2) == refreshedHeader, "refreshed header moved");
+        require(rows.get(3) == refreshedRow, "refreshed row moved");
+        require(rows.get(4) == nativeAfterA, "native after A moved");
+        require(rows.get(5) == nativeAfterB, "native after B moved");
     }
 
     private static void stressStableOwnerAcrossMutableRows() {


### PR DESCRIPTION
## Summary

- opens the keyboard automatically on the first Search entry
- retains selected-Search reselect keyboard behavior
- preserves global and subreddit Search context and hints
- keeps the Active subreddits section at one stable anchor during cold, disk, memory, and asynchronous refresh
- preserves identity-based ownership so Boost-native and value-equal rows are not removed

## Root cause

The 1.4.90 implementation focused the input only when Search was already selected. Initial Search creation scheduled the subreddit hint but never scheduled input focus or IME display.

The Active subreddits refresh removed Morphe-owned rows and appended replacements at the current end of Boost's mutable list, causing the section to jump after Boost added native rows.

## Validation

- `./tools/check-boost-search-route-contract.sh`
- `./tools/check-boost-search-dedup-contract.sh`
- `./gradlew clean :patches:buildAndroid --no-daemon`
- `git diff --check`
- 10,000-cycle identity ownership stress test
- cold-cache anchor: loading index `0`, refreshed index `0`
- warm disk/memory-cache anchor: unchanged through refresh
- first-entry keyboard from Home, Inbox, Profile, Subscriptions, and subreddit: PASS
- selected Search reselect keyboard: PASS
- global `Search reddit` hint: PASS
- subreddit `Search in r/<subreddit>` context and result: PASS
- one Active subreddits section without movement: PASS
- no app fatal exception observed

Local DEV-candidate MPP SHA-256:

`b1be09a6e06b79fdb3ec089aca9d6209b40dc27bf38b940a7a679807128bdbe7`

## Scope

Addresses #86, #94, and #95 while preserving the #61, #68, and #91 Search regression contracts. Only `com.rubenmayayo.reddit.dev` was installed and tested. Normal Boost and release metadata were not modified.
