### PR TITLE
chore(release): prepare Morphe patch bundle 1.4.93

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 # Changelog
 
 <!-- MORPHE_MANAGER_CHANGELOG_START -->
+## [1.4.93](https://github.com/brealorg/breal-morphe-patches/compare/morphe-patches-92...morphe-patches-93) (2026-07-22)
+
+* **Boost for Reddit:** Features
+
+- Add optional keyboard opening when entering Search.
+- Add Compact, Balanced, and Large inline media preview sizes.
+
 ## [1.4.92](https://github.com/brealorg/breal-morphe-patches/compare/morphe-patches-91...morphe-patches-92) (2026-07-19)
 
 * **Boost for Reddit:** Bug Fixes

--- a/README.md
+++ b/README.md
@@ -72,15 +72,14 @@ The repository shorthand shown at the top is the preferred Manager setup. Raw
 
 | Field | Value |
 |---|---|
-| Version | `1.4.92` |
-| Release tag | `morphe-patches-92` |
-| Asset | `patches-1.4.92.mpp` |
-| SHA256 | `a08bd7a43b765b44a81301ef709b8af64e82b3aedbc0e4cc76ee24309dc71b9f` |
+| Version | `1.4.93` |
+| Release tag | `morphe-patches-93` |
+| Asset | `patches-1.4.93.mpp` |
+| SHA256 | `1e0c54c6b37bb591f01e7fc7b48f3aa0f53b187623a4abf32d18896eff580338` |
 | Manager JSON | `https://raw.githubusercontent.com/brealorg/breal-morphe-patches/main/patches-bundle.json` |
-| Download URL | `https://github.com/brealorg/breal-morphe-patches/releases/download/morphe-patches-92/patches-1.4.92.mpp` |
+| Download URL | `https://github.com/brealorg/breal-morphe-patches/releases/download/morphe-patches-93/patches-1.4.93.mpp` |
 
-SHA256: `a08bd7a43b765b44a81301ef709b8af64e82b3aedbc0e4cc76ee24309dc71b9f`
-
+SHA256: `1e0c54c6b37bb591f01e7fc7b48f3aa0f53b187623a4abf32d18896eff580338`
 ## What this bundle does
 
 The current bundle is focused on practical hotfixes for tested app versions, especially Boost for Reddit behavior on newer Android versions.
@@ -127,7 +126,7 @@ Included Imgur patches:
 ### Patches list
 
 <!-- PATCHES_START -->
-> **Patch source version:** `1.4.92` • `main` • 52 unique patches • 104 package entries
+> **Patch source version:** `1.4.93` • `main` • 52 unique patches • 104 package entries
 
 <details>
 <summary><strong>Boost for Reddit</strong> • 43 patches</summary>
@@ -540,16 +539,16 @@ Compatibility with other app versions is not guaranteed.
 
 ## Verification
 
-Release `1.4.92` is prepared and locally verified with:
+Release `1.4.93` is prepared and locally verified with:
 
-- Release tag `morphe-patches-92`.
+- Release tag `morphe-patches-93`.
 - Local built MPP SHA256 matching README.
-`a08bd7a43b765b44a81301ef709b8af64e82b3aedbc0e4cc76ee24309dc71b9f`
-- `patches-bundle.json` returning version `1.4.92`.
-- `patches-bundle.json` pointing to the `morphe-patches-92` asset.
+`1e0c54c6b37bb591f01e7fc7b48f3aa0f53b187623a4abf32d18896eff580338`
+- `patches-bundle.json` returning version `1.4.93`.
+- `patches-bundle.json` pointing to the `morphe-patches-93` asset.
 - Expected release asset:
-`patches-1.4.92.mpp`
-- `a08bd7a43b765b44a81301ef709b8af64e82b3aedbc0e4cc76ee24309dc71b9f  patches-1.4.92.mpp`
+`patches-1.4.93.mpp`
+- `1e0c54c6b37bb591f01e7fc7b48f3aa0f53b187623a4abf32d18896eff580338  patches-1.4.93.mpp`
 
 ## Development notes
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,4 +3,4 @@ org.gradle.jvmargs = -Xms512M -Xmx2048M
 org.gradle.parallel = true
 android.useAndroidX = true
 kotlin.code.style = official
-version = 1.4.92
+version = 1.4.93

--- a/patches-bundle.json
+++ b/patches-bundle.json
@@ -1,7 +1,7 @@
 {
-  "created_at": "2026-07-19T10:33:52",
-  "description": "Bug Fixes\n\n- Stabilized Boost bottom-navigation visibility and hide-on-scroll.\n- Synchronized FAB motion across Home, Profile, Inbox and subreddits.\n- Restored Profile long-press and subreddit-aware Search.\n",
-  "download_url": "https://github.com/brealorg/breal-morphe-patches/releases/download/morphe-patches-92/patches-1.4.92.mpp",
-  "signature_download_url": "https://github.com/brealorg/breal-morphe-patches/releases/download/morphe-patches-92/patches-1.4.92.mpp.asc",
-  "version": "1.4.92"
+  "created_at": "2026-07-22T20:30:27",
+  "description": "Features\n\n- Add optional keyboard opening when entering Search.\n- Add Compact, Balanced, and Large inline media preview sizes.\n",
+  "download_url": "https://github.com/brealorg/breal-morphe-patches/releases/download/morphe-patches-93/patches-1.4.93.mpp",
+  "signature_download_url": "https://github.com/brealorg/breal-morphe-patches/releases/download/morphe-patches-93/patches-1.4.93.mpp.asc",
+  "version": "1.4.93"
 }

--- a/patches-list.json
+++ b/patches-list.json
@@ -1,6 +1,6 @@
 {
   "NOTE": "Do NOT manually edit this file. This file is automatically updated when semantic release (release.yml) runs. Manually editing this file can break your releases and break third party tools that use this file.",
-  "version": "1.4.92",
+  "version": "1.4.93",
   "patches": [
     {
       "name": "Add Boost Search bottom navigation",


### PR DESCRIPTION
## Summary

Prepares the protected-main metadata for Morphe patch bundle 1.4.93.

User-visible Boost changes:

- Add an optional setting to open the keyboard immediately when entering Search.
- Preserve discovery-first Search behavior by default.
- Add Compact, Balanced, and Large inline media preview sizes.

Addresses #70.
Addresses #86.

## Release identity

- Version: `1.4.93`
- Tag: `morphe-patches-93`
- Asset: `patches-1.4.93.mpp`
- Expected SHA-256: `1e0c54c6b37bb591f01e7fc7b48f3aa0f53b187623a4abf32d18896eff580338`

## Validation

- Release preparation: PASS
- Release gate: PASS
- MPP contains `classes.dex`: PASS
- MPP contains `extensions/boostforreddit.mpe`: PASS
- Project contracts: PASS
- Issue #70 static and DEV runtime validation: PASS
- Issue #86 static and DEV2 runtime validation: PASS
- `git diff --check`: PASS

This PR prepares metadata only. It does not create the tag, publish a GitHub Release, or close the user-visible issues.
