### PR TITLE
chore(project): harden metadata and workflow contracts

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,7 @@
+* @brealorg
+
+/.github/ @brealorg
+/extensions/ @brealorg
+/patches/ @brealorg
+/scripts/ @brealorg
+/tools/ @brealorg

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,7 +1,7 @@
 name: 🐞 Bug report
 description: Report a bug or an issue.
 title: "bug: "
-labels: ["Bug report"]
+labels: ["bug"]
 body:
   - type: markdown
     attributes:
@@ -10,7 +10,7 @@ body:
 
         Before creating a new bug report, please keep the following in mind:
 
-        - **Do not submit a duplicate bug report**: Search for existing bug reports [here](https://github.com/brealorg/breal-morphe-patches/issues?q=label%3A%22Bug+report%22).
+        - **Do not submit a duplicate bug report**: Search for existing bug reports [here](https://github.com/brealorg/breal-morphe-patches/issues?q=label%3A%22bug%22).
         - **Review the contribution guidelines**: Make sure your bug report adheres to them. You can find the guidelines [here](https://github.com/brealorg/breal-morphe-patches/blob/main/CONTRIBUTING.md).
         - **Release verification policy**: User-visible fixes stay open until the fix is released and verified through Morphe Manager / the normal installation path when applicable.
   - type: dropdown

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,7 +1,7 @@
 name: ⭐ Feature request
 description: Suggest an improvement or a new Morphe patch.
 title: "feat: "
-labels: ["Feature request"]
+labels: ["enhancement"]
 body:
   - type: markdown
     attributes:
@@ -10,7 +10,7 @@ body:
 
         Before creating a new feature request:
 
-        - **Search for duplicates**: Check existing feature requests [here](https://github.com/brealorg/breal-morphe-patches/issues?q=label%3A%22Feature+request%22).
+        - **Search for duplicates**: Check existing feature requests [here](https://github.com/brealorg/breal-morphe-patches/issues?q=label%3A%22enhancement%22).
         - **Review the contribution guidelines**: Read them [here](https://github.com/brealorg/breal-morphe-patches/blob/main/CONTRIBUTING.md).
         - Describe a concrete problem or use case. Requests are evaluated against project scope, maintenance cost, and available testing.
   - type: dropdown

--- a/.github/scripts/generate_patches_readme.py
+++ b/.github/scripts/generate_patches_readme.py
@@ -18,14 +18,11 @@ import sys
 from pathlib import Path
 
 AUTO_EXPAND_THRESHOLD = 20
-KNOWN_PACKAGE_LABELS = {
-    "com.rubenmayayo.reddit": "Boost for Reddit",
-    "com.rubenmayayo.reddit.dev": "Boost for Reddit Dev",
-    "com.rubenmayayo.lemmy": "Boost for Lemmy",
-    "com.imgur.mobile": "Imgur",
-    "com.google.android.youtube": "YouTube",
-    "app.morphe.android.youtube": "Morphe YouTube",
-}
+
+TOOLS_DIR = Path(__file__).resolve().parents[2] / "tools"
+sys.path.insert(0, str(TOOLS_DIR))
+
+from compatible_app_catalog import package_label
 
 START_PATTERN = r"<!--\s*PATCHES_START(?:_EXPANDED)?\s*-->"
 END_MARKER = "<!-- PATCHES_END -->"
@@ -60,9 +57,6 @@ def safe_text(value) -> str:
     if value is None:
         return ""
     return str(value).replace("\n", "<br>")
-
-def package_label(package_name: str, explicit: str = "") -> str:
-    return explicit or KNOWN_PACKAGE_LABELS.get(package_name, package_name or "Unknown package")
 
 def normalize_targets(value):
     if value is None:

--- a/.github/workflows/boost-bytecode-safety.yml
+++ b/.github/workflows/boost-bytecode-safety.yml
@@ -27,8 +27,8 @@ jobs:
   fixture-gate:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: '3.12'
       - name: Shell syntax

--- a/.github/workflows/build_pull_request.yml
+++ b/.github/workflows/build_pull_request.yml
@@ -16,16 +16,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
       - name: Setup Java
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@03ad4de0992f5dab5e18fcb136590ce7c4a0ac95 # v5
         with:
           distribution: 'temurin'
           java-version: '17'
 
       - name: Cache Gradle
-        uses: gradle/actions/setup-gradle@v6
+        uses: gradle/actions/setup-gradle@3f131e8634966bd73d06cc69884922b02e6faf92 # v6
         with:
           cache-provider: basic
 
@@ -35,7 +35,7 @@ jobs:
         run: ./gradlew :patches:buildAndroid --no-daemon
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
         with:
           name: patcheddit
           path: patches/build/libs

--- a/.github/workflows/release-feed-smoke.yml
+++ b/.github/workflows/release-feed-smoke.yml
@@ -25,16 +25,16 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
       - name: Set up Java
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@03ad4de0992f5dab5e18fcb136590ce7c4a0ac95 # v5
         with:
           distribution: temurin
           java-version: '17'
 
       - name: Set up Gradle
-        uses: gradle/actions/setup-gradle@v6
+        uses: gradle/actions/setup-gradle@3f131e8634966bd73d06cc69884922b02e6faf92 # v6
         with:
           cache-provider: basic
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,13 +57,13 @@ jobs:
           echo "RELEASE_COMMIT=$RELEASE_COMMIT"
 
       - name: Checkout exact main
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           ref: main
           fetch-depth: 0
 
       - name: Setup Java
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@03ad4de0992f5dab5e18fcb136590ce7c4a0ac95 # v5
         with:
           distribution: 'temurin'
           java-version: '17'
@@ -81,7 +81,7 @@ jobs:
         run: ./tools/check-project-contracts.sh
 
       - name: Cache Gradle
-        uses: gradle/actions/setup-gradle@v6
+        uses: gradle/actions/setup-gradle@3f131e8634966bd73d06cc69884922b02e6faf92 # v6
         with:
           cache-provider: basic
 
@@ -98,7 +98,7 @@ jobs:
           test -n "$GPG_FINGERPRINT"
 
       - name: Import GPG key
-        uses: crazy-max/ghaction-import-gpg@v7
+        uses: crazy-max/ghaction-import-gpg@2dc316deee8e90f13e1a351ab510b4d5bc0c82cd # v7.0.0
         with:
           gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
           passphrase: ${{ secrets.GPG_PASSPHRASE }}

--- a/.github/workflows/update-gradle-wrapper.yml
+++ b/.github/workflows/update-gradle-wrapper.yml
@@ -14,9 +14,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
       - name: Update Gradle Wrapper
-        uses: gradle-update/update-gradle-wrapper-action@v2
+        uses: gradle-update/update-gradle-wrapper-action@512b1875f3b6270828abfe77b247d5895a2da1e5 # v2.1.0
         with:
           target-branch: main

--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ Release process notes:
 - [Release validation policy](docs/release-validation-policy.md)
 - [Branch policy](docs/branch-policy.md)
 - [Final snapshot template](docs/final-snapshot-template.md)
+- [Supported app catalog](docs/supported-app-catalog.md)
 
 ## Project page
 
@@ -145,7 +146,7 @@ Included Imgur patches:
 | [Animate media in Boost gallery previews](#animate-media-in-boost-gallery-previews) | Autoplays selected Reddit gallery GIF and video media while preserving Boost's poster, data preferences, and full-screen media route. |  |
 | [Automatically undelete Imgur images](#automatically-undelete-imgur-images) |  |  |
 | [Automatically undelete Reddit content](#automatically-undelete-reddit-content) |  |  |
-| [Boost Morphe settings](#boost-morphe-settings) | Adds Boost Morphe settings for inline media previews, undelete toggles, adaptive refresh rate, source text visibility, and preview alignment. |  |
+| [Boost Morphe settings](#boost-morphe-settings) | Adds Boost Morphe settings for Search keyboard behavior, inline media previews, undelete toggles, adaptive refresh rate, source text visibility, and preview alignment. |  |
 | [Boost search default discovery](#boost-search-default-discovery) | Starts Boost search on an instant cached active-subreddit landing with Reddit-native labels. |  |
 | [Custom Synccit URL](#custom-synccit-url) | Allows Boost to use a custom self-hosted Synccit API endpoint. | • Synccit API URL |
 | [Disable ads](#disable-ads) |  |  |

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,24 @@
+# Security policy
+
+## Supported versions
+
+Security fixes are applied to the current `main` branch and the latest published
+Morphe patch bundle. Older bundles are not maintained as separate security
+release lines.
+
+## Reporting a vulnerability
+
+Use GitHub's private vulnerability reporting flow from the repository Security
+tab when the report includes an exploit, unpublished vulnerability details,
+credentials, tokens, private logs, or other sensitive data.
+
+Do not place secrets, authentication material, private URLs, or unredacted logs
+in a public issue. If private vulnerability reporting is unavailable, open a
+minimal public issue that contains no sensitive details and ask the repository
+owner to establish a private channel.
+
+Ordinary crashes, compatibility problems, and feature requests should use the
+normal issue forms.
+
+Include the affected app and version, Morphe bundle version, Android version,
+reproduction conditions, impact, and a minimal redacted proof when available.

--- a/docs/supported-app-catalog.md
+++ b/docs/supported-app-catalog.md
@@ -1,0 +1,35 @@
+# Supported app catalog
+
+This catalog lists the package identities currently declared by patch
+compatibility metadata and published in `patches-list.json`. It is a metadata
+contract, not a claim that every app/version combination has received the same
+runtime validation.
+
+`tools/compatible_app_catalog.py` is the shared tooling catalog. Project source
+contracts keep it aligned with Kotlin `Compatibility` declarations and the
+published feed.
+
+| Package name | Display name |
+|---|---|
+| `com.andrewshu.android.reddit` | rif is fun |
+| `com.andrewshu.android.redditdonation` | rif is fun golden platinum |
+| `com.imgur.mobile` | Imgur |
+| `com.laurencedawson.reddit_sync` | Sync for Reddit |
+| `com.laurencedawson.reddit_sync.dev` | Sync for Reddit Dev |
+| `com.laurencedawson.reddit_sync.pro` | Sync for Reddit Pro |
+| `com.onelouder.baconreader` | BaconReader |
+| `com.onelouder.baconreader.premium` | BaconReader Premium |
+| `com.rubenmayayo.reddit` | Boost for Reddit |
+| `free.reddit.news` | Relay for Reddit |
+| `io.syncapps.lemmy_sync` | Sync for Lemmy |
+| `me.edgan.redditslide` | Slide (fork) |
+| `ml.docilealligator.infinityforreddit.patreon` | Infinity for Reddit (Patreon) |
+| `ml.docilealligator.infinityforreddit.plus` | Infinity for Reddit+ |
+| `o.o.joey` | Joey for Reddit |
+| `o.o.joey.dev` | Joey for Reddit Dev |
+| `o.o.joey.pro` | Joey for Reddit Pro |
+| `org.cygnusx1.continuum` | Continuum |
+| `reddit.news` | Relay for Reddit Pro |
+
+Legacy aliases retained by normalization tooling are not additional supported
+patch targets.

--- a/tests/tools/test_compatible_app_catalog_source_contract.py
+++ b/tests/tools/test_compatible_app_catalog_source_contract.py
@@ -1,0 +1,97 @@
+from __future__ import annotations
+
+import json
+import re
+import sys
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(ROOT / "tools"))
+
+from compatible_app_catalog import SUPPORTED_APP_META
+
+
+COMPATIBILITY_PATTERN = re.compile(
+    r"Compatibility\(\s*"
+    r'name\s*=\s*"([^"]+)"\s*,\s*'
+    r'packageName\s*=\s*"([^"]+)"',
+    re.DOTALL,
+)
+
+
+class CompatibleAppCatalogSourceContractTest(unittest.TestCase):
+    def test_catalog_matches_patch_compatibility_declarations(self) -> None:
+        source_apps: dict[str, str] = {}
+        source_root = ROOT / "patches" / "src" / "main" / "kotlin"
+
+        for path in source_root.rglob("*.kt"):
+            for name, package_name in COMPATIBILITY_PATTERN.findall(
+                path.read_text(encoding="utf-8")
+            ):
+                previous = source_apps.setdefault(package_name, name)
+                self.assertEqual(previous, name, package_name)
+
+        catalog_apps = {
+            package_name: str(meta["name"])
+            for package_name, meta in SUPPORTED_APP_META.items()
+        }
+
+        self.assertEqual(19, len(source_apps))
+        self.assertEqual(source_apps, catalog_apps)
+
+    def test_catalog_matches_published_feed_names(self) -> None:
+        data = json.loads((ROOT / "patches-list.json").read_text(encoding="utf-8"))
+        feed_apps: dict[str, str] = {}
+
+        for patch in data.get("patches", []):
+            for app in patch.get("compatiblePackages") or []:
+                package_name = str(app["packageName"])
+                name = str(app["name"])
+                previous = feed_apps.setdefault(package_name, name)
+                self.assertEqual(previous, name, package_name)
+
+        catalog_apps = {
+            package_name: str(meta["name"])
+            for package_name, meta in SUPPORTED_APP_META.items()
+        }
+
+        self.assertEqual(19, len(feed_apps))
+        self.assertEqual(feed_apps, catalog_apps)
+
+    def test_supported_metadata_is_manager_complete(self) -> None:
+        required = {
+            "name",
+            "description",
+            "apkFileType",
+            "appIconColor",
+            "signatures",
+            "minSdk",
+        }
+        for package_name, meta in SUPPORTED_APP_META.items():
+            self.assertEqual(required, set(meta), package_name)
+            self.assertTrue(str(meta["name"]).strip(), package_name)
+            self.assertEqual("APK_REQUIRED", meta["apkFileType"], package_name)
+            self.assertEqual(21, meta["minSdk"], package_name)
+
+    def test_documented_catalog_matches_tooling_catalog(self) -> None:
+        table_pattern = re.compile(r"^\| `([^`]+)` \| ([^|]+?) \|$", re.MULTILINE)
+        documented_apps = dict(
+            table_pattern.findall(
+                (ROOT / "docs" / "supported-app-catalog.md").read_text(
+                    encoding="utf-8"
+                )
+            )
+        )
+        catalog_apps = {
+            package_name: str(meta["name"])
+            for package_name, meta in SUPPORTED_APP_META.items()
+        }
+
+        self.assertEqual(19, len(documented_apps))
+        self.assertEqual(catalog_apps, documented_apps)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/tools/test_github_actions_sha_pinning_source_contract.py
+++ b/tests/tools/test_github_actions_sha_pinning_source_contract.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+import re
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+USES_PATTERN = re.compile(r"^\s*-?\s*uses:\s*([^\s#]+)", re.MULTILINE)
+FULL_SHA_PATTERN = re.compile(r"^[0-9a-f]{40}$")
+
+
+class GitHubActionsShaPinningSourceContractTest(unittest.TestCase):
+    def test_remote_actions_are_pinned_to_full_commit_shas(self) -> None:
+        workflow_root = ROOT / ".github" / "workflows"
+        remote_uses = 0
+
+        for path in sorted(workflow_root.glob("*.yml")):
+            text = path.read_text(encoding="utf-8")
+            for action in USES_PATTERN.findall(text):
+                if action.startswith("./") or action.startswith("docker://"):
+                    continue
+
+                remote_uses += 1
+                self.assertIn("@", action, f"{path}: {action}")
+                reference = action.rsplit("@", 1)[1]
+                self.assertRegex(
+                    reference,
+                    FULL_SHA_PATTERN,
+                    f"{path}: mutable action reference {action}",
+                )
+
+        self.assertGreater(remote_uses, 0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/check-issue-form-label-contract.sh
+++ b/tools/check-issue-form-label-contract.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+BUG_FORM="$ROOT/.github/ISSUE_TEMPLATE/bug_report.yml"
+FEATURE_FORM="$ROOT/.github/ISSUE_TEMPLATE/feature_request.yml"
+
+check_exact_line() {
+  local file="$1"
+  local expected="$2"
+  local count
+
+  count="$(rg -Fxc -- "$expected" "$file" || true)"
+  if [[ "$count" != 1 ]]; then
+    echo "FAIL: expected exactly one '$expected' line in $file" >&2
+    exit 1
+  fi
+}
+
+test -f "$BUG_FORM"
+test -f "$FEATURE_FORM"
+
+check_exact_line "$BUG_FORM" 'labels: ["bug"]'
+check_exact_line "$FEATURE_FORM" 'labels: ["enhancement"]'
+
+rg -q -F 'label%3A%22bug%22' "$BUG_FORM"
+rg -q -F 'label%3A%22enhancement%22' "$FEATURE_FORM"
+
+if rg -n -F \
+  -e 'labels: ["Bug report"]' \
+  -e 'labels: ["Feature request"]' \
+  -e 'label%3A%22Bug+report%22' \
+  -e 'label%3A%22Feature+request%22' \
+  "$BUG_FORM" "$FEATURE_FORM"
+then
+  echo 'FAIL: issue forms reference retired label names' >&2
+  exit 1
+fi
+
+echo 'BUG_FORM_LABEL=bug'
+echo 'FEATURE_FORM_LABEL=enhancement'
+echo 'RESULT=MORPHE_ISSUE_FORM_LABEL_CONTRACT_OK'

--- a/tools/compatible_app_catalog.py
+++ b/tools/compatible_app_catalog.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python3
+"""Canonical app/package metadata used by feed normalization and README generation.
+
+SUPPORTED_APP_META mirrors the Compatibility declarations in patch source. Legacy
+display names are retained only so older feed shapes normalize without exposing raw
+package identifiers.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+def _meta(name: str, color: str = "#607D8B") -> dict[str, Any]:
+    return {
+        "name": name,
+        "description": None,
+        "apkFileType": "APK_REQUIRED",
+        "appIconColor": color,
+        "signatures": None,
+        "minSdk": 21,
+    }
+
+
+SUPPORTED_APP_META: dict[str, dict[str, Any]] = {
+    "com.andrewshu.android.reddit": _meta("rif is fun"),
+    "com.andrewshu.android.redditdonation": _meta("rif is fun golden platinum"),
+    "com.imgur.mobile": _meta("Imgur", "#1BB76E"),
+    "com.laurencedawson.reddit_sync": _meta("Sync for Reddit"),
+    "com.laurencedawson.reddit_sync.dev": _meta("Sync for Reddit Dev"),
+    "com.laurencedawson.reddit_sync.pro": _meta("Sync for Reddit Pro"),
+    "com.onelouder.baconreader": _meta("BaconReader"),
+    "com.onelouder.baconreader.premium": _meta("BaconReader Premium"),
+    "com.rubenmayayo.reddit": _meta("Boost for Reddit", "#FF4500"),
+    "free.reddit.news": _meta("Relay for Reddit"),
+    "io.syncapps.lemmy_sync": _meta("Sync for Lemmy"),
+    "me.edgan.redditslide": _meta("Slide (fork)"),
+    "ml.docilealligator.infinityforreddit.patreon": _meta("Infinity for Reddit (Patreon)"),
+    "ml.docilealligator.infinityforreddit.plus": _meta("Infinity for Reddit+"),
+    "o.o.joey": _meta("Joey for Reddit"),
+    "o.o.joey.dev": _meta("Joey for Reddit Dev"),
+    "o.o.joey.pro": _meta("Joey for Reddit Pro"),
+    "org.cygnusx1.continuum": _meta("Continuum"),
+    "reddit.news": _meta("Relay for Reddit Pro"),
+}
+
+LEGACY_APP_META: dict[str, dict[str, Any]] = {
+    "app.morphe.android.youtube": _meta("Morphe YouTube"),
+    "com.google.android.youtube": _meta("YouTube"),
+    "com.rubenmayayo.lemmy": _meta("Boost for Lemmy", "#00AEEF"),
+    "com.rubenmayayo.reddit.dev": _meta("Boost for Reddit Dev", "#FF4500"),
+}
+
+APP_META: dict[str, dict[str, Any]] = {
+    **SUPPORTED_APP_META,
+    **LEGACY_APP_META,
+}
+
+KNOWN_PACKAGE_LABELS = {
+    package_name: str(meta["name"])
+    for package_name, meta in APP_META.items()
+}
+
+
+def package_label(package_name: str, explicit: str = "") -> str:
+    return explicit or KNOWN_PACKAGE_LABELS.get(
+        package_name,
+        package_name or "Unknown package",
+    )

--- a/tools/normalize-patches-list-compatible-packages.py
+++ b/tools/normalize-patches-list-compatible-packages.py
@@ -3,21 +3,7 @@ import json
 import sys
 from pathlib import Path
 
-KNOWN_PACKAGE_LABELS = {
-    "com.rubenmayayo.reddit": "Boost for Reddit",
-    "com.rubenmayayo.reddit.dev": "Boost for Reddit Dev",
-    "com.rubenmayayo.lemmy": "Boost for Lemmy",
-    "com.imgur.mobile": "Imgur",
-    "com.google.android.youtube": "YouTube",
-    "app.morphe.android.youtube": "Morphe YouTube",
-    "com.laurencedawson.reddit_sync": "Sync for Reddit",
-    "com.laurencedawson.reddit_sync.dev": "Sync for Reddit Dev",
-    "com.laurencedawson.reddit_sync.pro": "Sync for Reddit Pro",
-    "o.o.joey": "Joey for Reddit",
-}
-
-def package_label(package_name: str, explicit: str = "") -> str:
-    return explicit or KNOWN_PACKAGE_LABELS.get(package_name, package_name or "Unknown package")
+from compatible_app_catalog import package_label
 
 def normalize_targets(value):
     if value is None:

--- a/tools/normalize-patches-list-manager-schema.py
+++ b/tools/normalize-patches-list-manager-schema.py
@@ -6,40 +6,7 @@ import json
 from pathlib import Path
 from typing import Any
 
-APP_META: dict[str, dict[str, Any]] = {
-    "com.rubenmayayo.reddit": {
-        "name": "Boost for Reddit",
-        "description": None,
-        "apkFileType": "APK_REQUIRED",
-        "appIconColor": "#FF4500",
-        "signatures": None,
-        "minSdk": 21,
-    },
-    "com.rubenmayayo.reddit.dev": {
-        "name": "Boost for Reddit Dev",
-        "description": None,
-        "apkFileType": "APK_REQUIRED",
-        "appIconColor": "#FF4500",
-        "signatures": None,
-        "minSdk": 21,
-    },
-    "com.rubenmayayo.lemmy": {
-        "name": "Boost for Lemmy",
-        "description": None,
-        "apkFileType": "APK_REQUIRED",
-        "appIconColor": "#00AEEF",
-        "signatures": None,
-        "minSdk": 21,
-    },
-    "com.imgur.mobile": {
-        "name": "Imgur",
-        "description": None,
-        "apkFileType": "APK_REQUIRED",
-        "appIconColor": "#1BB76E",
-        "signatures": None,
-        "minSdk": 21,
-    },
-}
+from compatible_app_catalog import APP_META
 
 PATCH_ORDER = ["name", "description", "default", "dependencies", "compatiblePackages", "options"]
 PACKAGE_ORDER = [


### PR DESCRIPTION
## Summary

- Add a canonical catalog for all 19 supported applications and reuse it across feed normalization and README generation.
- Add source contracts that detect catalog drift, invalid issue-form labels, and unpinned GitHub Actions.
- Pin every GitHub Action to a verified full commit SHA.
- Add CODEOWNERS, SECURITY.md, and supported-app catalog documentation.
- Correct the bug and feature issue-form labels and repair existing README metadata drift.

This removes duplicated compatibility metadata and makes future project drift fail during validation instead of silently reaching the published feed.

## Related issue

Addresses the project-wide audit follow-up; there is no single user-visible issue associated with these repository changes.

## Validation

- [x] The branch is based on the latest `main`.
- [x] Relevant static, source-contract, YAML, shell, and metadata checks pass.
- [x] Boost DEV validation is not applicable because this PR changes no runtime patch behavior.
- [x] Runtime evidence is not applicable because this PR has no user-visible behavior changes.
- [x] Documentation and repository metadata were updated where applicable.

## Evidence

- The canonical catalog matches all 19 Kotlin `Compatibility` declarations and the published feed.
- Five targeted source-contract tests passed.
- The issue-form label contract passed.
- All non-`javac` project contracts and source-contract tests passed.
- README generation is stable after correcting the existing Search keyboard description drift.
- Workflow and issue-form YAML parsed successfully.
- `git diff --check` passed.
- The complete local project-contract wrapper reaches the existing `javac`-dependent Boost search contract; CI provisions JDK 17 for that check.

## Risks and notes

- No Boost runtime code, release artifact, or Manager/Normal installation behavior changes.
- GitHub Action upgrades must now update their pinned commit SHAs deliberately.
- The compatibility contract intentionally fails if source declarations, documentation, or feed metadata diverge.
- The change can be rolled back by reverting this single commit.