### PR TITLE
fix(tools): harden Boost ADB device resolution

### DIFF
--- a/tests/tools/test_boost_adb_runtime_consumers.sh
+++ b/tests/tools/test_boost_adb_runtime_consumers.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+
+set -u
+
+ROOT="$(CDPATH= cd -- "$(dirname -- "$0")/../.." && pwd)"
+FAIL=0
+
+mark_fail() {
+  echo "FAIL: $*"
+  FAIL=1
+}
+
+require_text() {
+  local file="$1"
+  local text="$2"
+
+  grep -F -- "$text" "$file" >/dev/null 2>&1 ||
+    mark_fail "$file missing: $text"
+}
+
+forbid_pattern() {
+  local file="$1"
+  local pattern="$2"
+
+  if grep -E -- "$pattern" "$file" >/dev/null 2>&1; then
+    mark_fail "$file retains direct adb resolver pattern: $pattern"
+  fi
+}
+
+CONSUMERS=(
+  tools/boost-open-by-default.sh
+  tools/boost-dev-inline-media-size-runtime.sh
+  tools/boost-dev-inline-preview-source-toggle-runtime.sh
+  tools/boost-dev-issue-runtime.sh
+)
+
+for relative in "${CONSUMERS[@]}"; do
+  file="$ROOT/$relative"
+  echo "CHECK=$relative"
+
+  bash -n "$file" || mark_fail "$relative syntax"
+  require_text "$file" 'boost-adb-serial.sh'
+  require_text "$file" '--hint "${MORPHE_ADB_HINT:-192.168.1.248}"'
+  require_text "$file" '--expect-model "${MORPHE_ADB_EXPECT_MODEL:-Pixel_6}"'
+  require_text "$file" '--expect-device "${MORPHE_ADB_EXPECT_DEVICE:-oriole}"'
+
+  forbid_pattern "$file" 'choose_serial[[:space:]]*\('
+  forbid_pattern "$file" 'adb[[:space:]]+devices([[:space:]]|$)'
+  forbid_pattern "$file" 'adb[[:space:]]+mdns[[:space:]]+services'
+  forbid_pattern "$file" 'adb[[:space:]]+connect([[:space:]]|$)'
+done
+
+require_text "$ROOT/tools/boost-dev-from-mpp.sh" '--serial SERIAL'
+require_text "$ROOT/tools/boost-dev-runtime-capture.sh" '--serial SERIAL'
+
+echo
+if [ "$FAIL" -eq 0 ]; then
+  echo 'RESULT=MORPHE_HARDENING_V21_ADB_RUNTIME_CONSUMERS_OK'
+else
+  echo 'RESULT=MORPHE_HARDENING_V21_ADB_RUNTIME_CONSUMERS_FAIL'
+fi
+exit "$FAIL"

--- a/tests/tools/test_boost_adb_serial.sh
+++ b/tests/tools/test_boost_adb_serial.sh
@@ -1,0 +1,244 @@
+#!/usr/bin/env bash
+
+set -u
+
+FAIL=0
+ROOT="$(CDPATH= cd -- "$(dirname -- "$0")/../.." && pwd)"
+SCRIPT="$ROOT/tools/boost-adb-serial.sh"
+TMP_DIR="$(mktemp -d)"
+FAKE_BIN="$TMP_DIR/bin"
+
+cleanup() {
+  rm -rf -- "$TMP_DIR"
+}
+trap cleanup EXIT
+
+mark_fail() {
+  echo "FAIL: $*"
+  FAIL=1
+}
+
+assert_grep() {
+  local pattern="$1"
+  local file="$2"
+
+  grep -E "$pattern" "$file" >/dev/null 2>&1 ||
+    mark_fail "missing pattern $pattern in $file"
+}
+
+assert_absent() {
+  local path="$1"
+
+  if [ -e "$path" ]; then
+    mark_fail "unexpected path exists: $path"
+  fi
+}
+
+new_case() {
+  CASE_DIR="$TMP_DIR/$1"
+  mkdir -p "$CASE_DIR"
+  : >"$CASE_DIR/mdns.txt"
+}
+
+run_ok() {
+  local name="$1"
+  shift
+
+  echo
+  echo "--- OK: $name ---"
+  env \
+    -u ANDROID_SERIAL \
+    -u MORPHE_ADB_SERIAL \
+    -u MORPHE_ADB_HINT \
+    -u MORPHE_ADB_EXPECT_MODEL \
+    -u MORPHE_ADB_EXPECT_DEVICE \
+    PATH="$FAKE_BIN:$PATH" \
+    FAKE_ADB_STATE_DIR="$CASE_DIR" \
+    "$@" \
+    "$SCRIPT" >"$CASE_DIR/out" 2>"$CASE_DIR/err"
+  local rc=$?
+
+  cat "$CASE_DIR/out"
+  if [ -s "$CASE_DIR/err" ]; then
+    echo "stderr:"
+    cat "$CASE_DIR/err"
+  fi
+  if [ "$rc" -ne 0 ]; then
+    mark_fail "$name returned $rc, expected 0"
+  fi
+}
+
+run_fail() {
+  local name="$1"
+  shift
+
+  echo
+  echo "--- FAIL expected: $name ---"
+  env \
+    -u ANDROID_SERIAL \
+    -u MORPHE_ADB_SERIAL \
+    -u MORPHE_ADB_HINT \
+    -u MORPHE_ADB_EXPECT_MODEL \
+    -u MORPHE_ADB_EXPECT_DEVICE \
+    PATH="$FAKE_BIN:$PATH" \
+    FAKE_ADB_STATE_DIR="$CASE_DIR" \
+    "$@" \
+    "$SCRIPT" >"$CASE_DIR/out" 2>"$CASE_DIR/err"
+  local rc=$?
+
+  cat "$CASE_DIR/out"
+  if [ -s "$CASE_DIR/err" ]; then
+    echo "stderr:"
+    cat "$CASE_DIR/err"
+  fi
+  if [ "$rc" -eq 0 ]; then
+    mark_fail "$name returned 0, expected failure"
+  fi
+}
+
+mkdir -p "$FAKE_BIN"
+
+cat >"$FAKE_BIN/adb" <<'FAKE_ADB'
+#!/usr/bin/env bash
+set -u
+
+STATE_DIR="${FAKE_ADB_STATE_DIR:?}"
+
+case "${1:-} ${2:-}" in
+  "devices -l")
+    if [ -f "$STATE_DIR/connected" ] &&
+       [ -f "$STATE_DIR/devices-after.txt" ]; then
+      cat "$STATE_DIR/devices-after.txt"
+    else
+      cat "$STATE_DIR/devices-before.txt"
+    fi
+    ;;
+  "mdns services")
+    cat "$STATE_DIR/mdns.txt"
+    ;;
+  "connect "*)
+    printf '%s\n' "${2:-}" >>"$STATE_DIR/connect.log"
+    : >"$STATE_DIR/connected"
+    printf 'connected to %s\n' "${2:-}"
+    ;;
+  *)
+    echo "unexpected fake adb invocation: $*" >&2
+    exit 90
+    ;;
+esac
+FAKE_ADB
+
+cat >"$FAKE_BIN/sleep" <<'FAKE_SLEEP'
+#!/usr/bin/env bash
+exit 0
+FAKE_SLEEP
+
+chmod +x "$FAKE_BIN/adb" "$FAKE_BIN/sleep"
+
+new_case connected_concrete
+cat >"$CASE_DIR/devices-before.txt" <<'EOF'
+List of devices attached
+192.168.1.248:35999 device product:oriole_beta model:Pixel_6 device:oriole transport_id:78
+EOF
+run_ok connected_concrete \
+  ANDROID_SERIAL=192.168.1.248:5555 \
+  MORPHE_ADB_EXPECT_MODEL=Pixel_6 \
+  MORPHE_ADB_EXPECT_DEVICE=oriole
+assert_grep '^192\.168\.1\.248:35999$' "$CASE_DIR/out"
+assert_grep 'ignoring stale-prone ANDROID_SERIAL=192\.168\.1\.248:5555' "$CASE_DIR/err"
+assert_absent "$CASE_DIR/connect.log"
+
+new_case mdns_reconnect
+cat >"$CASE_DIR/devices-before.txt" <<'EOF'
+List of devices attached
+
+EOF
+cat >"$CASE_DIR/devices-after.txt" <<'EOF'
+List of devices attached
+192.168.1.248:35999 device product:oriole_beta model:Pixel_6 device:oriole transport_id:78
+EOF
+cat >"$CASE_DIR/mdns.txt" <<'EOF'
+adb-19021FDF600GBN-4kva4S _adb-tls-connect._tcp 192.168.1.248:35999
+EOF
+run_ok mdns_reconnect \
+  MORPHE_ADB_HINT=192.168.1.248 \
+  MORPHE_ADB_EXPECT_MODEL=Pixel_6 \
+  MORPHE_ADB_EXPECT_DEVICE=oriole
+assert_grep '^192\.168\.1\.248:35999$' "$CASE_DIR/out"
+assert_grep '^192\.168\.1\.248:35999$' "$CASE_DIR/connect.log"
+
+new_case alias_and_concrete
+cat >"$CASE_DIR/devices-before.txt" <<'EOF'
+List of devices attached
+adb-19021FDF600GBN-4kva4S._adb-tls-connect._tcp device product:oriole_beta model:Pixel_6 device:oriole transport_id:77
+192.168.1.248:35999 device product:oriole_beta model:Pixel_6 device:oriole transport_id:78
+EOF
+run_ok alias_and_concrete
+assert_grep '^192\.168\.1\.248:35999$' "$CASE_DIR/out"
+assert_absent "$CASE_DIR/connect.log"
+
+new_case hinted_multiple
+cat >"$CASE_DIR/devices-before.txt" <<'EOF'
+List of devices attached
+192.168.1.128:5555 device product:rk3588 model:Rock_5A device:rockchip transport_id:70
+192.168.1.248:35999 device product:oriole_beta model:Pixel_6 device:oriole transport_id:78
+EOF
+run_ok hinted_multiple MORPHE_ADB_HINT=192.168.1.248
+assert_grep '^192\.168\.1\.248:35999$' "$CASE_DIR/out"
+
+new_case shield_connected_pixel_mdns
+cat >"$CASE_DIR/devices-before.txt" <<'EOF'
+List of devices attached
+192.168.1.128:5555 device product:mdarcy model:SHIELD_Android_TV device:mdarcy transport_id:70
+EOF
+cat >"$CASE_DIR/devices-after.txt" <<'EOF'
+List of devices attached
+192.168.1.128:5555 device product:mdarcy model:SHIELD_Android_TV device:mdarcy transport_id:70
+192.168.1.248:35999 device product:oriole_beta model:Pixel_6 device:oriole transport_id:78
+EOF
+cat >"$CASE_DIR/mdns.txt" <<'EOF'
+adb-19021FDF600GBN-4kva4S _adb-tls-connect._tcp 192.168.1.248:35999
+EOF
+run_ok shield_connected_pixel_mdns \
+  MORPHE_ADB_HINT=192.168.1.248 \
+  MORPHE_ADB_EXPECT_MODEL=Pixel_6 \
+  MORPHE_ADB_EXPECT_DEVICE=oriole
+assert_grep '^192\.168\.1\.248:35999$' "$CASE_DIR/out"
+assert_grep '^192\.168\.1\.248:35999$' "$CASE_DIR/connect.log"
+
+new_case wrong_identity_at_hinted_endpoint
+cat >"$CASE_DIR/devices-before.txt" <<'EOF'
+List of devices attached
+192.168.1.248:35999 device product:mdarcy model:SHIELD_Android_TV device:mdarcy transport_id:70
+EOF
+run_fail wrong_identity_at_hinted_endpoint \
+  MORPHE_ADB_HINT=192.168.1.248 \
+  MORPHE_ADB_EXPECT_MODEL=Pixel_6 \
+  MORPHE_ADB_EXPECT_DEVICE=oriole
+assert_grep 'could not resolve a unique current adb target' "$CASE_DIR/err"
+
+new_case ambiguous_multiple
+cat >"$CASE_DIR/devices-before.txt" <<'EOF'
+List of devices attached
+192.168.1.128:5555 device product:rk3588 model:Rock_5A device:rockchip transport_id:70
+192.168.1.248:35999 device product:oriole_beta model:Pixel_6 device:oriole transport_id:78
+EOF
+run_fail ambiguous_multiple
+assert_grep 'could not resolve a unique current adb target' "$CASE_DIR/err"
+
+new_case stale_override
+cat >"$CASE_DIR/devices-before.txt" <<'EOF'
+List of devices attached
+192.168.1.248:35999 device product:oriole_beta model:Pixel_6 device:oriole transport_id:78
+EOF
+run_ok stale_override MORPHE_ADB_SERIAL=192.168.1.248:5555
+assert_grep '^192\.168\.1\.248:35999$' "$CASE_DIR/out"
+assert_grep 'MORPHE_ADB_SERIAL not connected, ignoring' "$CASE_DIR/err"
+
+echo
+if [ "$FAIL" -eq 0 ]; then
+  echo "RESULT=MORPHE_HARDENING_V21_BOOST_ADB_SERIAL_CONTRACT_OK"
+else
+  echo "RESULT=MORPHE_HARDENING_V21_BOOST_ADB_SERIAL_CONTRACT_FAIL"
+fi
+exit "$FAIL"

--- a/tools/boost-adb-serial.sh
+++ b/tools/boost-adb-serial.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 FORMAT="plain"
 HINT="${MORPHE_ADB_HINT:-}"
+EXPECTED_MODEL="${MORPHE_ADB_EXPECT_MODEL:-}"
+EXPECTED_DEVICE="${MORPHE_ADB_EXPECT_DEVICE:-}"
 
 usage() {
   cat <<'USAGE'
@@ -9,13 +11,17 @@ Usage:
 
 Options:
   --format plain|shell   Output serial only or shell assignment. Default: plain.
-  --hint TEXT            Stable device hint, e.g. IP/model/serial text.
+  --hint TEXT            Stable endpoint hint, normally the reserved device IP.
+  --expect-model MODEL   Require exact adb model metadata, e.g. Pixel_6.
+  --expect-device DEVICE Require exact adb device metadata, e.g. oriole.
   -h, --help             Show this help.
 
 Policy:
   - ANDROID_SERIAL is ignored because wireless-debugging ports rotate.
   - MORPHE_ADB_SERIAL is only a one-run override if already connected.
   - MORPHE_ADB_HINT is the preferred stable selector, e.g. 192.168.1.248.
+  - A supplied hint is strict; a non-matching device is never selected.
+  - MORPHE_ADB_EXPECT_MODEL and MORPHE_ADB_EXPECT_DEVICE fail closed.
   - mDNS _adb-tls-connect._tcp is used to discover/reconnect the current port.
   - TCP serials are preferred over adb-mdns aliases for runtime commands.
 USAGE
@@ -42,8 +48,26 @@ tcp_from_lines() {
   awk '$1 ~ /^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+:[0-9]+/ {print $1}'
 }
 
+identity_from_lines() {
+  awk -v expected_model="$EXPECTED_MODEL" -v expected_device="$EXPECTED_DEVICE" '
+    {
+      model_ok = (expected_model == "")
+      device_ok = (expected_device == "")
+      for (i = 3; i <= NF; i++) {
+        if ($i == "model:" expected_model) model_ok = 1
+        if ($i == "device:" expected_device) device_ok = 1
+      }
+      if (model_ok && device_ok) print
+    }
+  '
+}
+
 pick_active() {
-  LINES="$(adb_lines)"
+  ALL_LINES="$(adb_lines)"
+
+  [ -n "$ALL_LINES" ] || return 1
+
+  LINES="$(printf '%s\n' "$ALL_LINES" | identity_from_lines)"
 
   [ -n "$LINES" ] || return 1
 
@@ -69,6 +93,11 @@ pick_active() {
       emit "$(printf '%s\n' "$MATCHES" | awk '{print $1}')"
       return 0
     fi
+
+    # A stable hint is a strict identity boundary. If it does not match the
+    # connected device rows, reconnect through mDNS instead of selecting an
+    # unrelated single TCP target such as Android TV.
+    return 1
   fi
 
   TCP_ALL="$(printf '%s\n' "$LINES" | tcp_from_lines || true)"
@@ -122,6 +151,8 @@ while [ "$#" -gt 0 ]; do
   case "$1" in
     --format) FORMAT="${2:-}"; shift 2 ;;
     --hint) HINT="${2:-}"; shift 2 ;;
+    --expect-model) EXPECTED_MODEL="${2:-}"; shift 2 ;;
+    --expect-device) EXPECTED_DEVICE="${2:-}"; shift 2 ;;
     -h|--help) usage; exit 0 ;;
     *) echo "FAIL: unknown arg: $1"; exit 2 ;;
   esac
@@ -152,5 +183,5 @@ adb mdns services >&2 || true
 echo >&2
 echo "Hint examples:" >&2
 echo "  export MORPHE_ADB_HINT=192.168.1.248" >&2
-echo "  tools/boost-adb-serial.sh --hint 192.168.1.248" >&2
+echo "  tools/boost-adb-serial.sh --hint 192.168.1.248 --expect-model Pixel_6 --expect-device oriole" >&2
 die "could not resolve a unique current adb target"

--- a/tools/boost-dev-inline-media-size-runtime.sh
+++ b/tools/boost-dev-inline-media-size-runtime.sh
@@ -46,27 +46,12 @@ fi
 echo
 echo "===== ADB DEVICE ====="
 
-env -u ANDROID_SERIAL adb start-server >/dev/null 2>&1 || true
-env -u ANDROID_SERIAL adb devices -l
-
 SERIAL="$(
-  env -u ANDROID_SERIAL adb devices -l |
-    awk '
-      NR > 1 &&
-      $1 ~ /^adb-.*\._adb-tls-connect\._tcp$/ &&
-      $2 == "device" {
-        print $1
-        exit
-      }
-    '
-)"
-
-if [ -z "$SERIAL" ]; then
-  SERIAL="$(
-    env -u ANDROID_SERIAL adb devices -l |
-      awk 'NR > 1 && $2 == "device" {print $1; exit}'
-  )"
-fi
+  tools/boost-adb-serial.sh \
+    --hint "${MORPHE_ADB_HINT:-192.168.1.248}" \
+    --expect-model "${MORPHE_ADB_EXPECT_MODEL:-Pixel_6}" \
+    --expect-device "${MORPHE_ADB_EXPECT_DEVICE:-oriole}"
+)" || mark_fail "Could not resolve expected Pixel ADB device"
 
 echo "SERIAL=$SERIAL"
 

--- a/tools/boost-dev-inline-preview-source-toggle-runtime.sh
+++ b/tools/boost-dev-inline-preview-source-toggle-runtime.sh
@@ -28,7 +28,7 @@ Usage:
 Options:
   --mpp PATH                 MPP to test. Default: canonical current-version Android MPP
   --serial SERIAL            adb serial to use
-  --adb-endpoint HOST:PORT   run adb connect HOST:PORT, then use resulting device
+  --adb-endpoint HOST:PORT   prefer a connected Pixel endpoint; stale ports are ignored
   --name NAME                artifact name suffix
   --dev-package PKG          DEV package. Default: com.rubenmayayo.reddit.dev
   --marker MARKER            required post-bind runtime marker
@@ -147,36 +147,19 @@ fi
 echo
 echo "===== adb selection ====="
 
-env -u ANDROID_SERIAL adb start-server >/dev/null 2>&1 || true
-
 if [ -n "$ADB_ENDPOINT" ]; then
   echo "ADB_ENDPOINT=$ADB_ENDPOINT"
-  env -u ANDROID_SERIAL adb connect "$ADB_ENDPOINT" || true
-  sleep 1
+  export MORPHE_ADB_SERIAL="$ADB_ENDPOINT"
+elif [ -n "$SERIAL" ]; then
+  export MORPHE_ADB_SERIAL="$SERIAL"
 fi
 
-env -u ANDROID_SERIAL adb devices -l
-
-if [ -z "$SERIAL" ]; then
-  SERIAL="$(
-    env -u ANDROID_SERIAL adb devices -l |
-      awk '
-        NR > 1 &&
-        $1 ~ /^adb-.*\._adb-tls-connect\._tcp$/ &&
-        $2 == "device" {
-          print $1
-          exit
-        }
-      '
-  )"
-fi
-
-if [ -z "$SERIAL" ]; then
-  SERIAL="$(
-    env -u ANDROID_SERIAL adb devices -l |
-      awk 'NR > 1 && $2 == "device" {print $1; exit}'
-  )"
-fi
+SERIAL="$(
+  tools/boost-adb-serial.sh \
+    --hint "${MORPHE_ADB_HINT:-192.168.1.248}" \
+    --expect-model "${MORPHE_ADB_EXPECT_MODEL:-Pixel_6}" \
+    --expect-device "${MORPHE_ADB_EXPECT_DEVICE:-oriole}"
+)" || mark_fail "could not resolve expected Pixel adb target"
 
 echo "SERIAL=$SERIAL"
 

--- a/tools/boost-dev-issue-runtime.sh
+++ b/tools/boost-dev-issue-runtime.sh
@@ -74,7 +74,12 @@ echo "===== resolve adb ====="
 if [ -n "$SERIAL" ]; then
   export MORPHE_ADB_SERIAL="$SERIAL"
 fi
-SERIAL="$(tools/boost-adb-serial.sh)" || mark_fail "adb serial resolve failed"
+SERIAL="$(
+  tools/boost-adb-serial.sh \
+    --hint "${MORPHE_ADB_HINT:-192.168.1.248}" \
+    --expect-model "${MORPHE_ADB_EXPECT_MODEL:-Pixel_6}" \
+    --expect-device "${MORPHE_ADB_EXPECT_DEVICE:-oriole}"
+)" || mark_fail "adb serial resolve failed"
 echo "SERIAL=$SERIAL"
 adb -s "$SERIAL" get-state || mark_fail "adb target unavailable"
 

--- a/tools/boost-open-by-default.sh
+++ b/tools/boost-open-by-default.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
 set -u
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 
 PKG=""
 USER_ID="${MORPHE_ANDROID_USER:-0}"
@@ -44,37 +45,12 @@ fail() {
   exit 1
 }
 
-adb_ok() {
-  adb -s "$1" get-state >/dev/null 2>&1
-}
-
-choose_serial() {
-  if [ -n "${ANDROID_SERIAL:-}" ] && adb_ok "$ANDROID_SERIAL"; then
-    printf '%s\n' "$ANDROID_SERIAL"
-    return 0
-  fi
-
-  local concrete
-  concrete="$(adb devices | awk 'NR > 1 && $2 == "device" && $1 ~ /^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+:[0-9]+$/ { print $1; exit }')"
-  if [ -n "$concrete" ] && adb_ok "$concrete"; then
-    printf '%s\n' "$concrete"
-    return 0
-  fi
-
-  local mdns_addr
-  mdns_addr="$(adb mdns services 2>/dev/null | awk '$2 == "_adb-tls-connect._tcp" { print $3; exit }')"
-  if [ -n "$mdns_addr" ]; then
-    adb connect "$mdns_addr" >/dev/null 2>&1 || true
-    if adb_ok "$mdns_addr"; then
-      printf '%s\n' "$mdns_addr"
-      return 0
-    fi
-  fi
-
-  adb devices | awk 'NR > 1 && $2 == "device" { print $1; exit }'
-}
-
-SERIAL="$(choose_serial)"
+SERIAL="$(
+  "$ROOT/tools/boost-adb-serial.sh" \
+    --hint "${MORPHE_ADB_HINT:-192.168.1.248}" \
+    --expect-model "${MORPHE_ADB_EXPECT_MODEL:-Pixel_6}" \
+    --expect-device "${MORPHE_ADB_EXPECT_DEVICE:-oriole}"
+)" || fail "could not resolve expected Pixel adb target"
 [ -n "$SERIAL" ] || fail "no adb device found"
 
 if [ -z "$PKG" ]; then


### PR DESCRIPTION
## Summary

- Make Boost ADB resolution fail closed on stable IP, model, and device identity.
- Migrate four runtime consumers away from first-device and direct-mDNS selection.
- Add regression contracts for Pixel-versus-Shield selection, rotating ports, and stale overrides.

## Validation

- `tests/tools/test_boost_adb_serial.sh`
- `tests/tools/test_adb_resolve_device.sh`
- `tests/tools/test_boost_adb_runtime_consumers.sh`
- `tools/check-project-contracts.sh`
- Live resolution: Pixel 6 / `oriole` selected at `192.168.1.248:35999`; Shield not selected.

## Scope

- Tooling-only hardening; no product issue changes.
- No package or device mutations.
- Issue #106 worktree excluded and unchanged.