### PR TITLE
feat(boost): add adaptive inline media preview sizes

### DIFF
--- a/extensions/boostforreddit/src/main/java/app/morphe/extension/boostforreddit/giphy/InlineGiphyCommentPreview.java
+++ b/extensions/boostforreddit/src/main/java/app/morphe/extension/boostforreddit/giphy/InlineGiphyCommentPreview.java
@@ -35,6 +35,8 @@ public final class InlineGiphyCommentPreview {
             "morphe_boost_inline_media_comment_text_inset_v1";
     private static final int FALLBACK_COMMENT_TEXT_HORIZONTAL_INSET_DP = 8;
     private static final String LOG_TAG = "InlineGiphy";
+    private static final String ADAPTIVE_PREVIEW_SIZE_MARKER =
+            "MORPHE_BOOST_INLINE_MEDIA_ADAPTIVE_SIZE_ISSUE70_V4";
     private static final String PRERENDER_SOURCE_POLICY_MARKER =
             "morphe_boost_inline_media_prerender_source_policy_v10";
     private static final String PREF_INLINE_MEDIA_PREVIEWS_ENABLED =
@@ -43,6 +45,8 @@ public final class InlineGiphyCommentPreview {
             "morphe_boost_inline_media_preview_show_source_text";
     private static final String PREF_INLINE_MEDIA_PREVIEW_ALIGNMENT =
             "morphe_boost_inline_media_preview_alignment";
+    private static final String PREF_INLINE_MEDIA_PREVIEW_SIZE =
+            "morphe_boost_inline_media_preview_size";
     private static final String PREF_DIRECT_REDDIT_GIF_TAP_ACTION =
             "morphe_boost_direct_reddit_gif_tap_action";
     private static final String COMMENT_DIRECT_GIF_ROUTE_MARKER =
@@ -62,9 +66,13 @@ public final class InlineGiphyCommentPreview {
     private static final String ALIGNMENT_LEFT = "left";
     private static final String ALIGNMENT_CENTER = "center";
     private static final String ALIGNMENT_RIGHT = "right";
+    private static final String PREVIEW_SIZE_COMPACT = "compact";
+    private static final String PREVIEW_SIZE_BALANCED = "balanced";
+    private static final String PREVIEW_SIZE_LARGE = "large";
     private static final boolean DEFAULT_INLINE_MEDIA_PREVIEWS_ENABLED = true;
     private static final boolean DEFAULT_INLINE_MEDIA_PREVIEW_SHOW_SOURCE_TEXT = false;
     private static final String DEFAULT_INLINE_MEDIA_PREVIEW_ALIGNMENT = ALIGNMENT_CENTER;
+    private static final String DEFAULT_INLINE_MEDIA_PREVIEW_SIZE = PREVIEW_SIZE_BALANCED;
     private static final String DEFAULT_DIRECT_REDDIT_GIF_TAP_ACTION = TAP_ACTION_IMAGE_VIEWER;
     private static final String DEFAULT_GIPHY_PREVIEW_TAP_ACTION = TAP_ACTION_VIDEO_VIEWER;
     private static final String DEFAULT_STATIC_PREVIEW_TAP_ACTION = TAP_ACTION_IMAGE_VIEWER;
@@ -620,6 +628,11 @@ public final class InlineGiphyCommentPreview {
             final String gifUrl = previewSource.gifUrl;
             final String sourceUrl = previewSource.sourceUrl;
             final String previewAlignment = getPreviewAlignment(context);
+            final String previewSize = getPreviewSize(context);
+            final int maxPreviewHeightPx =
+                    resolveMaxPreviewHeightPx(context, previewSize);
+            final int previewWidthPx =
+                    resolvePreviewWidthPx(context, itemView, previewSize);
 
             LinearLayout container = new LinearLayout(context);
             container.setTag(PREVIEW_TAG);
@@ -629,10 +642,22 @@ public final class InlineGiphyCommentPreview {
             ImageView imageView = new ImageView(context);
             imageView.setAdjustViewBounds(true);
             imageView.setScaleType(ImageView.ScaleType.FIT_CENTER);
+            imageView.setContentDescription("Inline media preview");
+            imageView.setMaxHeight(maxPreviewHeightPx);
+            imageView.setMaxWidth(previewWidthPx);
 
             LinearLayout.LayoutParams imageParams = new LinearLayout.LayoutParams(
-                    imageWidthForAlignment(previewAlignment),
-                    dp(context, 170)
+                    previewWidthPx,
+                    ViewGroup.LayoutParams.WRAP_CONTENT
+            );
+
+            Log.d(
+                    LOG_TAG,
+                    ADAPTIVE_PREVIEW_SIZE_MARKER
+                            + ": mode=" + previewSize
+                            + " windowHeightDp=" + resolveWindowHeightDp(context)
+                            + " targetWidthPx=" + previewWidthPx
+                            + " maxHeightPx=" + maxPreviewHeightPx
             );
 
             container.addView(imageView, imageParams);
@@ -654,10 +679,69 @@ public final class InlineGiphyCommentPreview {
             imageView.setOnClickListener(mediaClickListener);
 
             if (!insertBelowCommentText(holder, (ViewGroup) itemView, container)) return;
-            loadWithGlide(context, glideRequestManager, gifUrl, imageView);
+            loadWithGlide(
+                    context,
+                    glideRequestManager,
+                    gifUrl,
+                    imageView
+            );
+
+            schedulePreviewMeasurementLog(
+                    imageView,
+                    previewSize,
+                    previewWidthPx,
+                    maxPreviewHeightPx
+            );
+
             syncWithCommentState(holder);
-        } catch (Throwable ignored) {
+        } catch (Throwable throwable) {
+            Log.w(
+                    LOG_TAG,
+                    ADAPTIVE_PREVIEW_SIZE_MARKER + ": bind failed",
+                    throwable
+            );
         }
+    }
+
+    private static void schedulePreviewMeasurementLog(
+            final ImageView imageView,
+            final String previewSize,
+            final int targetPreviewWidthPx,
+            final int maxPreviewHeightPx
+    ) {
+        if (imageView == null) {
+            return;
+        }
+
+        imageView.postDelayed(
+                new Runnable() {
+                    @Override
+                    public void run() {
+                        try {
+                            Log.d(
+                                    LOG_TAG,
+                                    ADAPTIVE_PREVIEW_SIZE_MARKER
+                                            + ": measured mode="
+                                            + normalizePreviewSize(previewSize)
+                                            + " widthPx=" + imageView.getWidth()
+                                            + " heightPx=" + imageView.getHeight()
+                                            + " targetWidthPx="
+                                            + targetPreviewWidthPx
+                                            + " maxHeightPx="
+                                            + maxPreviewHeightPx
+                            );
+                        } catch (Throwable throwable) {
+                            Log.w(
+                                    LOG_TAG,
+                                    ADAPTIVE_PREVIEW_SIZE_MARKER
+                                            + ": measurement failed",
+                                    throwable
+                            );
+                        }
+                    }
+                },
+                1500L
+        );
     }
 
     public static void syncWithCommentState(Object holder) {
@@ -738,6 +822,28 @@ public final class InlineGiphyCommentPreview {
             return normalizePreviewAlignment(value);
         } catch (Throwable ignored) {
             return DEFAULT_INLINE_MEDIA_PREVIEW_ALIGNMENT;
+        }
+    }
+
+    private static String getPreviewSize(Context context) {
+        if (context == null) {
+            return DEFAULT_INLINE_MEDIA_PREVIEW_SIZE;
+        }
+
+        try {
+            android.content.SharedPreferences preferences = context.getSharedPreferences(
+                    context.getPackageName() + "_preferences",
+                    Context.MODE_PRIVATE
+            );
+
+            String value = preferences.getString(
+                    PREF_INLINE_MEDIA_PREVIEW_SIZE,
+                    DEFAULT_INLINE_MEDIA_PREVIEW_SIZE
+            );
+
+            return normalizePreviewSize(value);
+        } catch (Throwable ignored) {
+            return DEFAULT_INLINE_MEDIA_PREVIEW_SIZE;
         }
     }
 
@@ -839,12 +945,148 @@ public final class InlineGiphyCommentPreview {
         return DEFAULT_INLINE_MEDIA_PREVIEW_ALIGNMENT;
     }
 
-    private static int imageWidthForAlignment(String alignment) {
-        if (ALIGNMENT_LEFT.equals(alignment) || ALIGNMENT_RIGHT.equals(alignment)) {
-            return ViewGroup.LayoutParams.WRAP_CONTENT;
+    private static String normalizePreviewSize(String value) {
+        if (value == null) {
+            return DEFAULT_INLINE_MEDIA_PREVIEW_SIZE;
         }
 
-        return ViewGroup.LayoutParams.MATCH_PARENT;
+        String normalized = value.trim().toLowerCase(java.util.Locale.US);
+        if (PREVIEW_SIZE_COMPACT.equals(normalized)
+                || PREVIEW_SIZE_BALANCED.equals(normalized)
+                || PREVIEW_SIZE_LARGE.equals(normalized)) {
+            return normalized;
+        }
+
+        return DEFAULT_INLINE_MEDIA_PREVIEW_SIZE;
+    }
+
+    private static int resolveMaxPreviewHeightPx(Context context, String previewSize) {
+        int windowHeightDp = resolveWindowHeightDp(context);
+        String normalizedSize = normalizePreviewSize(previewSize);
+
+        final int targetHeightDp;
+
+        if (PREVIEW_SIZE_COMPACT.equals(normalizedSize)) {
+            targetHeightDp = clamp(
+                    Math.round(windowHeightDp * 0.30f),
+                    140,
+                    260
+            );
+        } else if (PREVIEW_SIZE_LARGE.equals(normalizedSize)) {
+            targetHeightDp = clamp(
+                    Math.round(windowHeightDp * 0.70f),
+                    280,
+                    620
+            );
+        } else {
+            targetHeightDp = clamp(
+                    Math.round(windowHeightDp * 0.50f),
+                    200,
+                    420
+            );
+        }
+
+        return dp(context, targetHeightDp);
+    }
+
+    private static int resolveWindowHeightDp(Context context) {
+        if (context == null) {
+            return 800;
+        }
+
+        try {
+            android.content.res.Configuration configuration =
+                    context.getResources().getConfiguration();
+
+            if (configuration != null && configuration.screenHeightDp > 0) {
+                return configuration.screenHeightDp;
+            }
+        } catch (Throwable ignored) {
+        }
+
+        try {
+            android.util.DisplayMetrics metrics =
+                    context.getResources().getDisplayMetrics();
+
+            if (metrics != null && metrics.density > 0f && metrics.heightPixels > 0) {
+                return Math.round(metrics.heightPixels / metrics.density);
+            }
+        } catch (Throwable ignored) {
+        }
+
+        return 800;
+    }
+
+    private static int resolvePreviewWidthPx(
+            Context context,
+            View itemView,
+            String previewSize
+    ) {
+        int availableWidthPx =
+                resolveAvailablePreviewWidthPx(context, itemView);
+        String normalizedSize = normalizePreviewSize(previewSize);
+
+        final float widthFraction;
+
+        if (PREVIEW_SIZE_COMPACT.equals(normalizedSize)) {
+            widthFraction = 0.65f;
+        } else if (PREVIEW_SIZE_LARGE.equals(normalizedSize)) {
+            widthFraction = 1.00f;
+        } else {
+            widthFraction = 0.85f;
+        }
+
+        int targetWidthPx =
+                Math.round(availableWidthPx * widthFraction);
+        int minimumWidthPx =
+                Math.min(availableWidthPx, dp(context, 120));
+
+        return clamp(
+                targetWidthPx,
+                minimumWidthPx,
+                availableWidthPx
+        );
+    }
+
+    private static int resolveAvailablePreviewWidthPx(
+            Context context,
+            View itemView
+    ) {
+        int widthPx = itemView == null ? 0 : itemView.getWidth();
+
+        if (widthPx <= 0 && context != null) {
+            try {
+                int screenWidthDp =
+                        context.getResources()
+                                .getConfiguration()
+                                .screenWidthDp;
+
+                if (screenWidthDp > 0) {
+                    widthPx = dp(context, screenWidthDp);
+                }
+            } catch (Throwable ignored) {
+            }
+        }
+
+        if (widthPx <= 0 && context != null) {
+            try {
+                widthPx =
+                        context.getResources()
+                                .getDisplayMetrics()
+                                .widthPixels;
+            } catch (Throwable ignored) {
+            }
+        }
+
+        if (widthPx <= 0) {
+            widthPx = dp(context, 360);
+        }
+
+        return Math.max(dp(context, 120), widthPx);
+    }
+
+    private static int clamp(int value, int minimum, int maximum) {
+        return Math.max(minimum, Math.min(maximum, value));
     }
 
     private static void applyPreviewAlignment(LinearLayout container, String alignment) {
@@ -1577,7 +1819,12 @@ public final class InlineGiphyCommentPreview {
         return false;
     }
 
-    private static void loadWithGlide(Context context, Object glideRequestManager, String url, ImageView imageView) {
+    private static void loadWithGlide(
+            Context context,
+            Object glideRequestManager,
+            String url,
+            ImageView imageView
+    ) {
         try {
             Object requestManager = glideRequestManager;
 
@@ -1591,7 +1838,12 @@ public final class InlineGiphyCommentPreview {
             if (requestBuilder == null) return;
 
             invokeInto(requestBuilder, imageView);
-        } catch (Throwable ignored) {
+        } catch (Throwable throwable) {
+            Log.w(
+                    LOG_TAG,
+                    ADAPTIVE_PREVIEW_SIZE_MARKER + ": Glide load failed",
+                    throwable
+            );
         }
     }
 

--- a/extensions/boostforreddit/src/main/java/app/morphe/extension/boostforreddit/giphy/PreviewSizePreference.java
+++ b/extensions/boostforreddit/src/main/java/app/morphe/extension/boostforreddit/giphy/PreviewSizePreference.java
@@ -1,0 +1,93 @@
+package app.morphe.extension.boostforreddit.giphy;
+
+import android.content.Context;
+import android.util.AttributeSet;
+
+import androidx.preference.ListPreference;
+
+import java.util.Locale;
+
+public final class PreviewSizePreference extends ListPreference {
+    private static final String SIZE_COMPACT = "compact";
+    private static final String SIZE_BALANCED = "balanced";
+    private static final String SIZE_LARGE = "large";
+    private static final String DEFAULT_SIZE = SIZE_BALANCED;
+
+    private static final CharSequence[] ENTRIES = new CharSequence[]{
+            "Compact",
+            "Balanced",
+            "Large"
+    };
+
+    private static final CharSequence[] VALUES = new CharSequence[]{
+            SIZE_COMPACT,
+            SIZE_BALANCED,
+            SIZE_LARGE
+    };
+
+    public PreviewSizePreference(Context context, AttributeSet attrs) {
+        super(context, attrs);
+        configure();
+    }
+
+    public PreviewSizePreference(Context context) {
+        super(context);
+        configure();
+    }
+
+    private void configure() {
+        setEntries(ENTRIES);
+        setEntryValues(VALUES);
+        setDefaultValue(DEFAULT_SIZE);
+        setDialogTitle("Preview size");
+
+        String current = getValue();
+        if (current == null) {
+            setSummary(labelFor(DEFAULT_SIZE));
+        } else {
+            setSummary(labelFor(current));
+        }
+    }
+
+    @Override
+    public void setValue(String value) {
+        String normalized = normalize(value);
+        super.setValue(normalized);
+        setSummary(labelFor(normalized));
+    }
+
+    @Override
+    public CharSequence getSummary() {
+        return labelFor(getValue());
+    }
+
+    private static String labelFor(String size) {
+        String normalized = normalize(size);
+
+        if (SIZE_COMPACT.equals(normalized)) {
+            return "Compact";
+        }
+
+        if (SIZE_LARGE.equals(normalized)) {
+            return "Large";
+        }
+
+        return "Balanced";
+    }
+
+    private static String normalize(String value) {
+        if (value == null) {
+            return DEFAULT_SIZE;
+        }
+
+        String normalized = value.trim().toLowerCase(Locale.US);
+
+        if (SIZE_COMPACT.equals(normalized)
+                || SIZE_BALANCED.equals(normalized)
+                || SIZE_LARGE.equals(normalized)) {
+            return normalized;
+        }
+
+        return DEFAULT_SIZE;
+    }
+}

--- a/patches-list.json
+++ b/patches-list.json
@@ -147,7 +147,7 @@
     },
     {
       "name": "Boost Morphe settings",
-      "description": "Adds Boost Morphe settings for inline media previews, undelete toggles, adaptive refresh rate, source text visibility, and preview alignment.",
+      "description": "Adds Boost Morphe settings for Search keyboard behavior, inline media previews, undelete toggles, adaptive refresh rate, source text visibility, and preview alignment.",
       "default": false,
       "dependencies": [],
       "compatiblePackages": [

--- a/patches/src/main/kotlin/app/morphe/patches/reddit/customclients/boostforreddit/misc/settings/BoostMorpheSettingsSkeletonPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/reddit/customclients/boostforreddit/misc/settings/BoostMorpheSettingsSkeletonPatch.kt
@@ -45,6 +45,14 @@ val boostMorpheSettingsSkeletonPatch = resourcePatch(
                             android:dialogTitle="Preview alignment"
                             android:defaultValue="center" />
 
+                        <app.morphe.extension.boostforreddit.giphy.PreviewSizePreference
+                            android:icon="@drawable/ic_photo_outline_24dp"
+                            android:key="morphe_boost_inline_media_preview_size"
+                            android:title="Preview size"
+                            android:summary="Balanced"
+                            android:dialogTitle="Preview size"
+                            android:defaultValue="balanced" />
+
                         <app.morphe.extension.boostforreddit.giphy.MediaTapActionPreference
                             android:icon="@drawable/ic_photo_outline_24dp"
                             android:key="morphe_boost_direct_reddit_gif_tap_action"
@@ -158,6 +166,14 @@ val boostMorpheSettingsSkeletonPatch = resourcePatch(
                             android:summary="Center"
                             android:dialogTitle="Preview alignment"
                             android:defaultValue="center" />
+
+                        <app.morphe.extension.boostforreddit.giphy.PreviewSizePreference
+                            android:icon="@drawable/ic_photo_outline_24dp"
+                            android:key="morphe_boost_inline_media_preview_size"
+                            android:title="Preview size"
+                            android:summary="Balanced"
+                            android:dialogTitle="Preview size"
+                            android:defaultValue="balanced" />
 
                         <app.morphe.extension.boostforreddit.giphy.MediaTapActionPreference
                             android:icon="@drawable/ic_photo_outline_24dp"

--- a/tools/boost-dev-inline-media-size-runtime.sh
+++ b/tools/boost-dev-inline-media-size-runtime.sh
@@ -1,0 +1,315 @@
+#!/usr/bin/env bash
+set +e
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+MPP="${1:-patches/build/libs/patches-1.4.92.mpp}"
+
+DEV_PKG="com.rubenmayayo.reddit.dev.issue70"
+NORMAL_PKG="com.rubenmayayo.reddit"
+REGULAR_DEV_PKG="com.rubenmayayo.reddit.dev"
+LABEL="Boost Issue70"
+MARKER="MORPHE_BOOST_INLINE_MEDIA_ADAPTIVE_SIZE_ISSUE70_V4"
+
+FAIL=0
+SERIAL=""
+OUT="/tmp/boost-issue70-width-v4.$(date +%Y%m%d-%H%M%S)"
+BUILD_LOG="$OUT/build.log"
+
+mkdir -p "$OUT" logs
+
+mark_fail() {
+  echo "FAIL: $*"
+  FAIL=1
+}
+
+cd "$ROOT" || exit 1
+
+echo "===== ISSUE #70 WIDTH PRESET RUNTIME V4 ====="
+date -Is
+echo "ROOT=$ROOT"
+echo "MPP=$MPP"
+echo "OUT=$OUT"
+
+tools/check-boost-inline-media-size-contract.sh ||
+  mark_fail "V4 contract failed"
+
+test -s "$MPP" ||
+  mark_fail "MPP missing"
+
+if [ "$FAIL" -eq 0 ]; then
+  unzip -p "$MPP" extensions/boostforreddit.mpe 2>/dev/null |
+    strings |
+    grep -F "$MARKER" ||
+      mark_fail "V4 marker missing from MPP"
+fi
+
+echo
+echo "===== ADB DEVICE ====="
+
+env -u ANDROID_SERIAL adb start-server >/dev/null 2>&1 || true
+env -u ANDROID_SERIAL adb devices -l
+
+SERIAL="$(
+  env -u ANDROID_SERIAL adb devices -l |
+    awk '
+      NR > 1 &&
+      $1 ~ /^adb-.*\._adb-tls-connect\._tcp$/ &&
+      $2 == "device" {
+        print $1
+        exit
+      }
+    '
+)"
+
+if [ -z "$SERIAL" ]; then
+  SERIAL="$(
+    env -u ANDROID_SERIAL adb devices -l |
+      awk 'NR > 1 && $2 == "device" {print $1; exit}'
+  )"
+fi
+
+echo "SERIAL=$SERIAL"
+
+if [ -z "$SERIAL" ]; then
+  mark_fail "No usable ADB device"
+fi
+
+adbq() {
+  env -u ANDROID_SERIAL adb -s "$SERIAL" "$@"
+}
+
+package_update_time() {
+  adbq shell dumpsys package "$1" 2>/dev/null |
+    sed -n 's/^[[:space:]]*lastUpdateTime=//p' |
+    head -1 |
+    tr -d '\r'
+}
+
+if [ "$FAIL" -eq 0 ]; then
+  NORMAL_BEFORE="$(package_update_time "$NORMAL_PKG")"
+  REGULAR_DEV_BEFORE="$(package_update_time "$REGULAR_DEV_PKG")"
+
+  echo "NORMAL_BEFORE=${NORMAL_BEFORE:-NOT_INSTALLED}"
+  echo "REGULAR_DEV_BEFORE=${REGULAR_DEV_BEFORE:-NOT_INSTALLED}"
+fi
+
+echo
+echo "===== BUILD / INSTALL ISSUE70 DEV ====="
+
+if [ "$FAIL" -eq 0 ]; then
+  tools/boost-dev-from-mpp.sh \
+    --mpp "$MPP" \
+    --name "issue70-width-presets-v4" \
+    --dev-package "$DEV_PKG" \
+    --normal-package "$NORMAL_PKG" \
+    --label "$LABEL" \
+    --expected-target-sdk 35 \
+    --serial "$SERIAL" \
+    --marker "$MARKER" \
+    --install \
+    --no-verify-with-sdk \
+    > "$BUILD_LOG" 2>&1
+
+  BUILD_RC=$?
+
+  echo "BUILD_RC=$BUILD_RC"
+  echo "BUILD_LOG=$BUILD_LOG"
+
+  grep -E \
+    'INFO: Applied: (Show inline Giphy previews in comments|Boost Morphe settings|Spoof client)|targetSdkVersion|OK: DEV marker present|RESULT=MORPHE_BOOST_DEV_FROM_MPP' \
+    "$BUILD_LOG" ||
+    true
+
+  if [ "$BUILD_RC" -ne 0 ]; then
+    tail -100 "$BUILD_LOG"
+    mark_fail "DEV build/install failed"
+  fi
+
+  grep -Fq \
+    'RESULT=MORPHE_BOOST_DEV_FROM_MPP_OK' \
+    "$BUILD_LOG" ||
+      mark_fail "DEV success result missing"
+fi
+
+echo
+echo "===== LAUNCH ====="
+
+if [ "$FAIL" -eq 0 ]; then
+  adbq shell am force-stop "$DEV_PKG" >/dev/null 2>&1 || true
+  adbq logcat -c || true
+  adbq logcat -b crash -c || true
+
+  adbq shell monkey \
+    -p "$DEV_PKG" \
+    -c android.intent.category.LAUNCHER \
+    1 >/dev/null ||
+      mark_fail "Launch failed"
+
+  sleep 2
+fi
+
+capture_mode() {
+  local mode="$1"
+  local log="$OUT/${mode}-logcat.txt"
+  local screenshot="$OUT/${mode}.png"
+
+  echo
+  echo "============================================================"
+  echo "TEST: ${mode^^}"
+  echo "============================================================"
+  echo
+  echo "1. Velg Preview size → ${mode^}."
+  echo "2. Gå tilbake til samme kommentartråd."
+  echo "3. Bruk nøyaktig samme inline GIF/bilde som i de andre testene."
+  echo "4. Scroll mediet ut og inn igjen slik at det bindes på nytt."
+  echo "5. La mediet være synlig."
+  echo
+
+  adbq logcat -c || true
+  adbq logcat -b crash -c || true
+
+  printf 'Trykk ENTER når %s er synlig og stabil: ' "$mode"
+  IFS= read -r _
+
+  sleep 2
+
+  PID="$(adbq shell pidof "$DEV_PKG" | tr -d '\r\n ')"
+  echo "${mode^^}_PID=${PID:-NONE}"
+
+  [ -n "$PID" ] ||
+    mark_fail "$mode: process not alive"
+
+  adbq exec-out screencap -p > "$screenshot"
+
+  if [ ! -s "$screenshot" ]; then
+    mark_fail "$mode: screenshot missing"
+  else
+    sha256sum "$screenshot"
+  fi
+
+  adbq logcat \
+    -d \
+    -v threadtime \
+    -b main \
+    -b system \
+    -b crash \
+    > "$log" 2>&1
+
+  grep -F "$MARKER: mode=$mode" "$log" |
+    tail -3 ||
+      mark_fail "$mode: mode marker missing"
+
+  grep -F "$MARKER: measured mode=$mode" "$log" |
+    tail -10 ||
+      mark_fail "$mode: measurement marker missing"
+
+  if grep -E \
+    "$MARKER: (bind failed|measurement failed|Glide load failed)|VerifyError|IllegalAccessError|FATAL EXCEPTION|Process: ${DEV_PKG//./\\.}" \
+    "$log"
+  then
+    mark_fail "$mode: runtime blocker"
+  fi
+}
+
+if [ "$FAIL" -eq 0 ]; then
+  capture_mode compact
+  capture_mode balanced
+  capture_mode large
+fi
+
+extract_max_width() {
+  local mode="$1"
+
+  sed -n \
+    "s/.*${MARKER}: measured mode=${mode} widthPx=\([0-9][0-9]*\).*/\1/p" \
+    "$OUT/${mode}-logcat.txt" |
+    awk '$1 > 0' |
+    sort -n |
+    tail -1
+}
+
+echo
+echo "===== WIDTH ORDER AUDIT ====="
+
+if [ "$FAIL" -eq 0 ]; then
+  COMPACT_WIDTH="$(extract_max_width compact)"
+  BALANCED_WIDTH="$(extract_max_width balanced)"
+  LARGE_WIDTH="$(extract_max_width large)"
+
+  echo "COMPACT_MAX_MEASURED_WIDTH=${COMPACT_WIDTH:-NONE}"
+  echo "BALANCED_MAX_MEASURED_WIDTH=${BALANCED_WIDTH:-NONE}"
+  echo "LARGE_MAX_MEASURED_WIDTH=${LARGE_WIDTH:-NONE}"
+
+  if [ -z "$COMPACT_WIDTH" ] ||
+     [ -z "$BALANCED_WIDTH" ] ||
+     [ -z "$LARGE_WIDTH" ]; then
+    mark_fail "Could not resolve all measured widths"
+  elif [ "$COMPACT_WIDTH" -ge "$BALANCED_WIDTH" ]; then
+    mark_fail "Compact width is not smaller than Balanced"
+  elif [ "$BALANCED_WIDTH" -ge "$LARGE_WIDTH" ]; then
+    mark_fail "Balanced width is not smaller than Large"
+  else
+    echo "WIDTH_ORDER_COMPACT_LT_BALANCED_LT_LARGE=PASS"
+  fi
+fi
+
+echo
+echo "===== PACKAGE ISOLATION ====="
+
+if [ "$FAIL" -eq 0 ]; then
+  NORMAL_AFTER="$(package_update_time "$NORMAL_PKG")"
+  REGULAR_DEV_AFTER="$(package_update_time "$REGULAR_DEV_PKG")"
+
+  echo "NORMAL_AFTER=${NORMAL_AFTER:-NOT_INSTALLED}"
+  echo "REGULAR_DEV_AFTER=${REGULAR_DEV_AFTER:-NOT_INSTALLED}"
+
+  if [ "$NORMAL_BEFORE" != "$NORMAL_AFTER" ]; then
+    mark_fail "Normal Boost update time changed"
+  fi
+
+  if [ "$REGULAR_DEV_BEFORE" != "$REGULAR_DEV_AFTER" ]; then
+    mark_fail "Regular Boost DEV update time changed"
+  fi
+fi
+
+echo
+echo "===== MANUAL ACCEPTANCE ====="
+
+if [ "$FAIL" -eq 0 ]; then
+  cat <<'EOF'
+Bekreft:
+
+- samme medium var tydelig minst i Compact
+- samme medium var større i Balanced
+- samme medium var størst i Large
+- aspektforholdet var korrekt
+- ingen cropping eller strekking
+- tapping åpnet forventet Boost-viewer
+EOF
+
+  echo
+  printf 'Godkjent? [y/N]: '
+  IFS= read -r answer
+
+  case "$answer" in
+    y|Y|yes|YES|Yes)
+      echo "MANUAL_ACCEPTANCE=PASS"
+      ;;
+    *)
+      mark_fail "Manual acceptance not granted"
+      ;;
+  esac
+fi
+
+echo
+echo "===== FINAL ====="
+echo "OUT=$OUT"
+echo "SERIAL=$SERIAL"
+
+if [ "$FAIL" -eq 0 ]; then
+  echo "RESULT=MORPHE_ISSUE70_WIDTH_PRESETS_V4_PASS"
+else
+  echo "RESULT=MORPHE_ISSUE70_WIDTH_PRESETS_V4_FAIL"
+fi
+
+exit "$FAIL"

--- a/tools/check-boost-inline-media-size-contract.sh
+++ b/tools/check-boost-inline-media-size-contract.sh
@@ -1,0 +1,114 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SOURCE='extensions/boostforreddit/src/main/java/app/morphe/extension/boostforreddit/giphy/InlineGiphyCommentPreview.java'
+PREFERENCE='extensions/boostforreddit/src/main/java/app/morphe/extension/boostforreddit/giphy/PreviewSizePreference.java'
+SETTINGS='patches/src/main/kotlin/app/morphe/patches/reddit/customclients/boostforreddit/misc/settings/BoostMorpheSettingsSkeletonPatch.kt'
+
+test -f "$SOURCE"
+test -f "$PREFERENCE"
+test -f "$SETTINGS"
+
+rg -q -F \
+  'MORPHE_BOOST_INLINE_MEDIA_ADAPTIVE_SIZE_ISSUE70_V4' \
+  "$SOURCE"
+
+rg -q -F \
+  'DEFAULT_INLINE_MEDIA_PREVIEW_SIZE = PREVIEW_SIZE_BALANCED' \
+  "$SOURCE"
+
+rg -q -F 'widthFraction = 0.65f;' "$SOURCE"
+rg -q -F 'widthFraction = 0.85f;' "$SOURCE"
+rg -q -F 'widthFraction = 1.00f;' "$SOURCE"
+
+rg -q -F \
+  'resolvePreviewWidthPx(context, itemView, previewSize)' \
+  "$SOURCE"
+
+rg -q -F \
+  'resolveAvailablePreviewWidthPx(' \
+  "$SOURCE"
+
+rg -q -U \
+  'new LinearLayout\.LayoutParams\(\s*previewWidthPx,\s*ViewGroup\.LayoutParams\.WRAP_CONTENT\s*\)' \
+  "$SOURCE"
+
+rg -q -F \
+  'imageView.setMaxWidth(previewWidthPx);' \
+  "$SOURCE"
+
+rg -q -F \
+  'imageView.setMaxHeight(maxPreviewHeightPx);' \
+  "$SOURCE"
+
+rg -q -F \
+  'ImageView.ScaleType.FIT_CENTER' \
+  "$SOURCE"
+
+rg -q -F \
+  'imageView.setAdjustViewBounds(true);' \
+  "$SOURCE"
+
+rg -q -F \
+  'targetWidthPx=' \
+  "$SOURCE"
+
+rg -q -F \
+  '": measured mode="' \
+  "$SOURCE"
+
+rg -q -F \
+  'Math.round(windowHeightDp * 0.30f)' \
+  "$SOURCE"
+
+rg -q -F \
+  'Math.round(windowHeightDp * 0.50f)' \
+  "$SOURCE"
+
+rg -q -F \
+  'Math.round(windowHeightDp * 0.70f)' \
+  "$SOURCE"
+
+if rg -q -F 'dp(context, 170)' "$SOURCE"; then
+  echo 'FAIL: fixed 170 dp preview height remains' >&2
+  exit 1
+fi
+
+if rg -q -F 'imageWidthForAlignment(' "$SOURCE"; then
+  echo 'FAIL: obsolete alignment-based width remains' >&2
+  exit 1
+fi
+
+if rg -q -F 'invokeGlideOverride(' "$SOURCE"; then
+  echo 'FAIL: dead Glide override reflection remains' >&2
+  exit 1
+fi
+
+if rg -q -F 'no Glide override method found' "$SOURCE"; then
+  echo 'FAIL: obsolete Glide warning remains' >&2
+  exit 1
+fi
+
+test "$(
+  rg -c -F \
+    'android:key="morphe_boost_inline_media_preview_size"' \
+    "$SETTINGS"
+)" -eq 2
+
+test "$(
+  rg -c -F \
+    'android:defaultValue="balanced"' \
+    "$SETTINGS"
+)" -eq 2
+
+rg -q -F '"Compact"' "$PREFERENCE"
+rg -q -F '"Balanced"' "$PREFERENCE"
+rg -q -F '"Large"' "$PREFERENCE"
+
+echo 'FIXED_170_DP_REMOVED=PASS'
+echo 'WIDTH_PRESETS_65_85_100=PASS'
+echo 'HEIGHT_LIMITS_260_420_620=PASS'
+echo 'ASPECT_RATIO_PRESERVATION=PASS'
+echo 'DEAD_GLIDE_OVERRIDE_REMOVED=PASS'
+echo 'SETTINGS_CONTRACT=PASS'
+echo 'RESULT=MORPHE_ISSUE70_INLINE_MEDIA_SIZE_V4_CONTRACT_OK'


### PR DESCRIPTION
## Summary

Adds configurable inline GIF/image preview sizes to Boost.

The new presets are:

- **Compact:** 65% of available width
- **Balanced:** 85% of available width
- **Large:** 100% of available width

Balanced is the default.

Preview height remains adaptive to the available window height:

- Compact: 30%, clamped to 140–260 dp
- Balanced: 50%, clamped to 200–420 dp
- Large: 70%, clamped to 280–620 dp

Images and GIFs preserve their aspect ratio using `adjustViewBounds` and `FIT_CENTER`, without cropping or stretching.

## Changes

- Add `PreviewSizePreference`
- Add the preference to both Boost Morphe settings skeletons
- Replace the fixed 170 dp inline-preview height
- Apply explicit preset widths and adaptive maximum heights
- Add static contract coverage
- Add an isolated issue-specific DEV runtime verifier

## Validation

- Compact width measured at 701–702 px on the Pixel 6 test device
- Balanced width measured at 917–918 px
- Large width measured at 1079 px
- Width ordering verified: Compact < Balanced < Large
- Aspect ratio and viewer routing manually approved
- No cropping or stretching observed
- Normal Boost and the regular DEV package were not modified
- Issue #70 static contract: PASS
- Existing Boost Search route contract: PASS
- Integrated `:patches:buildAndroid`: PASS
- Runtime verifier shell syntax: PASS

Closes #70
