### PR TITLE
fix(release): make MPP builds reproducible

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,11 +75,11 @@ The repository shorthand shown at the top is the preferred Manager setup. Raw
 | Version | `1.4.93` |
 | Release tag | `morphe-patches-93` |
 | Asset | `patches-1.4.93.mpp` |
-| SHA256 | `1e0c54c6b37bb591f01e7fc7b48f3aa0f53b187623a4abf32d18896eff580338` |
+| SHA256 | `70f41972c86078032b0cfadfb01cd4ccfe5cbd0e579e9f778908098d6a276ea2` |
 | Manager JSON | `https://raw.githubusercontent.com/brealorg/breal-morphe-patches/main/patches-bundle.json` |
 | Download URL | `https://github.com/brealorg/breal-morphe-patches/releases/download/morphe-patches-93/patches-1.4.93.mpp` |
 
-SHA256: `1e0c54c6b37bb591f01e7fc7b48f3aa0f53b187623a4abf32d18896eff580338`
+SHA256: `70f41972c86078032b0cfadfb01cd4ccfe5cbd0e579e9f778908098d6a276ea2`
 ## What this bundle does
 
 The current bundle is focused on practical hotfixes for tested app versions, especially Boost for Reddit behavior on newer Android versions.
@@ -543,12 +543,12 @@ Release `1.4.93` is prepared and locally verified with:
 
 - Release tag `morphe-patches-93`.
 - Local built MPP SHA256 matching README.
-`1e0c54c6b37bb591f01e7fc7b48f3aa0f53b187623a4abf32d18896eff580338`
+`70f41972c86078032b0cfadfb01cd4ccfe5cbd0e579e9f778908098d6a276ea2`
 - `patches-bundle.json` returning version `1.4.93`.
 - `patches-bundle.json` pointing to the `morphe-patches-93` asset.
 - Expected release asset:
 `patches-1.4.93.mpp`
-- `1e0c54c6b37bb591f01e7fc7b48f3aa0f53b187623a4abf32d18896eff580338  patches-1.4.93.mpp`
+- `70f41972c86078032b0cfadfb01cd4ccfe5cbd0e579e9f778908098d6a276ea2  patches-1.4.93.mpp`
 
 ## Development notes
 

--- a/patches/build.gradle.kts
+++ b/patches/build.gradle.kts
@@ -71,3 +71,11 @@ publishing {
         }
     }
 }
+
+// MORPHE_DETERMINISTIC_MPP_MANIFEST_TIMESTAMP_V1
+// The upstream patch Gradle plugin injects System.currentTimeMillis(), which
+// makes identical source trees produce different MPP digests. Morphe Manager
+// does not consume this attribute, so retain it as a deterministic sentinel.
+tasks.withType<org.gradle.jvm.tasks.Jar>().configureEach {
+    manifest.attributes["Timestamp"] = "0"
+}

--- a/tests/tools/test_mpp_reproducible_manifest_source_contract.py
+++ b/tests/tools/test_mpp_reproducible_manifest_source_contract.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+import re
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+BUILD_FILE = ROOT / "patches" / "build.gradle.kts"
+MARKER = "MORPHE_DETERMINISTIC_MPP_MANIFEST_TIMESTAMP_V1"
+
+
+class MppReproducibleManifestSourceContractTest(unittest.TestCase):
+    def test_timestamp_has_one_deterministic_override(self) -> None:
+        text = BUILD_FILE.read_text(encoding="utf-8")
+
+        self.assertEqual(1, text.count(MARKER))
+        self.assertEqual(
+            1,
+            len(
+                re.findall(
+                    r'manifest\.attributes\["Timestamp"\]\s*=\s*"0"',
+                    text,
+                )
+            ),
+        )
+        self.assertIn(
+            "tasks.withType<org.gradle.jvm.tasks.Jar>().configureEach",
+            text,
+        )
+
+    def test_override_contains_no_active_wall_clock_expression(self) -> None:
+        text = BUILD_FILE.read_text(encoding="utf-8")
+        block = text.split(MARKER, 1)[1]
+
+        # Remove Kotlin line comments before checking executable text.
+        active_code = "\n".join(
+            line.split("//", 1)[0]
+            for line in block.splitlines()
+        )
+
+        self.assertNotIn("System.currentTimeMillis()", active_code)
+        self.assertNotIn("Instant.now()", active_code)
+        self.assertNotIn("LocalDateTime.now()", active_code)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Make Morphe MPP builds byte-for-byte reproducible.

The upstream Gradle plugin inserts the current time into
`META-INF/MANIFEST.MF`, causing identical source trees to produce different
MPP SHA-256 digests.

## Changes

- Override the manifest `Timestamp` with the deterministic value `0`.
- Add a source contract for the override.
- Update the prepared 1.4.93 SHA-256 in README.

## Validation

- Two clean builds produced identical MPP bytes.
- MPP SHA-256:
  `70f41972c86078032b0cfadfb01cd4ccfe5cbd0e579e9f778908098d6a276ea2`
- `Timestamp: 0`
- Release gate passed.
- Project contracts passed.

This PR does not publish 1.4.93, create a tag, update `dev`, or close issues.
