### PR TITLE
feat(boost): modernize Morphe settings

### DIFF
--- a/extensions/boostforreddit/src/main/java/app/morphe/extension/boostforreddit/settings/MorpheSettingsFragment.java
+++ b/extensions/boostforreddit/src/main/java/app/morphe/extension/boostforreddit/settings/MorpheSettingsFragment.java
@@ -1,0 +1,43 @@
+package app.morphe.extension.boostforreddit.settings;
+
+import android.content.Context;
+import android.content.res.Resources;
+import android.os.Bundle;
+
+import androidx.preference.PreferenceFragmentCompat;
+
+public final class MorpheSettingsFragment extends PreferenceFragmentCompat {
+    public static final String CONTRACT_MARKER =
+            "MORPHE_BOOST_TOP_LEVEL_SETTINGS_ISSUE106_V1";
+
+    private static final String RESOURCE_NAME = "morphe_boost_settings_skeleton";
+    private static final String BOOST_PACKAGE = "com.rubenmayayo.reddit";
+
+    @Override
+    public void onCreatePreferences(Bundle savedInstanceState, String rootKey) {
+        Context context = requireContext();
+        Resources resources = context.getResources();
+
+        int resourceId = resources.getIdentifier(
+                RESOURCE_NAME,
+                "xml",
+                context.getPackageName()
+        );
+
+        if (resourceId == 0) {
+            resourceId = resources.getIdentifier(
+                    RESOURCE_NAME,
+                    "xml",
+                    BOOST_PACKAGE
+            );
+        }
+
+        if (resourceId == 0) {
+            throw new IllegalStateException(
+                    "Missing Morphe settings resource: " + RESOURCE_NAME
+            );
+        }
+
+        setPreferencesFromResource(resourceId, rootKey);
+    }
+}

--- a/extensions/boostforreddit/src/main/java/app/morphe/extension/boostforreddit/settings/MorpheSettingsHubFragment.java
+++ b/extensions/boostforreddit/src/main/java/app/morphe/extension/boostforreddit/settings/MorpheSettingsHubFragment.java
@@ -1,0 +1,78 @@
+package app.morphe.extension.boostforreddit.settings;
+
+import android.content.Context;
+import android.content.Intent;
+import android.content.res.Resources;
+import android.os.Bundle;
+
+import androidx.preference.Preference;
+import androidx.preference.PreferenceFragmentCompat;
+
+public final class MorpheSettingsHubFragment extends PreferenceFragmentCompat {
+    public static final String CONTRACT_MARKER =
+            "MORPHE_BOOST_SETTINGS_HUBS_ISSUE106_V2_1";
+
+    public static final String RESOURCE_ARGUMENT =
+            "morphe_boost_settings_hub_resource";
+
+    private static final String RESOURCE_PREFIX =
+            "morphe_boost_settings_hub_";
+    private static final String BOOST_PACKAGE = "com.rubenmayayo.reddit";
+    private static final String BACKUP_KEY =
+            "morphe_boost_settings_backup";
+    private static final String BACKUP_ACTIVITY =
+            "com.rubenmayayo.reddit.BackupActivity";
+
+    @Override
+    public void onCreatePreferences(Bundle savedInstanceState, String rootKey) {
+        Bundle arguments = getArguments();
+        String resourceName = arguments == null
+                ? null
+                : arguments.getString(RESOURCE_ARGUMENT);
+
+        if (resourceName == null || !resourceName.startsWith(RESOURCE_PREFIX)) {
+            throw new IllegalArgumentException(
+                    "Missing Morphe settings hub resource"
+            );
+        }
+
+        Context context = requireContext();
+        Resources resources = context.getResources();
+        int resourceId = resources.getIdentifier(
+                resourceName,
+                "xml",
+                context.getPackageName()
+        );
+
+        if (resourceId == 0) {
+            resourceId = resources.getIdentifier(
+                    resourceName,
+                    "xml",
+                    BOOST_PACKAGE
+            );
+        }
+
+        if (resourceId == 0) {
+            throw new IllegalStateException(
+                    "Missing Morphe settings hub resource: " + resourceName
+            );
+        }
+
+        setPreferencesFromResource(resourceId, rootKey);
+        installBackupRoute(context);
+    }
+
+    private void installBackupRoute(Context context) {
+        Preference backup = findPreference(BACKUP_KEY);
+        if (backup == null) {
+            return;
+        }
+
+        backup.setOnPreferenceClickListener(preference -> {
+            Intent intent = new Intent();
+            intent.setClassName(context.getPackageName(), BACKUP_ACTIVITY);
+            startActivity(intent);
+            return true;
+        });
+    }
+}

--- a/extensions/boostforreddit/src/main/java/app/morphe/extension/boostforreddit/settings/MorpheSettingsLayout.java
+++ b/extensions/boostforreddit/src/main/java/app/morphe/extension/boostforreddit/settings/MorpheSettingsLayout.java
@@ -1,0 +1,63 @@
+package app.morphe.extension.boostforreddit.settings;
+
+import android.content.Context;
+import android.content.SharedPreferences;
+import android.content.res.Resources;
+import android.preference.PreferenceManager;
+
+import androidx.preference.PreferenceFragmentCompat;
+
+public final class MorpheSettingsLayout {
+    public static final String CONTRACT_MARKER =
+            "MORPHE_BOOST_SETTINGS_LAYOUT_ISSUE106_V2_1";
+
+    public static final String ENABLED_KEY =
+            "morphe_boost_settings_layout_v2_enabled";
+
+    private static final String V4_ENABLED_KEY =
+            "morphe_boost_settings_v4_enabled";
+
+    private static final String RESOURCE_NAME =
+            "morphe_boost_settings_layout_v2";
+    private static final String BOOST_PACKAGE = "com.rubenmayayo.reddit";
+
+    private MorpheSettingsLayout() {
+    }
+
+    public static int resolveRootResource(
+            PreferenceFragmentCompat fragment,
+            int originalResourceId
+    ) {
+        Context context = fragment.requireContext();
+        SharedPreferences preferences =
+                PreferenceManager.getDefaultSharedPreferences(context);
+
+        // Once the v4 choice has been made, OFF means the original Boost root.
+        // Existing v2 preview users are migrated by MorpheSettingsV4 before the
+        // HeaderFragment is created.
+        if (preferences.contains(V4_ENABLED_KEY)) {
+            return originalResourceId;
+        }
+
+        if (!preferences.getBoolean(ENABLED_KEY, false)) {
+            return originalResourceId;
+        }
+
+        Resources resources = context.getResources();
+        int resourceId = resources.getIdentifier(
+                RESOURCE_NAME,
+                "xml",
+                context.getPackageName()
+        );
+
+        if (resourceId == 0) {
+            resourceId = resources.getIdentifier(
+                    RESOURCE_NAME,
+                    "xml",
+                    BOOST_PACKAGE
+            );
+        }
+
+        return resourceId == 0 ? originalResourceId : resourceId;
+    }
+}

--- a/extensions/boostforreddit/src/main/java/app/morphe/extension/boostforreddit/settings/MorpheSettingsV14Ui.java
+++ b/extensions/boostforreddit/src/main/java/app/morphe/extension/boostforreddit/settings/MorpheSettingsV14Ui.java
@@ -1,0 +1,721 @@
+package app.morphe.extension.boostforreddit.settings;
+
+import android.content.Context;
+import android.content.res.ColorStateList;
+import android.graphics.Canvas;
+import android.graphics.Paint;
+import android.graphics.RectF;
+import android.graphics.drawable.Drawable;
+import android.graphics.drawable.GradientDrawable;
+import android.graphics.drawable.RippleDrawable;
+import android.os.Build;
+import android.text.TextUtils;
+import android.view.Gravity;
+import android.view.View;
+import android.view.ViewGroup;
+import android.view.accessibility.AccessibilityNodeInfo;
+import android.widget.Checkable;
+import android.widget.EditText;
+import android.widget.LinearLayout;
+import android.widget.TextView;
+
+/**
+ * Shared, ABI-safe Material 3 view primitives for the Settings v4 shell.
+ *
+ * <p>The Boost 1.12.12 APK does not expose every Material Components class.
+ * These primitives intentionally depend only on framework Views that are
+ * already part of Boost while implementing the M3 list, selection, field,
+ * state, spacing, and accessibility contracts used by Morphe settings.</p>
+ */
+final class MorpheSettingsV14Ui {
+    static final String CONTRACT_MARKER =
+            "MORPHE_BOOST_SETTINGS_V14_COHERENT_UI_ISSUE106_V1";
+    static final String ABI_MARKER =
+            "MORPHE_BOOST_SETTINGS_V14_FRAMEWORK_VIEW_ABI_ISSUE106_V1";
+    static final String SEGMENTED_LIST_MARKER =
+            "MORPHE_BOOST_SETTINGS_V14_SEGMENTED_LISTS_ISSUE106_V1";
+    static final String ACCESSIBILITY_MARKER =
+            "MORPHE_BOOST_SETTINGS_V14_SELECTION_A11Y_ISSUE106_V1";
+
+    private static final int ROW_SINGLE_DP = 56;
+    private static final int ROW_TWO_LINE_DP = 72;
+    private static final int GROUP_GAP_DP = 4;
+    private static final float OUTER_RADIUS_DP = 18.0f;
+    private static final float INNER_RADIUS_DP = 6.0f;
+
+    private MorpheSettingsV14Ui() {
+    }
+
+    static LinearLayout group(Context context) {
+        LinearLayout group = new LinearLayout(context);
+        group.setOrientation(LinearLayout.VERTICAL);
+        group.setClipChildren(false);
+        group.setClipToPadding(false);
+        return group;
+    }
+
+    static LinearLayout baseRow(
+            Context context,
+            MorpheSettingsV4Theme.Tokens tokens
+    ) {
+        LinearLayout row = new LinearLayout(context);
+        row.setOrientation(LinearLayout.HORIZONTAL);
+        row.setGravity(Gravity.CENTER_VERTICAL);
+        row.setMinimumHeight(dp(context, ROW_SINGLE_DP));
+        row.setPadding(dp(context, 16), dp(context, 8), dp(context, 12), dp(context, 8));
+        row.setClickable(true);
+        row.setFocusable(true);
+        row.setBackground(interactiveShape(
+                context,
+                rowColor(tokens, false),
+                corners(context, true, true),
+                tokens.navigationAccent().color
+        ));
+        return row;
+    }
+
+    static LinearLayout labels(
+            Context context,
+            MorpheSettingsV4Theme.Tokens tokens,
+            String titleValue,
+            String summaryValue
+    ) {
+        LinearLayout labels = new LinearLayout(context);
+        labels.setOrientation(LinearLayout.VERTICAL);
+        labels.setGravity(Gravity.CENTER_VERTICAL);
+
+        TextView title = text(context, titleValue, 16, tokens.textPrimary);
+        title.setMaxLines(2);
+        title.setEllipsize(TextUtils.TruncateAt.END);
+        labels.addView(title);
+
+        if (!TextUtils.isEmpty(summaryValue)) {
+            TextView summary = text(
+                    context,
+                    summaryValue,
+                    14,
+                    tokens.textSecondary
+            );
+            summary.setMaxLines(3);
+            summary.setEllipsize(TextUtils.TruncateAt.END);
+            summary.setLineSpacing(0, 1.06f);
+            LinearLayout.LayoutParams params = wrapParams();
+            params.topMargin = dp(context, 2);
+            labels.addView(summary, params);
+        }
+        return labels;
+    }
+
+    static TextView sectionLabel(
+            Context context,
+            MorpheSettingsV4Theme.Tokens tokens,
+            String value
+    ) {
+        TextView label = text(context, value, 14, tokens.primary);
+        label.setTypeface(android.graphics.Typeface.create(
+                "sans-serif-medium",
+                android.graphics.Typeface.NORMAL
+        ));
+        label.setLetterSpacing(0.01f);
+        label.setPadding(dp(context, 4), 0, dp(context, 4), 0);
+        return label;
+    }
+
+    static TextView supportingText(
+            Context context,
+            MorpheSettingsV4Theme.Tokens tokens,
+            String value
+    ) {
+        TextView text = text(context, value, 14, tokens.textSecondary);
+        text.setLineSpacing(0, 1.08f);
+        text.setPadding(dp(context, 4), dp(context, 8), dp(context, 4), 0);
+        return text;
+    }
+
+    static void addSegmentedRow(
+            LinearLayout group,
+            View row,
+            MorpheSettingsV4Theme.Tokens tokens
+    ) {
+        LinearLayout.LayoutParams params = new LinearLayout.LayoutParams(
+                ViewGroup.LayoutParams.MATCH_PARENT,
+                ViewGroup.LayoutParams.WRAP_CONTENT
+        );
+        if (group.getChildCount() > 0) {
+            params.topMargin = dp(group.getContext(), GROUP_GAP_DP);
+        }
+        group.addView(row, params);
+        restyleGroup(group, tokens);
+    }
+
+    static ChoiceRow choiceRow(
+            Context context,
+            MorpheSettingsV4Theme.Tokens tokens,
+            String title,
+            String summary,
+            boolean checked
+    ) {
+        return new ChoiceRow(context, tokens, title, summary, checked);
+    }
+
+    static View chevron(
+            Context context,
+            MorpheSettingsV4Theme.Tokens tokens
+    ) {
+        ChevronView chevron = new ChevronView(
+                context,
+                tokens.navigationAccent().color
+        );
+        chevron.setImportantForAccessibility(View.IMPORTANT_FOR_ACCESSIBILITY_NO);
+        chevron.setContentDescription(null);
+        return chevron;
+    }
+
+    static TextView action(
+            Context context,
+            MorpheSettingsV4Theme.Tokens tokens,
+            String value,
+            boolean filled
+    ) {
+        TextView action = text(
+                context,
+                value,
+                14,
+                filled
+                        ? tokens.navigationAccent().onContainer
+                        : tokens.navigationAccent().color
+        );
+        action.setGravity(Gravity.CENTER);
+        action.setMinHeight(dp(context, 48));
+        action.setPadding(dp(context, 18), dp(context, 10), dp(context, 18), dp(context, 10));
+        action.setClickable(true);
+        action.setFocusable(true);
+        int color = filled
+                ? tokens.navigationAccent().container
+                : MorpheSettingsV4Theme.blend(
+                        tokens.surfaceContainer,
+                        tokens.navigationAccent().container,
+                        tokens.dark ? 0.12f : 0.09f
+                );
+        action.setBackground(MorpheSettingsV4Theme.interactive(
+                context,
+                color,
+                24,
+                tokens.navigationAccent().color
+        ));
+        return action;
+    }
+
+    static Field outlinedField(
+            Context context,
+            MorpheSettingsV4Theme.Tokens tokens,
+            String labelValue,
+            String value
+    ) {
+        LinearLayout root = new LinearLayout(context);
+        root.setOrientation(LinearLayout.VERTICAL);
+        root.setPadding(dp(context, 16), dp(context, 8), dp(context, 16), dp(context, 8));
+        root.setMinimumHeight(dp(context, 64));
+        root.setBackground(fieldBackground(context, tokens));
+
+        TextView label = text(context, labelValue, 12, tokens.primary);
+        root.addView(label, matchWrapParams());
+
+        EditText input = new EditText(context);
+        input.setText(value);
+        input.setTextSize(16);
+        input.setTextColor(tokens.textPrimary);
+        input.setHintTextColor(tokens.textSecondary);
+        input.setSingleLine(true);
+        input.setPadding(0, 0, 0, 0);
+        input.setBackgroundColor(0x00000000);
+        input.setOnFocusChangeListener((view, focused) -> root.setSelected(focused));
+        root.addView(input, matchWrapParams());
+        return new Field(root, input);
+    }
+
+    static Drawable roundedSurface(
+            Context context,
+            MorpheSettingsV4Theme.Tokens tokens,
+            boolean selected
+    ) {
+        return interactiveShape(
+                context,
+                rowColor(tokens, selected),
+                corners(context, true, true),
+                tokens.navigationAccent().color
+        );
+    }
+
+    private static void restyleGroup(
+            LinearLayout group,
+            MorpheSettingsV4Theme.Tokens tokens
+    ) {
+        int count = group.getChildCount();
+        for (int index = 0; index < count; index++) {
+            View child = group.getChildAt(index);
+            boolean selected = child instanceof Checkable
+                    && ((Checkable) child).isChecked();
+            child.setBackground(interactiveShape(
+                    group.getContext(),
+                    rowColor(tokens, selected),
+                    corners(
+                            group.getContext(),
+                            index == 0,
+                            index == count - 1
+                    ),
+                    tokens.navigationAccent().color
+            ));
+            if (child instanceof ChoiceRow) {
+                ((ChoiceRow) child).applyCheckedColors();
+            }
+        }
+    }
+
+    private static int rowColor(
+            MorpheSettingsV4Theme.Tokens tokens,
+            boolean selected
+    ) {
+        if (selected) {
+            return MorpheSettingsV4Theme.blend(
+                    tokens.surfaceContainerHigh,
+                    tokens.secondaryContainer,
+                    tokens.dark ? 0.74f : 0.68f
+            );
+        }
+        return MorpheSettingsV4Theme.blend(
+                tokens.surfaceContainer,
+                tokens.secondaryContainer,
+                tokens.dark ? 0.055f : 0.04f
+        );
+    }
+
+    private static Drawable fieldBackground(
+            Context context,
+            MorpheSettingsV4Theme.Tokens tokens
+    ) {
+        GradientDrawable focused = shape(
+                context,
+                tokens.surfaceContainerHigh,
+                corners(context, true, true)
+        );
+        focused.setStroke(dp(context, 2), tokens.navigationAccent().color);
+        GradientDrawable normal = shape(
+                context,
+                tokens.surfaceContainer,
+                corners(context, true, true)
+        );
+        normal.setStroke(dp(context, 1), tokens.outline);
+
+        android.graphics.drawable.StateListDrawable states =
+                new android.graphics.drawable.StateListDrawable();
+        states.addState(new int[]{android.R.attr.state_selected}, focused);
+        states.addState(new int[]{android.R.attr.state_focused}, focused);
+        states.addState(new int[0], normal);
+        return states;
+    }
+
+    private static Drawable interactiveShape(
+            Context context,
+            int color,
+            float[] corners,
+            int rippleColor
+    ) {
+        Drawable content = shape(context, color, corners);
+        if (Build.VERSION.SDK_INT < 21) {
+            return content;
+        }
+        return new RippleDrawable(
+                ColorStateList.valueOf(
+                        MorpheSettingsV4Theme.withAlpha(rippleColor, 42)
+                ),
+                content,
+                null
+        );
+    }
+
+    private static GradientDrawable shape(
+            Context context,
+            int color,
+            float[] corners
+    ) {
+        GradientDrawable drawable = new GradientDrawable();
+        drawable.setColor(color);
+        drawable.setCornerRadii(corners);
+        return drawable;
+    }
+
+    private static float[] corners(
+            Context context,
+            boolean first,
+            boolean last
+    ) {
+        float top = dp(context, first ? OUTER_RADIUS_DP : INNER_RADIUS_DP);
+        float bottom = dp(context, last ? OUTER_RADIUS_DP : INNER_RADIUS_DP);
+        return new float[]{
+                top, top,
+                top, top,
+                bottom, bottom,
+                bottom, bottom
+        };
+    }
+
+    private static TextView text(
+            Context context,
+            String value,
+            int sizeSp,
+            int color
+    ) {
+        TextView text = new TextView(context);
+        text.setText(value);
+        text.setTextSize(sizeSp);
+        text.setTextColor(color);
+        return text;
+    }
+
+    private static int dp(Context context, float value) {
+        return MorpheSettingsV4Theme.dp(context, value);
+    }
+
+    private static LinearLayout.LayoutParams wrapParams() {
+        return new LinearLayout.LayoutParams(
+                ViewGroup.LayoutParams.WRAP_CONTENT,
+                ViewGroup.LayoutParams.WRAP_CONTENT
+        );
+    }
+
+    private static LinearLayout.LayoutParams matchWrapParams() {
+        return new LinearLayout.LayoutParams(
+                ViewGroup.LayoutParams.MATCH_PARENT,
+                ViewGroup.LayoutParams.WRAP_CONTENT
+        );
+    }
+
+    static final class Field {
+        final LinearLayout root;
+        final EditText input;
+
+        Field(LinearLayout root, EditText input) {
+            this.root = root;
+            this.input = input;
+        }
+    }
+
+    static final class ChoiceRow extends LinearLayout implements Checkable {
+        private final MorpheSettingsV4Theme.Tokens tokens;
+        private final TextView title;
+        private final TextView summary;
+        private final RadioIndicator indicator;
+        private boolean checked;
+
+        ChoiceRow(
+                Context context,
+                MorpheSettingsV4Theme.Tokens tokens,
+                String titleValue,
+                String summaryValue,
+                boolean checked
+        ) {
+            super(context);
+            this.tokens = tokens;
+            setOrientation(HORIZONTAL);
+            setGravity(Gravity.CENTER_VERTICAL);
+            setMinimumHeight(dp(context, TextUtils.isEmpty(summaryValue)
+                    ? ROW_SINGLE_DP
+                    : ROW_TWO_LINE_DP));
+            setPadding(dp(context, 16), dp(context, 8), dp(context, 12), dp(context, 8));
+            setClickable(true);
+            setFocusable(true);
+
+            LinearLayout labels = MorpheSettingsV14Ui.labels(
+                    context,
+                    tokens,
+                    titleValue,
+                    summaryValue
+            );
+            title = (TextView) labels.getChildAt(0);
+            summary = labels.getChildCount() > 1
+                    ? (TextView) labels.getChildAt(1)
+                    : null;
+            LayoutParams labelsParams = new LayoutParams(
+                    0,
+                    ViewGroup.LayoutParams.WRAP_CONTENT,
+                    1.0f
+            );
+            addView(labels, labelsParams);
+
+            indicator = new RadioIndicator(context, tokens);
+            indicator.setImportantForAccessibility(
+                    View.IMPORTANT_FOR_ACCESSIBILITY_NO
+            );
+            addView(indicator, new LayoutParams(dp(context, 48), dp(context, 48)));
+            setChecked(checked);
+        }
+
+        @Override
+        public void setChecked(boolean checked) {
+            this.checked = checked;
+            indicator.setChecked(checked);
+            applyCheckedColors();
+            ViewParentCompat.restyleParent(this, tokens);
+            refreshDrawableState();
+        }
+
+        @Override
+        public boolean isChecked() {
+            return checked;
+        }
+
+        @Override
+        public void toggle() {
+            setChecked(!checked);
+        }
+
+        @Override
+        public CharSequence getAccessibilityClassName() {
+            return "android.widget.RadioButton";
+        }
+
+        @Override
+        public void onInitializeAccessibilityNodeInfo(
+                AccessibilityNodeInfo info
+        ) {
+            super.onInitializeAccessibilityNodeInfo(info);
+            info.setCheckable(true);
+            info.setChecked(checked);
+        }
+
+        void setTitleTypeface(android.graphics.Typeface typeface) {
+            title.setTypeface(typeface);
+        }
+
+        void setTitleSize(float sizeSp) {
+            title.setTextSize(sizeSp);
+        }
+
+        private void applyCheckedColors() {
+            title.setTextColor(checked
+                    ? tokens.onSecondaryContainer
+                    : tokens.textPrimary);
+            if (summary != null) {
+                summary.setTextColor(checked
+                        ? MorpheSettingsV4Theme.blend(
+                                tokens.onSecondaryContainer,
+                                tokens.secondaryContainer,
+                                0.24f
+                        )
+                        : tokens.textSecondary);
+            }
+        }
+    }
+
+    interface OnToggleChangedListener {
+        void onToggleChanged(Toggle toggle, boolean checked);
+    }
+
+    /**
+     * M3-sized switch drawn with framework Canvas APIs. The complete View is a
+     * 56 x 48 dp touch target; the visual track is 52 x 32 dp.
+     */
+    static final class Toggle extends View implements Checkable {
+        private final Paint paint = new Paint(Paint.ANTI_ALIAS_FLAG);
+        private final RectF track = new RectF();
+        private final MorpheSettingsV4Theme.Tokens tokens;
+        private boolean checked;
+        private OnToggleChangedListener listener;
+
+        Toggle(
+                Context context,
+                MorpheSettingsV4Theme.Tokens tokens,
+                boolean checked
+        ) {
+            super(context);
+            this.tokens = tokens;
+            this.checked = checked;
+            setClickable(true);
+            setFocusable(true);
+            setOnClickListener(view -> toggle());
+        }
+
+        void setOnCheckedChangeListener(OnToggleChangedListener listener) {
+            this.listener = listener;
+        }
+
+        @Override
+        protected void onMeasure(int widthMeasureSpec, int heightMeasureSpec) {
+            setMeasuredDimension(dp(getContext(), 56), dp(getContext(), 48));
+        }
+
+        @Override
+        protected void onDraw(Canvas canvas) {
+            super.onDraw(canvas);
+            float left = dp(getContext(), 2);
+            float top = dp(getContext(), 8);
+            float right = getWidth() - dp(getContext(), 2);
+            float bottom = getHeight() - dp(getContext(), 8);
+            track.set(left, top, right, bottom);
+            float radius = dp(getContext(), 16);
+
+            paint.setStyle(Paint.Style.FILL);
+            paint.setColor(checked
+                    ? tokens.navigationAccent().color
+                    : MorpheSettingsV4Theme.blend(
+                            tokens.surfaceContainerHigh,
+                            tokens.outline,
+                            tokens.dark ? 0.42f : 0.30f
+                    ));
+            canvas.drawRoundRect(track, radius, radius, paint);
+
+            if (!checked) {
+                paint.setStyle(Paint.Style.STROKE);
+                paint.setStrokeWidth(dp(getContext(), 2));
+                paint.setColor(tokens.outline);
+                canvas.drawRoundRect(track, radius, radius, paint);
+            }
+
+            float thumbRadius = dp(getContext(), checked ? 12 : 8);
+            float centerX = checked
+                    ? right - dp(getContext(), 16)
+                    : left + dp(getContext(), 16);
+            paint.setStyle(Paint.Style.FILL);
+            paint.setColor(checked
+                    ? tokens.navigationAccent().onContainer
+                    : tokens.textSecondary);
+            canvas.drawCircle(
+                    centerX,
+                    getHeight() / 2.0f,
+                    thumbRadius,
+                    paint
+            );
+        }
+
+        @Override
+        public void setChecked(boolean checked) {
+            if (this.checked == checked) {
+                return;
+            }
+            this.checked = checked;
+            invalidate();
+            refreshDrawableState();
+            if (listener != null) {
+                listener.onToggleChanged(this, checked);
+            }
+        }
+
+        void setCheckedSilently(boolean checked) {
+            if (this.checked == checked) {
+                return;
+            }
+            this.checked = checked;
+            invalidate();
+            refreshDrawableState();
+        }
+
+        @Override
+        public boolean isChecked() {
+            return checked;
+        }
+
+        @Override
+        public void toggle() {
+            setChecked(!checked);
+        }
+
+        @Override
+        public CharSequence getAccessibilityClassName() {
+            return "android.widget.Switch";
+        }
+
+        @Override
+        public void onInitializeAccessibilityNodeInfo(
+                AccessibilityNodeInfo info
+        ) {
+            super.onInitializeAccessibilityNodeInfo(info);
+            info.setCheckable(true);
+            info.setChecked(checked);
+        }
+    }
+
+    private static final class ViewParentCompat {
+        private ViewParentCompat() {
+        }
+
+        static void restyleParent(
+                View child,
+                MorpheSettingsV4Theme.Tokens tokens
+        ) {
+            if (child.getParent() instanceof LinearLayout) {
+                restyleGroup((LinearLayout) child.getParent(), tokens);
+            }
+        }
+    }
+
+    private static final class RadioIndicator extends View {
+        private final Paint paint = new Paint(Paint.ANTI_ALIAS_FLAG);
+        private final MorpheSettingsV4Theme.Tokens tokens;
+        private boolean checked;
+
+        RadioIndicator(
+                Context context,
+                MorpheSettingsV4Theme.Tokens tokens
+        ) {
+            super(context);
+            this.tokens = tokens;
+        }
+
+        void setChecked(boolean checked) {
+            this.checked = checked;
+            invalidate();
+        }
+
+        @Override
+        protected void onDraw(Canvas canvas) {
+            super.onDraw(canvas);
+            float centerX = getWidth() / 2.0f;
+            float centerY = getHeight() / 2.0f;
+            float radius = dp(getContext(), 10);
+            paint.setStyle(Paint.Style.STROKE);
+            paint.setStrokeWidth(dp(getContext(), 2));
+            paint.setColor(checked
+                    ? tokens.navigationAccent().color
+                    : tokens.textSecondary);
+            canvas.drawCircle(centerX, centerY, radius, paint);
+            if (checked) {
+                paint.setStyle(Paint.Style.FILL);
+                canvas.drawCircle(
+                        centerX,
+                        centerY,
+                        dp(getContext(), 5),
+                        paint
+                );
+            }
+        }
+    }
+
+    private static final class ChevronView extends View {
+        private final Paint paint = new Paint(Paint.ANTI_ALIAS_FLAG);
+
+        ChevronView(Context context, int color) {
+            super(context);
+            paint.setColor(color);
+            paint.setStyle(Paint.Style.STROKE);
+            paint.setStrokeCap(Paint.Cap.ROUND);
+            paint.setStrokeJoin(Paint.Join.ROUND);
+            paint.setStrokeWidth(dp(context, 2));
+        }
+
+        @Override
+        protected void onMeasure(int widthMeasureSpec, int heightMeasureSpec) {
+            setMeasuredDimension(dp(getContext(), 40), dp(getContext(), 48));
+        }
+
+        @Override
+        protected void onDraw(Canvas canvas) {
+            super.onDraw(canvas);
+            float x = getWidth() * 0.45f;
+            float middle = getHeight() * 0.5f;
+            float size = dp(getContext(), 5);
+            canvas.drawLine(x, middle - size, x + size, middle, paint);
+            canvas.drawLine(x + size, middle, x, middle + size, paint);
+        }
+    }
+}

--- a/extensions/boostforreddit/src/main/java/app/morphe/extension/boostforreddit/settings/MorpheSettingsV4.java
+++ b/extensions/boostforreddit/src/main/java/app/morphe/extension/boostforreddit/settings/MorpheSettingsV4.java
@@ -11,6 +11,8 @@ import android.text.TextUtils;
 public final class MorpheSettingsV4 {
     public static final String CONTRACT_MARKER =
             "MORPHE_BOOST_SETTINGS_V4_ISSUE106_V1";
+    public static final String DEFAULT_ON_MARKER =
+            "MORPHE_BOOST_SETTINGS_V14_DEFAULT_ON_CLASSIC_FALLBACK_V1";
 
     public static final String ENABLED_KEY =
             "morphe_boost_settings_v4_enabled";
@@ -55,26 +57,35 @@ public final class MorpheSettingsV4 {
                 PreferenceManager.getDefaultSharedPreferences(context);
 
         if (preferences.contains(ENABLED_KEY)) {
-            boolean enabled = preferences.getBoolean(ENABLED_KEY, false);
+            boolean enabled = preferences.getBoolean(ENABLED_KEY, true);
             if (enabled) {
                 forceSystemThemeMode(preferences);
             }
             return enabled;
         }
 
-        // Preserve and migrate the choice made by existing issue #106 preview
-        // testers so the new toggle accurately reflects the active UI.
-        boolean legacyEnabled = preferences.getBoolean(
-                LEGACY_V2_ENABLED_KEY,
-                false
-        );
-        if (legacyEnabled) {
-            preferences.edit()
-                    .putBoolean(ENABLED_KEY, true)
-                    .putString(THEME_MODE_KEY, SYSTEM_THEME_MODE)
-                    .apply();
+        // Preserve the explicit choice made by issue #106 preview testers.
+        if (preferences.contains(LEGACY_V2_ENABLED_KEY)) {
+            boolean legacyEnabled = preferences.getBoolean(
+                    LEGACY_V2_ENABLED_KEY,
+                    false
+            );
+            SharedPreferences.Editor editor = preferences.edit()
+                    .putBoolean(ENABLED_KEY, legacyEnabled);
+            if (legacyEnabled) {
+                editor.putString(THEME_MODE_KEY, SYSTEM_THEME_MODE);
+            }
+            editor.apply();
+            return legacyEnabled;
         }
-        return legacyEnabled;
+
+        // Material settings is the shipping default. Classic Boost settings
+        // remains available as the final action on the Material home page.
+        preferences.edit()
+                .putBoolean(ENABLED_KEY, true)
+                .putString(THEME_MODE_KEY, SYSTEM_THEME_MODE)
+                .apply();
+        return true;
     }
 
     public static void setEnabled(Context context, boolean enabled) {

--- a/extensions/boostforreddit/src/main/java/app/morphe/extension/boostforreddit/settings/MorpheSettingsV4.java
+++ b/extensions/boostforreddit/src/main/java/app/morphe/extension/boostforreddit/settings/MorpheSettingsV4.java
@@ -17,6 +17,8 @@ public final class MorpheSettingsV4 {
 
     private static final String LEGACY_V2_ENABLED_KEY =
             "morphe_boost_settings_layout_v2_enabled";
+    private static final String THEME_MODE_KEY = "pref_theme_mode_type";
+    private static final String SYSTEM_THEME_MODE = "system";
     private static final String EXTRA_SHOW_FRAGMENT =
             "extra_show_fragment";
     private static final String FRAGMENT_NAME =
@@ -53,7 +55,11 @@ public final class MorpheSettingsV4 {
                 PreferenceManager.getDefaultSharedPreferences(context);
 
         if (preferences.contains(ENABLED_KEY)) {
-            return preferences.getBoolean(ENABLED_KEY, false);
+            boolean enabled = preferences.getBoolean(ENABLED_KEY, false);
+            if (enabled) {
+                forceSystemThemeMode(preferences);
+            }
+            return enabled;
         }
 
         // Preserve and migrate the choice made by existing issue #106 preview
@@ -63,15 +69,32 @@ public final class MorpheSettingsV4 {
                 false
         );
         if (legacyEnabled) {
-            preferences.edit().putBoolean(ENABLED_KEY, true).apply();
+            preferences.edit()
+                    .putBoolean(ENABLED_KEY, true)
+                    .putString(THEME_MODE_KEY, SYSTEM_THEME_MODE)
+                    .apply();
         }
         return legacyEnabled;
     }
 
     public static void setEnabled(Context context, boolean enabled) {
-        PreferenceManager.getDefaultSharedPreferences(context)
-                .edit()
-                .putBoolean(ENABLED_KEY, enabled)
-                .apply();
+        SharedPreferences preferences =
+                PreferenceManager.getDefaultSharedPreferences(context);
+        SharedPreferences.Editor editor = preferences.edit()
+                .putBoolean(ENABLED_KEY, enabled);
+        if (enabled) {
+            editor.putString(THEME_MODE_KEY, SYSTEM_THEME_MODE);
+        }
+        editor.apply();
+    }
+
+    private static void forceSystemThemeMode(SharedPreferences preferences) {
+        if (!SYSTEM_THEME_MODE.equals(
+                preferences.getString(THEME_MODE_KEY, SYSTEM_THEME_MODE)
+        )) {
+            preferences.edit()
+                    .putString(THEME_MODE_KEY, SYSTEM_THEME_MODE)
+                    .apply();
+        }
     }
 }

--- a/extensions/boostforreddit/src/main/java/app/morphe/extension/boostforreddit/settings/MorpheSettingsV4.java
+++ b/extensions/boostforreddit/src/main/java/app/morphe/extension/boostforreddit/settings/MorpheSettingsV4.java
@@ -1,0 +1,77 @@
+package app.morphe.extension.boostforreddit.settings;
+
+import android.app.Activity;
+import android.content.Context;
+import android.content.Intent;
+import android.content.SharedPreferences;
+import android.preference.PreferenceManager;
+import android.text.TextUtils;
+
+/** Entry-point and compatibility policy for the Morphe-owned settings UI. */
+public final class MorpheSettingsV4 {
+    public static final String CONTRACT_MARKER =
+            "MORPHE_BOOST_SETTINGS_V4_ISSUE106_V1";
+
+    public static final String ENABLED_KEY =
+            "morphe_boost_settings_v4_enabled";
+
+    private static final String LEGACY_V2_ENABLED_KEY =
+            "morphe_boost_settings_layout_v2_enabled";
+    private static final String EXTRA_SHOW_FRAGMENT =
+            "extra_show_fragment";
+    private static final String FRAGMENT_NAME =
+            "app.morphe.extension.boostforreddit.settings."
+                    + "MorpheSettingsV4Fragment";
+
+    private MorpheSettingsV4() {
+    }
+
+    /**
+     * Selects the v4 fragment only for a normal Settings launch. Explicit Boost
+     * deep links keep their requested destination.
+     */
+    public static void prepareIntent(Activity activity) {
+        if (activity == null || !isEnabled(activity)) {
+            return;
+        }
+
+        Intent intent = activity.getIntent();
+        if (intent == null) {
+            return;
+        }
+
+        String requestedFragment = intent.getStringExtra(EXTRA_SHOW_FRAGMENT);
+        if (!TextUtils.isEmpty(requestedFragment)) {
+            return;
+        }
+
+        intent.putExtra(EXTRA_SHOW_FRAGMENT, FRAGMENT_NAME);
+    }
+
+    public static boolean isEnabled(Context context) {
+        SharedPreferences preferences =
+                PreferenceManager.getDefaultSharedPreferences(context);
+
+        if (preferences.contains(ENABLED_KEY)) {
+            return preferences.getBoolean(ENABLED_KEY, false);
+        }
+
+        // Preserve and migrate the choice made by existing issue #106 preview
+        // testers so the new toggle accurately reflects the active UI.
+        boolean legacyEnabled = preferences.getBoolean(
+                LEGACY_V2_ENABLED_KEY,
+                false
+        );
+        if (legacyEnabled) {
+            preferences.edit().putBoolean(ENABLED_KEY, true).apply();
+        }
+        return legacyEnabled;
+    }
+
+    public static void setEnabled(Context context, boolean enabled) {
+        PreferenceManager.getDefaultSharedPreferences(context)
+                .edit()
+                .putBoolean(ENABLED_KEY, enabled)
+                .apply();
+    }
+}

--- a/extensions/boostforreddit/src/main/java/app/morphe/extension/boostforreddit/settings/MorpheSettingsV4AppIconFragment.java
+++ b/extensions/boostforreddit/src/main/java/app/morphe/extension/boostforreddit/settings/MorpheSettingsV4AppIconFragment.java
@@ -4,10 +4,7 @@ import android.app.Activity;
 import android.content.ComponentName;
 import android.content.Context;
 import android.content.pm.PackageManager;
-import android.content.res.ColorStateList;
-import android.graphics.Typeface;
 import android.graphics.drawable.Drawable;
-import android.os.Build;
 import android.os.Bundle;
 import android.view.Gravity;
 import android.view.LayoutInflater;
@@ -18,7 +15,6 @@ import android.view.ViewGroup;
 import android.widget.FrameLayout;
 import android.widget.ImageView;
 import android.widget.LinearLayout;
-import android.widget.RadioButton;
 import android.widget.ScrollView;
 import android.widget.TextView;
 import android.widget.Toast;
@@ -67,7 +63,7 @@ public final class MorpheSettingsV4AppIconFragment extends Fragment {
 
         LinearLayout content = new LinearLayout(context);
         content.setOrientation(LinearLayout.VERTICAL);
-        content.setPadding(dp(18), dp(12), dp(18), dp(32));
+        content.setPadding(dp(16), dp(10), dp(16), dp(32));
         scrollView.addView(
                 content,
                 new ScrollView.LayoutParams(
@@ -130,59 +126,24 @@ public final class MorpheSettingsV4AppIconFragment extends Fragment {
 
     private void addIconRow(LinearLayout group, IconOption option) {
         Context context = requireContext();
-        MorpheSettingsV4Theme.Accent accent = tokens.navigationAccent();
-        LinearLayout row = new LinearLayout(context);
-        row.setOrientation(LinearLayout.HORIZONTAL);
-        row.setGravity(Gravity.CENTER_VERTICAL);
-        row.setMinimumHeight(dp(84));
-        row.setPadding(dp(14), dp(10), dp(10), dp(10));
-        row.setClickable(true);
-        row.setFocusable(true);
-        row.setBackground(MorpheSettingsV4Theme.interactive(
+        MorpheSettingsV14Ui.ChoiceRow row =
+                MorpheSettingsV14Ui.choiceRow(
                 context,
-                0x00000000,
-                0,
-                accent.color
-        ));
+                tokens,
+                option.title,
+                "",
+                sameAlias(selectedAlias, option.alias)
+        );
+        row.setMinimumHeight(dp(84));
         row.setOnClickListener(view -> select(option));
 
-        row.addView(iconContainer(option), new LinearLayout.LayoutParams(
+        LinearLayout.LayoutParams iconParams = new LinearLayout.LayoutParams(
                 dp(56),
                 dp(56)
-        ));
-
-        TextView title = textView(option.title, 17, tokens.textPrimary);
-        title.setTypeface(Typeface.create("sans-serif-medium", Typeface.NORMAL));
-        LinearLayout.LayoutParams titleParams = new LinearLayout.LayoutParams(
-                0,
-                ViewGroup.LayoutParams.WRAP_CONTENT,
-                1.0f
         );
-        titleParams.setMarginStart(dp(16));
-        row.addView(title, titleParams);
-
-        RadioButton selected = new RadioButton(context);
-        selected.setClickable(false);
-        selected.setFocusable(false);
-        selected.setChecked(sameAlias(selectedAlias, option.alias));
-        if (Build.VERSION.SDK_INT >= 21) {
-            selected.setButtonTintList(new ColorStateList(
-                    new int[][]{
-                            new int[]{android.R.attr.state_checked},
-                            new int[]{-android.R.attr.state_checked}
-                    },
-                    new int[]{accent.color, tokens.textSecondary}
-            ));
-        }
-        row.addView(selected, new LinearLayout.LayoutParams(dp(48), dp(48)));
-
-        if (group.getChildCount() > 0) {
-            addDivider(group);
-        }
-        group.addView(row, new LinearLayout.LayoutParams(
-                ViewGroup.LayoutParams.MATCH_PARENT,
-                ViewGroup.LayoutParams.WRAP_CONTENT
-        ));
+        iconParams.setMarginEnd(dp(14));
+        row.addView(iconContainer(option), 0, iconParams);
+        MorpheSettingsV14Ui.addSegmentedRow(group, row, tokens);
     }
 
     private FrameLayout iconContainer(IconOption option) {
@@ -289,21 +250,7 @@ public final class MorpheSettingsV4AppIconFragment extends Fragment {
     }
 
     private LinearLayout addGroup(LinearLayout parent) {
-        Context context = requireContext();
-        MorpheSettingsV4Theme.Accent accent = tokens.navigationAccent();
-        int groupColor = MorpheSettingsV4Theme.blend(
-                tokens.surfaceContainer,
-                accent.container,
-                tokens.dark ? 0.035f : 0.025f
-        );
-        LinearLayout group = new LinearLayout(context);
-        group.setOrientation(LinearLayout.VERTICAL);
-        group.setBackground(MorpheSettingsV4Theme.rounded(
-                context,
-                groupColor,
-                24
-        ));
-        group.setClipToOutline(true);
+        LinearLayout group = MorpheSettingsV14Ui.group(requireContext());
         parent.addView(group, new LinearLayout.LayoutParams(
                 ViewGroup.LayoutParams.MATCH_PARENT,
                 ViewGroup.LayoutParams.WRAP_CONTENT
@@ -371,10 +318,11 @@ public final class MorpheSettingsV4AppIconFragment extends Fragment {
     }
 
     private void addSectionLabel(LinearLayout parent, String value) {
-        TextView label = textView(value, 14, tokens.primary);
-        label.setTypeface(Typeface.create("sans-serif-medium", Typeface.NORMAL));
-        label.setLetterSpacing(0.02f);
-        parent.addView(label);
+        parent.addView(MorpheSettingsV14Ui.sectionLabel(
+                requireContext(),
+                tokens,
+                value
+        ));
     }
 
     private TextView textView(String value, int sizeSp, int color) {

--- a/extensions/boostforreddit/src/main/java/app/morphe/extension/boostforreddit/settings/MorpheSettingsV4AppIconFragment.java
+++ b/extensions/boostforreddit/src/main/java/app/morphe/extension/boostforreddit/settings/MorpheSettingsV4AppIconFragment.java
@@ -224,21 +224,7 @@ public final class MorpheSettingsV4AppIconFragment extends Fragment {
     private void select(IconOption option) {
         Context context = requireContext();
         try {
-            PackageManager packageManager = context.getPackageManager();
-            for (IconOption candidate : ICONS) {
-                if (candidate.alias == null) {
-                    continue;
-                }
-                ComponentName component = aliasComponent(context, candidate.alias);
-                int state = candidate.alias.equals(option.alias)
-                        ? PackageManager.COMPONENT_ENABLED_STATE_ENABLED
-                        : PackageManager.COMPONENT_ENABLED_STATE_DISABLED;
-                packageManager.setComponentEnabledSetting(
-                        component,
-                        state,
-                        PackageManager.DONT_KILL_APP
-                );
-            }
+            applyIconSelection(context, option.alias);
             selectedAlias = option.alias;
             rebuildOptions();
             Toast.makeText(
@@ -257,7 +243,25 @@ public final class MorpheSettingsV4AppIconFragment extends Fragment {
         }
     }
 
-    private String selectedAlias(Context context) {
+    static void applyIconSelection(Context context, String selectedAlias) {
+        PackageManager packageManager = context.getPackageManager();
+        for (IconOption candidate : ICONS) {
+            if (candidate.alias == null) {
+                continue;
+            }
+            ComponentName component = aliasComponent(context, candidate.alias);
+            int state = candidate.alias.equals(selectedAlias)
+                    ? PackageManager.COMPONENT_ENABLED_STATE_ENABLED
+                    : PackageManager.COMPONENT_ENABLED_STATE_DISABLED;
+            packageManager.setComponentEnabledSetting(
+                    component,
+                    state,
+                    PackageManager.DONT_KILL_APP
+            );
+        }
+    }
+
+    static String selectedAlias(Context context) {
         PackageManager packageManager = context.getPackageManager();
         for (IconOption option : ICONS) {
             if (option.alias == null) {
@@ -273,7 +277,7 @@ public final class MorpheSettingsV4AppIconFragment extends Fragment {
         return null;
     }
 
-    private ComponentName aliasComponent(Context context, String alias) {
+    private static ComponentName aliasComponent(Context context, String alias) {
         return new ComponentName(
                 context.getPackageName(),
                 ALIAS_PREFIX + alias

--- a/extensions/boostforreddit/src/main/java/app/morphe/extension/boostforreddit/settings/MorpheSettingsV4AppIconFragment.java
+++ b/extensions/boostforreddit/src/main/java/app/morphe/extension/boostforreddit/settings/MorpheSettingsV4AppIconFragment.java
@@ -1,0 +1,404 @@
+package app.morphe.extension.boostforreddit.settings;
+
+import android.app.Activity;
+import android.content.ComponentName;
+import android.content.Context;
+import android.content.pm.PackageManager;
+import android.content.res.ColorStateList;
+import android.graphics.Typeface;
+import android.graphics.drawable.Drawable;
+import android.os.Build;
+import android.os.Bundle;
+import android.view.Gravity;
+import android.view.LayoutInflater;
+import android.view.Menu;
+import android.view.MenuItem;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.FrameLayout;
+import android.widget.ImageView;
+import android.widget.LinearLayout;
+import android.widget.RadioButton;
+import android.widget.ScrollView;
+import android.widget.TextView;
+import android.widget.Toast;
+
+import androidx.fragment.app.Fragment;
+
+import app.morphe.extension.boostforreddit.utils.BoostSystemBarInsetsFix;
+
+/** Morphe-owned Material 3 launcher-icon picker backed by Boost's aliases. */
+public final class MorpheSettingsV4AppIconFragment extends Fragment {
+    public static final String CONTRACT_MARKER =
+            "MORPHE_BOOST_SETTINGS_V4_APP_ICON_ISSUE106_V1";
+
+    private static final String ALIAS_PREFIX = "com.rubenmayayo.reddit.";
+
+    private static final IconOption[] ICONS = new IconOption[]{
+            new IconOption("Default", "ic_launcher", null),
+            new IconOption("Grey", "ic_launcher_grey", "grey"),
+            new IconOption("Vivid", "ic_launcher_vivid", "vivid"),
+            new IconOption("Metal", "ic_launcher_metal", "metal"),
+            new IconOption("Yellow", "ic_launcher_yellow", "yellow"),
+    };
+
+    private MorpheSettingsV4Theme.Tokens tokens;
+    private LinearLayout optionsGroup;
+    private String selectedAlias;
+
+    public MorpheSettingsV4AppIconFragment() {
+    }
+
+    @Override
+    public View onCreateView(
+            LayoutInflater inflater,
+            ViewGroup container,
+            Bundle savedInstanceState
+    ) {
+        Context context = inflater.getContext();
+        tokens = MorpheSettingsV4Theme.resolve(context);
+        selectedAlias = selectedAlias(context);
+        setHasOptionsMenu(true);
+
+        ScrollView scrollView = new ScrollView(context);
+        scrollView.setFillViewport(true);
+        scrollView.setClipToPadding(false);
+        scrollView.setBackgroundColor(tokens.background);
+
+        LinearLayout content = new LinearLayout(context);
+        content.setOrientation(LinearLayout.VERTICAL);
+        content.setPadding(dp(18), dp(12), dp(18), dp(32));
+        scrollView.addView(
+                content,
+                new ScrollView.LayoutParams(
+                        ViewGroup.LayoutParams.MATCH_PARENT,
+                        ViewGroup.LayoutParams.WRAP_CONTENT
+                )
+        );
+
+        addSectionLabel(content, "Launcher icon");
+        addSpace(content, 8);
+        optionsGroup = addGroup(content);
+        rebuildOptions();
+
+        addSpace(content, 18);
+        TextView note = textView(
+                "Your launcher may take a few minutes to show a new icon.",
+                14,
+                tokens.textSecondary
+        );
+        note.setLineSpacing(0, 1.08f);
+        LinearLayout.LayoutParams noteParams = new LinearLayout.LayoutParams(
+                ViewGroup.LayoutParams.MATCH_PARENT,
+                ViewGroup.LayoutParams.WRAP_CONTENT
+        );
+        noteParams.setMarginStart(dp(18));
+        noteParams.setMarginEnd(dp(18));
+        content.addView(note, noteParams);
+        return scrollView;
+    }
+
+    @Override
+    public void onResume() {
+        super.onResume();
+        styleHost();
+    }
+
+    @Override
+    public void onPause() {
+        Activity activity = hostActivity();
+        if (activity != null) {
+            BoostSystemBarInsetsFix.clearMorpheSettingsV4SystemBars(activity);
+        }
+        super.onPause();
+    }
+
+    @Override
+    public void onPrepareOptionsMenu(Menu menu) {
+        super.onPrepareOptionsMenu(menu);
+        hideMenuItem(menu, "action_generic_search");
+        hideMenuItem(menu, "action_search");
+        hideMenuItem(menu, "search");
+    }
+
+    private void rebuildOptions() {
+        optionsGroup.removeAllViews();
+        for (IconOption option : ICONS) {
+            addIconRow(optionsGroup, option);
+        }
+    }
+
+    private void addIconRow(LinearLayout group, IconOption option) {
+        Context context = requireContext();
+        MorpheSettingsV4Theme.Accent accent = tokens.navigationAccent();
+        LinearLayout row = new LinearLayout(context);
+        row.setOrientation(LinearLayout.HORIZONTAL);
+        row.setGravity(Gravity.CENTER_VERTICAL);
+        row.setMinimumHeight(dp(84));
+        row.setPadding(dp(14), dp(10), dp(10), dp(10));
+        row.setClickable(true);
+        row.setFocusable(true);
+        row.setBackground(MorpheSettingsV4Theme.interactive(
+                context,
+                0x00000000,
+                0,
+                accent.color
+        ));
+        row.setOnClickListener(view -> select(option));
+
+        row.addView(iconContainer(option), new LinearLayout.LayoutParams(
+                dp(56),
+                dp(56)
+        ));
+
+        TextView title = textView(option.title, 17, tokens.textPrimary);
+        title.setTypeface(Typeface.create("sans-serif-medium", Typeface.NORMAL));
+        LinearLayout.LayoutParams titleParams = new LinearLayout.LayoutParams(
+                0,
+                ViewGroup.LayoutParams.WRAP_CONTENT,
+                1.0f
+        );
+        titleParams.setMarginStart(dp(16));
+        row.addView(title, titleParams);
+
+        RadioButton selected = new RadioButton(context);
+        selected.setClickable(false);
+        selected.setFocusable(false);
+        selected.setChecked(sameAlias(selectedAlias, option.alias));
+        if (Build.VERSION.SDK_INT >= 21) {
+            selected.setButtonTintList(new ColorStateList(
+                    new int[][]{
+                            new int[]{android.R.attr.state_checked},
+                            new int[]{-android.R.attr.state_checked}
+                    },
+                    new int[]{accent.color, tokens.textSecondary}
+            ));
+        }
+        row.addView(selected, new LinearLayout.LayoutParams(dp(48), dp(48)));
+
+        if (group.getChildCount() > 0) {
+            addDivider(group);
+        }
+        group.addView(row, new LinearLayout.LayoutParams(
+                ViewGroup.LayoutParams.MATCH_PARENT,
+                ViewGroup.LayoutParams.WRAP_CONTENT
+        ));
+    }
+
+    private FrameLayout iconContainer(IconOption option) {
+        Context context = requireContext();
+        FrameLayout container = new FrameLayout(context);
+        container.setBackground(MorpheSettingsV4Theme.rounded(
+                context,
+                tokens.surfaceContainerHigh,
+                18
+        ));
+        container.setClipToOutline(true);
+
+        ImageView icon = new ImageView(context);
+        Drawable drawable = iconDrawable(option.resourceName);
+        if (drawable != null) {
+            icon.setImageDrawable(drawable);
+        }
+        icon.setScaleType(ImageView.ScaleType.CENTER_CROP);
+        container.addView(icon, new FrameLayout.LayoutParams(
+                ViewGroup.LayoutParams.MATCH_PARENT,
+                ViewGroup.LayoutParams.MATCH_PARENT,
+                Gravity.CENTER
+        ));
+        return container;
+    }
+
+    private Drawable iconDrawable(String resourceName) {
+        int resourceId = MorpheSettingsV4Catalog.resourceId(
+                requireContext(),
+                "mipmap",
+                resourceName
+        );
+        if (resourceId == 0) {
+            return null;
+        }
+        return requireContext().getResources().getDrawable(resourceId);
+    }
+
+    private void select(IconOption option) {
+        Context context = requireContext();
+        try {
+            PackageManager packageManager = context.getPackageManager();
+            for (IconOption candidate : ICONS) {
+                if (candidate.alias == null) {
+                    continue;
+                }
+                ComponentName component = aliasComponent(context, candidate.alias);
+                int state = candidate.alias.equals(option.alias)
+                        ? PackageManager.COMPONENT_ENABLED_STATE_ENABLED
+                        : PackageManager.COMPONENT_ENABLED_STATE_DISABLED;
+                packageManager.setComponentEnabledSetting(
+                        component,
+                        state,
+                        PackageManager.DONT_KILL_APP
+                );
+            }
+            selectedAlias = option.alias;
+            rebuildOptions();
+            Toast.makeText(
+                    context,
+                    option.alias == null
+                            ? "Default app icon selected"
+                            : option.title + " app icon selected",
+                    Toast.LENGTH_SHORT
+            ).show();
+        } catch (Throwable ignored) {
+            Toast.makeText(
+                    context,
+                    "This app icon is unavailable in the current Boost build.",
+                    Toast.LENGTH_SHORT
+            ).show();
+        }
+    }
+
+    private String selectedAlias(Context context) {
+        PackageManager packageManager = context.getPackageManager();
+        for (IconOption option : ICONS) {
+            if (option.alias == null) {
+                continue;
+            }
+            int state = packageManager.getComponentEnabledSetting(
+                    aliasComponent(context, option.alias)
+            );
+            if (state == PackageManager.COMPONENT_ENABLED_STATE_ENABLED) {
+                return option.alias;
+            }
+        }
+        return null;
+    }
+
+    private ComponentName aliasComponent(Context context, String alias) {
+        return new ComponentName(
+                context.getPackageName(),
+                ALIAS_PREFIX + alias
+        );
+    }
+
+    private boolean sameAlias(String first, String second) {
+        return first == null ? second == null : first.equals(second);
+    }
+
+    private LinearLayout addGroup(LinearLayout parent) {
+        Context context = requireContext();
+        MorpheSettingsV4Theme.Accent accent = tokens.navigationAccent();
+        int groupColor = MorpheSettingsV4Theme.blend(
+                tokens.surfaceContainer,
+                accent.container,
+                tokens.dark ? 0.035f : 0.025f
+        );
+        LinearLayout group = new LinearLayout(context);
+        group.setOrientation(LinearLayout.VERTICAL);
+        group.setBackground(MorpheSettingsV4Theme.rounded(
+                context,
+                groupColor,
+                24
+        ));
+        group.setClipToOutline(true);
+        parent.addView(group, new LinearLayout.LayoutParams(
+                ViewGroup.LayoutParams.MATCH_PARENT,
+                ViewGroup.LayoutParams.WRAP_CONTENT
+        ));
+        return group;
+    }
+
+    private void addDivider(LinearLayout group) {
+        View divider = new View(requireContext());
+        divider.setBackgroundColor(MorpheSettingsV4Theme.blend(
+                tokens.surfaceContainer,
+                tokens.outline,
+                tokens.dark ? 0.22f : 0.16f
+        ));
+        LinearLayout.LayoutParams params = new LinearLayout.LayoutParams(
+                ViewGroup.LayoutParams.MATCH_PARENT,
+                dp(1)
+        );
+        params.setMarginStart(dp(18));
+        params.setMarginEnd(dp(18));
+        group.addView(divider, params);
+    }
+
+    private void styleHost() {
+        Activity activity = hostActivity();
+        if (activity == null || tokens == null) {
+            return;
+        }
+        activity.setTitle("App icon");
+        BoostSystemBarInsetsFix.applyMorpheSettingsV4SystemBars(
+                activity,
+                tokens.background,
+                tokens.dark
+        );
+        int toolbarId = MorpheSettingsV4Catalog.resourceId(
+                activity,
+                "id",
+                "toolbar"
+        );
+        View toolbar = activity.findViewById(toolbarId);
+        if (toolbar != null) {
+            toolbar.setBackgroundColor(tokens.background);
+            toolbar.setElevation(0);
+        }
+    }
+
+    private Activity hostActivity() {
+        Context context = requireContext();
+        return context instanceof Activity ? (Activity) context : null;
+    }
+
+    private void hideMenuItem(Menu menu, String resourceName) {
+        int resourceId = MorpheSettingsV4Catalog.resourceId(
+                requireContext(),
+                "id",
+                resourceName
+        );
+        if (resourceId == 0) {
+            return;
+        }
+        MenuItem item = menu.findItem(resourceId);
+        if (item != null) {
+            item.setVisible(false);
+        }
+    }
+
+    private void addSectionLabel(LinearLayout parent, String value) {
+        TextView label = textView(value, 14, tokens.primary);
+        label.setTypeface(Typeface.create("sans-serif-medium", Typeface.NORMAL));
+        label.setLetterSpacing(0.02f);
+        parent.addView(label);
+    }
+
+    private TextView textView(String value, int sizeSp, int color) {
+        TextView textView = new TextView(requireContext());
+        textView.setText(value);
+        textView.setTextSize(sizeSp);
+        textView.setTextColor(color);
+        return textView;
+    }
+
+    private void addSpace(LinearLayout parent, int heightDp) {
+        View space = new View(requireContext());
+        parent.addView(space, new LinearLayout.LayoutParams(1, dp(heightDp)));
+    }
+
+    private int dp(float value) {
+        return MorpheSettingsV4Theme.dp(requireContext(), value);
+    }
+
+    private static final class IconOption {
+        final String title;
+        final String resourceName;
+        final String alias;
+
+        IconOption(String title, String resourceName, String alias) {
+            this.title = title;
+            this.resourceName = resourceName;
+            this.alias = alias;
+        }
+    }
+}

--- a/extensions/boostforreddit/src/main/java/app/morphe/extension/boostforreddit/settings/MorpheSettingsV4AppearanceFragment.java
+++ b/extensions/boostforreddit/src/main/java/app/morphe/extension/boostforreddit/settings/MorpheSettingsV4AppearanceFragment.java
@@ -2,6 +2,7 @@ package app.morphe.extension.boostforreddit.settings;
 
 import android.app.Activity;
 import android.content.Context;
+import android.content.Intent;
 import android.content.SharedPreferences;
 import android.content.res.ColorStateList;
 import android.graphics.Typeface;
@@ -26,7 +27,6 @@ import androidx.fragment.app.Fragment;
 import app.morphe.extension.boostforreddit.utils.BoostSystemBarInsetsFix;
 
 import java.lang.reflect.Field;
-import java.lang.reflect.Method;
 
 /** Morphe-owned appearance controls for the Settings v4 preview. */
 public final class MorpheSettingsV4AppearanceFragment extends Fragment {
@@ -42,6 +42,7 @@ public final class MorpheSettingsV4AppearanceFragment extends Fragment {
             "pref_colored_status_bar";
     private static final String KEY_COLORED_NAV_BAR =
             "pref_colored_nav_bar";
+    private static final String EXTRA_SHOW_FRAGMENT = "extra_show_fragment";
 
     private MorpheSettingsV4Theme.Tokens tokens;
     private SharedPreferences preferences;
@@ -101,7 +102,9 @@ public final class MorpheSettingsV4AppearanceFragment extends Fragment {
                 "App icon",
                 "Choose the icon shown by your launcher",
                 true,
-                view -> openBoostHelper("w")
+                view -> openMorpheFragment(
+                        MorpheSettingsV4Catalog.V4_APP_ICON_FRAGMENT
+                )
         );
 
         addSpace(content, 24);
@@ -336,19 +339,16 @@ public final class MorpheSettingsV4AppearanceFragment extends Fragment {
         }
     }
 
-    private void openBoostHelper(String methodName) {
+    private void openMorpheFragment(String fragmentName) {
         Activity activity = hostActivity();
         if (activity == null) {
             showUnavailable();
             return;
         }
         try {
-            Class<?> helper = Class.forName(
-                    "com.rubenmayayo.reddit.ui.activities.i"
-            );
-            Method method = helper.getDeclaredMethod(methodName, Context.class);
-            method.setAccessible(true);
-            method.invoke(null, activity);
+            Intent intent = new Intent(activity, activity.getClass());
+            intent.putExtra(EXTRA_SHOW_FRAGMENT, fragmentName);
+            activity.startActivity(intent);
         } catch (Throwable ignored) {
             showUnavailable();
         }

--- a/extensions/boostforreddit/src/main/java/app/morphe/extension/boostforreddit/settings/MorpheSettingsV4AppearanceFragment.java
+++ b/extensions/boostforreddit/src/main/java/app/morphe/extension/boostforreddit/settings/MorpheSettingsV4AppearanceFragment.java
@@ -1,0 +1,457 @@
+package app.morphe.extension.boostforreddit.settings;
+
+import android.app.Activity;
+import android.content.Context;
+import android.content.SharedPreferences;
+import android.content.res.ColorStateList;
+import android.graphics.Typeface;
+import android.os.Build;
+import android.os.Bundle;
+import android.preference.PreferenceManager;
+import android.text.TextUtils;
+import android.view.Gravity;
+import android.view.LayoutInflater;
+import android.view.Menu;
+import android.view.MenuItem;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.LinearLayout;
+import android.widget.ScrollView;
+import android.widget.Switch;
+import android.widget.TextView;
+import android.widget.Toast;
+
+import androidx.fragment.app.Fragment;
+
+import app.morphe.extension.boostforreddit.utils.BoostSystemBarInsetsFix;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+
+/** Morphe-owned appearance controls for the Settings v4 preview. */
+public final class MorpheSettingsV4AppearanceFragment extends Fragment {
+    public static final String CONTRACT_MARKER =
+            "MORPHE_BOOST_SETTINGS_V4_APPEARANCE_ISSUE106_V1";
+    public static final String COMPACT_GROUPS_MARKER =
+            "MORPHE_BOOST_SETTINGS_V4_COMPACT_GROUPS_ISSUE106_V1";
+    public static final String SYSTEM_THEME_MARKER =
+            "MORPHE_BOOST_SETTINGS_V4_SYSTEM_THEME_ISSUE106_V1";
+
+    private static final String KEY_DYNAMIC_COLORS = "pref_dynamic_colors";
+    private static final String KEY_COLORED_STATUS_BAR =
+            "pref_colored_status_bar";
+    private static final String KEY_COLORED_NAV_BAR =
+            "pref_colored_nav_bar";
+
+    private MorpheSettingsV4Theme.Tokens tokens;
+    private SharedPreferences preferences;
+
+    public MorpheSettingsV4AppearanceFragment() {
+    }
+
+    @Override
+    public View onCreateView(
+            LayoutInflater inflater,
+            ViewGroup container,
+            Bundle savedInstanceState
+    ) {
+        Context context = inflater.getContext();
+        tokens = MorpheSettingsV4Theme.resolve(context);
+        preferences = PreferenceManager.getDefaultSharedPreferences(context);
+        setHasOptionsMenu(true);
+
+        ScrollView scrollView = new ScrollView(context);
+        scrollView.setFillViewport(true);
+        scrollView.setClipToPadding(false);
+        scrollView.setBackgroundColor(tokens.background);
+
+        LinearLayout content = new LinearLayout(context);
+        content.setOrientation(LinearLayout.VERTICAL);
+        int horizontal = dp(18);
+        content.setPadding(horizontal, dp(12), horizontal, dp(32));
+        scrollView.addView(
+                content,
+                new ScrollView.LayoutParams(
+                        ViewGroup.LayoutParams.MATCH_PARENT,
+                        ViewGroup.LayoutParams.WRAP_CONTENT
+                )
+        );
+
+        addSectionLabel(content, "Appearance");
+        addSpace(content, 8);
+
+        LinearLayout appearanceGroup = addGroup(content);
+        if (Build.VERSION.SDK_INT >= 31) {
+            addSwitchRow(
+                    appearanceGroup,
+                    "Dynamic color",
+                    "Use Android's selected color palette",
+                    preferences.getBoolean(KEY_DYNAMIC_COLORS, false),
+                    checked -> updateDynamicColors(checked)
+            );
+        }
+
+        addSpace(content, 24);
+        addSectionLabel(content, "Personalization");
+        addSpace(content, 8);
+
+        LinearLayout personalizationGroup = addGroup(content);
+        addNavigationRow(
+                personalizationGroup,
+                "App icon",
+                "Choose the icon shown by your launcher",
+                true,
+                view -> openBoostHelper("w")
+        );
+
+        addSpace(content, 24);
+        addSectionLabel(content, "System bars");
+        addSpace(content, 8);
+
+        LinearLayout systemBarsGroup = addGroup(content);
+        addSwitchRow(
+                systemBarsGroup,
+                "Colored status bar",
+                "Match the status bar to Boost's toolbar",
+                preferences.getBoolean(KEY_COLORED_STATUS_BAR, true),
+                checked -> updateSystemBarPreference(
+                        KEY_COLORED_STATUS_BAR,
+                        checked
+                )
+        );
+        addSwitchRow(
+                systemBarsGroup,
+                "Colored navigation bar",
+                "Match the system navigation area to Boost's toolbar",
+                preferences.getBoolean(KEY_COLORED_NAV_BAR, false),
+                checked -> updateSystemBarPreference(
+                        KEY_COLORED_NAV_BAR,
+                        checked
+                )
+        );
+
+        return scrollView;
+    }
+
+    @Override
+    public void onResume() {
+        super.onResume();
+        styleHost();
+    }
+
+    @Override
+    public void onPause() {
+        Activity activity = hostActivity();
+        if (activity != null) {
+            BoostSystemBarInsetsFix.clearMorpheSettingsV4SystemBars(activity);
+        }
+        super.onPause();
+    }
+
+    @Override
+    public void onPrepareOptionsMenu(Menu menu) {
+        super.onPrepareOptionsMenu(menu);
+        hideMenuItem(menu, "action_generic_search");
+        hideMenuItem(menu, "action_search");
+        hideMenuItem(menu, "search");
+    }
+
+    private LinearLayout addGroup(LinearLayout parent) {
+        Context context = requireContext();
+        MorpheSettingsV4Theme.Accent accent = tokens.navigationAccent();
+        int groupColor = MorpheSettingsV4Theme.blend(
+                tokens.surfaceContainer,
+                accent.container,
+                tokens.dark ? 0.035f : 0.025f
+        );
+        LinearLayout group = new LinearLayout(context);
+        group.setOrientation(LinearLayout.VERTICAL);
+        group.setBackground(MorpheSettingsV4Theme.rounded(
+                context,
+                groupColor,
+                24
+        ));
+        group.setClipToOutline(true);
+        parent.addView(group, new LinearLayout.LayoutParams(
+                ViewGroup.LayoutParams.MATCH_PARENT,
+                ViewGroup.LayoutParams.WRAP_CONTENT
+        ));
+        return group;
+    }
+
+    private void addNavigationRow(
+            LinearLayout parent,
+            String titleValue,
+            String summaryValue,
+            boolean enabled,
+            View.OnClickListener listener
+    ) {
+        Context context = requireContext();
+        MorpheSettingsV4Theme.Accent accent = tokens.navigationAccent();
+        LinearLayout row = baseRow(context);
+        row.setEnabled(enabled);
+        row.setAlpha(enabled ? 1.0f : 0.44f);
+        if (enabled) {
+            row.setClickable(true);
+            row.setFocusable(true);
+            row.setOnClickListener(listener);
+        }
+
+        row.addView(createLabels(titleValue, summaryValue), labelsParams());
+
+        TextView chevron = textView("›", 28, accent.color);
+        chevron.setGravity(Gravity.CENTER);
+        row.addView(chevron, new LinearLayout.LayoutParams(dp(28), dp(44)));
+        addGroupedRow(parent, row);
+    }
+
+    private void addSwitchRow(
+            LinearLayout parent,
+            String titleValue,
+            String summaryValue,
+            boolean checked,
+            CheckedChange change
+    ) {
+        Context context = requireContext();
+        MorpheSettingsV4Theme.Accent accent = tokens.navigationAccent();
+        LinearLayout row = baseRow(context);
+        row.setClickable(true);
+        row.setFocusable(true);
+        row.addView(createLabels(titleValue, summaryValue), labelsParams());
+
+        Switch toggle = new Switch(context);
+        toggle.setChecked(checked);
+        if (Build.VERSION.SDK_INT >= 21) {
+            int[][] states = new int[][]{
+                    new int[]{android.R.attr.state_checked},
+                    new int[]{-android.R.attr.state_checked}
+            };
+            toggle.setThumbTintList(new ColorStateList(
+                    states,
+                    new int[]{accent.color, tokens.textSecondary}
+            ));
+            toggle.setTrackTintList(new ColorStateList(
+                    states,
+                    new int[]{
+                            MorpheSettingsV4Theme.blend(
+                                    tokens.surfaceContainerHigh,
+                                    accent.container,
+                                    0.72f
+                            ),
+                            tokens.surfaceContainerHigh
+                    }
+            ));
+        }
+        toggle.setOnCheckedChangeListener(
+                (button, value) -> change.onChanged(value)
+        );
+        row.setOnClickListener(view -> toggle.toggle());
+        row.addView(toggle, new LinearLayout.LayoutParams(
+                ViewGroup.LayoutParams.WRAP_CONTENT,
+                ViewGroup.LayoutParams.WRAP_CONTENT
+        ));
+        addGroupedRow(parent, row);
+    }
+
+    private LinearLayout baseRow(Context context) {
+        MorpheSettingsV4Theme.Accent accent = tokens.navigationAccent();
+        LinearLayout row = new LinearLayout(context);
+        row.setOrientation(LinearLayout.HORIZONTAL);
+        row.setGravity(Gravity.CENTER_VERTICAL);
+        row.setMinimumHeight(dp(68));
+        row.setPadding(dp(18), dp(10), dp(14), dp(10));
+        row.setBackground(MorpheSettingsV4Theme.interactive(
+                context,
+                0x00000000,
+                0,
+                accent.color
+        ));
+        return row;
+    }
+
+    private void addGroupedRow(LinearLayout group, LinearLayout row) {
+        if (group.getChildCount() > 0) {
+            addGroupDivider(group);
+        }
+        group.addView(row, new LinearLayout.LayoutParams(
+                ViewGroup.LayoutParams.MATCH_PARENT,
+                ViewGroup.LayoutParams.WRAP_CONTENT
+        ));
+    }
+
+    private void addGroupDivider(LinearLayout group) {
+        View divider = new View(requireContext());
+        divider.setBackgroundColor(MorpheSettingsV4Theme.blend(
+                tokens.surfaceContainer,
+                tokens.outline,
+                tokens.dark ? 0.22f : 0.16f
+        ));
+        LinearLayout.LayoutParams params = new LinearLayout.LayoutParams(
+                ViewGroup.LayoutParams.MATCH_PARENT,
+                dp(1)
+        );
+        params.setMarginStart(dp(18));
+        params.setMarginEnd(dp(18));
+        group.addView(divider, params);
+    }
+
+    private LinearLayout createLabels(String titleValue, String summaryValue) {
+        LinearLayout labels = new LinearLayout(requireContext());
+        labels.setOrientation(LinearLayout.VERTICAL);
+
+        TextView title = textView(titleValue, 16, tokens.textPrimary);
+        title.setTypeface(Typeface.create("sans-serif-medium", Typeface.NORMAL));
+        labels.addView(title);
+
+        if (!TextUtils.isEmpty(summaryValue)) {
+            TextView summary = textView(summaryValue, 14, tokens.textSecondary);
+            summary.setLineSpacing(0, 1.04f);
+            summary.setMaxLines(3);
+            LinearLayout.LayoutParams summaryParams = wrapParams();
+            summaryParams.topMargin = dp(3);
+            labels.addView(summary, summaryParams);
+        }
+        return labels;
+    }
+
+    private void updateDynamicColors(boolean enabled) {
+        preferences.edit().putBoolean(KEY_DYNAMIC_COLORS, enabled).apply();
+        setBoostStaticBoolean("i");
+        recreateHost();
+    }
+
+    private void updateSystemBarPreference(String key, boolean enabled) {
+        preferences.edit().putBoolean(key, enabled).apply();
+        setBoostStaticBoolean("h");
+        recreateHost();
+    }
+
+    private void setBoostStaticBoolean(String fieldName) {
+        try {
+            Class<?> settings = Class.forName("id.b");
+            Field field = settings.getDeclaredField(fieldName);
+            field.setAccessible(true);
+            field.setBoolean(null, true);
+        } catch (Throwable ignored) {
+        }
+    }
+
+    private void openBoostHelper(String methodName) {
+        Activity activity = hostActivity();
+        if (activity == null) {
+            showUnavailable();
+            return;
+        }
+        try {
+            Class<?> helper = Class.forName(
+                    "com.rubenmayayo.reddit.ui.activities.i"
+            );
+            Method method = helper.getDeclaredMethod(methodName, Context.class);
+            method.setAccessible(true);
+            method.invoke(null, activity);
+        } catch (Throwable ignored) {
+            showUnavailable();
+        }
+    }
+
+    private void styleHost() {
+        Activity activity = hostActivity();
+        if (activity == null || tokens == null) {
+            return;
+        }
+        activity.setTitle("Appearance");
+        BoostSystemBarInsetsFix.applyMorpheSettingsV4SystemBars(
+                activity,
+                tokens.background,
+                tokens.dark
+        );
+        int toolbarId = MorpheSettingsV4Catalog.resourceId(
+                activity,
+                "id",
+                "toolbar"
+        );
+        View toolbar = activity.findViewById(toolbarId);
+        if (toolbar != null) {
+            toolbar.setBackgroundColor(tokens.background);
+            toolbar.setElevation(0);
+        }
+    }
+
+    private Activity hostActivity() {
+        Context context = requireContext();
+        return context instanceof Activity ? (Activity) context : null;
+    }
+
+    private void recreateHost() {
+        Activity activity = hostActivity();
+        if (activity != null) {
+            activity.recreate();
+        }
+    }
+
+    private void hideMenuItem(Menu menu, String resourceName) {
+        int resourceId = MorpheSettingsV4Catalog.resourceId(
+                requireContext(),
+                "id",
+                resourceName
+        );
+        if (resourceId == 0) {
+            return;
+        }
+        MenuItem item = menu.findItem(resourceId);
+        if (item != null) {
+            item.setVisible(false);
+        }
+    }
+
+    private void addSectionLabel(LinearLayout parent, String value) {
+        TextView label = textView(value, 14, tokens.primary);
+        label.setTypeface(Typeface.create("sans-serif-medium", Typeface.NORMAL));
+        label.setLetterSpacing(0.02f);
+        parent.addView(label);
+    }
+
+    private TextView textView(String value, int sizeSp, int color) {
+        TextView textView = new TextView(requireContext());
+        textView.setText(value);
+        textView.setTextSize(sizeSp);
+        textView.setTextColor(color);
+        return textView;
+    }
+
+    private LinearLayout.LayoutParams labelsParams() {
+        return new LinearLayout.LayoutParams(
+                0,
+                ViewGroup.LayoutParams.WRAP_CONTENT,
+                1.0f
+        );
+    }
+
+    private LinearLayout.LayoutParams wrapParams() {
+        return new LinearLayout.LayoutParams(
+                ViewGroup.LayoutParams.WRAP_CONTENT,
+                ViewGroup.LayoutParams.WRAP_CONTENT
+        );
+    }
+
+    private void addSpace(LinearLayout parent, int heightDp) {
+        View space = new View(requireContext());
+        parent.addView(space, new LinearLayout.LayoutParams(1, dp(heightDp)));
+    }
+
+    private int dp(float value) {
+        return MorpheSettingsV4Theme.dp(requireContext(), value);
+    }
+
+    private void showUnavailable() {
+        Toast.makeText(
+                requireContext(),
+                "This appearance control is unavailable in the current Boost build.",
+                Toast.LENGTH_SHORT
+        ).show();
+    }
+
+    private interface CheckedChange {
+        void onChanged(boolean checked);
+    }
+}

--- a/extensions/boostforreddit/src/main/java/app/morphe/extension/boostforreddit/settings/MorpheSettingsV4AppearanceFragment.java
+++ b/extensions/boostforreddit/src/main/java/app/morphe/extension/boostforreddit/settings/MorpheSettingsV4AppearanceFragment.java
@@ -318,18 +318,37 @@ public final class MorpheSettingsV4AppearanceFragment extends Fragment {
     }
 
     private void updateDynamicColors(boolean enabled) {
+        applyDynamicColors(preferences, enabled);
+        recreateHost();
+    }
+
+    static void applyDynamicColors(
+            SharedPreferences preferences,
+            boolean enabled
+    ) {
         preferences.edit().putBoolean(KEY_DYNAMIC_COLORS, enabled).apply();
         setBoostStaticBoolean("i");
-        recreateHost();
     }
 
     private void updateSystemBarPreference(String key, boolean enabled) {
-        preferences.edit().putBoolean(key, enabled).apply();
-        setBoostStaticBoolean("h");
+        applySystemBarPreference(preferences, key, enabled);
         recreateHost();
     }
 
-    private void setBoostStaticBoolean(String fieldName) {
+    static void applySystemBarPreference(
+            SharedPreferences preferences,
+            String key,
+            boolean enabled
+    ) {
+        if (!KEY_COLORED_STATUS_BAR.equals(key)
+                && !KEY_COLORED_NAV_BAR.equals(key)) {
+            throw new IllegalArgumentException("unsupported system bar key " + key);
+        }
+        preferences.edit().putBoolean(key, enabled).apply();
+        setBoostStaticBoolean("h");
+    }
+
+    private static void setBoostStaticBoolean(String fieldName) {
         try {
             Class<?> settings = Class.forName("id.b");
             Field field = settings.getDeclaredField(fieldName);

--- a/extensions/boostforreddit/src/main/java/app/morphe/extension/boostforreddit/settings/MorpheSettingsV4AppearanceFragment.java
+++ b/extensions/boostforreddit/src/main/java/app/morphe/extension/boostforreddit/settings/MorpheSettingsV4AppearanceFragment.java
@@ -4,7 +4,6 @@ import android.app.Activity;
 import android.content.Context;
 import android.content.Intent;
 import android.content.SharedPreferences;
-import android.content.res.ColorStateList;
 import android.graphics.Typeface;
 import android.os.Build;
 import android.os.Bundle;
@@ -18,7 +17,6 @@ import android.view.View;
 import android.view.ViewGroup;
 import android.widget.LinearLayout;
 import android.widget.ScrollView;
-import android.widget.Switch;
 import android.widget.TextView;
 import android.widget.Toast;
 
@@ -68,8 +66,8 @@ public final class MorpheSettingsV4AppearanceFragment extends Fragment {
 
         LinearLayout content = new LinearLayout(context);
         content.setOrientation(LinearLayout.VERTICAL);
-        int horizontal = dp(18);
-        content.setPadding(horizontal, dp(12), horizontal, dp(32));
+        int horizontal = dp(16);
+        content.setPadding(horizontal, dp(10), horizontal, dp(32));
         scrollView.addView(
                 content,
                 new ScrollView.LayoutParams(
@@ -160,21 +158,7 @@ public final class MorpheSettingsV4AppearanceFragment extends Fragment {
     }
 
     private LinearLayout addGroup(LinearLayout parent) {
-        Context context = requireContext();
-        MorpheSettingsV4Theme.Accent accent = tokens.navigationAccent();
-        int groupColor = MorpheSettingsV4Theme.blend(
-                tokens.surfaceContainer,
-                accent.container,
-                tokens.dark ? 0.035f : 0.025f
-        );
-        LinearLayout group = new LinearLayout(context);
-        group.setOrientation(LinearLayout.VERTICAL);
-        group.setBackground(MorpheSettingsV4Theme.rounded(
-                context,
-                groupColor,
-                24
-        ));
-        group.setClipToOutline(true);
+        LinearLayout group = MorpheSettingsV14Ui.group(requireContext());
         parent.addView(group, new LinearLayout.LayoutParams(
                 ViewGroup.LayoutParams.MATCH_PARENT,
                 ViewGroup.LayoutParams.WRAP_CONTENT
@@ -190,7 +174,6 @@ public final class MorpheSettingsV4AppearanceFragment extends Fragment {
             View.OnClickListener listener
     ) {
         Context context = requireContext();
-        MorpheSettingsV4Theme.Accent accent = tokens.navigationAccent();
         LinearLayout row = baseRow(context);
         row.setEnabled(enabled);
         row.setAlpha(enabled ? 1.0f : 0.44f);
@@ -202,9 +185,7 @@ public final class MorpheSettingsV4AppearanceFragment extends Fragment {
 
         row.addView(createLabels(titleValue, summaryValue), labelsParams());
 
-        TextView chevron = textView("›", 28, accent.color);
-        chevron.setGravity(Gravity.CENTER);
-        row.addView(chevron, new LinearLayout.LayoutParams(dp(28), dp(44)));
+        row.addView(MorpheSettingsV14Ui.chevron(context, tokens));
         addGroupedRow(parent, row);
     }
 
@@ -222,29 +203,8 @@ public final class MorpheSettingsV4AppearanceFragment extends Fragment {
         row.setFocusable(true);
         row.addView(createLabels(titleValue, summaryValue), labelsParams());
 
-        Switch toggle = new Switch(context);
-        toggle.setChecked(checked);
-        if (Build.VERSION.SDK_INT >= 21) {
-            int[][] states = new int[][]{
-                    new int[]{android.R.attr.state_checked},
-                    new int[]{-android.R.attr.state_checked}
-            };
-            toggle.setThumbTintList(new ColorStateList(
-                    states,
-                    new int[]{accent.color, tokens.textSecondary}
-            ));
-            toggle.setTrackTintList(new ColorStateList(
-                    states,
-                    new int[]{
-                            MorpheSettingsV4Theme.blend(
-                                    tokens.surfaceContainerHigh,
-                                    accent.container,
-                                    0.72f
-                            ),
-                            tokens.surfaceContainerHigh
-                    }
-            ));
-        }
+        MorpheSettingsV14Ui.Toggle toggle =
+                new MorpheSettingsV14Ui.Toggle(context, tokens, checked);
         toggle.setOnCheckedChangeListener(
                 (button, value) -> change.onChanged(value)
         );
@@ -257,29 +217,11 @@ public final class MorpheSettingsV4AppearanceFragment extends Fragment {
     }
 
     private LinearLayout baseRow(Context context) {
-        MorpheSettingsV4Theme.Accent accent = tokens.navigationAccent();
-        LinearLayout row = new LinearLayout(context);
-        row.setOrientation(LinearLayout.HORIZONTAL);
-        row.setGravity(Gravity.CENTER_VERTICAL);
-        row.setMinimumHeight(dp(68));
-        row.setPadding(dp(18), dp(10), dp(14), dp(10));
-        row.setBackground(MorpheSettingsV4Theme.interactive(
-                context,
-                0x00000000,
-                0,
-                accent.color
-        ));
-        return row;
+        return MorpheSettingsV14Ui.baseRow(context, tokens);
     }
 
     private void addGroupedRow(LinearLayout group, LinearLayout row) {
-        if (group.getChildCount() > 0) {
-            addGroupDivider(group);
-        }
-        group.addView(row, new LinearLayout.LayoutParams(
-                ViewGroup.LayoutParams.MATCH_PARENT,
-                ViewGroup.LayoutParams.WRAP_CONTENT
-        ));
+        MorpheSettingsV14Ui.addSegmentedRow(group, row, tokens);
     }
 
     private void addGroupDivider(LinearLayout group) {
@@ -299,22 +241,12 @@ public final class MorpheSettingsV4AppearanceFragment extends Fragment {
     }
 
     private LinearLayout createLabels(String titleValue, String summaryValue) {
-        LinearLayout labels = new LinearLayout(requireContext());
-        labels.setOrientation(LinearLayout.VERTICAL);
-
-        TextView title = textView(titleValue, 16, tokens.textPrimary);
-        title.setTypeface(Typeface.create("sans-serif-medium", Typeface.NORMAL));
-        labels.addView(title);
-
-        if (!TextUtils.isEmpty(summaryValue)) {
-            TextView summary = textView(summaryValue, 14, tokens.textSecondary);
-            summary.setLineSpacing(0, 1.04f);
-            summary.setMaxLines(3);
-            LinearLayout.LayoutParams summaryParams = wrapParams();
-            summaryParams.topMargin = dp(3);
-            labels.addView(summary, summaryParams);
-        }
-        return labels;
+        return MorpheSettingsV14Ui.labels(
+                requireContext(),
+                tokens,
+                titleValue,
+                summaryValue
+        );
     }
 
     private void updateDynamicColors(boolean enabled) {
@@ -424,10 +356,11 @@ public final class MorpheSettingsV4AppearanceFragment extends Fragment {
     }
 
     private void addSectionLabel(LinearLayout parent, String value) {
-        TextView label = textView(value, 14, tokens.primary);
-        label.setTypeface(Typeface.create("sans-serif-medium", Typeface.NORMAL));
-        label.setLetterSpacing(0.02f);
-        parent.addView(label);
+        parent.addView(MorpheSettingsV14Ui.sectionLabel(
+                requireContext(),
+                tokens,
+                value
+        ));
     }
 
     private TextView textView(String value, int sizeSp, int color) {

--- a/extensions/boostforreddit/src/main/java/app/morphe/extension/boostforreddit/settings/MorpheSettingsV4BindingRuntimeAuditFragment.java
+++ b/extensions/boostforreddit/src/main/java/app/morphe/extension/boostforreddit/settings/MorpheSettingsV4BindingRuntimeAuditFragment.java
@@ -1,0 +1,1740 @@
+package app.morphe.extension.boostforreddit.settings;
+
+import android.app.Activity;
+import android.content.ComponentName;
+import android.content.Context;
+import android.content.ContextWrapper;
+import android.content.Intent;
+import android.content.SharedPreferences;
+import android.content.pm.PackageManager;
+import android.graphics.drawable.ColorDrawable;
+import android.graphics.drawable.Drawable;
+import android.os.Build;
+import android.os.Bundle;
+import android.preference.PreferenceManager;
+import android.text.TextUtils;
+import android.util.Log;
+import android.util.TypedValue;
+import android.view.Gravity;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.view.Window;
+import android.widget.SeekBar;
+import android.widget.TextView;
+
+import androidx.fragment.app.Fragment;
+
+import app.morphe.extension.boostforreddit.utils.BoostSystemBarInsetsFix;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Explicit DEV-only transaction used by the repository runtime binding audit.
+ * This fragment is never linked from the settings UI.
+ */
+public final class MorpheSettingsV4BindingRuntimeAuditFragment extends Fragment {
+    public static final String CONTRACT_MARKER =
+            "MORPHE_BOOST_SETTINGS_BINDING_RUNTIME_AUDIT_ISSUE106_V1";
+    public static final String EFFECT_CONTRACT_MARKER =
+            "MORPHE_BOOST_SETTINGS_APPEARANCE_LAYOUT_EFFECT_AUDIT_ISSUE106_V1";
+    public static final String HARNESS_CONTRACT_MARKER =
+            "MORPHE_BOOST_SETTINGS_AUDIT_HARNESS_V56";
+    public static final String SYSTEM_BAR_RENDER_CONTRACT_MARKER =
+            "MORPHE_BOOST_SETTINGS_AUDIT_SYSTEM_BARS_ANDROID15_V56_1";
+
+    private static final String TAG = "MorpheSettingsAudit";
+    private static final String DEV_PACKAGE = "com.rubenmayayo.reddit.dev";
+    private static final String EXTRA_PHASE =
+            "morphe_settings_binding_audit_phase";
+    private static final String EXTRA_NONCE =
+            "morphe_settings_binding_audit_nonce";
+    private static final String EXTRA_SCOPE =
+            "morphe_settings_binding_audit_scope";
+    private static final String SCOPE_APPEARANCE_LAYOUT = "appearance-layout";
+    private static final String PHASE_WRITE = "write";
+    private static final String PHASE_VERIFY_RESTORE = "verify_restore";
+    private static final String PHASE_RECOVER = "recover";
+    private static final String PHASE_RECOVER_FORCE = "recover_force";
+    private static final String STATUS_BAR_SURFACE_TAG =
+            "MORPHE_BOOST_COMMENTS_SYSTEM_BAR_SURFACE_V1";
+    private static final String NAVIGATION_BAR_SURFACE_TAG =
+            "MORPHE_BOOST_SETTINGS_V4_NAVIGATION_SURFACE_ISSUE106_V3";
+
+    private static final String SNAPSHOT_PREFERENCES =
+            "morphe.settings.binding.runtime.snapshot";
+    private static final String SNAPSHOT_ACTIVE = "snapshot_active";
+    private static final String SNAPSHOT_NONCE = "snapshot_nonce";
+    private static final String SNAPSHOT_SCOPE = "snapshot_scope";
+    private static final String SNAPSHOT_STARTED_AT = "snapshot_started_at";
+    private static final String SNAPSHOT_AUDIT_ICON_ALIAS =
+            "snapshot_audit_icon_alias";
+    private static final String SNAPSHOT_ICON_STATES_PRESENT =
+            "snapshot_icon_states_present";
+    private static final long SNAPSHOT_LOCK_TIMEOUT_MS = 30L * 60L * 1000L;
+    private static final String SAVED_VIEW_PREFERENCES =
+            "com.rubenmayayo.reddit.VIEW_PER_SUBSCRIPTION";
+    private static final String SAVED_VIEW_AUDIT_KEY =
+            "__morphe_runtime_binding_audit__";
+
+    private static final String[] BOOLEAN_KEYS = new String[]{
+            "pref_dynamic_colors",
+            "pref_colored_status_bar",
+            "pref_colored_nav_bar",
+            "pref_view_per_subscription",
+            "pref_left_handed",
+            "pref_show_subreddit_prefix",
+            "pref_cards_rounded_corners",
+            "pref_cards_full_preview",
+            "pref_cards_subreddit_icon",
+            "pref_cards_gallery_carousel",
+            "pref_cards_links_as_thumbnails",
+            "pref_cards_preview_self",
+            "pref_mini_cards_rounded_corners",
+            "pref_mini_cards_truncate_title",
+            "pref_mini_cards_buttons_visible",
+            "pref_dense_buttons_visible",
+            "pref_load_readability",
+            "pref_lock_sidebar",
+    };
+
+    private static final String[] BOOLEAN_DEFAULT_TRUE_KEYS = new String[]{
+            "pref_colored_status_bar",
+            "pref_cards_subreddit_icon",
+            "pref_cards_gallery_carousel",
+            "pref_cards_links_as_thumbnails",
+            "pref_cards_preview_self",
+            "pref_mini_cards_rounded_corners",
+            "pref_mini_cards_truncate_title",
+    };
+
+    private static final String[] STRING_KEYS = new String[]{
+            "pref_view",
+            "pref_title_font",
+            "pref_font_size_title",
+            "pref_comments_font",
+            "pref_font_size",
+    };
+
+    private static final String[] INTEGER_KEYS = new String[]{
+            "pref_cards_preview_self_lines",
+    };
+
+    private static final String[] VIEW_VALUES = new String[]{
+            "0", "7", "1", "4", "5", "2", "6", "3"
+    };
+
+    private static final int[] SAVED_VIEW_VALUES = new int[]{
+            0, 7, 1, 4, 5, 2, 6, 3
+    };
+
+    private static final String[] FONT_VALUES = new String[]{
+            "",
+            "sans-serif-thin",
+            "sans-serif-light",
+            "sans-serif",
+            "sans-serif-medium",
+            "sans-serif-black",
+            "sans-serif-condensed-light",
+            "sans-serif-condensed",
+            "serif",
+            "monospace",
+            "serif-monospace",
+            "sans-serif-smallcaps",
+            "RobotoSlab-Regular.ttf",
+    };
+
+    private static final String[] FONT_SIZE_VALUES = new String[]{
+            "XSmall", "Small", "Medium", "Large", "XLarge", "XXLarge"
+    };
+
+    private static final int INTEGER_MINIMUM = 0;
+    private static final int INTEGER_MAXIMUM = 100;
+    private static final int AUDIT_ITEM_COUNT = 26;
+    private static final int DOMAIN_ACTION_COUNT = 196;
+    private static final int EFFECT_AUDIT_RELOAD_COUNT = 26;
+    private static final int RENDER_PROBE_COUNT = 6;
+
+    private static final String ICON_ALIAS_PREFIX = "com.rubenmayayo.reddit.";
+    private static final String[] ICON_RESOURCES = new String[]{
+            "ic_launcher",
+            "ic_launcher_grey",
+            "ic_launcher_vivid",
+            "ic_launcher_metal",
+            "ic_launcher_yellow",
+    };
+    private static final String[] ICON_ALIASES = new String[]{
+            "grey", "vivid", "metal", "yellow"
+    };
+    private static final String[] ICON_AUDIT_VALUES = new String[]{
+            "", "grey", "vivid", "metal", "yellow"
+    };
+
+    @Override
+    public View onCreateView(
+            LayoutInflater inflater,
+            ViewGroup container,
+            Bundle savedInstanceState
+    ) {
+        Activity activity = activityFromContext(inflater.getContext());
+        Intent intent = activity == null ? null : activity.getIntent();
+        String phase = intent == null ? null : intent.getStringExtra(EXTRA_PHASE);
+        String nonce = intent == null ? null : intent.getStringExtra(EXTRA_NONCE);
+        String scope = intent == null ? null : intent.getStringExtra(EXTRA_SCOPE);
+        if (intent != null) {
+            intent.removeExtra(EXTRA_PHASE);
+            intent.removeExtra(EXTRA_NONCE);
+            intent.removeExtra(EXTRA_SCOPE);
+        }
+        if (!TextUtils.isEmpty(phase) && activity != null) {
+            runAudit(activity, phase, nonce, scope);
+        }
+
+        TextView status = new TextView(inflater.getContext());
+        status.setText("Morphe DEV binding audit");
+        status.setTextSize(18);
+        status.setGravity(Gravity.CENTER);
+        return status;
+    }
+
+    private static Activity activityFromContext(Context context) {
+        Context current = context;
+        while (current instanceof ContextWrapper) {
+            if (current instanceof Activity) {
+                return (Activity) current;
+            }
+            Context base = ((ContextWrapper) current).getBaseContext();
+            if (base == current) {
+                break;
+            }
+            current = base;
+        }
+        return current instanceof Activity ? (Activity) current : null;
+    }
+
+    private static void runAudit(
+            Context context,
+            String phase,
+            String nonce,
+            String scope
+    ) {
+        if (!DEV_PACKAGE.equals(context.getPackageName())) {
+            Log.e(TAG, "MORPHE_BINDING_AUDIT_REFUSED_NON_DEV_PACKAGE");
+            return;
+        }
+
+        if (!SCOPE_APPEARANCE_LAYOUT.equals(scope)) {
+            Log.e(TAG, "MORPHE_BINDING_AUDIT_FAIL scope=unsupported");
+            return;
+        }
+
+        try {
+            if (PHASE_WRITE.equals(phase)) {
+                writeAuditValues(context, nonce, scope);
+            } else if (PHASE_VERIFY_RESTORE.equals(phase)) {
+                verifyReloadAndRestore(context, nonce, scope);
+            } else if (PHASE_RECOVER.equals(phase)) {
+                recoverIfNeeded(context, nonce, scope, false);
+            } else if (PHASE_RECOVER_FORCE.equals(phase)) {
+                recoverIfNeeded(context, nonce, scope, true);
+            } else {
+                Log.e(TAG, "MORPHE_BINDING_AUDIT_FAIL phase=unknown");
+            }
+        } catch (Throwable throwable) {
+            Log.e(TAG, "MORPHE_BINDING_AUDIT_FAIL phase=" + phase, throwable);
+        }
+    }
+
+    private static void writeAuditValues(
+            Context context,
+            String nonce,
+            String scope
+    ) {
+        if (TextUtils.isEmpty(nonce)) {
+            Log.e(TAG, "MORPHE_BINDING_AUDIT_FAIL phase=write missing_nonce");
+            return;
+        }
+
+        SharedPreferences snapshot = snapshotPreferences(context);
+        if (snapshot.getBoolean(SNAPSHOT_ACTIVE, false)) {
+            long startedAt = snapshot.getLong(SNAPSHOT_STARTED_AT, 0L);
+            long now = System.currentTimeMillis();
+            boolean fresh = startedAt > 0L
+                    && (startedAt > now
+                    || now - startedAt < SNAPSHOT_LOCK_TIMEOUT_MS);
+            if (fresh) {
+                Log.e(
+                        TAG,
+                        "MORPHE_BINDING_AUDIT_FAIL phase=write active_lock"
+                );
+                return;
+            }
+            boolean recovered = restoreOriginalValues(context, snapshot);
+            if (!recovered) {
+                Log.e(TAG, "MORPHE_BINDING_AUDIT_FAIL phase=write stale_restore");
+                return;
+            }
+            snapshot.edit().clear().commit();
+            Log.w(TAG, "MORPHE_BINDING_AUDIT_STALE_SNAPSHOT_RECOVERED");
+        }
+
+        SharedPreferences defaults =
+                PreferenceManager.getDefaultSharedPreferences(context);
+        SharedPreferences savedViews = context.getSharedPreferences(
+                SAVED_VIEW_PREFERENCES,
+                Context.MODE_PRIVATE
+        );
+
+        if (!validateExistingTypes(defaults)) {
+            Log.e(TAG, "MORPHE_BINDING_AUDIT_FAIL phase=write invalid_existing_type");
+            return;
+        }
+        if (!createSnapshot(
+                context,
+                snapshot,
+                defaults,
+                savedViews,
+                nonce,
+                scope
+        )) {
+            Log.e(TAG, "MORPHE_BINDING_AUDIT_FAIL phase=write snapshot_commit");
+            return;
+        }
+
+        try {
+            exerciseFullDomainsViaUiActions(
+                    context,
+                    defaults,
+                    savedViews,
+                    snapshot
+            );
+            runRenderedEffectProbes(context, snapshot);
+            if (!verifyIconComponents(context)) {
+                throw new IllegalStateException("app icon component audit failed");
+            }
+            Log.i(TAG, "MORPHE_BINDING_AUDIT_APP_ICONS_OK");
+            Log.i(TAG, "MORPHE_BINDING_AUDIT_WRITE_OK nonce=" + nonce);
+        } catch (Throwable throwable) {
+            boolean restored = restoreOriginalValues(context, snapshot);
+            if (restored) {
+                snapshot.edit().clear().commit();
+            }
+            Log.e(
+                    TAG,
+                    "MORPHE_BINDING_AUDIT_FAIL phase=write restored=" + restored,
+                    throwable
+            );
+        }
+    }
+
+    private static void verifyReloadAndRestore(
+            Context context,
+            String nonce,
+            String scope
+    ) {
+        SharedPreferences snapshot = snapshotPreferences(context);
+        if (!snapshot.getBoolean(SNAPSHOT_ACTIVE, false)) {
+            Log.e(TAG, "MORPHE_BINDING_AUDIT_FAIL phase=verify no_snapshot");
+            return;
+        }
+
+        String expectedNonce = snapshot.getString(SNAPSHOT_NONCE, "");
+        String expectedScope = snapshot.getString(SNAPSHOT_SCOPE, "");
+        boolean nonceMatches = !TextUtils.isEmpty(nonce)
+                && nonce.equals(expectedNonce)
+                && scope.equals(expectedScope);
+        boolean verified = false;
+        boolean effectsReloaded = false;
+        boolean iconsVerified = false;
+        try {
+            verified = nonceMatches && verifyPersistedAuditValues(context, snapshot);
+            effectsReloaded = verified
+                    && verifyNativeConsumersAfterReload(context, snapshot);
+            iconsVerified = verified
+                    && verifyExpectedAuditIcon(context, snapshot)
+                    && verifyIconComponents(context);
+            if (verified) {
+                Log.i(TAG, "MORPHE_BINDING_AUDIT_RELOAD_OK nonce=" + expectedNonce);
+            }
+            if (iconsVerified) {
+                Log.i(TAG, "MORPHE_BINDING_AUDIT_APP_ICONS_OK");
+            }
+        } catch (Throwable throwable) {
+            Log.e(TAG, "MORPHE_BINDING_AUDIT_VERIFY_EXCEPTION", throwable);
+        }
+
+        boolean restored = restoreOriginalValues(context, snapshot);
+        if (restored) {
+            snapshot.edit().clear().commit();
+            Log.i(TAG, "MORPHE_BINDING_AUDIT_RESTORE_OK nonce=" + expectedNonce);
+        }
+
+        if (verified && effectsReloaded && iconsVerified && restored) {
+            Log.i(
+                    TAG,
+                    "RESULT=MORPHE_BOOST_SETTINGS_APPEARANCE_LAYOUT_AUDIT_V56_APP_PASS"
+            );
+        } else {
+            Log.e(
+                    TAG,
+                    "MORPHE_BINDING_AUDIT_FAIL phase=verify"
+                            + " nonce=" + nonceMatches
+                            + " persisted=" + verified
+                            + " effects_reloaded=" + effectsReloaded
+                            + " icons=" + iconsVerified
+                            + " restored=" + restored
+            );
+        }
+    }
+
+    private static void recoverIfNeeded(
+            Context context,
+            String nonce,
+            String scope,
+            boolean force
+    ) {
+        SharedPreferences snapshot = snapshotPreferences(context);
+        if (!snapshot.getBoolean(SNAPSHOT_ACTIVE, false)) {
+            Log.i(TAG, "MORPHE_BINDING_AUDIT_RECOVERY_NOT_NEEDED");
+            return;
+        }
+        String expectedNonce = snapshot.getString(SNAPSHOT_NONCE, "");
+        String expectedScope = snapshot.getString(SNAPSHOT_SCOPE, "");
+        if (!force && (!TextUtils.equals(nonce, expectedNonce)
+                || !TextUtils.equals(scope, expectedScope))) {
+            Log.e(TAG, "MORPHE_BINDING_AUDIT_FAIL phase=recover owner_mismatch");
+            return;
+        }
+        if (force) {
+            Log.w(TAG, "MORPHE_BINDING_AUDIT_ORPHAN_RECOVERY_FORCED");
+        }
+        boolean restored = restoreOriginalValues(context, snapshot);
+        if (restored) {
+            snapshot.edit().clear().commit();
+            Log.i(TAG, "MORPHE_BINDING_AUDIT_RECOVERY_OK");
+        } else {
+            Log.e(TAG, "MORPHE_BINDING_AUDIT_FAIL phase=recover");
+        }
+    }
+
+    private static SharedPreferences snapshotPreferences(Context context) {
+        return context.getSharedPreferences(
+                SNAPSHOT_PREFERENCES,
+                Context.MODE_PRIVATE
+        );
+    }
+
+    private static boolean validateExistingTypes(SharedPreferences defaults) {
+        Map<String, ?> values = defaults.getAll();
+        for (String key : BOOLEAN_KEYS) {
+            if (defaults.contains(key) && !(values.get(key) instanceof Boolean)) {
+                return false;
+            }
+        }
+        for (String key : STRING_KEYS) {
+            if (defaults.contains(key) && !(values.get(key) instanceof String)) {
+                return false;
+            }
+        }
+        for (String key : INTEGER_KEYS) {
+            if (defaults.contains(key) && !(values.get(key) instanceof Integer)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private static boolean createSnapshot(
+            Context context,
+            SharedPreferences snapshot,
+            SharedPreferences defaults,
+            SharedPreferences savedViews,
+            String nonce,
+            String scope
+    ) {
+        SharedPreferences.Editor editor = snapshot.edit().clear()
+                .putBoolean(SNAPSHOT_ACTIVE, true)
+                .putString(SNAPSHOT_NONCE, nonce)
+                .putString(SNAPSHOT_SCOPE, scope)
+                .putLong(SNAPSHOT_STARTED_AT, System.currentTimeMillis());
+        for (String key : BOOLEAN_KEYS) {
+            snapshotValue(editor, "default", key, defaults);
+        }
+        for (String key : STRING_KEYS) {
+            snapshotValue(editor, "default", key, defaults);
+        }
+        for (String key : INTEGER_KEYS) {
+            snapshotValue(editor, "default", key, defaults);
+        }
+        snapshotValue(editor, "saved", SAVED_VIEW_AUDIT_KEY, savedViews);
+        snapshotIconComponents(context, editor);
+        String originalAlias = MorpheSettingsV4AppIconFragment.selectedAlias(
+                context
+        );
+        String auditAlias = "grey".equals(originalAlias) ? "vivid" : "grey";
+        editor.putString(SNAPSHOT_AUDIT_ICON_ALIAS, auditAlias);
+        return editor.commit();
+    }
+
+    private static void snapshotIconComponents(
+            Context context,
+            SharedPreferences.Editor editor
+    ) {
+        PackageManager packageManager = context.getPackageManager();
+        editor.putBoolean(SNAPSHOT_ICON_STATES_PRESENT, true);
+        for (String alias : ICON_ALIASES) {
+            int state = packageManager.getComponentEnabledSetting(
+                    iconAliasComponent(context, alias)
+            );
+            editor.putInt("icon_state:" + alias, state);
+        }
+    }
+
+    private static void snapshotValue(
+            SharedPreferences.Editor editor,
+            String store,
+            String key,
+            SharedPreferences preferences
+    ) {
+        String identity = store + ":" + key;
+        boolean present = preferences.contains(key);
+        editor.putBoolean("present:" + identity, present);
+        if (!present) {
+            return;
+        }
+        Object value = preferences.getAll().get(key);
+        putSnapshotValue(editor, identity, value);
+    }
+
+    private static void putSnapshotValue(
+            SharedPreferences.Editor editor,
+            String identity,
+            Object value
+    ) {
+        String typeKey = "type:" + identity;
+        String valueKey = "value:" + identity;
+        if (value instanceof Boolean) {
+            editor.putString(typeKey, "boolean").putBoolean(valueKey, (Boolean) value);
+        } else if (value instanceof String) {
+            editor.putString(typeKey, "string").putString(valueKey, (String) value);
+        } else if (value instanceof Integer) {
+            editor.putString(typeKey, "integer").putInt(valueKey, (Integer) value);
+        } else if (value instanceof Long) {
+            editor.putString(typeKey, "long").putLong(valueKey, (Long) value);
+        } else if (value instanceof Float) {
+            editor.putString(typeKey, "float").putFloat(valueKey, (Float) value);
+        } else if (value instanceof Set) {
+            @SuppressWarnings("unchecked")
+            Set<String> strings = new HashSet<>((Set<String>) value);
+            editor.putString(typeKey, "string_set").putStringSet(valueKey, strings);
+        } else {
+            throw new IllegalStateException("unsupported preference type for " + identity);
+        }
+    }
+
+    private static void exerciseFullDomainsViaUiActions(
+            Context context,
+            SharedPreferences defaults,
+            SharedPreferences savedViews,
+            SharedPreferences snapshot
+    ) throws Exception {
+        int actions = 0;
+        int items = 0;
+        for (String key : BOOLEAN_KEYS) {
+            actions += exerciseBooleanDomain(defaults, snapshot, key);
+            logAuditItem(key, 2);
+            items++;
+        }
+        for (String key : STRING_KEYS) {
+            int domainCount = exerciseStringDomain(defaults, snapshot, key);
+            actions += domainCount;
+            logAuditItem(key, domainCount);
+            items++;
+        }
+        actions += exerciseIntegerDomain(
+                defaults,
+                snapshot,
+                "pref_cards_preview_self_lines"
+        );
+        logAuditItem(
+                "pref_cards_preview_self_lines",
+                INTEGER_MAXIMUM - INTEGER_MINIMUM + 1
+        );
+        items++;
+
+        actions += exerciseSavedViewDomain(savedViews, snapshot);
+        logAuditItem("saved_views", SAVED_VIEW_VALUES.length);
+        items++;
+
+        actions += exerciseAppIconDomain(context, snapshot);
+        logAuditItem("app_icon", ICON_AUDIT_VALUES.length);
+        items++;
+
+        if (items != AUDIT_ITEM_COUNT || actions != DOMAIN_ACTION_COUNT) {
+            throw new IllegalStateException(
+                    "domain audit count items=" + items
+                            + " actions=" + actions
+            );
+        }
+        Log.i(
+                TAG,
+                "MORPHE_DOMAIN_AUDIT_OK items=" + items
+                        + " actions=" + actions
+        );
+    }
+
+    private static int exerciseBooleanDomain(
+            SharedPreferences defaults,
+            SharedPreferences snapshot,
+            String key
+    ) throws Exception {
+        String effectField = effectFieldForKey(key);
+        Object originalEffect = effectField == null
+                ? null
+                : boostStaticField(effectField);
+        boolean prefix = "pref_show_subreddit_prefix".equals(key);
+        Object originalPrefix = prefix ? boostStaticField("c") : null;
+        boolean expected = expectedAuditBoolean(snapshot, key);
+        try {
+            assertBooleanDomainValue(
+                    defaults,
+                    key,
+                    !expected,
+                    effectField,
+                    prefix
+            );
+            assertBooleanDomainValue(
+                    defaults,
+                    key,
+                    expected,
+                    effectField,
+                    prefix
+            );
+        } finally {
+            if (prefix) {
+                setBoostStaticField("c", originalPrefix);
+            }
+            if (effectField != null) {
+                setBoostStaticField(effectField, originalEffect);
+            }
+        }
+        return 2;
+    }
+
+    private static void assertBooleanDomainValue(
+            SharedPreferences defaults,
+            String key,
+            boolean value,
+            String effectField,
+            boolean prefix
+    ) throws Exception {
+        if (effectField != null) {
+            setBoostStaticField(effectField, false);
+        }
+        if (prefix) {
+            setBoostStaticField("c", "__morphe_effect_audit__");
+        }
+        applyBooleanUiAction(defaults, key, value);
+        assertNativeBoolean(key, value);
+        assertEffectState(key, effectField);
+        if (prefix) {
+            String expectedPrefix = value ? "r/" : "";
+            if (!expectedPrefix.equals(boostStaticField("c"))) {
+                throw new IllegalStateException(
+                        "subreddit prefix cache mismatch"
+                );
+            }
+        }
+    }
+
+    private static int exerciseStringDomain(
+            SharedPreferences defaults,
+            SharedPreferences snapshot,
+            String key
+    ) throws Exception {
+        String effectField = effectFieldForKey(key);
+        Object originalEffect = effectField == null
+                ? null
+                : boostStaticField(effectField);
+        String expected = expectedAuditString(snapshot, key);
+        String[] domain = stringDomain(key);
+        try {
+            for (String value : domain) {
+                if (!expected.equals(value)) {
+                    assertStringDomainValue(
+                            defaults,
+                            key,
+                            value,
+                            effectField
+                    );
+                }
+            }
+            assertStringDomainValue(
+                    defaults,
+                    key,
+                    expected,
+                    effectField
+            );
+        } finally {
+            if (effectField != null) {
+                setBoostStaticField(effectField, originalEffect);
+            }
+        }
+        return domain.length;
+    }
+
+    private static void assertStringDomainValue(
+            SharedPreferences defaults,
+            String key,
+            String value,
+            String effectField
+    ) throws Exception {
+        if (effectField != null) {
+            setBoostStaticField(effectField, false);
+        }
+        applyStringUiAction(defaults, key, value);
+        assertNativeString(key, value);
+        assertEffectState(key, effectField);
+    }
+
+    private static int exerciseIntegerDomain(
+            SharedPreferences defaults,
+            SharedPreferences snapshot,
+            String key
+    ) throws Exception {
+        Object originalEffect = boostStaticField("g");
+        int expected = expectedAuditInteger(snapshot, key);
+        try {
+            for (int value = INTEGER_MINIMUM;
+                    value <= INTEGER_MAXIMUM;
+                    value++) {
+                if (value != expected) {
+                    assertIntegerDomainValue(defaults, key, value);
+                }
+            }
+            assertIntegerDomainValue(defaults, key, expected);
+        } finally {
+            setBoostStaticField("g", originalEffect);
+        }
+        return INTEGER_MAXIMUM - INTEGER_MINIMUM + 1;
+    }
+
+    private static void assertIntegerDomainValue(
+            SharedPreferences defaults,
+            String key,
+            int value
+    ) throws Exception {
+        setBoostStaticField("g", false);
+        MorpheSettingsV4PostViewsFragment.applyPreviewLinesPreference(
+                defaults,
+                value
+        );
+        assertNativeInteger(key, value);
+        assertEffectState(key, "g");
+    }
+
+    private static int exerciseSavedViewDomain(
+            SharedPreferences savedViews,
+            SharedPreferences snapshot
+    ) {
+        int expected = expectedSavedViewAuditValue(snapshot);
+        for (int value : SAVED_VIEW_VALUES) {
+            if (value != expected) {
+                MorpheSettingsV4SavedViewsFragment.applySavedView(
+                        savedViews,
+                        SAVED_VIEW_AUDIT_KEY,
+                        value
+                );
+                assertInteger(savedViews, SAVED_VIEW_AUDIT_KEY, value);
+            }
+        }
+        MorpheSettingsV4SavedViewsFragment.applySavedView(
+                savedViews,
+                SAVED_VIEW_AUDIT_KEY,
+                expected
+        );
+        assertInteger(savedViews, SAVED_VIEW_AUDIT_KEY, expected);
+        return SAVED_VIEW_VALUES.length;
+    }
+
+    private static int exerciseAppIconDomain(
+            Context context,
+            SharedPreferences snapshot
+    ) {
+        String expected = snapshot.getString(SNAPSHOT_AUDIT_ICON_ALIAS, "grey");
+        for (String value : ICON_AUDIT_VALUES) {
+            if (!expected.equals(value)) {
+                String alias = TextUtils.isEmpty(value) ? null : value;
+                MorpheSettingsV4AppIconFragment.applyIconSelection(
+                        context,
+                        alias
+                );
+                assertSelectedIcon(context, alias);
+            }
+        }
+        MorpheSettingsV4AppIconFragment.applyIconSelection(context, expected);
+        assertSelectedIcon(context, expected);
+        return ICON_AUDIT_VALUES.length;
+    }
+
+    private static void assertSelectedIcon(Context context, String expected) {
+        if (!TextUtils.equals(
+                expected,
+                MorpheSettingsV4AppIconFragment.selectedAlias(context)
+        )) {
+            throw new IllegalStateException("app icon action did not apply");
+        }
+        if (!verifyIconComponents(context)) {
+            throw new IllegalStateException("app icon components invalid");
+        }
+    }
+
+    private static void assertEffectState(
+            String key,
+            String effectField
+    ) throws Exception {
+        if (effectField != null
+                && !Boolean.TRUE.equals(boostStaticField(effectField))) {
+            throw new IllegalStateException(
+                    "native cache flag not invalidated for " + key
+            );
+        }
+    }
+
+    private static void runRenderedEffectProbes(
+            Context context,
+            SharedPreferences snapshot
+    ) {
+        int count = 0;
+        TextView title = new TextView(context);
+        String titleFont = expectedAuditString(snapshot, "pref_title_font");
+        String titleSize = expectedAuditString(
+                snapshot,
+                "pref_font_size_title"
+        );
+        for (String value : FONT_VALUES) {
+            MorpheSettingsV4FontsFragment.applyPreviewTypography(
+                    title,
+                    value,
+                    titleSize,
+                    true
+            );
+            assertTypography(title, value, titleSize, true);
+        }
+        for (String value : FONT_SIZE_VALUES) {
+            MorpheSettingsV4FontsFragment.applyPreviewTypography(
+                    title,
+                    titleFont,
+                    value,
+                    true
+            );
+            assertTypography(title, titleFont, value, true);
+        }
+        MorpheSettingsV4FontsFragment.applyPreviewTypography(
+                title,
+                titleFont,
+                titleSize,
+                true
+        );
+        assertTypography(title, titleFont, titleSize, true);
+        logRenderProbe(
+                "title_typography",
+                "pref_title_font,pref_font_size_title"
+        );
+        count++;
+
+        TextView comments = new TextView(context);
+        String commentsFont = expectedAuditString(
+                snapshot,
+                "pref_comments_font"
+        );
+        String commentsSize = expectedAuditString(
+                snapshot,
+                "pref_font_size"
+        );
+        for (String value : FONT_VALUES) {
+            MorpheSettingsV4FontsFragment.applyPreviewTypography(
+                    comments,
+                    value,
+                    commentsSize,
+                    false
+            );
+            assertTypography(comments, value, commentsSize, false);
+        }
+        for (String value : FONT_SIZE_VALUES) {
+            MorpheSettingsV4FontsFragment.applyPreviewTypography(
+                    comments,
+                    commentsFont,
+                    value,
+                    false
+            );
+            assertTypography(comments, commentsFont, value, false);
+        }
+        MorpheSettingsV4FontsFragment.applyPreviewTypography(
+                comments,
+                commentsFont,
+                commentsSize,
+                false
+        );
+        assertTypography(comments, commentsFont, commentsSize, false);
+        logRenderProbe(
+                "comment_typography",
+                "pref_comments_font,pref_font_size"
+        );
+        count++;
+
+        View savedViewsRow = new View(context);
+        boolean remember = expectedAuditBoolean(
+                snapshot,
+                "pref_view_per_subscription"
+        );
+        MorpheSettingsV4PostViewsFragment.applyDependentRowState(
+                savedViewsRow,
+                null,
+                !remember
+        );
+        assertEnabledState(savedViewsRow, null, !remember);
+        MorpheSettingsV4PostViewsFragment.applyDependentRowState(
+                savedViewsRow,
+                null,
+                remember
+        );
+        assertEnabledState(savedViewsRow, null, remember);
+        logRenderProbe("saved_views_enabled", "pref_view_per_subscription");
+        count++;
+
+        View previewLinesRow = new View(context);
+        SeekBar previewLinesControl = new SeekBar(context);
+        boolean previewText = expectedAuditBoolean(
+                snapshot,
+                "pref_cards_preview_self"
+        );
+        MorpheSettingsV4PostViewsFragment.applyDependentRowState(
+                previewLinesRow,
+                previewLinesControl,
+                !previewText
+        );
+        assertEnabledState(
+                previewLinesRow,
+                previewLinesControl,
+                !previewText
+        );
+        MorpheSettingsV4PostViewsFragment.applyDependentRowState(
+                previewLinesRow,
+                previewLinesControl,
+                previewText
+        );
+        assertEnabledState(
+                previewLinesRow,
+                previewLinesControl,
+                previewText
+        );
+        logRenderProbe("preview_lines_enabled", "pref_cards_preview_self");
+        count++;
+
+        TextView defaultViewSummary = new TextView(context);
+        Set<String> viewTitles = new HashSet<>();
+        for (String value : VIEW_VALUES) {
+            String renderedTitle = MorpheSettingsV4PostViewsFragment.viewTitle(
+                    value
+            );
+            defaultViewSummary.setText(renderedTitle);
+            if (TextUtils.isEmpty(defaultViewSummary.getText())
+                    || !viewTitles.add(renderedTitle)) {
+                throw new IllegalStateException(
+                        "default-view summary render mismatch"
+                );
+            }
+        }
+        logRenderProbe("default_view_summary", "pref_view");
+        count++;
+
+        Activity activity = context instanceof Activity
+                ? (Activity) context
+                : null;
+        if (activity == null) {
+            throw new IllegalStateException("render probe missing activity");
+        }
+        Window window = activity.getWindow();
+        int originalStatus = window.getStatusBarColor();
+        int originalNavigation = window.getNavigationBarColor();
+        MorpheSettingsV4Theme.Tokens tokens = MorpheSettingsV4Theme.resolve(
+                context
+        );
+        try {
+            BoostSystemBarInsetsFix.applyMorpheSettingsV4SystemBars(
+                    activity,
+                    tokens.background,
+                    tokens.dark
+            );
+            assertSettingsSystemBarRendering(activity, tokens.background);
+        } finally {
+            BoostSystemBarInsetsFix.clearMorpheSettingsV4SystemBars(activity);
+            window.setStatusBarColor(originalStatus);
+            window.setNavigationBarColor(originalNavigation);
+        }
+        logRenderProbe(
+                "settings_shell_system_bars",
+                "-"
+        );
+        count++;
+
+        if (count != RENDER_PROBE_COUNT) {
+            throw new IllegalStateException("render probe count " + count);
+        }
+        Log.i(TAG, "MORPHE_RENDER_AUDIT_OK count=" + count);
+    }
+
+    private static void assertSettingsSystemBarRendering(
+            Activity activity,
+            int expectedColor
+    ) {
+        Window window = activity.getWindow();
+        View decor = window == null ? null : window.getDecorView();
+        if (window == null || decor == null) {
+            throw new IllegalStateException("system-bar render missing window");
+        }
+
+        int decorColor = backgroundColor(decor);
+        int statusSurfaceColor = backgroundColor(
+                decor.findViewWithTag(STATUS_BAR_SURFACE_TAG)
+        );
+        int navigationSurfaceColor = backgroundColor(
+                decor.findViewWithTag(NAVIGATION_BAR_SURFACE_TAG)
+        );
+
+        // Android 15 enforces edge-to-edge for targetSdk 35: the status-bar
+        // Window color is transparent and setStatusBarColor() has no visual
+        // effect. The visible result is therefore owned by the inset surfaces.
+        boolean legacyWindowColorsMatch = Build.VERSION.SDK_INT >= 35
+                || window.getStatusBarColor() == expectedColor
+                && window.getNavigationBarColor() == expectedColor;
+        if (decorColor != expectedColor
+                || statusSurfaceColor != expectedColor
+                || navigationSurfaceColor != expectedColor
+                || !legacyWindowColorsMatch) {
+            throw new IllegalStateException(
+                    "settings system-bar render mismatch"
+                            + " sdk=" + Build.VERSION.SDK_INT
+                            + " expected=" + colorHex(expectedColor)
+                            + " decor=" + colorHex(decorColor)
+                            + " status_surface=" + colorHex(statusSurfaceColor)
+                            + " navigation_surface="
+                            + colorHex(navigationSurfaceColor)
+                            + " status_window="
+                            + colorHex(window.getStatusBarColor())
+                            + " navigation_window="
+                            + colorHex(window.getNavigationBarColor())
+            );
+        }
+
+        Log.i(
+                TAG,
+                "MORPHE_SYSTEM_BAR_RENDER_AUDIT_OK sdk="
+                        + Build.VERSION.SDK_INT
+                        + " mode="
+                        + (Build.VERSION.SDK_INT >= 35
+                        ? "edge_to_edge_surfaces"
+                        : "legacy_window_and_surfaces")
+                        + " color=" + colorHex(expectedColor)
+        );
+    }
+
+    private static int backgroundColor(View view) {
+        if (view == null) {
+            return 0;
+        }
+        Drawable background = view.getBackground();
+        return background instanceof ColorDrawable
+                ? ((ColorDrawable) background).getColor()
+                : 0;
+    }
+
+    private static String colorHex(int color) {
+        return String.format("#%08X", color);
+    }
+
+    private static void assertTypography(
+            TextView view,
+            String font,
+            String size,
+            boolean title
+    ) {
+        if (view.getTypeface() == null
+                || !view.getTypeface().equals(
+                MorpheSettingsV4FontsFragment.typefaceFor(font)
+        )) {
+            throw new IllegalStateException("font render mismatch");
+        }
+        float expected = TypedValue.applyDimension(
+                TypedValue.COMPLEX_UNIT_SP,
+                MorpheSettingsV4FontsFragment.previewSizeSp(size, title),
+                view.getResources().getDisplayMetrics()
+        );
+        if (Math.abs(view.getTextSize() - expected) > 0.5f) {
+            throw new IllegalStateException("text-size render mismatch");
+        }
+    }
+
+    private static void assertEnabledState(
+            View row,
+            View control,
+            boolean expected
+    ) {
+        float expectedAlpha = expected ? 1.0f : 0.44f;
+        if (row.isEnabled() != expected
+                || row.isClickable() != expected
+                || row.isFocusable() != expected
+                || Math.abs(row.getAlpha() - expectedAlpha) > 0.001f
+                || control != null && control.isEnabled() != expected) {
+            throw new IllegalStateException("dependent-row render mismatch");
+        }
+    }
+
+    private static void logRenderProbe(String probe, String keys) {
+        Log.i(
+                TAG,
+                "MORPHE_RENDER_AUDIT_ITEM_OK probe=" + probe
+                        + " keys=" + keys
+        );
+    }
+
+    private static void logAuditItem(String key, int domainCount) {
+        String consumer;
+        String effect;
+        if ("saved_views".equals(key)) {
+            consumer = "VIEW_PER_SUBSCRIPTION";
+            effect = "canonical_named_preferences";
+        } else if ("app_icon".equals(key)) {
+            consumer = "PackageManager";
+            effect = "launcher_alias";
+        } else {
+            consumer = "id.b." + nativeConsumerForKey(key);
+            String field = effectFieldForKey(key);
+            effect = field == null ? "direct_consumer" : field;
+        }
+        Log.i(
+                TAG,
+                "MORPHE_AUDIT_ITEM_OK key=" + key
+                        + " domain_count=" + domainCount
+                        + " consumer=" + consumer
+                        + " effect=" + effect
+                        + " render=" + renderProbeForKey(key)
+        );
+    }
+
+    private static String renderProbeForKey(String key) {
+        if ("pref_title_font".equals(key)
+                || "pref_font_size_title".equals(key)) {
+            return "title_typography";
+        }
+        if ("pref_comments_font".equals(key)
+                || "pref_font_size".equals(key)) {
+            return "comment_typography";
+        }
+        if ("pref_view_per_subscription".equals(key)) {
+            return "saved_views_enabled";
+        }
+        if ("pref_view".equals(key)) {
+            return "default_view_summary";
+        }
+        if ("pref_cards_preview_self".equals(key)) {
+            return "preview_lines_enabled";
+        }
+        if ("app_icon".equals(key)) {
+            return "launcher_components";
+        }
+        return "not_rendered";
+    }
+
+    private static ComponentName iconAliasComponent(
+            Context context,
+            String alias
+    ) {
+        return new ComponentName(
+                context.getPackageName(),
+                ICON_ALIAS_PREFIX + alias
+        );
+    }
+
+    private static void applyBooleanUiAction(
+            SharedPreferences defaults,
+            String key,
+            boolean value
+    ) {
+        if ("pref_dynamic_colors".equals(key)) {
+            MorpheSettingsV4AppearanceFragment.applyDynamicColors(
+                    defaults,
+                    value
+            );
+            return;
+        }
+        if ("pref_colored_status_bar".equals(key)
+                || "pref_colored_nav_bar".equals(key)) {
+            MorpheSettingsV4AppearanceFragment.applySystemBarPreference(
+                    defaults,
+                    key,
+                    value
+            );
+            return;
+        }
+        if ("pref_show_subreddit_prefix".equals(key)) {
+            MorpheSettingsV4PostViewsFragment.applySubredditPrefix(
+                    defaults,
+                    value
+            );
+            return;
+        }
+        MorpheSettingsV4PostViewsFragment.applyBooleanPreference(
+                defaults,
+                key,
+                value,
+                effectFieldForKey(key)
+        );
+    }
+
+    private static void applyStringUiAction(
+            SharedPreferences defaults,
+            String key,
+            String value
+    ) {
+        if ("pref_view".equals(key)) {
+            MorpheSettingsV4PostViewsFragment.applyDefaultViewPreference(
+                    defaults,
+                    value
+            );
+            return;
+        }
+        MorpheSettingsV4FontsFragment.applyFontPreference(
+                defaults,
+                key,
+                value
+        );
+    }
+
+    private static boolean verifyNativeConsumersAfterReload(
+            Context context,
+            SharedPreferences snapshot
+    ) throws Exception {
+        int count = 0;
+        for (String key : BOOLEAN_KEYS) {
+            assertNativeBoolean(
+                    key,
+                    expectedAuditBoolean(snapshot, key)
+            );
+            count++;
+        }
+        for (String key : STRING_KEYS) {
+            assertNativeString(
+                    key,
+                    expectedAuditString(snapshot, key)
+            );
+            count++;
+        }
+        assertNativeInteger(
+                "pref_cards_preview_self_lines",
+                expectedAuditInteger(
+                        snapshot,
+                        "pref_cards_preview_self_lines"
+                )
+        );
+        count++;
+
+        SharedPreferences savedViews = context.getSharedPreferences(
+                SAVED_VIEW_PREFERENCES,
+                Context.MODE_PRIVATE
+        );
+        assertInteger(
+                savedViews,
+                SAVED_VIEW_AUDIT_KEY,
+                expectedSavedViewAuditValue(snapshot)
+        );
+        count++;
+
+        if (!verifyExpectedAuditIcon(context, snapshot)) {
+            throw new IllegalStateException(
+                    "app icon did not survive cold reload"
+            );
+        }
+        count++;
+
+        if (count != EFFECT_AUDIT_RELOAD_COUNT) {
+            throw new IllegalStateException(
+                    "effect audit reload count " + count
+            );
+        }
+        Log.i(TAG, "MORPHE_DOMAIN_AUDIT_RELOAD_OK count=" + count);
+        return true;
+    }
+
+    private static void assertNativeBoolean(
+            String key,
+            boolean expected
+    ) throws Exception {
+        Object actual = invokeNativeConsumer(nativeConsumerForKey(key));
+        if (!(actual instanceof Boolean) || ((Boolean) actual) != expected) {
+            throw new IllegalStateException(
+                    "native boolean consumer mismatch for " + key
+            );
+        }
+    }
+
+    private static void assertNativeString(
+            String key,
+            String expected
+    ) throws Exception {
+        Object actual = invokeNativeConsumer(nativeConsumerForKey(key));
+        if (!expected.equals(actual)) {
+            throw new IllegalStateException(
+                    "native string consumer mismatch for " + key
+            );
+        }
+    }
+
+    private static void assertNativeInteger(
+            String key,
+            int expected
+    ) throws Exception {
+        Object actual = invokeNativeConsumer(nativeConsumerForKey(key));
+        if (!(actual instanceof Integer) || ((Integer) actual) != expected) {
+            throw new IllegalStateException(
+                    "native integer consumer mismatch for " + key
+            );
+        }
+    }
+
+    private static Object invokeNativeConsumer(String methodName)
+            throws Exception {
+        Class<?> settingsClass = Class.forName("id.b");
+        Method singleton = settingsClass.getDeclaredMethod("v0");
+        singleton.setAccessible(true);
+        Object settings = singleton.invoke(null);
+        Method consumer = settingsClass.getDeclaredMethod(methodName);
+        consumer.setAccessible(true);
+        return consumer.invoke(settings);
+    }
+
+    private static Object boostStaticField(String name) throws Exception {
+        Field field = Class.forName("id.b").getDeclaredField(name);
+        field.setAccessible(true);
+        return field.get(null);
+    }
+
+    private static void setBoostStaticField(String name, Object value)
+            throws Exception {
+        Field field = Class.forName("id.b").getDeclaredField(name);
+        field.setAccessible(true);
+        field.set(null, value);
+    }
+
+    private static String effectFieldForKey(String key) {
+        switch (key) {
+            case "pref_dynamic_colors":
+            case "pref_lock_sidebar":
+            case "pref_show_subreddit_prefix":
+                return "i";
+            case "pref_colored_status_bar":
+            case "pref_colored_nav_bar":
+            case "pref_left_handed":
+            case "pref_dense_buttons_visible":
+            case "pref_title_font":
+                return "h";
+            case "pref_cards_rounded_corners":
+            case "pref_cards_full_preview":
+            case "pref_cards_subreddit_icon":
+            case "pref_cards_gallery_carousel":
+            case "pref_cards_links_as_thumbnails":
+            case "pref_cards_preview_self":
+            case "pref_cards_preview_self_lines":
+            case "pref_mini_cards_rounded_corners":
+            case "pref_mini_cards_truncate_title":
+            case "pref_mini_cards_buttons_visible":
+                return "g";
+            case "pref_font_size_title":
+            case "pref_font_size":
+                return "d";
+            default:
+                return null;
+        }
+    }
+
+    private static String nativeConsumerForKey(String key) {
+        switch (key) {
+            case "pref_dynamic_colors": return "m2";
+            case "pref_colored_status_bar": return "r1";
+            case "pref_colored_nav_bar": return "m1";
+            case "pref_view": return "Y3";
+            case "pref_view_per_subscription": return "L2";
+            case "pref_left_handed": return "s2";
+            case "pref_show_subreddit_prefix": return "S7";
+            case "pref_cards_rounded_corners": return "Y0";
+            case "pref_cards_full_preview": return "V0";
+            case "pref_cards_subreddit_icon": return "e3";
+            case "pref_cards_gallery_carousel": return "L3";
+            case "pref_cards_links_as_thumbnails": return "Q";
+            case "pref_cards_preview_self": return "f4";
+            case "pref_cards_preview_self_lines": return "g4";
+            case "pref_mini_cards_rounded_corners": return "D2";
+            case "pref_mini_cards_truncate_title": return "Y7";
+            case "pref_mini_cards_buttons_visible": return "B2";
+            case "pref_dense_buttons_visible": return "h2";
+            case "pref_load_readability": return "I0";
+            case "pref_lock_sidebar": return "w2";
+            case "pref_title_font": return "m4";
+            case "pref_font_size_title": return "q0";
+            case "pref_comments_font": return "W";
+            case "pref_font_size": return "p0";
+            default:
+                throw new IllegalArgumentException(
+                        "missing native consumer for " + key
+                );
+        }
+    }
+
+    private static boolean verifyPersistedAuditValues(
+            Context context,
+            SharedPreferences snapshot
+    ) {
+        SharedPreferences defaults =
+                PreferenceManager.getDefaultSharedPreferences(context);
+        SharedPreferences savedViews = context.getSharedPreferences(
+                SAVED_VIEW_PREFERENCES,
+                Context.MODE_PRIVATE
+        );
+        for (String key : BOOLEAN_KEYS) {
+            assertBoolean(defaults, key, expectedAuditBoolean(snapshot, key));
+        }
+        for (String key : STRING_KEYS) {
+            assertString(defaults, key, expectedAuditString(snapshot, key));
+        }
+        for (String key : INTEGER_KEYS) {
+            assertInteger(defaults, key, expectedAuditInteger(snapshot, key));
+        }
+        assertInteger(
+                savedViews,
+                SAVED_VIEW_AUDIT_KEY,
+                expectedSavedViewAuditValue(snapshot)
+        );
+        return true;
+    }
+
+    private static boolean restoreOriginalValues(
+            Context context,
+            SharedPreferences snapshot
+    ) {
+        if (!snapshot.getBoolean(SNAPSHOT_ACTIVE, false)) {
+            return true;
+        }
+        SharedPreferences defaults =
+                PreferenceManager.getDefaultSharedPreferences(context);
+        SharedPreferences savedViews = context.getSharedPreferences(
+                SAVED_VIEW_PREFERENCES,
+                Context.MODE_PRIVATE
+        );
+
+        SharedPreferences.Editor defaultEditor = defaults.edit();
+        for (String key : BOOLEAN_KEYS) {
+            restoreValue(defaultEditor, snapshot, "default", key);
+        }
+        for (String key : STRING_KEYS) {
+            restoreValue(defaultEditor, snapshot, "default", key);
+        }
+        for (String key : INTEGER_KEYS) {
+            restoreValue(defaultEditor, snapshot, "default", key);
+        }
+        SharedPreferences.Editor savedEditor = savedViews.edit();
+        restoreValue(savedEditor, snapshot, "saved", SAVED_VIEW_AUDIT_KEY);
+
+        boolean defaultsRestored = defaultEditor.commit();
+        boolean savedViewsRestored = savedEditor.commit();
+        boolean preferencesRestored = defaultsRestored
+                && savedViewsRestored
+                && restoredValuesMatch(defaults, savedViews, snapshot);
+        boolean iconsRestored = restoreIconComponents(context, snapshot);
+        return preferencesRestored && iconsRestored;
+    }
+
+    private static boolean restoreIconComponents(
+            Context context,
+            SharedPreferences snapshot
+    ) {
+        if (!snapshot.getBoolean(SNAPSHOT_ICON_STATES_PRESENT, false)) {
+            return true;
+        }
+        PackageManager packageManager = context.getPackageManager();
+        try {
+            for (String alias : ICON_ALIASES) {
+                packageManager.setComponentEnabledSetting(
+                        iconAliasComponent(context, alias),
+                        snapshot.getInt(
+                                "icon_state:" + alias,
+                                PackageManager.COMPONENT_ENABLED_STATE_DEFAULT
+                        ),
+                        PackageManager.DONT_KILL_APP
+                );
+            }
+            for (String alias : ICON_ALIASES) {
+                int expected = snapshot.getInt(
+                        "icon_state:" + alias,
+                        PackageManager.COMPONENT_ENABLED_STATE_DEFAULT
+                );
+                int actual = packageManager.getComponentEnabledSetting(
+                        iconAliasComponent(context, alias)
+                );
+                if (actual != expected) {
+                    return false;
+                }
+            }
+            return true;
+        } catch (Throwable throwable) {
+            Log.e(TAG, "MORPHE_BINDING_AUDIT_ICON_RESTORE_FAIL", throwable);
+            return false;
+        }
+    }
+
+    private static void restoreValue(
+            SharedPreferences.Editor editor,
+            SharedPreferences snapshot,
+            String store,
+            String key
+    ) {
+        String identity = store + ":" + key;
+        if (!snapshot.getBoolean("present:" + identity, false)) {
+            editor.remove(key);
+            return;
+        }
+        String type = snapshot.getString("type:" + identity, "");
+        String valueKey = "value:" + identity;
+        if ("boolean".equals(type)) {
+            editor.putBoolean(key, snapshot.getBoolean(valueKey, false));
+        } else if ("string".equals(type)) {
+            editor.putString(key, snapshot.getString(valueKey, ""));
+        } else if ("integer".equals(type)) {
+            editor.putInt(key, snapshot.getInt(valueKey, 0));
+        } else if ("long".equals(type)) {
+            editor.putLong(key, snapshot.getLong(valueKey, 0L));
+        } else if ("float".equals(type)) {
+            editor.putFloat(key, snapshot.getFloat(valueKey, 0.0f));
+        } else if ("string_set".equals(type)) {
+            Set<String> value = snapshot.getStringSet(valueKey, new HashSet<String>());
+            editor.putStringSet(key, new HashSet<>(value));
+        } else {
+            throw new IllegalStateException("missing snapshot type for " + identity);
+        }
+    }
+
+    private static boolean restoredValuesMatch(
+            SharedPreferences defaults,
+            SharedPreferences savedViews,
+            SharedPreferences snapshot
+    ) {
+        for (String key : BOOLEAN_KEYS) {
+            if (!restoredValueMatches(defaults, snapshot, "default", key)) {
+                return false;
+            }
+        }
+        for (String key : STRING_KEYS) {
+            if (!restoredValueMatches(defaults, snapshot, "default", key)) {
+                return false;
+            }
+        }
+        for (String key : INTEGER_KEYS) {
+            if (!restoredValueMatches(defaults, snapshot, "default", key)) {
+                return false;
+            }
+        }
+        return restoredValueMatches(
+                savedViews,
+                snapshot,
+                "saved",
+                SAVED_VIEW_AUDIT_KEY
+        );
+    }
+
+    private static boolean restoredValueMatches(
+            SharedPreferences preferences,
+            SharedPreferences snapshot,
+            String store,
+            String key
+    ) {
+        String identity = store + ":" + key;
+        boolean expectedPresent = snapshot.getBoolean("present:" + identity, false);
+        if (preferences.contains(key) != expectedPresent) {
+            return false;
+        }
+        if (!expectedPresent) {
+            return true;
+        }
+        Object expected = snapshot.getAll().get("value:" + identity);
+        Object actual = preferences.getAll().get(key);
+        return expected == null ? actual == null : expected.equals(actual);
+    }
+
+    private static boolean expectedAuditBoolean(
+            SharedPreferences snapshot,
+            String key
+    ) {
+        String identity = "default:" + key;
+        boolean defaultValue = defaultBooleanForKey(key);
+        boolean original = snapshot.getBoolean("present:" + identity, false)
+                ? snapshot.getBoolean("value:" + identity, defaultValue)
+                : defaultValue;
+        return !original;
+    }
+
+    private static String expectedAuditString(
+            SharedPreferences snapshot,
+            String key
+    ) {
+        String identity = "default:" + key;
+        String defaultValue = defaultStringForKey(key);
+        String original = snapshot.getBoolean("present:" + identity, false)
+                ? snapshot.getString("value:" + identity, defaultValue)
+                : defaultValue;
+        String[] domain = stringDomain(key);
+        for (String candidate : domain) {
+            if (!original.equals(candidate)) {
+                return candidate;
+            }
+        }
+        throw new IllegalStateException("no alternate string value for " + key);
+    }
+
+    private static int expectedAuditInteger(
+            SharedPreferences snapshot,
+            String key
+    ) {
+        String identity = "default:" + key;
+        int original = snapshot.getInt("value:" + identity, INTEGER_MINIMUM);
+        return original == 37 ? 38 : 37;
+    }
+
+    private static int expectedSavedViewAuditValue(SharedPreferences snapshot) {
+        String identity = "saved:" + SAVED_VIEW_AUDIT_KEY;
+        Object originalValue = snapshot.getAll().get("value:" + identity);
+        int original = originalValue instanceof Integer
+                ? (Integer) originalValue
+                : Integer.MIN_VALUE;
+        for (int candidate : SAVED_VIEW_VALUES) {
+            if (candidate != original) {
+                return candidate;
+            }
+        }
+        throw new IllegalStateException("no alternate saved-view value");
+    }
+
+    private static boolean defaultBooleanForKey(String key) {
+        for (String candidate : BOOLEAN_DEFAULT_TRUE_KEYS) {
+            if (candidate.equals(key)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static String defaultStringForKey(String key) {
+        if ("pref_view".equals(key)) {
+            return "0";
+        }
+        if ("pref_title_font".equals(key) || "pref_comments_font".equals(key)) {
+            return "";
+        }
+        if ("pref_font_size_title".equals(key) || "pref_font_size".equals(key)) {
+            return "Medium";
+        }
+        throw new IllegalArgumentException("missing string default for " + key);
+    }
+
+    private static String[] stringDomain(String key) {
+        if ("pref_view".equals(key)) {
+            return VIEW_VALUES;
+        }
+        if ("pref_title_font".equals(key) || "pref_comments_font".equals(key)) {
+            return FONT_VALUES;
+        }
+        if ("pref_font_size_title".equals(key) || "pref_font_size".equals(key)) {
+            return FONT_SIZE_VALUES;
+        }
+        throw new IllegalArgumentException("missing domain for " + key);
+    }
+
+    private static boolean verifyExpectedAuditIcon(
+            Context context,
+            SharedPreferences snapshot
+    ) {
+        String expected = snapshot.getString(SNAPSHOT_AUDIT_ICON_ALIAS, "grey");
+        return TextUtils.equals(
+                expected,
+                MorpheSettingsV4AppIconFragment.selectedAlias(context)
+        );
+    }
+
+    private static boolean verifyIconComponents(Context context) {
+        for (String resource : ICON_RESOURCES) {
+            if (context.getResources().getIdentifier(
+                    resource,
+                    "mipmap",
+                    context.getPackageName()
+            ) == 0) {
+                return false;
+            }
+        }
+
+        PackageManager packageManager = context.getPackageManager();
+        int enabledAliases = 0;
+        for (String alias : ICON_ALIASES) {
+            ComponentName component = new ComponentName(
+                    context.getPackageName(),
+                    ICON_ALIAS_PREFIX + alias
+            );
+            try {
+                packageManager.getActivityInfo(
+                        component,
+                        PackageManager.MATCH_DISABLED_COMPONENTS
+                );
+            } catch (PackageManager.NameNotFoundException exception) {
+                return false;
+            }
+            if (packageManager.getComponentEnabledSetting(component)
+                    == PackageManager.COMPONENT_ENABLED_STATE_ENABLED) {
+                enabledAliases++;
+            }
+        }
+        return enabledAliases <= 1;
+    }
+
+    private static void assertBoolean(
+            SharedPreferences preferences,
+            String key,
+            boolean expected
+    ) {
+        if (!preferences.contains(key) || preferences.getBoolean(key, !expected) != expected) {
+            throw new IllegalStateException("boolean readback failed for " + key);
+        }
+    }
+
+    private static void assertString(
+            SharedPreferences preferences,
+            String key,
+            String expected
+    ) {
+        if (!preferences.contains(key)
+                || !expected.equals(preferences.getString(key, null))) {
+            throw new IllegalStateException("string readback failed for " + key);
+        }
+    }
+
+    private static void assertInteger(
+            SharedPreferences preferences,
+            String key,
+            int expected
+    ) {
+        if (!preferences.contains(key) || preferences.getInt(key, -1) != expected) {
+            throw new IllegalStateException("integer readback failed for " + key);
+        }
+    }
+}

--- a/extensions/boostforreddit/src/main/java/app/morphe/extension/boostforreddit/settings/MorpheSettingsV4Catalog.java
+++ b/extensions/boostforreddit/src/main/java/app/morphe/extension/boostforreddit/settings/MorpheSettingsV4Catalog.java
@@ -18,6 +18,12 @@ final class MorpheSettingsV4Catalog {
             "app.morphe.extension.boostforreddit.settings.MorpheSettingsFragment";
     static final String BACKUP_ACTIVITY =
             "com.rubenmayayo.reddit.BackupActivity";
+    static final String V4_APPEARANCE_FRAGMENT =
+            "app.morphe.extension.boostforreddit.settings."
+                    + "MorpheSettingsV4AppearanceFragment";
+    static final String CLASSIC_APPEARANCE_FRAGMENT =
+            "com.rubenmayayo.reddit.ui.preferences.v2."
+                    + "PreferenceFragmentAppearanceCompat";
 
     private static final String ANDROID_NAMESPACE =
             "http://schemas.android.com/apk/res/android";
@@ -154,9 +160,9 @@ final class MorpheSettingsV4Catalog {
             new Category(
                     "appearance_layout",
                     "Appearance & layout",
-                    "Theme, post layout, and fonts",
+                    "Colors, post layout, and fonts",
                     "ic_color_lens_24dp",
-                    leaf("Theme & appearance", "Theme, dark mode, and app icon", "ic_color_lens_24dp", "PreferenceFragmentAppearanceCompat", "pref_appearance_v2"),
+                    Leaf.fragment("Appearance", "Dynamic color, app icon, and system bars", "ic_color_lens_24dp", V4_APPEARANCE_FRAGMENT, null),
                     leaf("Post views", "Cards, lists, thumbnails, and density", "ic_view_carousel_24dp", "PreferenceFragmentViewsCompat", "pref_views_v2"),
                     leaf("Fonts", "Font family, size, and style", "ic_format_size_24dp", "PreferenceFragmentFontsCompat", "pref_fonts_v2")
             ),
@@ -223,7 +229,8 @@ final class MorpheSettingsV4Catalog {
                     "General behavior and older features",
                     "ic_settings_24dp",
                     leaf("General", "General app behavior", "ic_settings_24dp", "PreferenceFragmentGeneralCompat", "pref_general_v2"),
-                    leaf("Legacy features", "Older Boost features and compatibility", "ic_restore_black_24dp", "PreferenceFragmentMiscCompat", "pref_misc_v2")
+                    leaf("Legacy features", "Older Boost features and compatibility", "ic_restore_black_24dp", "PreferenceFragmentMiscCompat", "pref_misc_v2"),
+                    Leaf.fragment("Classic theme editor", "Legacy Boost palettes and per-color customization", "ic_color_lens_24dp", CLASSIC_APPEARANCE_FRAGMENT, null)
             ),
             new Category(
                     "about",
@@ -264,7 +271,35 @@ final class MorpheSettingsV4Catalog {
                 addLeafAndXml(context, result, seen, category.title, leaf);
             }
         }
+        addV4AppearanceSearchItems(result, seen);
         return result;
+    }
+
+    private static void addV4AppearanceSearchItems(
+            List<SearchItem> result,
+            Set<String> seen
+    ) {
+        String[][] items = new String[][]{
+                {"Dynamic color", "Use the color palette selected by Android", "pref_dynamic_colors"},
+                {"App icon", "Choose the icon shown by your launcher", "pref_app_icon"},
+                {"Colored status bar", "Match the status bar to Boost's toolbar", "pref_colored_status_bar"},
+                {"Colored navigation bar", "Match the navigation area to Boost's toolbar", "pref_colored_nav_bar"},
+        };
+        for (String[] item : items) {
+            addSearchItem(
+                    result,
+                    seen,
+                    new SearchItem(
+                            item[0],
+                            item[1],
+                            "Appearance & layout · Appearance",
+                            "ic_color_lens_24dp",
+                            V4_APPEARANCE_FRAGMENT,
+                            null,
+                            item[2]
+                    )
+            );
+        }
     }
 
     private static void addLeafAndXml(

--- a/extensions/boostforreddit/src/main/java/app/morphe/extension/boostforreddit/settings/MorpheSettingsV4Catalog.java
+++ b/extensions/boostforreddit/src/main/java/app/morphe/extension/boostforreddit/settings/MorpheSettingsV4Catalog.java
@@ -1,0 +1,422 @@
+package app.morphe.extension.boostforreddit.settings;
+
+import android.content.Context;
+import android.content.res.Resources;
+import android.content.res.XmlResourceParser;
+import android.text.TextUtils;
+
+import org.xmlpull.v1.XmlPullParser;
+
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+
+final class MorpheSettingsV4Catalog {
+    static final String BOOST_PACKAGE = "com.rubenmayayo.reddit";
+    static final String MORPHE_FRAGMENT =
+            "app.morphe.extension.boostforreddit.settings.MorpheSettingsFragment";
+    static final String BACKUP_ACTIVITY =
+            "com.rubenmayayo.reddit.BackupActivity";
+
+    private static final String ANDROID_NAMESPACE =
+            "http://schemas.android.com/apk/res/android";
+    private static final String FRAGMENT_PREFIX =
+            "com.rubenmayayo.reddit.ui.preferences.v2.";
+
+    static final class Leaf {
+        final String title;
+        final String summary;
+        final String iconName;
+        final String fragmentName;
+        final String resourceName;
+        final String activityName;
+
+        Leaf(
+                String title,
+                String summary,
+                String iconName,
+                String fragmentName,
+                String resourceName,
+                String activityName
+        ) {
+            this.title = title;
+            this.summary = summary;
+            this.iconName = iconName;
+            this.fragmentName = fragmentName;
+            this.resourceName = resourceName;
+            this.activityName = activityName;
+        }
+
+        static Leaf fragment(
+                String title,
+                String summary,
+                String iconName,
+                String fragmentClass,
+                String resourceName
+        ) {
+            return new Leaf(
+                    title,
+                    summary,
+                    iconName,
+                    fragmentClass,
+                    resourceName,
+                    null
+            );
+        }
+
+        static Leaf activity(
+                String title,
+                String summary,
+                String iconName,
+                String activityClass
+        ) {
+            return new Leaf(
+                    title,
+                    summary,
+                    iconName,
+                    null,
+                    null,
+                    activityClass
+            );
+        }
+    }
+
+    static final class Category {
+        final String id;
+        final String title;
+        final String summary;
+        final String iconName;
+        final Leaf[] leaves;
+
+        Category(
+                String id,
+                String title,
+                String summary,
+                String iconName,
+                Leaf... leaves
+        ) {
+            this.id = id;
+            this.title = title;
+            this.summary = summary;
+            this.iconName = iconName;
+            this.leaves = leaves;
+        }
+    }
+
+    static final class SearchItem {
+        final String title;
+        final String summary;
+        final String category;
+        final String iconName;
+        final String fragmentName;
+        final String activityName;
+        final String preferenceKey;
+
+        SearchItem(
+                String title,
+                String summary,
+                String category,
+                String iconName,
+                String fragmentName,
+                String activityName,
+                String preferenceKey
+        ) {
+            this.title = title;
+            this.summary = summary;
+            this.category = category;
+            this.iconName = iconName;
+            this.fragmentName = fragmentName;
+            this.activityName = activityName;
+            this.preferenceKey = preferenceKey;
+        }
+
+        boolean matches(String normalizedQuery) {
+            if (TextUtils.isEmpty(normalizedQuery)) {
+                return true;
+            }
+            return normalize(title).contains(normalizedQuery)
+                    || normalize(summary).contains(normalizedQuery)
+                    || normalize(category).contains(normalizedQuery)
+                    || normalize(preferenceKey).contains(normalizedQuery);
+        }
+    }
+
+    private static final Leaf MORPHE = Leaf.fragment(
+            "Morphe",
+            "Features added by Morphe patches",
+            "ic_puzzle_24dp",
+            MORPHE_FRAGMENT,
+            "morphe_boost_settings_skeleton"
+    );
+
+    private static final Category[] CATEGORIES = new Category[]{
+            new Category(
+                    "appearance_layout",
+                    "Appearance & layout",
+                    "Theme, post layout, and fonts",
+                    "ic_color_lens_24dp",
+                    leaf("Theme & appearance", "Theme, dark mode, and app icon", "ic_color_lens_24dp", "PreferenceFragmentAppearanceCompat", "pref_appearance_v2"),
+                    leaf("Post views", "Cards, lists, thumbnails, and density", "ic_view_carousel_24dp", "PreferenceFragmentViewsCompat", "pref_views_v2"),
+                    leaf("Fonts", "Font family, size, and style", "ic_format_size_24dp", "PreferenceFragmentFontsCompat", "pref_fonts_v2")
+            ),
+            new Category(
+                    "posts_comments",
+                    "Posts & comments",
+                    "Post and comment behavior",
+                    "ic_post_24dp",
+                    leaf("Posts", "Post display and interaction behavior", "ic_post_24dp", "PreferenceFragmentPostsCompat", "pref_posts_v2"),
+                    leaf("Comments", "Comment display and interaction behavior", "ic_comment_outline_white_24dp", "PreferenceFragmentCommentsCompat", "pref_comments_v2")
+            ),
+            new Category(
+                    "navigation",
+                    "Navigation",
+                    "Toolbar, bottom navigation, and drawer",
+                    "ic_toolbar_24dp",
+                    leaf("Toolbar", "Toolbar buttons and behavior", "ic_toolbar_24dp", "PreferenceFragmentToolbarCompat", "pref_toolbar_v2"),
+                    leaf("Bottom navigation", "Tabs and bottom navigation behavior", "ic_bottomnav_24dp", "PreferenceFragmentBottomNavigationCompat", "pref_bottom_navigation_v2"),
+                    leaf("Navigation drawer", "Drawer items and ordering", "ic_dock_left_24dp", "PreferenceFragmentDrawerCompat", "pref_drawer_v2")
+            ),
+            new Category(
+                    "media_links",
+                    "Media & links",
+                    "Viewers, players, and link handling",
+                    "ic_photo_outline_24dp",
+                    leaf("Media viewer", "Images, GIFs, video, and viewer behavior", "ic_photo_outline_24dp", "PreferenceFragmentMediaCompat", "pref_media_v2"),
+                    leaf("Link handling", "Browser and in-app link behavior", "ic_link_24dp", "PreferenceFragmentLinksCompat", "pref_links_v2")
+            ),
+            new Category(
+                    "search_filters",
+                    "Search & filters",
+                    "Search behavior and content filters",
+                    "ic_search_color_24dp",
+                    leaf("Search", "Search behavior and defaults", "ic_search_color_24dp", "PreferenceFragmentSearchCompat", "pref_search_v2"),
+                    leaf("Content filters", "Keywords, domains, and content rules", "ic_filter_list_24dp", "PreferenceFragmentFiltersCompat", "pref_filters_v2")
+            ),
+            new Category(
+                    "notifications",
+                    "Notifications",
+                    "Check interval, notification tone, and inbox",
+                    "ic_notifications_black_24dp",
+                    leaf("Notifications", "Messages and notification behavior", "ic_notifications_black_24dp", "PreferenceFragmentMessagesCompat", "pref_messages_v2")
+            ),
+            new Category(
+                    "data_storage",
+                    "Data & storage",
+                    "Bandwidth, cache, downloads, and backup",
+                    "outline_data_usage_24",
+                    leaf("Data usage", "Bandwidth, cache, and data-saving behavior", "outline_data_usage_24", "PreferenceFragmentDataSavingCompat", "pref_data_v2"),
+                    leaf("Downloads", "Download folder and file behavior", "ic_file_download_24dp", "PreferenceFragmentDownloadsCompat", "pref_downloads_v2"),
+                    Leaf.activity("Backup", "Export or import Boost settings", "ic_save_24dp", BACKUP_ACTIVITY)
+            ),
+            new Category(
+                    "account_privacy",
+                    "Account & privacy",
+                    "Reddit preferences, history, and privacy",
+                    "ic_person_24dp",
+                    Leaf.fragment("Reddit preferences", "Website and account preferences", "ic_subreddit_24dp", FRAGMENT_PREFIX + "PreferenceFragmentAccountCompat", null),
+                    leaf("History & privacy", "History, recent items, and privacy controls", "ic_restore_black_24dp", "PreferenceFragmentPrivacyCompat", "pref_privacy_v2")
+            ),
+            new Category(
+                    "app_legacy",
+                    "App behavior & legacy",
+                    "General behavior and older features",
+                    "ic_settings_24dp",
+                    leaf("General", "General app behavior", "ic_settings_24dp", "PreferenceFragmentGeneralCompat", "pref_general_v2"),
+                    leaf("Legacy features", "Older Boost features and compatibility", "ic_restore_black_24dp", "PreferenceFragmentMiscCompat", "pref_misc_v2")
+            ),
+            new Category(
+                    "about",
+                    "About",
+                    "Support, privacy, licenses, and app information",
+                    "ic_help_24dp",
+                    leaf("About Boost", "Support, licenses, privacy, and version", "ic_help_24dp", "PreferenceFragmentAboutCompat", "pref_about_v2")
+            )
+    };
+
+    private MorpheSettingsV4Catalog() {
+    }
+
+    static Leaf morphe() {
+        return MORPHE;
+    }
+
+    static Category[] categories() {
+        return CATEGORIES.clone();
+    }
+
+    static Category findCategory(String id) {
+        for (Category category : CATEGORIES) {
+            if (category.id.equals(id)) {
+                return category;
+            }
+        }
+        return null;
+    }
+
+    static List<SearchItem> buildSearchIndex(Context context) {
+        List<SearchItem> result = new ArrayList<>();
+        Set<String> seen = new LinkedHashSet<>();
+
+        addLeafAndXml(context, result, seen, "Morphe", MORPHE);
+        for (Category category : CATEGORIES) {
+            for (Leaf leaf : category.leaves) {
+                addLeafAndXml(context, result, seen, category.title, leaf);
+            }
+        }
+        return result;
+    }
+
+    private static void addLeafAndXml(
+            Context context,
+            List<SearchItem> result,
+            Set<String> seen,
+            String category,
+            Leaf leaf
+    ) {
+        addSearchItem(
+                result,
+                seen,
+                new SearchItem(
+                        leaf.title,
+                        leaf.summary,
+                        category,
+                        leaf.iconName,
+                        leaf.fragmentName,
+                        leaf.activityName,
+                        null
+                )
+        );
+
+        if (leaf.resourceName == null || leaf.fragmentName == null) {
+            return;
+        }
+
+        Resources resources = context.getResources();
+        int resourceId = resourceId(context, "xml", leaf.resourceName);
+        if (resourceId == 0) {
+            return;
+        }
+
+        XmlResourceParser parser = null;
+        try {
+            parser = resources.getXml(resourceId);
+            int event;
+            while ((event = parser.next()) != XmlPullParser.END_DOCUMENT) {
+                if (event != XmlPullParser.START_TAG) {
+                    continue;
+                }
+
+                String tag = parser.getName();
+                if ("PreferenceScreen".equals(tag)
+                        || "PreferenceCategory".equals(tag)) {
+                    continue;
+                }
+
+                String title = attributeText(resources, parser, "title");
+                if (TextUtils.isEmpty(title)) {
+                    continue;
+                }
+
+                String summary = attributeText(resources, parser, "summary");
+                String key = attributeText(resources, parser, "key");
+                String nestedFragment = parser.getAttributeValue(
+                        ANDROID_NAMESPACE,
+                        "fragment"
+                );
+                String destination = TextUtils.isEmpty(nestedFragment)
+                        ? leaf.fragmentName
+                        : nestedFragment;
+
+                addSearchItem(
+                        result,
+                        seen,
+                        new SearchItem(
+                                title,
+                                summary,
+                                category + " · " + leaf.title,
+                                leaf.iconName,
+                                destination,
+                                null,
+                                key
+                        )
+                );
+            }
+        } catch (Exception ignored) {
+            // Search indexing is best-effort; navigation remains available.
+        } finally {
+            if (parser != null) {
+                parser.close();
+            }
+        }
+    }
+
+    private static void addSearchItem(
+            List<SearchItem> result,
+            Set<String> seen,
+            SearchItem item
+    ) {
+        String signature = normalize(item.title)
+                + "|" + normalize(item.fragmentName)
+                + "|" + normalize(item.activityName)
+                + "|" + normalize(item.preferenceKey);
+        if (seen.add(signature)) {
+            result.add(item);
+        }
+    }
+
+    static int resourceId(Context context, String type, String name) {
+        Resources resources = context.getResources();
+        int resourceId = resources.getIdentifier(
+                name,
+                type,
+                context.getPackageName()
+        );
+        if (resourceId == 0) {
+            resourceId = resources.getIdentifier(name, type, BOOST_PACKAGE);
+        }
+        return resourceId;
+    }
+
+    private static String attributeText(
+            Resources resources,
+            XmlResourceParser parser,
+            String name
+    ) {
+        int resourceId = parser.getAttributeResourceValue(
+                ANDROID_NAMESPACE,
+                name,
+                0
+        );
+        if (resourceId != 0) {
+            try {
+                return resources.getText(resourceId).toString();
+            } catch (Resources.NotFoundException ignored) {
+                return "";
+            }
+        }
+
+        String value = parser.getAttributeValue(ANDROID_NAMESPACE, name);
+        return value == null ? "" : value;
+    }
+
+    static String normalize(String value) {
+        return value == null ? "" : value.trim().toLowerCase();
+    }
+
+    private static Leaf leaf(
+            String title,
+            String summary,
+            String iconName,
+            String fragmentClass,
+            String resourceName
+    ) {
+        return Leaf.fragment(
+                title,
+                summary,
+                iconName,
+                FRAGMENT_PREFIX + fragmentClass,
+                resourceName
+        );
+    }
+}

--- a/extensions/boostforreddit/src/main/java/app/morphe/extension/boostforreddit/settings/MorpheSettingsV4Catalog.java
+++ b/extensions/boostforreddit/src/main/java/app/morphe/extension/boostforreddit/settings/MorpheSettingsV4Catalog.java
@@ -14,8 +14,6 @@ import java.util.Set;
 
 final class MorpheSettingsV4Catalog {
     static final String BOOST_PACKAGE = "com.rubenmayayo.reddit";
-    static final String MORPHE_FRAGMENT =
-            "app.morphe.extension.boostforreddit.settings.MorpheSettingsFragment";
     static final String BACKUP_ACTIVITY =
             "com.rubenmayayo.reddit.BackupActivity";
     static final String V4_APPEARANCE_FRAGMENT =
@@ -33,6 +31,18 @@ final class MorpheSettingsV4Catalog {
     static final String V4_FONTS_FRAGMENT =
             "app.morphe.extension.boostforreddit.settings."
                     + "MorpheSettingsV4FontsFragment";
+    static final String V4_TOOLBAR_FRAGMENT =
+            "app.morphe.extension.boostforreddit.settings."
+                    + "MorpheSettingsV4ToolbarFragment";
+    static final String V4_DATA_STORAGE_FRAGMENT =
+            "app.morphe.extension.boostforreddit.settings."
+                    + "MorpheSettingsV4DataStorageFragment";
+    static final String V4_DOWNLOADS_FRAGMENT =
+            "app.morphe.extension.boostforreddit.settings."
+                    + "MorpheSettingsV4DownloadsFragment";
+    private static final String V4_NATIVE_PAGES =
+            "app.morphe.extension.boostforreddit.settings."
+                    + "MorpheSettingsV4NativePages$";
     static final String CLASSIC_APPEARANCE_FRAGMENT =
             "com.rubenmayayo.reddit.ui.preferences.v2."
                     + "PreferenceFragmentAppearanceCompat";
@@ -164,7 +174,7 @@ final class MorpheSettingsV4Catalog {
             "Morphe",
             "Features added by Morphe patches",
             "ic_puzzle_24dp",
-            MORPHE_FRAGMENT,
+            V4_NATIVE_PAGES + "Morphe",
             "morphe_boost_settings_skeleton"
     );
 
@@ -183,48 +193,47 @@ final class MorpheSettingsV4Catalog {
                     "Posts & comments",
                     "Post and comment behavior",
                     "ic_post_24dp",
-                    leaf("Posts", "Post display and interaction behavior", "ic_post_24dp", "PreferenceFragmentPostsCompat", "pref_posts_v2"),
-                    leaf("Comments", "Comment display and interaction behavior", "ic_comment_outline_white_24dp", "PreferenceFragmentCommentsCompat", "pref_comments_v2")
+                    nativeLeaf("Posts", "Post display and interaction behavior", "ic_post_24dp", "Posts", "pref_posts_v2"),
+                    nativeLeaf("Comments", "Comment display and interaction behavior", "ic_comment_outline_white_24dp", "Comments", "pref_comments_v2")
             ),
             new Category(
                     "navigation",
                     "Navigation",
                     "Toolbar, bottom navigation, and drawer",
                     "ic_toolbar_24dp",
-                    leaf("Toolbar", "Toolbar buttons and behavior", "ic_toolbar_24dp", "PreferenceFragmentToolbarCompat", "pref_toolbar_v2"),
-                    leaf("Bottom navigation", "Tabs and bottom navigation behavior", "ic_bottomnav_24dp", "PreferenceFragmentBottomNavigationCompat", "pref_bottom_navigation_v2"),
-                    leaf("Navigation drawer", "Drawer items and ordering", "ic_dock_left_24dp", "PreferenceFragmentDrawerCompat", "pref_drawer_v2")
+                    Leaf.fragment("Toolbar", "Toolbar buttons and behavior", "ic_toolbar_24dp", V4_TOOLBAR_FRAGMENT, "pref_toolbar_v2"),
+                    nativeLeaf("Bottom navigation", "Tabs and bottom navigation behavior", "ic_bottomnav_24dp", "BottomNavigation", "pref_bottom_navigation_v2"),
+                    nativeLeaf("Navigation drawer", "Drawer items and ordering", "ic_dock_left_24dp", "Drawer", "pref_drawer_v2")
             ),
             new Category(
                     "media_links",
                     "Media & links",
                     "Viewers, players, and link handling",
                     "ic_photo_outline_24dp",
-                    leaf("Media viewer", "Images, GIFs, video, and viewer behavior", "ic_photo_outline_24dp", "PreferenceFragmentMediaCompat", "pref_media_v2"),
-                    leaf("Link handling", "Browser and in-app link behavior", "ic_link_24dp", "PreferenceFragmentLinksCompat", "pref_links_v2")
+                    nativeLeaf("Media viewer", "Images, GIFs, video, and viewer behavior", "ic_photo_outline_24dp", "Media", "pref_media_v2"),
+                    nativeLeaf("Link handling", "Browser and in-app link behavior", "ic_link_24dp", "Links", "pref_links_v2")
             ),
             new Category(
                     "search_filters",
                     "Search & filters",
                     "Search behavior and content filters",
                     "ic_search_color_24dp",
-                    leaf("Search", "Search behavior and defaults", "ic_search_color_24dp", "PreferenceFragmentSearchCompat", "pref_search_v2"),
-                    leaf("Content filters", "Keywords, domains, and content rules", "ic_filter_list_24dp", "PreferenceFragmentFiltersCompat", "pref_filters_v2")
+                    nativeLeaf("Search", "Search behavior and defaults", "ic_search_color_24dp", "Search", "pref_search_v2"),
+                    nativeLeaf("Content filters", "Keywords, domains, and content rules", "ic_filter_list_24dp", "Filters", "pref_filters_v2")
             ),
             new Category(
                     "notifications",
                     "Notifications",
                     "Check interval, notification tone, and inbox",
                     "ic_notifications_black_24dp",
-                    leaf("Notifications", "Messages and notification behavior", "ic_notifications_black_24dp", "PreferenceFragmentMessagesCompat", "pref_messages_v2")
+                    nativeLeaf("Notifications", "Messages and notification behavior", "ic_notifications_black_24dp", "Messages", "pref_messages_v2")
             ),
             new Category(
                     "data_storage",
-                    "Data & storage",
-                    "Bandwidth, cache, downloads, and backup",
-                    "outline_data_usage_24",
-                    leaf("Data usage", "Bandwidth, cache, and data-saving behavior", "outline_data_usage_24", "PreferenceFragmentDataSavingCompat", "pref_data_v2"),
-                    leaf("Downloads", "Download folder and file behavior", "ic_file_download_24dp", "PreferenceFragmentDownloadsCompat", "pref_downloads_v2"),
+                    "Backup",
+                    "Data storage, export, and import",
+                    "ic_save_24dp",
+                    Leaf.fragment("Data storage", "Bandwidth, media quality, downloads, and cache", "outline_data_usage_24", V4_DATA_STORAGE_FRAGMENT, "pref_data_v2"),
                     Leaf.activity("Backup", "Export or import Boost settings", "ic_save_24dp", BACKUP_ACTIVITY)
             ),
             new Category(
@@ -233,23 +242,21 @@ final class MorpheSettingsV4Catalog {
                     "Reddit preferences, history, and privacy",
                     "ic_person_24dp",
                     Leaf.fragment("Reddit preferences", "Website and account preferences", "ic_subreddit_24dp", FRAGMENT_PREFIX + "PreferenceFragmentAccountCompat", null),
-                    leaf("History & privacy", "History, recent items, and privacy controls", "ic_restore_black_24dp", "PreferenceFragmentPrivacyCompat", "pref_privacy_v2")
+                    nativeLeaf("History & privacy", "History, recent items, and privacy controls", "ic_restore_black_24dp", "Privacy", "pref_privacy_v2")
             ),
             new Category(
                     "app_legacy",
-                    "App behavior & legacy",
-                    "General behavior and older features",
+                    "App behavior",
+                    "Composing, subscriptions, and exit behavior",
                     "ic_settings_24dp",
-                    leaf("General", "General app behavior", "ic_settings_24dp", "PreferenceFragmentGeneralCompat", "pref_general_v2"),
-                    leaf("Legacy features", "Older Boost features and compatibility", "ic_restore_black_24dp", "PreferenceFragmentMiscCompat", "pref_misc_v2"),
-                    Leaf.fragment("Classic theme editor", "Legacy Boost palettes and per-color customization", "ic_color_lens_24dp", CLASSIC_APPEARANCE_FRAGMENT, null)
+                    nativeLeaf("General", "Unique app behavior and composing options", "ic_settings_24dp", "General", "pref_general_v2")
             ),
             new Category(
                     "about",
                     "About",
                     "Support, privacy, licenses, and app information",
                     "ic_help_24dp",
-                    leaf("About Boost", "Support, licenses, privacy, and version", "ic_help_24dp", "PreferenceFragmentAboutCompat", "pref_about_v2")
+                    nativeLeaf("About Boost", "Support, licenses, privacy, and version", "ic_help_24dp", "About", "pref_about_v2")
             )
     };
 
@@ -443,7 +450,9 @@ final class MorpheSettingsV4Catalog {
                 );
                 String destination = TextUtils.isEmpty(nestedFragment)
                         ? leaf.fragmentName
-                        : nestedFragment;
+                        : MorpheSettingsV4NativePages.nativeDestination(
+                                nestedFragment
+                        );
 
                 addSearchItem(
                         result,
@@ -533,6 +542,22 @@ final class MorpheSettingsV4Catalog {
                 summary,
                 iconName,
                 FRAGMENT_PREFIX + fragmentClass,
+                resourceName
+        );
+    }
+
+    private static Leaf nativeLeaf(
+            String title,
+            String summary,
+            String iconName,
+            String pageClass,
+            String resourceName
+    ) {
+        return Leaf.fragment(
+                title,
+                summary,
+                iconName,
+                V4_NATIVE_PAGES + pageClass,
                 resourceName
         );
     }

--- a/extensions/boostforreddit/src/main/java/app/morphe/extension/boostforreddit/settings/MorpheSettingsV4Catalog.java
+++ b/extensions/boostforreddit/src/main/java/app/morphe/extension/boostforreddit/settings/MorpheSettingsV4Catalog.java
@@ -21,6 +21,18 @@ final class MorpheSettingsV4Catalog {
     static final String V4_APPEARANCE_FRAGMENT =
             "app.morphe.extension.boostforreddit.settings."
                     + "MorpheSettingsV4AppearanceFragment";
+    static final String V4_APP_ICON_FRAGMENT =
+            "app.morphe.extension.boostforreddit.settings."
+                    + "MorpheSettingsV4AppIconFragment";
+    static final String V4_POST_VIEWS_FRAGMENT =
+            "app.morphe.extension.boostforreddit.settings."
+                    + "MorpheSettingsV4PostViewsFragment";
+    static final String V4_SAVED_VIEWS_FRAGMENT =
+            "app.morphe.extension.boostforreddit.settings."
+                    + "MorpheSettingsV4SavedViewsFragment";
+    static final String V4_FONTS_FRAGMENT =
+            "app.morphe.extension.boostforreddit.settings."
+                    + "MorpheSettingsV4FontsFragment";
     static final String CLASSIC_APPEARANCE_FRAGMENT =
             "com.rubenmayayo.reddit.ui.preferences.v2."
                     + "PreferenceFragmentAppearanceCompat";
@@ -163,8 +175,8 @@ final class MorpheSettingsV4Catalog {
                     "Colors, post layout, and fonts",
                     "ic_color_lens_24dp",
                     Leaf.fragment("Appearance", "Dynamic color, app icon, and system bars", "ic_color_lens_24dp", V4_APPEARANCE_FRAGMENT, null),
-                    leaf("Post views", "Cards, lists, thumbnails, and density", "ic_view_carousel_24dp", "PreferenceFragmentViewsCompat", "pref_views_v2"),
-                    leaf("Fonts", "Font family, size, and style", "ic_format_size_24dp", "PreferenceFragmentFontsCompat", "pref_fonts_v2")
+                    Leaf.fragment("Post views", "Cards, lists, thumbnails, and density", "ic_view_carousel_24dp", V4_POST_VIEWS_FRAGMENT, null),
+                    Leaf.fragment("Fonts", "Font family, size, and style", "ic_format_size_24dp", V4_FONTS_FRAGMENT, null)
             ),
             new Category(
                     "posts_comments",
@@ -272,6 +284,8 @@ final class MorpheSettingsV4Catalog {
             }
         }
         addV4AppearanceSearchItems(result, seen);
+        addV4PostViewsSearchItems(result, seen);
+        addV4FontsSearchItems(result, seen);
         return result;
     }
 
@@ -295,6 +309,74 @@ final class MorpheSettingsV4Catalog {
                             "Appearance & layout · Appearance",
                             "ic_color_lens_24dp",
                             V4_APPEARANCE_FRAGMENT,
+                            null,
+                            item[2]
+                    )
+            );
+        }
+    }
+
+    private static void addV4PostViewsSearchItems(
+            List<SearchItem> result,
+            Set<String> seen
+    ) {
+        String[][] items = new String[][]{
+                {"Default view", "Choose cards, compact, columns, images, or swipe", "pref_view"},
+                {"Remember per community", "Use the last selected view for each community", "pref_view_per_subscription"},
+                {"Manage saved views", "Review community-specific views", "pref_view_per_sub"},
+                {"Thumbnails on left", "Place post thumbnails on the left side", "pref_left_handed"},
+                {"Communities start with r/", "Show Reddit's prefix before community names", "pref_show_subreddit_prefix"},
+                {"Rounded corners", "Round card image corners", "pref_cards_rounded_corners"},
+                {"Full height images", "Use full-height card images", "pref_cards_full_preview"},
+                {"Show community icon", "Show community icons on cards", "pref_cards_subreddit_icon"},
+                {"Carousel for multiple images", "Swipe through gallery images on cards", "pref_cards_gallery_carousel"},
+                {"Show thumbnails for link posts", "Use thumbnails instead of large previews", "pref_cards_links_as_thumbnails"},
+                {"Preview text from posts", "Show text previews on cards", "pref_cards_preview_self"},
+                {"Lines to preview", "Set the number of post-text preview lines", "pref_cards_preview_self_lines"},
+                {"Small-card rounded corners", "Round small-card image corners", "pref_mini_cards_rounded_corners"},
+                {"Truncate small-card titles", "Limit small-card titles to two lines", "pref_mini_cards_truncate_title"},
+                {"Small-card buttons", "Keep small-card buttons visible", "pref_mini_cards_buttons_visible"},
+                {"Dense-view buttons", "Keep dense-view buttons visible", "pref_dense_buttons_visible"},
+                {"Preview external links", "Load text previews for external links", "pref_load_readability"},
+                {"Lock sidebar", "Disable opening the sidebar with a swipe", "pref_lock_sidebar"},
+        };
+        for (String[] item : items) {
+            addSearchItem(
+                    result,
+                    seen,
+                    new SearchItem(
+                            item[0],
+                            item[1],
+                            "Appearance & layout · Post views",
+                            "ic_view_carousel_24dp",
+                            V4_POST_VIEWS_FRAGMENT,
+                            null,
+                            item[2]
+                    )
+            );
+        }
+    }
+
+    private static void addV4FontsSearchItems(
+            List<SearchItem> result,
+            Set<String> seen
+    ) {
+        String[][] items = new String[][]{
+                {"Title font", "Choose the font used for post titles", "pref_title_font"},
+                {"Title text size", "Choose the size used for post titles", "pref_font_size_title"},
+                {"Comments font", "Choose the font used for comments and messages", "pref_comments_font"},
+                {"Comments text size", "Choose the size used for comments and messages", "pref_font_size"},
+        };
+        for (String[] item : items) {
+            addSearchItem(
+                    result,
+                    seen,
+                    new SearchItem(
+                            item[0],
+                            item[1],
+                            "Appearance & layout · Fonts",
+                            "ic_format_size_24dp",
+                            V4_FONTS_FRAGMENT,
                             null,
                             item[2]
                     )

--- a/extensions/boostforreddit/src/main/java/app/morphe/extension/boostforreddit/settings/MorpheSettingsV4DataStorageFragment.java
+++ b/extensions/boostforreddit/src/main/java/app/morphe/extension/boostforreddit/settings/MorpheSettingsV4DataStorageFragment.java
@@ -1,0 +1,778 @@
+package app.morphe.extension.boostforreddit.settings;
+
+import android.app.Activity;
+import android.app.Dialog;
+import android.content.Context;
+import android.content.Intent;
+import android.content.SharedPreferences;
+import android.graphics.Color;
+import android.graphics.Typeface;
+import android.graphics.drawable.ColorDrawable;
+import android.os.Bundle;
+import android.preference.PreferenceManager;
+import android.text.TextUtils;
+import android.view.Gravity;
+import android.view.LayoutInflater;
+import android.view.Menu;
+import android.view.MenuItem;
+import android.view.View;
+import android.view.ViewGroup;
+import android.view.Window;
+import android.widget.LinearLayout;
+import android.widget.ScrollView;
+import android.widget.TextView;
+import android.widget.Toast;
+
+import androidx.fragment.app.Fragment;
+
+import app.morphe.extension.boostforreddit.utils.BoostSystemBarInsetsFix;
+
+import java.lang.reflect.Method;
+
+/** Morphe-owned data and storage controls backed by Boost's canonical keys. */
+public final class MorpheSettingsV4DataStorageFragment extends Fragment {
+    public static final String CONTRACT_MARKER =
+            "MORPHE_BOOST_SETTINGS_V4_DATA_STORAGE_ISSUE106_V2";
+
+    private static final String EXTRA_SHOW_FRAGMENT =
+            "extra_show_fragment";
+
+    private static final String KEY_DOWNLOAD_FOLDERS =
+            "pref_download_folders";
+    private static final String KEY_REDUCE_MOBILE = "pref_reduce_mobile";
+    private static final String KEY_REDUCE_WIFI = "pref_reduce_wifi";
+    private static final String KEY_AUTOPLAY = "pref_autoplay_cards";
+    private static final String KEY_VIDEO_QUALITY = "pref_video_quality";
+    private static final String KEY_VIDEO_QUALITY_MIN =
+            "pref_video_quality_min";
+    private static final String KEY_VIDEO_QUALITY_MAX =
+            "pref_video_quality_max";
+    private static final String KEY_LOAD_IMAGES = "pref_load_images";
+    private static final String KEY_CACHE_CURRENT_SIZE =
+            "pref_cache_current_size";
+    private static final String KEY_CACHE_MAX_SIZE = "pref_cache_max_size";
+
+    private static final String[] AUTOPLAY_TITLES = new String[]{
+            "Always",
+            "When on Wi-Fi",
+            "Never",
+    };
+    private static final String[] AUTOPLAY_VALUES = new String[]{
+            "0", "1", "2",
+    };
+    private static final String[] VIDEO_QUALITY_TITLES = new String[]{
+            "Prefer lower size",
+            "Prefer best quality",
+            "Auto based on data saving settings",
+    };
+    private static final String[] VIDEO_QUALITY_VALUES = new String[]{
+            "0", "1", "2",
+    };
+    private static final String[] RESOLUTION_TITLES = new String[]{
+            "240p", "360p", "480p", "720p (HD)", "1080p (HD)",
+    };
+    private static final String[] RESOLUTION_VALUES = new String[]{
+            "240", "360", "480", "720", "1080",
+    };
+    private static final String[] IMAGE_TITLES = new String[]{
+            "Enabled",
+            "Disabled",
+            "Auto based on network",
+    };
+    private static final String[] IMAGE_VALUES = new String[]{
+            "0", "1", "2",
+    };
+    private static final String[] CACHE_SIZE_TITLES = new String[]{
+            "128MB", "256MB", "512MB", "1GB", "2GB",
+    };
+    private static final String[] CACHE_SIZE_VALUES = new String[]{
+            "128", "256", "512", "1024", "2048",
+    };
+
+    private MorpheSettingsV4Theme.Tokens tokens;
+    private SharedPreferences preferences;
+    private TextView autoplaySummary;
+    private TextView videoQualitySummary;
+    private TextView videoQualityMinSummary;
+    private TextView videoQualityMaxSummary;
+    private TextView loadImagesSummary;
+    private TextView cacheCurrentSizeSummary;
+    private TextView cacheMaxSizeSummary;
+    private LinearLayout videoQualityMinRow;
+    private LinearLayout videoQualityMaxRow;
+    private boolean autoplayWasDisabled;
+
+    public MorpheSettingsV4DataStorageFragment() {
+    }
+
+    @Override
+    public View onCreateView(
+            LayoutInflater inflater,
+            ViewGroup container,
+            Bundle savedInstanceState
+    ) {
+        Context context = inflater.getContext();
+        tokens = MorpheSettingsV4Theme.resolve(context);
+        preferences = PreferenceManager.getDefaultSharedPreferences(context);
+        autoplayWasDisabled = "2".equals(preferenceString(KEY_AUTOPLAY, "1"));
+        setHasOptionsMenu(true);
+
+        ScrollView scrollView = new ScrollView(context);
+        scrollView.setFillViewport(true);
+        scrollView.setClipToPadding(false);
+        scrollView.setBackgroundColor(tokens.background);
+
+        LinearLayout content = new LinearLayout(context);
+        content.setOrientation(LinearLayout.VERTICAL);
+        int horizontal = dp(16);
+        content.setPadding(horizontal, dp(10), horizontal, dp(32));
+        scrollView.addView(
+                content,
+                new ScrollView.LayoutParams(
+                        ViewGroup.LayoutParams.MATCH_PARENT,
+                        ViewGroup.LayoutParams.WRAP_CONTENT
+                )
+        );
+
+        addSectionLabel(content, "Downloads");
+        addSpace(content, 8);
+        LinearLayout downloadsGroup = addGroup(content);
+        addNavigationRow(
+                downloadsGroup,
+                "Configure downloads",
+                "Change download folder location and folder organization",
+                true,
+                view -> openDownloadFolders()
+        );
+
+        addSpace(content, 24);
+        addSectionLabel(content, "Data saver");
+        addSpace(content, 8);
+        LinearLayout dataSaverGroup = addGroup(content);
+        addSwitchRow(
+                dataSaverGroup,
+                "Mobile data saver",
+                "Load lower-size media on mobile data",
+                preferences.getBoolean(KEY_REDUCE_MOBILE, true),
+                checked -> {
+                    preferences.edit().putBoolean(KEY_REDUCE_MOBILE, checked).apply();
+                    updateVideoQualityRows();
+                }
+        );
+        addSwitchRow(
+                dataSaverGroup,
+                "Wi-Fi data saver",
+                "Load lower-size media on Wi-Fi",
+                preferences.getBoolean(KEY_REDUCE_WIFI, false),
+                checked -> {
+                    preferences.edit().putBoolean(KEY_REDUCE_WIFI, checked).apply();
+                    updateVideoQualityRows();
+                }
+        );
+
+        addSpace(content, 24);
+        addSectionLabel(content, "Videos");
+        addSpace(content, 8);
+        LinearLayout videosGroup = addGroup(content);
+        LinearLayout autoplayRow = addNavigationRow(
+                videosGroup,
+                "Autoplay videos",
+                titleFor(
+                        AUTOPLAY_TITLES,
+                        AUTOPLAY_VALUES,
+                        preferenceString(KEY_AUTOPLAY, "1")
+                ),
+                true,
+                view -> showChoiceDialog(
+                        "Autoplay videos",
+                        KEY_AUTOPLAY,
+                        AUTOPLAY_TITLES,
+                        AUTOPLAY_VALUES,
+                        "1",
+                        autoplaySummary,
+                        this::onAutoplayChanged
+                )
+        );
+        autoplaySummary = rowSummary(autoplayRow);
+
+        LinearLayout qualityRow = addNavigationRow(
+                videosGroup,
+                "Video quality",
+                titleFor(
+                        VIDEO_QUALITY_TITLES,
+                        VIDEO_QUALITY_VALUES,
+                        preferenceString(KEY_VIDEO_QUALITY, "0")
+                ),
+                true,
+                view -> showChoiceDialog(
+                        "Video quality",
+                        KEY_VIDEO_QUALITY,
+                        VIDEO_QUALITY_TITLES,
+                        VIDEO_QUALITY_VALUES,
+                        "0",
+                        videoQualitySummary,
+                        this::updateVideoQualityRows
+                )
+        );
+        videoQualitySummary = rowSummary(qualityRow);
+
+        videoQualityMinRow = addNavigationRow(
+                videosGroup,
+                "Minimum quality",
+                titleFor(
+                        RESOLUTION_TITLES,
+                        RESOLUTION_VALUES,
+                        preferenceString(KEY_VIDEO_QUALITY_MIN, "480")
+                ),
+                true,
+                view -> showChoiceDialog(
+                        "Minimum quality",
+                        KEY_VIDEO_QUALITY_MIN,
+                        RESOLUTION_TITLES,
+                        RESOLUTION_VALUES,
+                        "480",
+                        videoQualityMinSummary,
+                        null
+                )
+        );
+        videoQualityMinSummary = rowSummary(videoQualityMinRow);
+
+        videoQualityMaxRow = addNavigationRow(
+                videosGroup,
+                "Maximum quality",
+                titleFor(
+                        RESOLUTION_TITLES,
+                        RESOLUTION_VALUES,
+                        preferenceString(KEY_VIDEO_QUALITY_MAX, "1080")
+                ),
+                true,
+                view -> showChoiceDialog(
+                        "Maximum quality",
+                        KEY_VIDEO_QUALITY_MAX,
+                        RESOLUTION_TITLES,
+                        RESOLUTION_VALUES,
+                        "1080",
+                        videoQualityMaxSummary,
+                        null
+                )
+        );
+        videoQualityMaxSummary = rowSummary(videoQualityMaxRow);
+        updateVideoQualityRows();
+
+        addSpace(content, 24);
+        addSectionLabel(content, "Images");
+        addSpace(content, 8);
+        LinearLayout imagesGroup = addGroup(content);
+        LinearLayout imagesRow = addNavigationRow(
+                imagesGroup,
+                "Load images",
+                titleFor(
+                        IMAGE_TITLES,
+                        IMAGE_VALUES,
+                        preferenceString(KEY_LOAD_IMAGES, "0")
+                ),
+                true,
+                view -> showChoiceDialog(
+                        "Load images",
+                        KEY_LOAD_IMAGES,
+                        IMAGE_TITLES,
+                        IMAGE_VALUES,
+                        "0",
+                        loadImagesSummary,
+                        null
+                )
+        );
+        loadImagesSummary = rowSummary(imagesRow);
+
+        addSpace(content, 24);
+        addSectionLabel(content, "Cache");
+        addSpace(content, 8);
+        LinearLayout cacheGroup = addGroup(content);
+        LinearLayout clearCacheRow = addNavigationRow(
+                cacheGroup,
+                "Clear cache",
+                "Delete images and videos from cache",
+                true,
+                view -> clearCache()
+        );
+        cacheCurrentSizeSummary = rowSummary(clearCacheRow);
+
+        LinearLayout cacheSizeRow = addNavigationRow(
+                cacheGroup,
+                "Maximum cache size",
+                titleFor(
+                        CACHE_SIZE_TITLES,
+                        CACHE_SIZE_VALUES,
+                        preferenceString(KEY_CACHE_MAX_SIZE, "128")
+                ),
+                true,
+                view -> showChoiceDialog(
+                        "Maximum cache size",
+                        KEY_CACHE_MAX_SIZE,
+                        CACHE_SIZE_TITLES,
+                        CACHE_SIZE_VALUES,
+                        "128",
+                        cacheMaxSizeSummary,
+                        this::resizeCache
+                )
+        );
+        cacheMaxSizeSummary = rowSummary(cacheSizeRow);
+        refreshCacheSummary();
+        return scrollView;
+    }
+
+    @Override
+    public void onResume() {
+        super.onResume();
+        styleHost();
+        refreshCacheSummary();
+        updateVideoQualityRows();
+    }
+
+    @Override
+    public void onPause() {
+        Activity activity = hostActivity();
+        if (activity != null) {
+            BoostSystemBarInsetsFix.clearMorpheSettingsV4SystemBars(activity);
+        }
+        super.onPause();
+    }
+
+    @Override
+    public void onPrepareOptionsMenu(Menu menu) {
+        super.onPrepareOptionsMenu(menu);
+        hideMenuItem(menu, "action_generic_search");
+        hideMenuItem(menu, "action_search");
+        hideMenuItem(menu, "search");
+    }
+
+    private LinearLayout addGroup(LinearLayout parent) {
+        LinearLayout group = MorpheSettingsV14Ui.group(requireContext());
+        parent.addView(group, new LinearLayout.LayoutParams(
+                ViewGroup.LayoutParams.MATCH_PARENT,
+                ViewGroup.LayoutParams.WRAP_CONTENT
+        ));
+        return group;
+    }
+
+    private LinearLayout addNavigationRow(
+            LinearLayout parent,
+            String titleValue,
+            String summaryValue,
+            boolean enabled,
+            View.OnClickListener listener
+    ) {
+        LinearLayout row = baseRow(requireContext());
+        row.addView(createLabels(titleValue, summaryValue), labelsParams());
+
+        row.addView(MorpheSettingsV14Ui.chevron(requireContext(), tokens));
+        row.setOnClickListener(listener);
+        setRowEnabled(row, enabled);
+        addGroupedRow(parent, row);
+        return row;
+    }
+
+    private void addSwitchRow(
+            LinearLayout parent,
+            String titleValue,
+            String summaryValue,
+            boolean checked,
+            CheckedChange change
+    ) {
+        MorpheSettingsV4Theme.Accent accent = tokens.navigationAccent();
+        LinearLayout row = baseRow(requireContext());
+        row.setClickable(true);
+        row.setFocusable(true);
+        row.addView(createLabels(titleValue, summaryValue), labelsParams());
+
+        MorpheSettingsV14Ui.Toggle toggle =
+                new MorpheSettingsV14Ui.Toggle(
+                        requireContext(),
+                        tokens,
+                        checked
+                );
+        toggle.setOnCheckedChangeListener(
+                (button, value) -> change.onChanged(value)
+        );
+        row.setOnClickListener(view -> toggle.toggle());
+        row.addView(toggle, new LinearLayout.LayoutParams(
+                ViewGroup.LayoutParams.WRAP_CONTENT,
+                ViewGroup.LayoutParams.WRAP_CONTENT
+        ));
+        addGroupedRow(parent, row);
+    }
+
+    private void showChoiceDialog(
+            String titleValue,
+            String key,
+            String[] titles,
+            String[] values,
+            String defaultValue,
+            TextView summary,
+            Runnable afterChange
+    ) {
+        Context context = requireContext();
+        Dialog dialog = new Dialog(context);
+        LinearLayout content = new LinearLayout(context);
+        content.setOrientation(LinearLayout.VERTICAL);
+        content.setPadding(dp(20), dp(20), dp(20), dp(14));
+        content.setBackground(MorpheSettingsV4Theme.rounded(
+                context,
+                tokens.surfaceContainerHigh,
+                28
+        ));
+
+        TextView heading = textView(titleValue, 20, tokens.textPrimary);
+        heading.setTypeface(Typeface.create("sans-serif-medium", Typeface.NORMAL));
+        LinearLayout.LayoutParams headingParams = wrapParams();
+        headingParams.setMarginStart(dp(8));
+        headingParams.bottomMargin = dp(8);
+        content.addView(heading, headingParams);
+
+        String selected = preferenceString(key, defaultValue);
+        LinearLayout choiceGroup = MorpheSettingsV14Ui.group(context);
+        content.addView(choiceGroup, new LinearLayout.LayoutParams(
+                ViewGroup.LayoutParams.MATCH_PARENT,
+                ViewGroup.LayoutParams.WRAP_CONTENT
+        ));
+        for (int index = 0; index < titles.length; index++) {
+            final int choice = index;
+            MorpheSettingsV14Ui.ChoiceRow row =
+                    MorpheSettingsV14Ui.choiceRow(
+                    context,
+                    tokens,
+                    titles[index],
+                    "",
+                    values[index].equals(selected)
+            );
+            row.setOnClickListener(view -> {
+                String oldValue = preferenceString(key, defaultValue);
+                preferences.edit().putString(key, values[choice]).apply();
+                if (summary != null) {
+                    summary.setText(titles[choice]);
+                }
+                if (KEY_AUTOPLAY.equals(key)) {
+                    onAutoplayChoice(oldValue, values[choice]);
+                }
+                if (afterChange != null) {
+                    afterChange.run();
+                }
+                dialog.dismiss();
+            });
+            MorpheSettingsV14Ui.addSegmentedRow(choiceGroup, row, tokens);
+        }
+
+        TextView cancel = textView("Cancel", 14, tokens.navigationAccent().color);
+        cancel.setTypeface(Typeface.create("sans-serif-medium", Typeface.NORMAL));
+        cancel.setGravity(Gravity.CENTER);
+        cancel.setAllCaps(false);
+        cancel.setPadding(dp(14), dp(10), dp(14), dp(10));
+        cancel.setOnClickListener(view -> dialog.dismiss());
+        LinearLayout.LayoutParams cancelParams = wrapParams();
+        cancelParams.gravity = Gravity.END;
+        cancelParams.topMargin = dp(4);
+        content.addView(cancel, cancelParams);
+
+        dialog.setContentView(content);
+        Window window = dialog.getWindow();
+        if (window != null) {
+            window.setBackgroundDrawable(new ColorDrawable(Color.TRANSPARENT));
+        }
+        dialog.show();
+        window = dialog.getWindow();
+        if (window != null) {
+            int width = context.getResources().getDisplayMetrics().widthPixels
+                    - dp(40);
+            window.setLayout(width, ViewGroup.LayoutParams.WRAP_CONTENT);
+        }
+    }
+
+    private void onAutoplayChanged() {
+        autoplayWasDisabled = "2".equals(preferenceString(KEY_AUTOPLAY, "1"));
+    }
+
+    private void onAutoplayChoice(String oldValue, String newValue) {
+        if (autoplayWasDisabled
+                && "2".equals(oldValue)
+                && !"2".equals(newValue)) {
+            Toast.makeText(
+                    requireContext(),
+                    "Changes will be applied on app restart",
+                    Toast.LENGTH_SHORT
+            ).show();
+        }
+        autoplayWasDisabled = "2".equals(newValue);
+    }
+
+    private void updateVideoQualityRows() {
+        if (preferences == null) {
+            return;
+        }
+        String quality = preferenceString(KEY_VIDEO_QUALITY, "0");
+        boolean minimumEnabled;
+        boolean maximumEnabled;
+        if ("1".equals(quality)) {
+            minimumEnabled = false;
+            maximumEnabled = true;
+        } else if ("2".equals(quality)) {
+            boolean mobile = preferences.getBoolean(KEY_REDUCE_MOBILE, true);
+            boolean wifi = preferences.getBoolean(KEY_REDUCE_WIFI, false);
+            minimumEnabled = mobile || wifi;
+            maximumEnabled = !(mobile && wifi);
+        } else {
+            minimumEnabled = true;
+            maximumEnabled = false;
+        }
+        setRowEnabled(videoQualityMinRow, minimumEnabled);
+        setRowEnabled(videoQualityMaxRow, maximumEnabled);
+    }
+
+    private void openDownloadFolders() {
+        Activity activity = hostActivity();
+        if (activity == null) {
+            showUnavailable();
+            return;
+        }
+        try {
+            Intent intent = new Intent(activity, activity.getClass());
+            intent.putExtra(
+                    EXTRA_SHOW_FRAGMENT,
+                    MorpheSettingsV4Catalog.V4_DOWNLOADS_FRAGMENT
+            );
+            activity.startActivity(intent);
+        } catch (Throwable ignored) {
+            showUnavailable();
+        }
+    }
+
+    private void clearCache() {
+        if (!invokeStaticVoid("qb.a", "a", requireContext())) {
+            showUnavailable();
+            return;
+        }
+        refreshCacheSummary();
+        if (cacheCurrentSizeSummary != null) {
+            cacheCurrentSizeSummary.postDelayed(this::refreshCacheSummary, 350);
+        }
+    }
+
+    private void resizeCache() {
+        invokeStaticVoid("qb.b", "d", requireContext());
+    }
+
+    private void refreshCacheSummary() {
+        if (cacheCurrentSizeSummary == null || getContext() == null) {
+            return;
+        }
+        Object result = invokeStatic("qb.a", "b", requireContext());
+        if (result instanceof String && !TextUtils.isEmpty((String) result)) {
+            cacheCurrentSizeSummary.setText((String) result);
+        } else {
+            cacheCurrentSizeSummary.setText(
+                    "Delete images and videos from cache"
+            );
+        }
+    }
+
+    private Object invokeStatic(
+            String className,
+            String methodName,
+            Context context
+    ) {
+        try {
+            Class<?> type = Class.forName(className);
+            Method method = type.getDeclaredMethod(methodName, Context.class);
+            method.setAccessible(true);
+            return method.invoke(null, context);
+        } catch (Throwable ignored) {
+            return null;
+        }
+    }
+
+    private boolean invokeStaticVoid(
+            String className,
+            String methodName,
+            Context context
+    ) {
+        try {
+            Class<?> type = Class.forName(className);
+            Method method = type.getDeclaredMethod(methodName, Context.class);
+            method.setAccessible(true);
+            method.invoke(null, context);
+            return true;
+        } catch (Throwable ignored) {
+            return false;
+        }
+    }
+
+    private String preferenceString(String key, String defaultValue) {
+        try {
+            return preferences.getString(key, defaultValue);
+        } catch (ClassCastException ignored) {
+            return defaultValue;
+        }
+    }
+
+    static String titleFor(
+            String[] titles,
+            String[] values,
+            String value
+    ) {
+        for (int index = 0; index < values.length; index++) {
+            if (values[index].equals(value)) {
+                return titles[index];
+            }
+        }
+        return titles[0];
+    }
+
+    private void styleHost() {
+        Activity activity = hostActivity();
+        if (activity == null || tokens == null) {
+            return;
+        }
+        activity.setTitle("Data storage");
+        BoostSystemBarInsetsFix.applyMorpheSettingsV4SystemBars(
+                activity,
+                tokens.background,
+                tokens.dark
+        );
+        int toolbarId = MorpheSettingsV4Catalog.resourceId(
+                activity,
+                "id",
+                "toolbar"
+        );
+        View toolbar = activity.findViewById(toolbarId);
+        if (toolbar != null) {
+            toolbar.setBackgroundColor(tokens.background);
+            toolbar.setElevation(0);
+        }
+    }
+
+    private Activity hostActivity() {
+        Context context = requireContext();
+        return context instanceof Activity ? (Activity) context : null;
+    }
+
+    private void hideMenuItem(Menu menu, String resourceName) {
+        int resourceId = MorpheSettingsV4Catalog.resourceId(
+                requireContext(),
+                "id",
+                resourceName
+        );
+        if (resourceId == 0) {
+            return;
+        }
+        MenuItem item = menu.findItem(resourceId);
+        if (item != null) {
+            item.setVisible(false);
+        }
+    }
+
+    private LinearLayout baseRow(Context context) {
+        return MorpheSettingsV14Ui.baseRow(context, tokens);
+    }
+
+    private void addGroupedRow(LinearLayout group, LinearLayout row) {
+        MorpheSettingsV14Ui.addSegmentedRow(group, row, tokens);
+    }
+
+    private void addGroupDivider(LinearLayout group) {
+        View divider = new View(requireContext());
+        divider.setBackgroundColor(MorpheSettingsV4Theme.blend(
+                tokens.surfaceContainer,
+                tokens.outline,
+                tokens.dark ? 0.22f : 0.16f
+        ));
+        LinearLayout.LayoutParams params = new LinearLayout.LayoutParams(
+                ViewGroup.LayoutParams.MATCH_PARENT,
+                dp(1)
+        );
+        params.setMarginStart(dp(18));
+        params.setMarginEnd(dp(18));
+        group.addView(divider, params);
+    }
+
+    private LinearLayout createLabels(String titleValue, String summaryValue) {
+        return MorpheSettingsV14Ui.labels(
+                requireContext(),
+                tokens,
+                titleValue,
+                summaryValue
+        );
+    }
+
+    private TextView rowSummary(LinearLayout row) {
+        if (row.getChildCount() == 0
+                || !(row.getChildAt(0) instanceof LinearLayout)) {
+            return null;
+        }
+        LinearLayout labels = (LinearLayout) row.getChildAt(0);
+        return labels.getChildCount() > 1
+                && labels.getChildAt(1) instanceof TextView
+                ? (TextView) labels.getChildAt(1)
+                : null;
+    }
+
+    private void setRowEnabled(View row, boolean enabled) {
+        if (row == null) {
+            return;
+        }
+        row.setEnabled(enabled);
+        row.setClickable(enabled);
+        row.setFocusable(enabled);
+        row.setAlpha(enabled ? 1.0f : 0.44f);
+    }
+
+    private void addSectionLabel(LinearLayout parent, String value) {
+        parent.addView(MorpheSettingsV14Ui.sectionLabel(
+                requireContext(),
+                tokens,
+                value
+        ));
+    }
+
+    private TextView textView(String value, int sizeSp, int color) {
+        TextView textView = new TextView(requireContext());
+        textView.setText(value);
+        textView.setTextSize(sizeSp);
+        textView.setTextColor(color);
+        return textView;
+    }
+
+    private LinearLayout.LayoutParams labelsParams() {
+        return new LinearLayout.LayoutParams(
+                0,
+                ViewGroup.LayoutParams.WRAP_CONTENT,
+                1.0f
+        );
+    }
+
+    private LinearLayout.LayoutParams wrapParams() {
+        return new LinearLayout.LayoutParams(
+                ViewGroup.LayoutParams.WRAP_CONTENT,
+                ViewGroup.LayoutParams.WRAP_CONTENT
+        );
+    }
+
+    private void addSpace(LinearLayout parent, int heightDp) {
+        View space = new View(requireContext());
+        parent.addView(space, new LinearLayout.LayoutParams(1, dp(heightDp)));
+    }
+
+    private int dp(float value) {
+        return MorpheSettingsV4Theme.dp(requireContext(), value);
+    }
+
+    private void showUnavailable() {
+        Toast.makeText(
+                requireContext(),
+                "This data and storage control is unavailable in the current Boost build.",
+                Toast.LENGTH_SHORT
+        ).show();
+    }
+
+    private interface CheckedChange {
+        void onChanged(boolean checked);
+    }
+}

--- a/extensions/boostforreddit/src/main/java/app/morphe/extension/boostforreddit/settings/MorpheSettingsV4DownloadsFragment.java
+++ b/extensions/boostforreddit/src/main/java/app/morphe/extension/boostforreddit/settings/MorpheSettingsV4DownloadsFragment.java
@@ -1,0 +1,612 @@
+package app.morphe.extension.boostforreddit.settings;
+
+import android.app.Activity;
+import android.content.Context;
+import android.content.Intent;
+import android.content.SharedPreferences;
+import android.graphics.Color;
+import android.graphics.Typeface;
+import android.net.Uri;
+import android.os.Bundle;
+import android.preference.PreferenceManager;
+import android.text.TextUtils;
+import android.view.Gravity;
+import android.view.LayoutInflater;
+import android.view.Menu;
+import android.view.MenuItem;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.LinearLayout;
+import android.widget.ScrollView;
+import android.widget.TextView;
+import android.widget.Toast;
+
+import androidx.fragment.app.Fragment;
+
+import app.morphe.extension.boostforreddit.utils.BoostSystemBarInsetsFix;
+
+import java.lang.reflect.Method;
+
+/** Morphe-owned M3 surface for Boost's complete download-folder contract. */
+public final class MorpheSettingsV4DownloadsFragment extends Fragment {
+    public static final String CONTRACT_MARKER =
+            "MORPHE_BOOST_SETTINGS_V4_DOWNLOADS_ISSUE106_V1";
+
+    private static final int REQUEST_FOLDER = 0x4ee9;
+    private static final int FOLDER_DEFAULT = 0;
+    private static final int FOLDER_IMAGES = 1;
+    private static final int FOLDER_VIDEOS = 2;
+    private static final int FOLDER_GIFS = 3;
+
+    private static final String[] FOLDER_KEYS = new String[]{
+            "pref_download_folder_default",
+            "pref_download_folder_img",
+            "pref_download_folder_mp4",
+            "pref_download_folder_gif",
+    };
+    private static final String KEY_COMMUNITY_SUBFOLDERS =
+            "pref_download_folder_per_subreddit";
+
+    private final FolderRow[] folderRows = new FolderRow[4];
+    private MorpheSettingsV4Theme.Tokens tokens;
+    private SharedPreferences preferences;
+    private int pendingFolderType = -1;
+
+    public MorpheSettingsV4DownloadsFragment() {
+    }
+
+    @Override
+    public View onCreateView(
+            LayoutInflater inflater,
+            ViewGroup container,
+            Bundle savedInstanceState
+    ) {
+        Context context = inflater.getContext();
+        tokens = MorpheSettingsV4Theme.resolve(context);
+        preferences = PreferenceManager.getDefaultSharedPreferences(context);
+        if (savedInstanceState != null) {
+            pendingFolderType = savedInstanceState.getInt(
+                    "morphe_pending_folder_type",
+                    -1
+            );
+        }
+        setHasOptionsMenu(true);
+
+        ScrollView scrollView = new ScrollView(context);
+        scrollView.setFillViewport(true);
+        scrollView.setClipToPadding(false);
+        scrollView.setBackgroundColor(tokens.background);
+
+        LinearLayout content = new LinearLayout(context);
+        content.setOrientation(LinearLayout.VERTICAL);
+        int horizontal = dp(16);
+        content.setPadding(horizontal, dp(10), horizontal, dp(32));
+        scrollView.addView(
+                content,
+                new ScrollView.LayoutParams(
+                        ViewGroup.LayoutParams.MATCH_PARENT,
+                        ViewGroup.LayoutParams.WRAP_CONTENT
+                )
+        );
+
+        addSectionLabel(content, "Download folders");
+        addSpace(content, 8);
+        LinearLayout foldersGroup = addGroup(content);
+        folderRows[FOLDER_DEFAULT] = addFolderRow(
+                foldersGroup,
+                "Default folder",
+                FOLDER_DEFAULT
+        );
+        folderRows[FOLDER_IMAGES] = addFolderRow(
+                foldersGroup,
+                "Images",
+                FOLDER_IMAGES
+        );
+        folderRows[FOLDER_VIDEOS] = addFolderRow(
+                foldersGroup,
+                "Videos",
+                FOLDER_VIDEOS
+        );
+        folderRows[FOLDER_GIFS] = addFolderRow(
+                foldersGroup,
+                "GIFs",
+                FOLDER_GIFS
+        );
+        applyBoostFolderVisibility();
+
+        addSpace(content, 24);
+        addSectionLabel(content, "Organization");
+        addSpace(content, 8);
+        LinearLayout organizationGroup = addGroup(content);
+        addSwitchRow(
+                organizationGroup,
+                "Community subfolders",
+                "Organize downloaded media into community folders",
+                communitySubfoldersEnabled(),
+                this::setCommunitySubfoldersEnabled
+        );
+
+        refreshFolderRows();
+        return scrollView;
+    }
+
+    @Override
+    public void onResume() {
+        super.onResume();
+        styleHost();
+        refreshFolderRows();
+    }
+
+    @Override
+    public void onPause() {
+        Activity activity = hostActivity();
+        if (activity != null) {
+            BoostSystemBarInsetsFix.clearMorpheSettingsV4SystemBars(activity);
+        }
+        super.onPause();
+    }
+
+    @Override
+    public void onSaveInstanceState(Bundle outState) {
+        outState.putInt("morphe_pending_folder_type", pendingFolderType);
+        super.onSaveInstanceState(outState);
+    }
+
+    @Override
+    public void onPrepareOptionsMenu(Menu menu) {
+        super.onPrepareOptionsMenu(menu);
+        hideMenuItem(menu, "action_generic_search");
+        hideMenuItem(menu, "action_search");
+        hideMenuItem(menu, "search");
+    }
+
+    @Override
+    public void onActivityResult(
+            int requestCode,
+            int resultCode,
+            Intent data
+    ) {
+        super.onActivityResult(requestCode, resultCode, data);
+        if (requestCode != REQUEST_FOLDER
+                || resultCode != Activity.RESULT_OK
+                || data == null
+                || data.getData() == null
+                || pendingFolderType < FOLDER_DEFAULT
+                || pendingFolderType > FOLDER_GIFS) {
+            return;
+        }
+
+        Uri folder = data.getData();
+        int permissionFlags = data.getFlags()
+                & (Intent.FLAG_GRANT_READ_URI_PERMISSION
+                | Intent.FLAG_GRANT_WRITE_URI_PERMISSION);
+        if (permissionFlags == 0) {
+            permissionFlags = Intent.FLAG_GRANT_READ_URI_PERMISSION
+                    | Intent.FLAG_GRANT_WRITE_URI_PERMISSION;
+        }
+        try {
+            requireContext().getContentResolver().takePersistableUriPermission(
+                    folder,
+                    permissionFlags
+            );
+        } catch (SecurityException ignored) {
+            // Some document providers grant access without a persistable flag.
+        }
+
+        int folderType = pendingFolderType;
+        pendingFolderType = -1;
+        String value = folder.toString();
+        if (!invokeBoostVoid(
+                "D6",
+                new Class<?>[]{int.class, String.class},
+                folderType,
+                value
+        )) {
+            preferences.edit().putString(FOLDER_KEYS[folderType], value).apply();
+        }
+        refreshFolderRows();
+    }
+
+    private FolderRow addFolderRow(
+            LinearLayout parent,
+            String titleValue,
+            int folderType
+    ) {
+        MorpheSettingsV4Theme.Accent accent = tokens.navigationAccent();
+        LinearLayout row = baseRow(requireContext());
+        LinearLayout labels = createLabels(titleValue, "Not set");
+        row.addView(labels, labelsParams());
+
+        TextView reset = textView("Reset", 13, accent.color);
+        reset.setTypeface(Typeface.create(
+                "sans-serif-medium",
+                Typeface.NORMAL
+        ));
+        reset.setGravity(Gravity.CENTER);
+        reset.setPadding(dp(10), dp(8), dp(10), dp(8));
+        reset.setBackground(MorpheSettingsV4Theme.interactive(
+                requireContext(),
+                Color.TRANSPARENT,
+                16,
+                accent.color
+        ));
+        reset.setOnClickListener(view -> resetFolder(folderType));
+        row.addView(reset, new LinearLayout.LayoutParams(
+                ViewGroup.LayoutParams.WRAP_CONTENT,
+                ViewGroup.LayoutParams.WRAP_CONTENT
+        ));
+
+        TextView chevron = textView("›", 28, accent.color);
+        chevron.setGravity(Gravity.CENTER);
+        row.addView(chevron, new LinearLayout.LayoutParams(dp(28), dp(44)));
+        row.setOnClickListener(view -> chooseFolder(folderType));
+        addGroupedRow(parent, row);
+
+        TextView summary = labels.getChildCount() > 1
+                && labels.getChildAt(1) instanceof TextView
+                ? (TextView) labels.getChildAt(1)
+                : null;
+        return new FolderRow(row, summary, reset);
+    }
+
+    private void addSwitchRow(
+            LinearLayout parent,
+            String titleValue,
+            String summaryValue,
+            boolean checked,
+            CheckedChange change
+    ) {
+        LinearLayout row = baseRow(requireContext());
+        row.setClickable(true);
+        row.setFocusable(true);
+        row.addView(createLabels(titleValue, summaryValue), labelsParams());
+
+        MorpheSettingsV14Ui.Toggle toggle =
+                new MorpheSettingsV14Ui.Toggle(
+                        requireContext(),
+                        tokens,
+                        checked
+                );
+        toggle.setOnCheckedChangeListener(
+                (button, value) -> change.onChanged(value)
+        );
+        row.setOnClickListener(view -> toggle.toggle());
+        row.addView(toggle, new LinearLayout.LayoutParams(
+                ViewGroup.LayoutParams.WRAP_CONTENT,
+                ViewGroup.LayoutParams.WRAP_CONTENT
+        ));
+        addGroupedRow(parent, row);
+    }
+
+    private void chooseFolder(int folderType) {
+        pendingFolderType = folderType;
+        Intent intent = new Intent(Intent.ACTION_OPEN_DOCUMENT_TREE);
+        intent.addFlags(
+                Intent.FLAG_GRANT_READ_URI_PERMISSION
+                        | Intent.FLAG_GRANT_WRITE_URI_PERMISSION
+                        | Intent.FLAG_GRANT_PERSISTABLE_URI_PERMISSION
+        );
+        try {
+            startActivityForResult(intent, REQUEST_FOLDER);
+        } catch (Throwable ignored) {
+            pendingFolderType = -1;
+            showUnavailable();
+        }
+    }
+
+    private void resetFolder(int folderType) {
+        if (!invokeBoostVoid(
+                "D6",
+                new Class<?>[]{int.class, String.class},
+                folderType,
+                null
+        )) {
+            preferences.edit().remove(FOLDER_KEYS[folderType]).apply();
+        }
+        refreshFolderRows();
+    }
+
+    private void refreshFolderRows() {
+        if (preferences == null) {
+            return;
+        }
+        for (int folderType = FOLDER_DEFAULT;
+                folderType <= FOLDER_GIFS;
+                folderType++) {
+            FolderRow folderRow = folderRows[folderType];
+            if (folderRow == null) {
+                continue;
+            }
+            if (folderRow.summary != null) {
+                folderRow.summary.setText(folderSummary(folderType));
+            }
+            folderRow.reset.setVisibility(
+                    hasCustomFolder(folderType) ? View.VISIBLE : View.GONE
+            );
+        }
+    }
+
+    private String folderSummary(int folderType) {
+        Object value = invokeBoost(
+                "d0",
+                new Class<?>[]{int.class},
+                folderType
+        );
+        if (!(value instanceof String) || TextUtils.isEmpty((String) value)) {
+            value = preferences.getString(FOLDER_KEYS[folderType], "");
+        }
+        if (!(value instanceof String) || TextUtils.isEmpty((String) value)) {
+            return "Not set";
+        }
+        return friendlyFolder((String) value);
+    }
+
+    private boolean hasCustomFolder(int folderType) {
+        Object value = invokeBoost(
+                "O",
+                new Class<?>[]{int.class},
+                folderType
+        );
+        return value instanceof Boolean
+                ? (Boolean) value
+                : preferences.contains(FOLDER_KEYS[folderType]);
+    }
+
+    private boolean communitySubfoldersEnabled() {
+        Object value = invokeBoost("l2", new Class<?>[0]);
+        return value instanceof Boolean
+                ? (Boolean) value
+                : preferences.getBoolean(KEY_COMMUNITY_SUBFOLDERS, false);
+    }
+
+    private void setCommunitySubfoldersEnabled(boolean enabled) {
+        if (!invokeBoostVoid(
+                "E6",
+                new Class<?>[]{boolean.class},
+                enabled
+        )) {
+            preferences.edit()
+                    .putBoolean(KEY_COMMUNITY_SUBFOLDERS, enabled)
+                    .apply();
+        }
+    }
+
+    private void applyBoostFolderVisibility() {
+        boolean storageAccessFramework = invokeStaticBoolean(
+                "sb.a",
+                "f",
+                true
+        );
+        boolean typedFolders = storageAccessFramework && invokeStaticBoolean(
+                "sb.a",
+                "g",
+                true
+        );
+        setFolderRowVisible(FOLDER_DEFAULT, storageAccessFramework);
+        setFolderRowVisible(FOLDER_IMAGES, typedFolders);
+        setFolderRowVisible(FOLDER_VIDEOS, typedFolders);
+        setFolderRowVisible(FOLDER_GIFS, typedFolders);
+    }
+
+    private void setFolderRowVisible(int folderType, boolean visible) {
+        FolderRow folderRow = folderRows[folderType];
+        if (folderRow != null) {
+            folderRow.row.setVisibility(visible ? View.VISIBLE : View.GONE);
+        }
+    }
+
+    private Object invokeBoost(
+            String methodName,
+            Class<?>[] parameterTypes,
+            Object... arguments
+    ) {
+        try {
+            Class<?> type = Class.forName("id.b");
+            Method instanceMethod = type.getDeclaredMethod("v0");
+            instanceMethod.setAccessible(true);
+            Object instance = instanceMethod.invoke(null);
+            Method method = type.getDeclaredMethod(methodName, parameterTypes);
+            method.setAccessible(true);
+            return method.invoke(instance, arguments);
+        } catch (Throwable ignored) {
+            return null;
+        }
+    }
+
+    private boolean invokeBoostVoid(
+            String methodName,
+            Class<?>[] parameterTypes,
+            Object... arguments
+    ) {
+        try {
+            Class<?> type = Class.forName("id.b");
+            Method instanceMethod = type.getDeclaredMethod("v0");
+            instanceMethod.setAccessible(true);
+            Object instance = instanceMethod.invoke(null);
+            Method method = type.getDeclaredMethod(methodName, parameterTypes);
+            method.setAccessible(true);
+            method.invoke(instance, arguments);
+            return true;
+        } catch (Throwable ignored) {
+            return false;
+        }
+    }
+
+    private boolean invokeStaticBoolean(
+            String className,
+            String methodName,
+            boolean fallback
+    ) {
+        try {
+            Class<?> type = Class.forName(className);
+            Method method = type.getDeclaredMethod(methodName);
+            method.setAccessible(true);
+            Object value = method.invoke(null);
+            return value instanceof Boolean ? (Boolean) value : fallback;
+        } catch (Throwable ignored) {
+            return fallback;
+        }
+    }
+
+    private String friendlyFolder(String rawValue) {
+        String value = Uri.decode(rawValue);
+        int tree = value.indexOf("/tree/");
+        if (tree >= 0 && tree + 6 < value.length()) {
+            value = value.substring(tree + 6);
+        }
+        if (value.startsWith("primary:")) {
+            value = "Internal storage / " + value.substring(8);
+        }
+        value = value.replace(':', '/');
+        return value.replace("/", " / ").replaceAll("\\s+", " ").trim();
+    }
+
+    private LinearLayout addGroup(LinearLayout parent) {
+        LinearLayout group = MorpheSettingsV14Ui.group(requireContext());
+        parent.addView(group, new LinearLayout.LayoutParams(
+                ViewGroup.LayoutParams.MATCH_PARENT,
+                ViewGroup.LayoutParams.WRAP_CONTENT
+        ));
+        return group;
+    }
+
+    private LinearLayout baseRow(Context context) {
+        return MorpheSettingsV14Ui.baseRow(context, tokens);
+    }
+
+    private void addGroupedRow(LinearLayout group, LinearLayout row) {
+        MorpheSettingsV14Ui.addSegmentedRow(group, row, tokens);
+    }
+
+    private void addGroupDivider(LinearLayout group) {
+        View divider = new View(requireContext());
+        divider.setBackgroundColor(MorpheSettingsV4Theme.blend(
+                tokens.surfaceContainer,
+                tokens.outline,
+                tokens.dark ? 0.22f : 0.16f
+        ));
+        LinearLayout.LayoutParams params = new LinearLayout.LayoutParams(
+                ViewGroup.LayoutParams.MATCH_PARENT,
+                dp(1)
+        );
+        params.setMarginStart(dp(18));
+        params.setMarginEnd(dp(18));
+        group.addView(divider, params);
+    }
+
+    private LinearLayout createLabels(String titleValue, String summaryValue) {
+        return MorpheSettingsV14Ui.labels(
+                requireContext(),
+                tokens,
+                titleValue,
+                summaryValue
+        );
+    }
+
+    private void styleHost() {
+        Activity activity = hostActivity();
+        if (activity == null || tokens == null) {
+            return;
+        }
+        activity.setTitle("Configure downloads");
+        BoostSystemBarInsetsFix.applyMorpheSettingsV4SystemBars(
+                activity,
+                tokens.background,
+                tokens.dark
+        );
+        int toolbarId = MorpheSettingsV4Catalog.resourceId(
+                activity,
+                "id",
+                "toolbar"
+        );
+        View toolbar = activity.findViewById(toolbarId);
+        if (toolbar != null) {
+            toolbar.setBackgroundColor(tokens.background);
+            toolbar.setElevation(0);
+        }
+    }
+
+    private Activity hostActivity() {
+        Context context = requireContext();
+        return context instanceof Activity ? (Activity) context : null;
+    }
+
+    private void hideMenuItem(Menu menu, String resourceName) {
+        int resourceId = MorpheSettingsV4Catalog.resourceId(
+                requireContext(),
+                "id",
+                resourceName
+        );
+        if (resourceId == 0) {
+            return;
+        }
+        MenuItem item = menu.findItem(resourceId);
+        if (item != null) {
+            item.setVisible(false);
+        }
+    }
+
+    private void addSectionLabel(LinearLayout parent, String value) {
+        parent.addView(MorpheSettingsV14Ui.sectionLabel(
+                requireContext(),
+                tokens,
+                value
+        ));
+    }
+
+    private TextView textView(String value, int sizeSp, int color) {
+        TextView textView = new TextView(requireContext());
+        textView.setText(value);
+        textView.setTextSize(sizeSp);
+        textView.setTextColor(color);
+        return textView;
+    }
+
+    private LinearLayout.LayoutParams labelsParams() {
+        return new LinearLayout.LayoutParams(
+                0,
+                ViewGroup.LayoutParams.WRAP_CONTENT,
+                1.0f
+        );
+    }
+
+    private LinearLayout.LayoutParams wrapParams() {
+        return new LinearLayout.LayoutParams(
+                ViewGroup.LayoutParams.WRAP_CONTENT,
+                ViewGroup.LayoutParams.WRAP_CONTENT
+        );
+    }
+
+    private void addSpace(LinearLayout parent, int heightDp) {
+        View space = new View(requireContext());
+        parent.addView(space, new LinearLayout.LayoutParams(1, dp(heightDp)));
+    }
+
+    private int dp(float value) {
+        return MorpheSettingsV4Theme.dp(requireContext(), value);
+    }
+
+    private void showUnavailable() {
+        Toast.makeText(
+                requireContext(),
+                "Folder selection is unavailable in the current Boost build.",
+                Toast.LENGTH_SHORT
+        ).show();
+    }
+
+    private static final class FolderRow {
+        final View row;
+        final TextView summary;
+        final TextView reset;
+
+        FolderRow(View row, TextView summary, TextView reset) {
+            this.row = row;
+            this.summary = summary;
+            this.reset = reset;
+        }
+    }
+
+    private interface CheckedChange {
+        void onChanged(boolean checked);
+    }
+}

--- a/extensions/boostforreddit/src/main/java/app/morphe/extension/boostforreddit/settings/MorpheSettingsV4FontsFragment.java
+++ b/extensions/boostforreddit/src/main/java/app/morphe/extension/boostforreddit/settings/MorpheSettingsV4FontsFragment.java
@@ -413,9 +413,17 @@ public final class MorpheSettingsV4FontsFragment extends Fragment {
     }
 
     private void saveFontPreference(String key, String value) {
+        applyFontPreference(preferences, key, value);
+        updatePreviewAndSummaries();
+    }
+
+    static void applyFontPreference(
+            SharedPreferences preferences,
+            String key,
+            String value
+    ) {
         preferences.edit().putString(key, value).apply();
         markNativeFontCacheDirty(key);
-        updatePreviewAndSummaries();
     }
 
     private void showResetConfirmation() {
@@ -440,14 +448,7 @@ public final class MorpheSettingsV4FontsFragment extends Fragment {
         actions.addView(cancel);
         TextView reset = dialogAction("Restore");
         reset.setOnClickListener(view -> {
-            preferences.edit()
-                    .remove(KEY_TITLE_FONT)
-                    .remove(KEY_TITLE_SIZE)
-                    .remove(KEY_COMMENTS_FONT)
-                    .remove(KEY_COMMENTS_SIZE)
-                    .apply();
-            markNativeFontCacheDirty(KEY_TITLE_SIZE);
-            markNativeFontCacheDirty(KEY_TITLE_FONT);
+            resetFontPreferences(preferences);
             dialog.dismiss();
             updatePreviewAndSummaries();
         });
@@ -474,20 +475,32 @@ public final class MorpheSettingsV4FontsFragment extends Fragment {
         setText(titleSizeSummary, sizeTitle(titleSizeValue));
         setText(commentsFontSummary, fontTitle(commentsFontValue));
         setText(commentsSizeSummary, sizeTitle(commentsSizeValue));
-        if (previewTitle != null) {
-            previewTitle.setTypeface(typefaceFor(titleFontValue));
-            previewTitle.setTextSize(previewSizeSp(titleSizeValue, true));
-        }
-        if (previewComment != null) {
-            previewComment.setTypeface(typefaceFor(commentsFontValue));
-            previewComment.setTextSize(previewSizeSp(
-                    commentsSizeValue,
-                    false
-            ));
-        }
+        applyPreviewTypography(
+                previewTitle,
+                titleFontValue,
+                titleSizeValue,
+                true
+        );
+        applyPreviewTypography(
+                previewComment,
+                commentsFontValue,
+                commentsSizeValue,
+                false
+        );
     }
 
-    private void markNativeFontCacheDirty(String key) {
+    static void resetFontPreferences(SharedPreferences preferences) {
+        preferences.edit()
+                .remove(KEY_TITLE_FONT)
+                .remove(KEY_TITLE_SIZE)
+                .remove(KEY_COMMENTS_FONT)
+                .remove(KEY_COMMENTS_SIZE)
+                .apply();
+        markNativeFontCacheDirty(KEY_TITLE_SIZE);
+        markNativeFontCacheDirty(KEY_TITLE_FONT);
+    }
+
+    private static void markNativeFontCacheDirty(String key) {
         String fieldName = null;
         if (KEY_TITLE_SIZE.equals(key) || KEY_COMMENTS_SIZE.equals(key)) {
             fieldName = "d";
@@ -505,7 +518,20 @@ public final class MorpheSettingsV4FontsFragment extends Fragment {
         }
     }
 
-    private Typeface typefaceFor(String value) {
+    static void applyPreviewTypography(
+            TextView preview,
+            String fontValue,
+            String sizeValue,
+            boolean title
+    ) {
+        if (preview == null) {
+            return;
+        }
+        preview.setTypeface(typefaceFor(fontValue));
+        preview.setTextSize(previewSizeSp(sizeValue, title));
+    }
+
+    static Typeface typefaceFor(String value) {
         if (TextUtils.isEmpty(value)) {
             return Typeface.DEFAULT;
         }
@@ -516,7 +542,7 @@ public final class MorpheSettingsV4FontsFragment extends Fragment {
         return result == null ? Typeface.DEFAULT : result;
     }
 
-    private int previewSizeSp(String value, boolean title) {
+    static int previewSizeSp(String value, boolean title) {
         int index = indexOf(SIZE_VALUES, value);
         if (index < 0) {
             index = 2;
@@ -536,7 +562,7 @@ public final class MorpheSettingsV4FontsFragment extends Fragment {
         return index < 0 ? "Medium" : SIZE_TITLES[index];
     }
 
-    private int indexOf(String[] values, String target) {
+    private static int indexOf(String[] values, String target) {
         for (int index = 0; index < values.length; index++) {
             if (TextUtils.equals(values[index], target)) {
                 return index;

--- a/extensions/boostforreddit/src/main/java/app/morphe/extension/boostforreddit/settings/MorpheSettingsV4FontsFragment.java
+++ b/extensions/boostforreddit/src/main/java/app/morphe/extension/boostforreddit/settings/MorpheSettingsV4FontsFragment.java
@@ -4,11 +4,9 @@ import android.app.Activity;
 import android.app.Dialog;
 import android.content.Context;
 import android.content.SharedPreferences;
-import android.content.res.ColorStateList;
 import android.graphics.Color;
 import android.graphics.Typeface;
 import android.graphics.drawable.ColorDrawable;
-import android.os.Build;
 import android.os.Bundle;
 import android.preference.PreferenceManager;
 import android.text.TextUtils;
@@ -20,7 +18,6 @@ import android.view.View;
 import android.view.ViewGroup;
 import android.view.Window;
 import android.widget.LinearLayout;
-import android.widget.RadioButton;
 import android.widget.ScrollView;
 import android.widget.TextView;
 
@@ -121,7 +118,7 @@ public final class MorpheSettingsV4FontsFragment extends Fragment {
 
         LinearLayout content = new LinearLayout(context);
         content.setOrientation(LinearLayout.VERTICAL);
-        content.setPadding(dp(18), dp(12), dp(18), dp(32));
+        content.setPadding(dp(16), dp(10), dp(16), dp(32));
         scrollView.addView(content, new ScrollView.LayoutParams(
                 ViewGroup.LayoutParams.MATCH_PARENT,
                 ViewGroup.LayoutParams.WRAP_CONTENT
@@ -332,9 +329,7 @@ public final class MorpheSettingsV4FontsFragment extends Fragment {
 
         LinearLayout labels = createLabels(titleValue, summaryValue);
         row.addView(labels, labelsParams());
-        TextView chevron = textView("›", 28, accent.color);
-        chevron.setGravity(Gravity.CENTER);
-        row.addView(chevron, new LinearLayout.LayoutParams(dp(36), dp(48)));
+        row.addView(MorpheSettingsV14Ui.chevron(requireContext(), tokens));
         addGroupedRow(group, row);
         return row;
     }
@@ -354,22 +349,20 @@ public final class MorpheSettingsV4FontsFragment extends Fragment {
         ));
         for (int index = 0; index < FONT_TITLES.length; index++) {
             final int choice = index;
-            LinearLayout row = dialogChoiceRow();
-            RadioButton radio = radioButton(
+            MorpheSettingsV14Ui.ChoiceRow row =
+                    MorpheSettingsV14Ui.choiceRow(
+                    requireContext(),
+                    tokens,
+                    FONT_TITLES[index],
+                    "",
                     TextUtils.equals(selected, FONT_VALUES[index])
             );
-            row.addView(radio);
-            TextView label = textView(FONT_TITLES[index], 16, tokens.textPrimary);
-            label.setTypeface(typefaceFor(FONT_VALUES[index]));
-            row.addView(label, labelsParams());
+            row.setTitleTypeface(typefaceFor(FONT_VALUES[index]));
             row.setOnClickListener(view -> {
                 saveFontPreference(key, FONT_VALUES[choice]);
                 dialog.dismiss();
             });
-            choices.addView(row, new LinearLayout.LayoutParams(
-                    ViewGroup.LayoutParams.MATCH_PARENT,
-                    ViewGroup.LayoutParams.WRAP_CONTENT
-            ));
+            MorpheSettingsV14Ui.addSegmentedRow(choices, row, tokens);
         }
         LinearLayout.LayoutParams choicesParams = new LinearLayout.LayoutParams(
                 ViewGroup.LayoutParams.MATCH_PARENT,
@@ -388,25 +381,20 @@ public final class MorpheSettingsV4FontsFragment extends Fragment {
 
         for (int index = 0; index < SIZE_TITLES.length; index++) {
             final int choice = index;
-            LinearLayout row = dialogChoiceRow();
-            row.addView(radioButton(TextUtils.equals(
-                    selected,
-                    SIZE_VALUES[index]
-            )));
-            TextView label = textView(
+            MorpheSettingsV14Ui.ChoiceRow row =
+                    MorpheSettingsV14Ui.choiceRow(
+                    requireContext(),
+                    tokens,
                     SIZE_TITLES[index],
-                    previewSizeSp(SIZE_VALUES[index], false),
-                    tokens.textPrimary
+                    "",
+                    TextUtils.equals(selected, SIZE_VALUES[index])
             );
-            row.addView(label, labelsParams());
+            row.setTitleSize(previewSizeSp(SIZE_VALUES[index], false));
             row.setOnClickListener(view -> {
                 saveFontPreference(key, SIZE_VALUES[choice]);
                 dialog.dismiss();
             });
-            content.addView(row, new LinearLayout.LayoutParams(
-                    ViewGroup.LayoutParams.MATCH_PARENT,
-                    ViewGroup.LayoutParams.WRAP_CONTENT
-            ));
+            MorpheSettingsV14Ui.addSegmentedRow(content, row, tokens);
         }
         addDialogAction(content, "Cancel", () -> dialog.dismiss());
         showDialog(dialog, content);
@@ -577,26 +565,6 @@ public final class MorpheSettingsV4FontsFragment extends Fragment {
         }
     }
 
-    private RadioButton radioButton(boolean checked) {
-        RadioButton radio = new RadioButton(requireContext());
-        radio.setChecked(checked);
-        radio.setClickable(false);
-        radio.setFocusable(false);
-        if (Build.VERSION.SDK_INT >= 21) {
-            radio.setButtonTintList(new ColorStateList(
-                    new int[][]{
-                            new int[]{android.R.attr.state_checked},
-                            new int[]{-android.R.attr.state_checked},
-                    },
-                    new int[]{
-                            tokens.navigationAccent().color,
-                            tokens.textSecondary,
-                    }
-            ));
-        }
-        return radio;
-    }
-
     private LinearLayout dialogContent() {
         LinearLayout content = new LinearLayout(requireContext());
         content.setOrientation(LinearLayout.VERTICAL);
@@ -684,17 +652,7 @@ public final class MorpheSettingsV4FontsFragment extends Fragment {
     }
 
     private LinearLayout addGroup(LinearLayout parent) {
-        Context context = requireContext();
-        MorpheSettingsV4Theme.Accent accent = tokens.navigationAccent();
-        int color = MorpheSettingsV4Theme.blend(
-                tokens.surfaceContainer,
-                accent.container,
-                tokens.dark ? 0.035f : 0.025f
-        );
-        LinearLayout group = new LinearLayout(context);
-        group.setOrientation(LinearLayout.VERTICAL);
-        group.setBackground(MorpheSettingsV4Theme.rounded(context, color, 24));
-        group.setClipToOutline(true);
+        LinearLayout group = MorpheSettingsV14Ui.group(requireContext());
         parent.addView(group, new LinearLayout.LayoutParams(
                 ViewGroup.LayoutParams.MATCH_PARENT,
                 ViewGroup.LayoutParams.WRAP_CONTENT
@@ -703,38 +661,16 @@ public final class MorpheSettingsV4FontsFragment extends Fragment {
     }
 
     private void addGroupedRow(LinearLayout group, LinearLayout row) {
-        if (group.getChildCount() > 0) {
-            View divider = new View(requireContext());
-            divider.setBackgroundColor(MorpheSettingsV4Theme.blend(
-                    tokens.surfaceContainer,
-                    tokens.outline,
-                    tokens.dark ? 0.22f : 0.16f
-            ));
-            LinearLayout.LayoutParams dividerParams = new LinearLayout.LayoutParams(
-                    ViewGroup.LayoutParams.MATCH_PARENT,
-                    dp(1)
-            );
-            dividerParams.setMarginStart(dp(18));
-            dividerParams.setMarginEnd(dp(18));
-            group.addView(divider, dividerParams);
-        }
-        group.addView(row, new LinearLayout.LayoutParams(
-                ViewGroup.LayoutParams.MATCH_PARENT,
-                ViewGroup.LayoutParams.WRAP_CONTENT
-        ));
+        MorpheSettingsV14Ui.addSegmentedRow(group, row, tokens);
     }
 
     private LinearLayout createLabels(String titleValue, String summaryValue) {
-        LinearLayout labels = new LinearLayout(requireContext());
-        labels.setOrientation(LinearLayout.VERTICAL);
-        TextView title = textView(titleValue, 16, tokens.textPrimary);
-        title.setTypeface(Typeface.create("sans-serif-medium", Typeface.NORMAL));
-        labels.addView(title);
-        TextView summary = textView(summaryValue, 14, tokens.textSecondary);
-        LinearLayout.LayoutParams summaryParams = wrapParams();
-        summaryParams.topMargin = dp(3);
-        labels.addView(summary, summaryParams);
-        return labels;
+        return MorpheSettingsV14Ui.labels(
+                requireContext(),
+                tokens,
+                titleValue,
+                summaryValue
+        );
     }
 
     private TextView rowSummary(LinearLayout row) {
@@ -793,10 +729,11 @@ public final class MorpheSettingsV4FontsFragment extends Fragment {
     }
 
     private void addSectionLabel(LinearLayout parent, String value) {
-        TextView label = textView(value, 14, tokens.primary);
-        label.setTypeface(Typeface.create("sans-serif-medium", Typeface.NORMAL));
-        label.setLetterSpacing(0.02f);
-        parent.addView(label);
+        parent.addView(MorpheSettingsV14Ui.sectionLabel(
+                requireContext(),
+                tokens,
+                value
+        ));
     }
 
     private TextView textView(String value, int sizeSp, int color) {

--- a/extensions/boostforreddit/src/main/java/app/morphe/extension/boostforreddit/settings/MorpheSettingsV4FontsFragment.java
+++ b/extensions/boostforreddit/src/main/java/app/morphe/extension/boostforreddit/settings/MorpheSettingsV4FontsFragment.java
@@ -1,0 +1,807 @@
+package app.morphe.extension.boostforreddit.settings;
+
+import android.app.Activity;
+import android.app.Dialog;
+import android.content.Context;
+import android.content.SharedPreferences;
+import android.content.res.ColorStateList;
+import android.graphics.Color;
+import android.graphics.Typeface;
+import android.graphics.drawable.ColorDrawable;
+import android.os.Build;
+import android.os.Bundle;
+import android.preference.PreferenceManager;
+import android.text.TextUtils;
+import android.view.Gravity;
+import android.view.LayoutInflater;
+import android.view.Menu;
+import android.view.MenuItem;
+import android.view.View;
+import android.view.ViewGroup;
+import android.view.Window;
+import android.widget.LinearLayout;
+import android.widget.RadioButton;
+import android.widget.ScrollView;
+import android.widget.TextView;
+
+import androidx.fragment.app.Fragment;
+
+import app.morphe.extension.boostforreddit.utils.BoostSystemBarInsetsFix;
+
+import java.lang.reflect.Field;
+
+/** Material 3 editor for Boost's canonical post and comment font preferences. */
+public final class MorpheSettingsV4FontsFragment extends Fragment {
+    public static final String CONTRACT_MARKER =
+            "MORPHE_BOOST_SETTINGS_V4_FONTS_ISSUE106_V1";
+    public static final String PREVIEW_CONTRACT_MARKER =
+            "MORPHE_BOOST_SETTINGS_V4_FONT_PREVIEWS_ISSUE106_V2";
+    public static final String SPECIMEN_CONTRACT_MARKER =
+            "MORPHE_BOOST_SETTINGS_V4_FONT_SPECIMEN_ISSUE106_V3";
+
+    private static final String KEY_TITLE_FONT = "pref_title_font";
+    private static final String KEY_TITLE_SIZE = "pref_font_size_title";
+    private static final String KEY_COMMENTS_FONT = "pref_comments_font";
+    private static final String KEY_COMMENTS_SIZE = "pref_font_size";
+
+    private static final String[] FONT_TITLES = new String[]{
+            "Default",
+            "Thin",
+            "Light",
+            "Regular",
+            "Medium",
+            "Black",
+            "Condensed light",
+            "Condensed regular",
+            "Serif",
+            "Monospace",
+            "Serif monospace",
+            "Small caps",
+            "Roboto Slab",
+    };
+    private static final String[] FONT_VALUES = new String[]{
+            "",
+            "sans-serif-thin",
+            "sans-serif-light",
+            "sans-serif",
+            "sans-serif-medium",
+            "sans-serif-black",
+            "sans-serif-condensed-light",
+            "sans-serif-condensed",
+            "serif",
+            "monospace",
+            "serif-monospace",
+            "sans-serif-smallcaps",
+            "RobotoSlab-Regular.ttf",
+    };
+    private static final String[] SIZE_TITLES = new String[]{
+            "Extra small",
+            "Small",
+            "Medium",
+            "Large",
+            "Extra large",
+            "Extra extra large",
+    };
+    private static final String[] SIZE_VALUES = new String[]{
+            "XSmall",
+            "Small",
+            "Medium",
+            "Large",
+            "XLarge",
+            "XXLarge",
+    };
+
+    private MorpheSettingsV4Theme.Tokens tokens;
+    private SharedPreferences preferences;
+    private TextView previewTitle;
+    private TextView previewComment;
+    private TextView titleFontSummary;
+    private TextView titleSizeSummary;
+    private TextView commentsFontSummary;
+    private TextView commentsSizeSummary;
+
+    public MorpheSettingsV4FontsFragment() {
+    }
+
+    @Override
+    public View onCreateView(
+            LayoutInflater inflater,
+            ViewGroup container,
+            Bundle savedInstanceState
+    ) {
+        Context context = inflater.getContext();
+        tokens = MorpheSettingsV4Theme.resolve(context);
+        preferences = PreferenceManager.getDefaultSharedPreferences(context);
+        setHasOptionsMenu(true);
+
+        ScrollView scrollView = new ScrollView(context);
+        scrollView.setFillViewport(true);
+        scrollView.setClipToPadding(false);
+        scrollView.setBackgroundColor(tokens.background);
+
+        LinearLayout content = new LinearLayout(context);
+        content.setOrientation(LinearLayout.VERTICAL);
+        content.setPadding(dp(18), dp(12), dp(18), dp(32));
+        scrollView.addView(content, new ScrollView.LayoutParams(
+                ViewGroup.LayoutParams.MATCH_PARENT,
+                ViewGroup.LayoutParams.WRAP_CONTENT
+        ));
+
+        addSectionLabel(content, "Live preview");
+        addSpace(content, 8);
+        addPreview(content);
+
+        addSpace(content, 18);
+        addSectionLabel(content, "Posts");
+        addSpace(content, 8);
+        LinearLayout posts = addGroup(content);
+        LinearLayout titleFont = addNavigationRow(
+                posts,
+                "Title font",
+                fontTitle(preferences.getString(KEY_TITLE_FONT, "")),
+                view -> showFontDialog(KEY_TITLE_FONT, "Title font")
+        );
+        titleFontSummary = rowSummary(titleFont);
+        LinearLayout titleSize = addNavigationRow(
+                posts,
+                "Title text size",
+                sizeTitle(preferences.getString(KEY_TITLE_SIZE, "Medium")),
+                view -> showSizeDialog(KEY_TITLE_SIZE, "Title text size")
+        );
+        titleSizeSummary = rowSummary(titleSize);
+
+        addSpace(content, 18);
+        addSectionLabel(content, "Comments & messages");
+        addSpace(content, 8);
+        LinearLayout comments = addGroup(content);
+        LinearLayout commentsFont = addNavigationRow(
+                comments,
+                "Comments font",
+                fontTitle(preferences.getString(KEY_COMMENTS_FONT, "")),
+                view -> showFontDialog(KEY_COMMENTS_FONT, "Comments font")
+        );
+        commentsFontSummary = rowSummary(commentsFont);
+        LinearLayout commentsSize = addNavigationRow(
+                comments,
+                "Comments text size",
+                sizeTitle(preferences.getString(KEY_COMMENTS_SIZE, "Medium")),
+                view -> showSizeDialog(KEY_COMMENTS_SIZE, "Comments text size")
+        );
+        commentsSizeSummary = rowSummary(commentsSize);
+
+        addSpace(content, 18);
+        TextView reset = actionText("Restore font defaults");
+        reset.setOnClickListener(view -> showResetConfirmation());
+        LinearLayout.LayoutParams resetParams = wrapParams();
+        resetParams.gravity = Gravity.CENTER_HORIZONTAL;
+        content.addView(reset, resetParams);
+
+        updatePreviewAndSummaries();
+        return scrollView;
+    }
+
+    @Override
+    public void onResume() {
+        super.onResume();
+        updatePreviewAndSummaries();
+        styleHost();
+    }
+
+    @Override
+    public void onPause() {
+        Activity activity = hostActivity();
+        if (activity != null) {
+            BoostSystemBarInsetsFix.clearMorpheSettingsV4SystemBars(activity);
+        }
+        super.onPause();
+    }
+
+    @Override
+    public void onPrepareOptionsMenu(Menu menu) {
+        super.onPrepareOptionsMenu(menu);
+        hideMenuItem(menu, "action_generic_search");
+        hideMenuItem(menu, "action_search");
+        hideMenuItem(menu, "search");
+    }
+
+    private void addPreview(LinearLayout parent) {
+        Context context = requireContext();
+        MorpheSettingsV4Theme.Accent accent = tokens.navigationAccent();
+
+        LinearLayout previewCanvas = new LinearLayout(context);
+        previewCanvas.setOrientation(LinearLayout.VERTICAL);
+        previewCanvas.setPadding(dp(18), dp(16), dp(18), dp(18));
+        int previewSurface = MorpheSettingsV4Theme.blend(
+                tokens.surfaceContainerHigh,
+                accent.container,
+                tokens.dark ? 0.07f : 0.05f
+        );
+        previewCanvas.setBackground(MorpheSettingsV4Theme.rounded(
+                context,
+                previewSurface,
+                24
+        ));
+        previewCanvas.setClipToOutline(true);
+        parent.addView(previewCanvas, new LinearLayout.LayoutParams(
+                ViewGroup.LayoutParams.MATCH_PARENT,
+                ViewGroup.LayoutParams.WRAP_CONTENT
+        ));
+
+        TextView postMeta = textView(
+                "r/BoostForReddit  ·  just now",
+                12,
+                tokens.textSecondary
+        );
+        postMeta.setTypeface(Typeface.create(
+                "sans-serif-medium",
+                Typeface.NORMAL
+        ));
+        previewCanvas.addView(postMeta, wrapParams());
+
+        previewTitle = textView(
+                "A post title using your chosen font",
+                18,
+                tokens.textPrimary
+        );
+        LinearLayout.LayoutParams titleParams = wrapParams();
+        titleParams.topMargin = dp(6);
+        previewCanvas.addView(previewTitle, titleParams);
+
+        addPreviewDivider(previewCanvas);
+
+        TextView commentMeta = textView(
+                "u/morphe  ·  moments ago",
+                12,
+                tokens.textSecondary
+        );
+        commentMeta.setTypeface(Typeface.create(
+                "sans-serif-medium",
+                Typeface.NORMAL
+        ));
+        previewCanvas.addView(commentMeta, wrapParams());
+
+        LinearLayout commentThread = new LinearLayout(context);
+        commentThread.setOrientation(LinearLayout.HORIZONTAL);
+        LinearLayout.LayoutParams threadParams = new LinearLayout.LayoutParams(
+                ViewGroup.LayoutParams.MATCH_PARENT,
+                ViewGroup.LayoutParams.WRAP_CONTENT
+        );
+        threadParams.topMargin = dp(8);
+        previewCanvas.addView(commentThread, threadParams);
+
+        View threadRail = new View(context);
+        threadRail.setBackground(MorpheSettingsV4Theme.rounded(
+                context,
+                accent.color,
+                1.5f
+        ));
+        LinearLayout.LayoutParams railParams = new LinearLayout.LayoutParams(
+                dp(3),
+                ViewGroup.LayoutParams.MATCH_PARENT
+        );
+        railParams.setMarginEnd(dp(10));
+        commentThread.addView(threadRail, railParams);
+
+        previewComment = textView(
+                "This comment uses your selected comment font and size.",
+                15,
+                tokens.textPrimary
+        );
+        previewComment.setLineSpacing(0, 1.08f);
+        commentThread.addView(previewComment, labelsParams());
+    }
+
+    private void addPreviewDivider(LinearLayout parent) {
+        View divider = new View(requireContext());
+        divider.setBackgroundColor(MorpheSettingsV4Theme.blend(
+                tokens.surfaceContainerHigh,
+                tokens.outline,
+                tokens.dark ? 0.28f : 0.20f
+        ));
+        LinearLayout.LayoutParams params = new LinearLayout.LayoutParams(
+                ViewGroup.LayoutParams.MATCH_PARENT,
+                dp(1)
+        );
+        params.topMargin = dp(16);
+        params.bottomMargin = dp(16);
+        parent.addView(divider, params);
+    }
+
+    private LinearLayout addNavigationRow(
+            LinearLayout group,
+            String titleValue,
+            String summaryValue,
+            View.OnClickListener listener
+    ) {
+        Context context = requireContext();
+        MorpheSettingsV4Theme.Accent accent = tokens.navigationAccent();
+        LinearLayout row = new LinearLayout(context);
+        row.setOrientation(LinearLayout.HORIZONTAL);
+        row.setGravity(Gravity.CENTER_VERTICAL);
+        row.setMinimumHeight(dp(72));
+        row.setPadding(dp(18), dp(9), dp(12), dp(9));
+        row.setClickable(true);
+        row.setFocusable(true);
+        row.setBackground(MorpheSettingsV4Theme.interactive(
+                context,
+                Color.TRANSPARENT,
+                0,
+                accent.color
+        ));
+        row.setOnClickListener(listener);
+
+        LinearLayout labels = createLabels(titleValue, summaryValue);
+        row.addView(labels, labelsParams());
+        TextView chevron = textView("›", 28, accent.color);
+        chevron.setGravity(Gravity.CENTER);
+        row.addView(chevron, new LinearLayout.LayoutParams(dp(36), dp(48)));
+        addGroupedRow(group, row);
+        return row;
+    }
+
+    private void showFontDialog(String key, String titleValue) {
+        String selected = preferences.getString(key, "");
+        Dialog dialog = new Dialog(requireContext());
+        LinearLayout content = dialogContent();
+        addDialogHeading(content, titleValue);
+
+        ScrollView choicesScroll = new ScrollView(requireContext());
+        LinearLayout choices = new LinearLayout(requireContext());
+        choices.setOrientation(LinearLayout.VERTICAL);
+        choicesScroll.addView(choices, new ScrollView.LayoutParams(
+                ViewGroup.LayoutParams.MATCH_PARENT,
+                ViewGroup.LayoutParams.WRAP_CONTENT
+        ));
+        for (int index = 0; index < FONT_TITLES.length; index++) {
+            final int choice = index;
+            LinearLayout row = dialogChoiceRow();
+            RadioButton radio = radioButton(
+                    TextUtils.equals(selected, FONT_VALUES[index])
+            );
+            row.addView(radio);
+            TextView label = textView(FONT_TITLES[index], 16, tokens.textPrimary);
+            label.setTypeface(typefaceFor(FONT_VALUES[index]));
+            row.addView(label, labelsParams());
+            row.setOnClickListener(view -> {
+                saveFontPreference(key, FONT_VALUES[choice]);
+                dialog.dismiss();
+            });
+            choices.addView(row, new LinearLayout.LayoutParams(
+                    ViewGroup.LayoutParams.MATCH_PARENT,
+                    ViewGroup.LayoutParams.WRAP_CONTENT
+            ));
+        }
+        LinearLayout.LayoutParams choicesParams = new LinearLayout.LayoutParams(
+                ViewGroup.LayoutParams.MATCH_PARENT,
+                dp(430)
+        );
+        content.addView(choicesScroll, choicesParams);
+        addDialogAction(content, "Cancel", () -> dialog.dismiss());
+        showDialog(dialog, content);
+    }
+
+    private void showSizeDialog(String key, String titleValue) {
+        String selected = preferences.getString(key, "Medium");
+        Dialog dialog = new Dialog(requireContext());
+        LinearLayout content = dialogContent();
+        addDialogHeading(content, titleValue);
+
+        for (int index = 0; index < SIZE_TITLES.length; index++) {
+            final int choice = index;
+            LinearLayout row = dialogChoiceRow();
+            row.addView(radioButton(TextUtils.equals(
+                    selected,
+                    SIZE_VALUES[index]
+            )));
+            TextView label = textView(
+                    SIZE_TITLES[index],
+                    previewSizeSp(SIZE_VALUES[index], false),
+                    tokens.textPrimary
+            );
+            row.addView(label, labelsParams());
+            row.setOnClickListener(view -> {
+                saveFontPreference(key, SIZE_VALUES[choice]);
+                dialog.dismiss();
+            });
+            content.addView(row, new LinearLayout.LayoutParams(
+                    ViewGroup.LayoutParams.MATCH_PARENT,
+                    ViewGroup.LayoutParams.WRAP_CONTENT
+            ));
+        }
+        addDialogAction(content, "Cancel", () -> dialog.dismiss());
+        showDialog(dialog, content);
+    }
+
+    private void saveFontPreference(String key, String value) {
+        preferences.edit().putString(key, value).apply();
+        markNativeFontCacheDirty(key);
+        updatePreviewAndSummaries();
+    }
+
+    private void showResetConfirmation() {
+        Dialog dialog = new Dialog(requireContext());
+        LinearLayout content = dialogContent();
+        addDialogHeading(content, "Restore font defaults?");
+        TextView body = textView(
+                "Post titles, comments, and messages will return to Boost's default fonts and sizes.",
+                14,
+                tokens.textSecondary
+        );
+        body.setLineSpacing(0, 1.08f);
+        LinearLayout.LayoutParams bodyParams = wrapParams();
+        bodyParams.topMargin = dp(6);
+        bodyParams.bottomMargin = dp(10);
+        content.addView(body, bodyParams);
+
+        LinearLayout actions = new LinearLayout(requireContext());
+        actions.setGravity(Gravity.END | Gravity.CENTER_VERTICAL);
+        TextView cancel = dialogAction("Cancel");
+        cancel.setOnClickListener(view -> dialog.dismiss());
+        actions.addView(cancel);
+        TextView reset = dialogAction("Restore");
+        reset.setOnClickListener(view -> {
+            preferences.edit()
+                    .remove(KEY_TITLE_FONT)
+                    .remove(KEY_TITLE_SIZE)
+                    .remove(KEY_COMMENTS_FONT)
+                    .remove(KEY_COMMENTS_SIZE)
+                    .apply();
+            markNativeFontCacheDirty(KEY_TITLE_SIZE);
+            markNativeFontCacheDirty(KEY_TITLE_FONT);
+            dialog.dismiss();
+            updatePreviewAndSummaries();
+        });
+        actions.addView(reset);
+        content.addView(actions, new LinearLayout.LayoutParams(
+                ViewGroup.LayoutParams.MATCH_PARENT,
+                ViewGroup.LayoutParams.WRAP_CONTENT
+        ));
+        showDialog(dialog, content);
+    }
+
+    private void updatePreviewAndSummaries() {
+        if (preferences == null) {
+            return;
+        }
+        String titleFontValue = preferences.getString(KEY_TITLE_FONT, "");
+        String titleSizeValue = preferences.getString(KEY_TITLE_SIZE, "Medium");
+        String commentsFontValue = preferences.getString(KEY_COMMENTS_FONT, "");
+        String commentsSizeValue = preferences.getString(
+                KEY_COMMENTS_SIZE,
+                "Medium"
+        );
+        setText(titleFontSummary, fontTitle(titleFontValue));
+        setText(titleSizeSummary, sizeTitle(titleSizeValue));
+        setText(commentsFontSummary, fontTitle(commentsFontValue));
+        setText(commentsSizeSummary, sizeTitle(commentsSizeValue));
+        if (previewTitle != null) {
+            previewTitle.setTypeface(typefaceFor(titleFontValue));
+            previewTitle.setTextSize(previewSizeSp(titleSizeValue, true));
+        }
+        if (previewComment != null) {
+            previewComment.setTypeface(typefaceFor(commentsFontValue));
+            previewComment.setTextSize(previewSizeSp(
+                    commentsSizeValue,
+                    false
+            ));
+        }
+    }
+
+    private void markNativeFontCacheDirty(String key) {
+        String fieldName = null;
+        if (KEY_TITLE_SIZE.equals(key) || KEY_COMMENTS_SIZE.equals(key)) {
+            fieldName = "d";
+        } else if (KEY_TITLE_FONT.equals(key)) {
+            fieldName = "h";
+        }
+        if (fieldName == null) {
+            return;
+        }
+        try {
+            Field field = Class.forName("id.b").getDeclaredField(fieldName);
+            field.setAccessible(true);
+            field.setBoolean(null, true);
+        } catch (Throwable ignored) {
+        }
+    }
+
+    private Typeface typefaceFor(String value) {
+        if (TextUtils.isEmpty(value)) {
+            return Typeface.DEFAULT;
+        }
+        if (value.endsWith(".ttf")) {
+            return Typeface.create("serif", Typeface.NORMAL);
+        }
+        Typeface result = Typeface.create(value, Typeface.NORMAL);
+        return result == null ? Typeface.DEFAULT : result;
+    }
+
+    private int previewSizeSp(String value, boolean title) {
+        int index = indexOf(SIZE_VALUES, value);
+        if (index < 0) {
+            index = 2;
+        }
+        int[] bodySizes = new int[]{12, 13, 15, 17, 19, 21};
+        int[] titleSizes = new int[]{14, 16, 18, 20, 22, 24};
+        return title ? titleSizes[index] : bodySizes[index];
+    }
+
+    private String fontTitle(String value) {
+        int index = indexOf(FONT_VALUES, value);
+        return index < 0 ? "Default" : FONT_TITLES[index];
+    }
+
+    private String sizeTitle(String value) {
+        int index = indexOf(SIZE_VALUES, value);
+        return index < 0 ? "Medium" : SIZE_TITLES[index];
+    }
+
+    private int indexOf(String[] values, String target) {
+        for (int index = 0; index < values.length; index++) {
+            if (TextUtils.equals(values[index], target)) {
+                return index;
+            }
+        }
+        return -1;
+    }
+
+    private void setText(TextView view, String value) {
+        if (view != null) {
+            view.setText(value);
+        }
+    }
+
+    private RadioButton radioButton(boolean checked) {
+        RadioButton radio = new RadioButton(requireContext());
+        radio.setChecked(checked);
+        radio.setClickable(false);
+        radio.setFocusable(false);
+        if (Build.VERSION.SDK_INT >= 21) {
+            radio.setButtonTintList(new ColorStateList(
+                    new int[][]{
+                            new int[]{android.R.attr.state_checked},
+                            new int[]{-android.R.attr.state_checked},
+                    },
+                    new int[]{
+                            tokens.navigationAccent().color,
+                            tokens.textSecondary,
+                    }
+            ));
+        }
+        return radio;
+    }
+
+    private LinearLayout dialogContent() {
+        LinearLayout content = new LinearLayout(requireContext());
+        content.setOrientation(LinearLayout.VERTICAL);
+        content.setPadding(dp(20), dp(20), dp(20), dp(14));
+        content.setBackground(MorpheSettingsV4Theme.rounded(
+                requireContext(),
+                tokens.surfaceContainerHigh,
+                28
+        ));
+        return content;
+    }
+
+    private void addDialogHeading(LinearLayout content, String value) {
+        TextView heading = textView(value, 20, tokens.textPrimary);
+        heading.setTypeface(Typeface.create("sans-serif-medium", Typeface.NORMAL));
+        LinearLayout.LayoutParams params = wrapParams();
+        params.setMarginStart(dp(8));
+        params.bottomMargin = dp(8);
+        content.addView(heading, params);
+    }
+
+    private LinearLayout dialogChoiceRow() {
+        LinearLayout row = new LinearLayout(requireContext());
+        row.setOrientation(LinearLayout.HORIZONTAL);
+        row.setGravity(Gravity.CENTER_VERTICAL);
+        row.setMinimumHeight(dp(52));
+        row.setPadding(dp(4), 0, dp(8), 0);
+        row.setBackground(MorpheSettingsV4Theme.interactive(
+                requireContext(),
+                Color.TRANSPARENT,
+                16,
+                tokens.navigationAccent().color
+        ));
+        return row;
+    }
+
+    private void addDialogAction(
+            LinearLayout content,
+            String value,
+            Runnable action
+    ) {
+        TextView button = dialogAction(value);
+        button.setOnClickListener(view -> action.run());
+        LinearLayout.LayoutParams params = wrapParams();
+        params.gravity = Gravity.END;
+        params.topMargin = dp(4);
+        content.addView(button, params);
+    }
+
+    private TextView dialogAction(String value) {
+        TextView button = textView(value, 14, tokens.navigationAccent().color);
+        button.setTypeface(Typeface.create("sans-serif-medium", Typeface.NORMAL));
+        button.setGravity(Gravity.CENTER);
+        button.setAllCaps(false);
+        button.setPadding(dp(14), dp(10), dp(14), dp(10));
+        button.setBackground(MorpheSettingsV4Theme.interactive(
+                requireContext(),
+                Color.TRANSPARENT,
+                18,
+                tokens.navigationAccent().color
+        ));
+        return button;
+    }
+
+    private TextView actionText(String value) {
+        TextView action = dialogAction(value);
+        action.setTextSize(15);
+        return action;
+    }
+
+    private void showDialog(Dialog dialog, LinearLayout content) {
+        Context context = requireContext();
+        dialog.setContentView(content);
+        Window window = dialog.getWindow();
+        if (window != null) {
+            window.setBackgroundDrawable(new ColorDrawable(Color.TRANSPARENT));
+        }
+        dialog.show();
+        window = dialog.getWindow();
+        if (window != null) {
+            int width = context.getResources().getDisplayMetrics().widthPixels
+                    - dp(40);
+            window.setLayout(width, ViewGroup.LayoutParams.WRAP_CONTENT);
+        }
+    }
+
+    private LinearLayout addGroup(LinearLayout parent) {
+        Context context = requireContext();
+        MorpheSettingsV4Theme.Accent accent = tokens.navigationAccent();
+        int color = MorpheSettingsV4Theme.blend(
+                tokens.surfaceContainer,
+                accent.container,
+                tokens.dark ? 0.035f : 0.025f
+        );
+        LinearLayout group = new LinearLayout(context);
+        group.setOrientation(LinearLayout.VERTICAL);
+        group.setBackground(MorpheSettingsV4Theme.rounded(context, color, 24));
+        group.setClipToOutline(true);
+        parent.addView(group, new LinearLayout.LayoutParams(
+                ViewGroup.LayoutParams.MATCH_PARENT,
+                ViewGroup.LayoutParams.WRAP_CONTENT
+        ));
+        return group;
+    }
+
+    private void addGroupedRow(LinearLayout group, LinearLayout row) {
+        if (group.getChildCount() > 0) {
+            View divider = new View(requireContext());
+            divider.setBackgroundColor(MorpheSettingsV4Theme.blend(
+                    tokens.surfaceContainer,
+                    tokens.outline,
+                    tokens.dark ? 0.22f : 0.16f
+            ));
+            LinearLayout.LayoutParams dividerParams = new LinearLayout.LayoutParams(
+                    ViewGroup.LayoutParams.MATCH_PARENT,
+                    dp(1)
+            );
+            dividerParams.setMarginStart(dp(18));
+            dividerParams.setMarginEnd(dp(18));
+            group.addView(divider, dividerParams);
+        }
+        group.addView(row, new LinearLayout.LayoutParams(
+                ViewGroup.LayoutParams.MATCH_PARENT,
+                ViewGroup.LayoutParams.WRAP_CONTENT
+        ));
+    }
+
+    private LinearLayout createLabels(String titleValue, String summaryValue) {
+        LinearLayout labels = new LinearLayout(requireContext());
+        labels.setOrientation(LinearLayout.VERTICAL);
+        TextView title = textView(titleValue, 16, tokens.textPrimary);
+        title.setTypeface(Typeface.create("sans-serif-medium", Typeface.NORMAL));
+        labels.addView(title);
+        TextView summary = textView(summaryValue, 14, tokens.textSecondary);
+        LinearLayout.LayoutParams summaryParams = wrapParams();
+        summaryParams.topMargin = dp(3);
+        labels.addView(summary, summaryParams);
+        return labels;
+    }
+
+    private TextView rowSummary(LinearLayout row) {
+        if (row.getChildCount() == 0
+                || !(row.getChildAt(0) instanceof LinearLayout)) {
+            return null;
+        }
+        LinearLayout labels = (LinearLayout) row.getChildAt(0);
+        return labels.getChildCount() > 1
+                && labels.getChildAt(1) instanceof TextView
+                ? (TextView) labels.getChildAt(1)
+                : null;
+    }
+
+    private void styleHost() {
+        Activity activity = hostActivity();
+        if (activity == null || tokens == null) {
+            return;
+        }
+        activity.setTitle("Fonts");
+        BoostSystemBarInsetsFix.applyMorpheSettingsV4SystemBars(
+                activity,
+                tokens.background,
+                tokens.dark
+        );
+        int toolbarId = MorpheSettingsV4Catalog.resourceId(
+                activity,
+                "id",
+                "toolbar"
+        );
+        View toolbar = activity.findViewById(toolbarId);
+        if (toolbar != null) {
+            toolbar.setBackgroundColor(tokens.background);
+            toolbar.setElevation(0);
+        }
+    }
+
+    private Activity hostActivity() {
+        Context context = requireContext();
+        return context instanceof Activity ? (Activity) context : null;
+    }
+
+    private void hideMenuItem(Menu menu, String resourceName) {
+        int resourceId = MorpheSettingsV4Catalog.resourceId(
+                requireContext(),
+                "id",
+                resourceName
+        );
+        if (resourceId == 0) {
+            return;
+        }
+        MenuItem item = menu.findItem(resourceId);
+        if (item != null) {
+            item.setVisible(false);
+        }
+    }
+
+    private void addSectionLabel(LinearLayout parent, String value) {
+        TextView label = textView(value, 14, tokens.primary);
+        label.setTypeface(Typeface.create("sans-serif-medium", Typeface.NORMAL));
+        label.setLetterSpacing(0.02f);
+        parent.addView(label);
+    }
+
+    private TextView textView(String value, int sizeSp, int color) {
+        TextView view = new TextView(requireContext());
+        view.setText(value);
+        view.setTextSize(sizeSp);
+        view.setTextColor(color);
+        return view;
+    }
+
+    private LinearLayout.LayoutParams labelsParams() {
+        return new LinearLayout.LayoutParams(
+                0,
+                ViewGroup.LayoutParams.WRAP_CONTENT,
+                1.0f
+        );
+    }
+
+    private LinearLayout.LayoutParams wrapParams() {
+        return new LinearLayout.LayoutParams(
+                ViewGroup.LayoutParams.WRAP_CONTENT,
+                ViewGroup.LayoutParams.WRAP_CONTENT
+        );
+    }
+
+    private void addSpace(LinearLayout parent, int heightDp) {
+        View space = new View(requireContext());
+        parent.addView(space, new LinearLayout.LayoutParams(1, dp(heightDp)));
+    }
+
+    private int dp(float value) {
+        return MorpheSettingsV4Theme.dp(requireContext(), value);
+    }
+}

--- a/extensions/boostforreddit/src/main/java/app/morphe/extension/boostforreddit/settings/MorpheSettingsV4Fragment.java
+++ b/extensions/boostforreddit/src/main/java/app/morphe/extension/boostforreddit/settings/MorpheSettingsV4Fragment.java
@@ -4,8 +4,6 @@ import android.app.Activity;
 import android.content.Context;
 import android.content.Intent;
 import android.content.res.ColorStateList;
-import android.graphics.Color;
-import android.graphics.Typeface;
 import android.graphics.drawable.Drawable;
 import android.os.Bundle;
 import android.text.Editable;
@@ -34,9 +32,8 @@ import java.util.ArrayList;
 import java.util.List;
 
 /**
- * Morphe-owned, non-Compose settings shell. Complex Boost preference behavior
- * remains delegated to its original fragments while v4 owns discovery,
- * grouping, search, navigation, and visual hierarchy.
+ * Morphe-owned, non-Compose settings shell. Migrated pages own their controls
+ * and Boost bindings; remaining pages use Boost's classic fragments.
  */
 public final class MorpheSettingsV4Fragment extends Fragment {
     public static final String CONTRACT_MARKER =
@@ -93,8 +90,8 @@ public final class MorpheSettingsV4Fragment extends Fragment {
 
         LinearLayout content = new LinearLayout(context);
         content.setOrientation(LinearLayout.VERTICAL);
-        int horizontal = dp(20);
-        content.setPadding(horizontal, dp(16), horizontal, dp(36));
+        int horizontal = dp(16);
+        content.setPadding(horizontal, dp(10), horizontal, dp(36));
         scrollView.addView(
                 content,
                 new ScrollView.LayoutParams(
@@ -143,10 +140,8 @@ public final class MorpheSettingsV4Fragment extends Fragment {
     }
 
     private void buildRoot(LinearLayout content) {
-        addMorpheHero(content);
-        addSpace(content, 18);
         addSearchField(content);
-        addSpace(content, 24);
+        addSpace(content, 22);
 
         dynamicContent = new LinearLayout(requireContext());
         dynamicContent.setOrientation(LinearLayout.VERTICAL);
@@ -169,97 +164,24 @@ public final class MorpheSettingsV4Fragment extends Fragment {
             return;
         }
 
-        addHubHeader(content, category);
-        addSpace(content, 22);
-        addSectionLabel(content, "Choose a section");
+        addSectionLabel(content, category.title);
         addSpace(content, 10);
 
+        LinearLayout group = MorpheSettingsV14Ui.group(requireContext());
+        content.addView(group, new LinearLayout.LayoutParams(
+                ViewGroup.LayoutParams.MATCH_PARENT,
+                ViewGroup.LayoutParams.WRAP_CONTENT
+        ));
         for (MorpheSettingsV4Catalog.Leaf leaf : category.leaves) {
-            View card = createNavigationCard(
+            View row = createNavigationCard(
                     leaf.title,
                     leaf.summary,
                     leaf.iconName,
                     false,
                     view -> openLeaf(leaf, null)
             );
-            content.addView(card, cardLayoutParams());
+            MorpheSettingsV14Ui.addSegmentedRow(group, row, tokens);
         }
-    }
-
-    private void addMorpheHero(LinearLayout parent) {
-        Context context = requireContext();
-        int heroColor = MorpheSettingsV4Theme.blend(
-                tokens.surfaceContainerHigh,
-                tokens.primaryContainer,
-                tokens.dark ? 0.56f : 0.48f
-        );
-        LinearLayout card = new LinearLayout(context);
-        card.setOrientation(LinearLayout.HORIZONTAL);
-        card.setGravity(Gravity.CENTER_VERTICAL);
-        card.setPadding(dp(18), dp(18), dp(16), dp(18));
-        card.setMinimumHeight(dp(104));
-        card.setBackground(MorpheSettingsV4Theme.interactive(
-                context,
-                heroColor,
-                28,
-                tokens.primary
-        ));
-        card.setClickable(true);
-        card.setFocusable(true);
-        card.setOnClickListener(view -> openLeaf(
-                MorpheSettingsV4Catalog.morphe(),
-                null
-        ));
-
-        card.addView(createIconContainer(
-                "ic_puzzle_24dp",
-                tokens.primary,
-                MorpheSettingsV4Theme.blend(
-                        tokens.surfaceContainerHigh,
-                        tokens.primaryContainer,
-                        tokens.dark ? 0.64f : 0.54f
-                ),
-                52
-        ));
-
-        LinearLayout text = new LinearLayout(context);
-        text.setOrientation(LinearLayout.VERTICAL);
-        LinearLayout.LayoutParams textParams = new LinearLayout.LayoutParams(
-                0,
-                ViewGroup.LayoutParams.WRAP_CONTENT,
-                1.0f
-        );
-        textParams.setMarginStart(dp(16));
-        card.addView(text, textParams);
-
-        TextView badge = textView("MORPHE · V4 PREVIEW", 11, tokens.primary);
-        badge.setTypeface(Typeface.DEFAULT_BOLD);
-        text.addView(badge);
-
-        TextView title = textView("Morphe settings", 21, tokens.textPrimary);
-        title.setTypeface(Typeface.create("sans-serif-medium", Typeface.NORMAL));
-        LinearLayout.LayoutParams titleParams = wrapParams();
-        titleParams.topMargin = dp(4);
-        text.addView(title, titleParams);
-
-        TextView summary = textView(
-                "Patches, previews, recovery, and interface controls",
-                14,
-                tokens.textSecondary
-        );
-        summary.setLineSpacing(0, 1.08f);
-        LinearLayout.LayoutParams summaryParams = wrapParams();
-        summaryParams.topMargin = dp(3);
-        text.addView(summary, summaryParams);
-
-        TextView chevron = textView("›", 32, tokens.primary);
-        chevron.setGravity(Gravity.CENTER);
-        card.addView(chevron, new LinearLayout.LayoutParams(dp(28), dp(52)));
-
-        parent.addView(card, new LinearLayout.LayoutParams(
-                ViewGroup.LayoutParams.MATCH_PARENT,
-                ViewGroup.LayoutParams.WRAP_CONTENT
-        ));
     }
 
     private void addSearchField(LinearLayout parent) {
@@ -335,41 +257,93 @@ public final class MorpheSettingsV4Fragment extends Fragment {
     }
 
     private void renderCategories() {
-        addSectionLabel(dynamicContent, "Browse by task");
+        addSectionLabel(dynamicContent, "Morphe");
         addSpace(dynamicContent, 10);
-
-        for (MorpheSettingsV4Catalog.Category category
-                : MorpheSettingsV4Catalog.categories()) {
-            View card = createNavigationCard(
-                    category.title,
-                    category.summary,
-                    category.iconName,
-                    false,
-                    view -> navigateToHub(category)
-            );
-            dynamicContent.addView(card, cardLayoutParams());
-        }
-
-        addSpace(dynamicContent, 10);
-        TextView classic = textView(
-                "Open classic Boost settings",
-                14,
-                tokens.primary
-        );
-        classic.setTypeface(Typeface.create("sans-serif-medium", Typeface.NORMAL));
-        classic.setGravity(Gravity.CENTER);
-        classic.setPadding(dp(16), dp(14), dp(16), dp(14));
-        classic.setBackground(MorpheSettingsV4Theme.interactive(
-                requireContext(),
-                Color.TRANSPARENT,
-                22,
-                tokens.primary
-        ));
-        classic.setOnClickListener(view -> openClassicSettings());
-        dynamicContent.addView(classic, new LinearLayout.LayoutParams(
+        LinearLayout morpheGroup = MorpheSettingsV14Ui.group(requireContext());
+        dynamicContent.addView(morpheGroup, new LinearLayout.LayoutParams(
                 ViewGroup.LayoutParams.MATCH_PARENT,
                 ViewGroup.LayoutParams.WRAP_CONTENT
         ));
+        MorpheSettingsV4Catalog.Leaf morphe = MorpheSettingsV4Catalog.morphe();
+        MorpheSettingsV14Ui.addSegmentedRow(
+                morpheGroup,
+                createNavigationCard(
+                        "Patch features",
+                        "Media routing, recovery, search, and performance",
+                        morphe.iconName,
+                        true,
+                        view -> openLeaf(morphe, null)
+                ),
+                tokens
+        );
+
+        renderHomeSection(
+                "Look & feel",
+                "appearance_layout"
+        );
+        renderHomeSection(
+                "Reading & interaction",
+                "posts_comments",
+                "search_filters"
+        );
+        renderHomeSection(
+                "Navigation & media",
+                "navigation",
+                "media_links"
+        );
+        renderHomeSection(
+                "Data & account",
+                "notifications",
+                "data_storage",
+                "account_privacy"
+        );
+        renderHomeSection(
+                "App & support",
+                "app_legacy",
+                "about"
+        );
+
+        addSpace(dynamicContent, 12);
+        TextView classic = MorpheSettingsV14Ui.action(
+                requireContext(),
+                tokens,
+                "Open classic Boost settings",
+                false
+        );
+        classic.setOnClickListener(view -> openClassicSettings());
+        dynamicContent.addView(classic, wrapParams());
+    }
+
+    private void renderHomeSection(String title, String... categoryIds) {
+        addSpace(dynamicContent, 24);
+        addSectionLabel(dynamicContent, title);
+        addSpace(dynamicContent, 10);
+
+        LinearLayout group = MorpheSettingsV14Ui.group(requireContext());
+        dynamicContent.addView(group, new LinearLayout.LayoutParams(
+                ViewGroup.LayoutParams.MATCH_PARENT,
+                ViewGroup.LayoutParams.WRAP_CONTENT
+        ));
+        for (String categoryId : categoryIds) {
+            MorpheSettingsV4Catalog.Category category =
+                    MorpheSettingsV4Catalog.findCategory(categoryId);
+            if (category == null) {
+                continue;
+            }
+            for (MorpheSettingsV4Catalog.Leaf leaf : category.leaves) {
+                MorpheSettingsV14Ui.addSegmentedRow(
+                        group,
+                        createNavigationCard(
+                                leaf.title,
+                                leaf.summary,
+                                leaf.iconName,
+                                false,
+                                view -> openLeaf(leaf, null)
+                        ),
+                        tokens
+                );
+            }
+        }
     }
 
     private void renderSearchResults(String normalizedQuery) {
@@ -400,6 +374,11 @@ public final class MorpheSettingsV4Fragment extends Fragment {
             return;
         }
 
+        LinearLayout group = MorpheSettingsV14Ui.group(requireContext());
+        dynamicContent.addView(group, new LinearLayout.LayoutParams(
+                ViewGroup.LayoutParams.MATCH_PARENT,
+                ViewGroup.LayoutParams.WRAP_CONTENT
+        ));
         int limit = Math.min(matches.size(), 80);
         for (int index = 0; index < limit; index++) {
             MorpheSettingsV4Catalog.SearchItem item = matches.get(index);
@@ -407,14 +386,14 @@ public final class MorpheSettingsV4Fragment extends Fragment {
             if (!TextUtils.isEmpty(item.summary)) {
                 secondary += "\n" + item.summary;
             }
-            View card = createNavigationCard(
+            View row = createNavigationCard(
                     item.title,
                     secondary,
                     item.iconName,
                     false,
                     view -> openSearchItem(item)
             );
-            dynamicContent.addView(card, cardLayoutParams());
+            MorpheSettingsV14Ui.addSegmentedRow(group, row, tokens);
         }
 
         if (matches.size() > limit) {
@@ -423,66 +402,6 @@ public final class MorpheSettingsV4Fragment extends Fragment {
                     "Showing the first " + limit + " results. Keep typing to narrow the search."
             );
         }
-    }
-
-    private void addHubHeader(
-            LinearLayout parent,
-            MorpheSettingsV4Catalog.Category category
-    ) {
-        Context context = requireContext();
-        MorpheSettingsV4Theme.Accent accent =
-                tokens.navigationAccent();
-        LinearLayout header = new LinearLayout(context);
-        header.setOrientation(LinearLayout.HORIZONTAL);
-        header.setGravity(Gravity.CENTER_VERTICAL);
-        header.setPadding(dp(18), dp(18), dp(18), dp(18));
-        header.setBackground(MorpheSettingsV4Theme.rounded(
-                context,
-                MorpheSettingsV4Theme.blend(
-                        tokens.surfaceContainerHigh,
-                        accent.container,
-                        tokens.dark ? 0.34f : 0.28f
-                ),
-                28
-        ));
-        header.addView(createIconContainer(
-                category.iconName,
-                accent.color,
-                MorpheSettingsV4Theme.blend(
-                        tokens.surfaceContainerHigh,
-                        accent.container,
-                        tokens.dark ? 0.54f : 0.46f
-                ),
-                52
-        ));
-
-        LinearLayout labels = new LinearLayout(context);
-        labels.setOrientation(LinearLayout.VERTICAL);
-        LinearLayout.LayoutParams labelsParams = new LinearLayout.LayoutParams(
-                0,
-                ViewGroup.LayoutParams.WRAP_CONTENT,
-                1.0f
-        );
-        labelsParams.setMarginStart(dp(16));
-        header.addView(labels, labelsParams);
-
-        TextView title = textView(category.title, 21, tokens.textPrimary);
-        title.setTypeface(Typeface.create("sans-serif-medium", Typeface.NORMAL));
-        labels.addView(title);
-
-        TextView summary = textView(
-                category.summary,
-                14,
-                tokens.textSecondary
-        );
-        LinearLayout.LayoutParams summaryParams = wrapParams();
-        summaryParams.topMargin = dp(4);
-        labels.addView(summary, summaryParams);
-
-        parent.addView(header, new LinearLayout.LayoutParams(
-                ViewGroup.LayoutParams.MATCH_PARENT,
-                ViewGroup.LayoutParams.WRAP_CONTENT
-        ));
     }
 
     private View createNavigationCard(
@@ -494,17 +413,6 @@ public final class MorpheSettingsV4Fragment extends Fragment {
     ) {
         Context context = requireContext();
         MorpheSettingsV4Theme.Accent accent = tokens.navigationAccent();
-        int cardColor = highlighted
-                ? MorpheSettingsV4Theme.blend(
-                        tokens.surfaceContainerHigh,
-                        accent.container,
-                        tokens.dark ? 0.18f : 0.14f
-                )
-                : MorpheSettingsV4Theme.blend(
-                        tokens.surfaceContainer,
-                        accent.container,
-                        tokens.dark ? 0.06f : 0.05f
-                );
         int iconBackground = highlighted
                 ? MorpheSettingsV4Theme.blend(
                         tokens.surfaceContainerHigh,
@@ -518,17 +426,8 @@ public final class MorpheSettingsV4Fragment extends Fragment {
                 );
         int iconColor = accent.color;
 
-        LinearLayout card = new LinearLayout(context);
-        card.setOrientation(LinearLayout.HORIZONTAL);
-        card.setGravity(Gravity.CENTER_VERTICAL);
-        card.setMinimumHeight(dp(84));
-        card.setPadding(dp(16), dp(13), dp(12), dp(13));
-        card.setBackground(MorpheSettingsV4Theme.interactive(
-                context,
-                cardColor,
-                22,
-                accent.color
-        ));
+        LinearLayout card = MorpheSettingsV14Ui.baseRow(context, tokens);
+        card.setMinimumHeight(dp(TextUtils.isEmpty(summaryValue) ? 56 : 72));
         card.setClickable(true);
         card.setFocusable(true);
         card.setOnClickListener(clickListener);
@@ -537,7 +436,7 @@ public final class MorpheSettingsV4Fragment extends Fragment {
                 iconName,
                 iconColor,
                 iconBackground,
-                46
+                40
         ));
 
         LinearLayout labels = new LinearLayout(context);
@@ -547,30 +446,23 @@ public final class MorpheSettingsV4Fragment extends Fragment {
                 ViewGroup.LayoutParams.WRAP_CONTENT,
                 1.0f
         );
-        labelsParams.setMarginStart(dp(15));
+        labelsParams.setMarginStart(dp(14));
         card.addView(labels, labelsParams);
 
-        TextView title = textView(titleValue, 17, tokens.textPrimary);
-        title.setTypeface(Typeface.create("sans-serif-medium", Typeface.NORMAL));
+        TextView title = textView(titleValue, 16, tokens.textPrimary);
         labels.addView(title);
 
         if (!TextUtils.isEmpty(summaryValue)) {
             TextView summary = textView(summaryValue, 14, tokens.textSecondary);
-            summary.setLineSpacing(0, 1.08f);
-            summary.setMaxLines(3);
+            summary.setLineSpacing(0, 1.06f);
+            summary.setMaxLines(2);
             summary.setEllipsize(TextUtils.TruncateAt.END);
             LinearLayout.LayoutParams summaryParams = wrapParams();
             summaryParams.topMargin = dp(3);
             labels.addView(summary, summaryParams);
         }
 
-        TextView chevron = textView(
-                "›",
-                30,
-                MorpheSettingsV4Theme.withAlpha(accent.color, 184)
-        );
-        chevron.setGravity(Gravity.CENTER);
-        card.addView(chevron, new LinearLayout.LayoutParams(dp(28), dp(48)));
+        card.addView(MorpheSettingsV14Ui.chevron(context, tokens));
         return card;
     }
 
@@ -607,22 +499,6 @@ public final class MorpheSettingsV4Fragment extends Fragment {
         container.addView(iconView, iconParams);
         container.setLayoutParams(new LinearLayout.LayoutParams(dp(sizeDp), dp(sizeDp)));
         return container;
-    }
-
-    private void navigateToHub(MorpheSettingsV4Catalog.Category category) {
-        Activity activity = hostActivity();
-        if (activity == null) {
-            showUnavailable();
-            return;
-        }
-
-        Intent intent = new Intent(activity, activity.getClass());
-        intent.putExtra(
-                EXTRA_SHOW_FRAGMENT,
-                MorpheSettingsV4Fragment.class.getName()
-        );
-        intent.putExtra(ARGUMENT_PAGE, category.id);
-        activity.startActivity(intent);
     }
 
     private void openSearchItem(MorpheSettingsV4Catalog.SearchItem item) {
@@ -759,17 +635,19 @@ public final class MorpheSettingsV4Fragment extends Fragment {
     }
 
     private void addSectionLabel(LinearLayout parent, String value) {
-        TextView label = textView(value, 14, tokens.primary);
-        label.setTypeface(Typeface.create("sans-serif-medium", Typeface.NORMAL));
-        label.setLetterSpacing(0.02f);
-        parent.addView(label);
+        parent.addView(MorpheSettingsV14Ui.sectionLabel(
+                requireContext(),
+                tokens,
+                value
+        ));
     }
 
     private void addBodyText(LinearLayout parent, String value) {
-        TextView text = textView(value, 15, tokens.textSecondary);
-        text.setLineSpacing(0, 1.12f);
-        text.setPadding(dp(4), dp(8), dp(4), dp(16));
-        parent.addView(text);
+        parent.addView(MorpheSettingsV14Ui.supportingText(
+                requireContext(),
+                tokens,
+                value
+        ));
     }
 
     private TextView textView(String value, int sizeSp, int color) {
@@ -778,15 +656,6 @@ public final class MorpheSettingsV4Fragment extends Fragment {
         textView.setTextSize(sizeSp);
         textView.setTextColor(color);
         return textView;
-    }
-
-    private LinearLayout.LayoutParams cardLayoutParams() {
-        LinearLayout.LayoutParams params = new LinearLayout.LayoutParams(
-                ViewGroup.LayoutParams.MATCH_PARENT,
-                ViewGroup.LayoutParams.WRAP_CONTENT
-        );
-        params.bottomMargin = dp(10);
-        return params;
     }
 
     private LinearLayout.LayoutParams wrapParams() {

--- a/extensions/boostforreddit/src/main/java/app/morphe/extension/boostforreddit/settings/MorpheSettingsV4Fragment.java
+++ b/extensions/boostforreddit/src/main/java/app/morphe/extension/boostforreddit/settings/MorpheSettingsV4Fragment.java
@@ -1,0 +1,815 @@
+package app.morphe.extension.boostforreddit.settings;
+
+import android.app.Activity;
+import android.content.Context;
+import android.content.Intent;
+import android.content.res.ColorStateList;
+import android.graphics.Color;
+import android.graphics.Typeface;
+import android.graphics.drawable.Drawable;
+import android.os.Bundle;
+import android.text.Editable;
+import android.text.TextUtils;
+import android.text.TextWatcher;
+import android.view.Gravity;
+import android.view.LayoutInflater;
+import android.view.Menu;
+import android.view.MenuItem;
+import android.view.View;
+import android.view.ViewGroup;
+import android.view.inputmethod.EditorInfo;
+import android.widget.EditText;
+import android.widget.FrameLayout;
+import android.widget.ImageView;
+import android.widget.LinearLayout;
+import android.widget.ScrollView;
+import android.widget.TextView;
+import android.widget.Toast;
+
+import androidx.fragment.app.Fragment;
+
+import app.morphe.extension.boostforreddit.utils.BoostSystemBarInsetsFix;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Morphe-owned, non-Compose settings shell. Complex Boost preference behavior
+ * remains delegated to its original fragments while v4 owns discovery,
+ * grouping, search, navigation, and visual hierarchy.
+ */
+public final class MorpheSettingsV4Fragment extends Fragment {
+    public static final String CONTRACT_MARKER =
+            "MORPHE_BOOST_SETTINGS_V4_UI_ISSUE106_V1";
+    public static final String COLOR_CONTRACT_MARKER =
+            "MORPHE_BOOST_SETTINGS_V4_SUBTLE_COLOR_ISSUE106_V1";
+    public static final String SYSTEM_BARS_CONTRACT_MARKER =
+            "MORPHE_BOOST_SETTINGS_V4_SYSTEM_BARS_ISSUE106_V1";
+    public static final String SYSTEM_BAR_OWNER_CONTRACT_MARKER =
+            "MORPHE_BOOST_SETTINGS_V4_SYSTEM_BAR_OWNER_ISSUE106_V2";
+
+    private static final String ARGUMENT_PAGE =
+            "morphe_boost_settings_v4_page";
+    private static final String PAGE_ROOT = "root";
+    private static final String EXTRA_SHOW_FRAGMENT = "extra_show_fragment";
+    private static final String CLASSIC_HEADER_FRAGMENT =
+            "com.rubenmayayo.reddit.ui.preferences.v2."
+                    + "SettingsActivityCompat$HeaderFragment";
+
+    private MorpheSettingsV4Theme.Tokens tokens;
+    private LinearLayout dynamicContent;
+    private EditText searchField;
+    private List<MorpheSettingsV4Catalog.SearchItem> searchIndex;
+    private String page = PAGE_ROOT;
+
+    public MorpheSettingsV4Fragment() {
+    }
+
+    @Override
+    public View onCreateView(
+            LayoutInflater inflater,
+            ViewGroup container,
+            Bundle savedInstanceState
+    ) {
+        Context context = inflater.getContext();
+        tokens = MorpheSettingsV4Theme.resolve(context);
+        setHasOptionsMenu(true);
+
+        Activity activity = hostActivity();
+        if (activity != null) {
+            Intent intent = activity.getIntent();
+            String requestedPage = intent == null
+                    ? null
+                    : intent.getStringExtra(ARGUMENT_PAGE);
+            if (!TextUtils.isEmpty(requestedPage)) {
+                page = requestedPage;
+            }
+        }
+
+        ScrollView scrollView = new ScrollView(context);
+        scrollView.setFillViewport(true);
+        scrollView.setBackgroundColor(tokens.background);
+        scrollView.setClipToPadding(false);
+
+        LinearLayout content = new LinearLayout(context);
+        content.setOrientation(LinearLayout.VERTICAL);
+        int horizontal = dp(20);
+        content.setPadding(horizontal, dp(16), horizontal, dp(36));
+        scrollView.addView(
+                content,
+                new ScrollView.LayoutParams(
+                        ViewGroup.LayoutParams.MATCH_PARENT,
+                        ViewGroup.LayoutParams.WRAP_CONTENT
+                )
+        );
+
+        if (PAGE_ROOT.equals(page)) {
+            buildRoot(content);
+        } else {
+            buildHub(content, page);
+        }
+        return scrollView;
+    }
+
+    @Override
+    public void onResume() {
+        super.onResume();
+        styleHostAndTitle();
+    }
+
+    @Override
+    public void onPause() {
+        Activity activity = hostActivity();
+        if (activity != null) {
+            BoostSystemBarInsetsFix.clearMorpheSettingsV4SystemBars(activity);
+        }
+        super.onPause();
+    }
+
+    @Override
+    public void onPrepareOptionsMenu(Menu menu) {
+        super.onPrepareOptionsMenu(menu);
+        hideMenuItem(menu, "action_generic_search");
+        hideMenuItem(menu, "action_search");
+        hideMenuItem(menu, "search");
+        hideMenuItem(menu, "menu_search");
+    }
+
+    @Override
+    public void onDestroyView() {
+        dynamicContent = null;
+        searchField = null;
+        super.onDestroyView();
+    }
+
+    private void buildRoot(LinearLayout content) {
+        addMorpheHero(content);
+        addSpace(content, 18);
+        addSearchField(content);
+        addSpace(content, 24);
+
+        dynamicContent = new LinearLayout(requireContext());
+        dynamicContent.setOrientation(LinearLayout.VERTICAL);
+        content.addView(
+                dynamicContent,
+                new LinearLayout.LayoutParams(
+                        ViewGroup.LayoutParams.MATCH_PARENT,
+                        ViewGroup.LayoutParams.WRAP_CONTENT
+                )
+        );
+        renderRootContent("");
+    }
+
+    private void buildHub(LinearLayout content, String categoryId) {
+        MorpheSettingsV4Catalog.Category category =
+                MorpheSettingsV4Catalog.findCategory(categoryId);
+        if (category == null) {
+            addSectionLabel(content, "Settings");
+            addBodyText(content, "This settings category is unavailable.");
+            return;
+        }
+
+        addHubHeader(content, category);
+        addSpace(content, 22);
+        addSectionLabel(content, "Choose a section");
+        addSpace(content, 10);
+
+        for (MorpheSettingsV4Catalog.Leaf leaf : category.leaves) {
+            View card = createNavigationCard(
+                    leaf.title,
+                    leaf.summary,
+                    leaf.iconName,
+                    false,
+                    view -> openLeaf(leaf, null)
+            );
+            content.addView(card, cardLayoutParams());
+        }
+    }
+
+    private void addMorpheHero(LinearLayout parent) {
+        Context context = requireContext();
+        int heroColor = MorpheSettingsV4Theme.blend(
+                tokens.surfaceContainerHigh,
+                tokens.primaryContainer,
+                tokens.dark ? 0.56f : 0.48f
+        );
+        LinearLayout card = new LinearLayout(context);
+        card.setOrientation(LinearLayout.HORIZONTAL);
+        card.setGravity(Gravity.CENTER_VERTICAL);
+        card.setPadding(dp(18), dp(18), dp(16), dp(18));
+        card.setMinimumHeight(dp(104));
+        card.setBackground(MorpheSettingsV4Theme.interactive(
+                context,
+                heroColor,
+                28,
+                tokens.primary
+        ));
+        card.setClickable(true);
+        card.setFocusable(true);
+        card.setOnClickListener(view -> openLeaf(
+                MorpheSettingsV4Catalog.morphe(),
+                null
+        ));
+
+        card.addView(createIconContainer(
+                "ic_puzzle_24dp",
+                tokens.primary,
+                MorpheSettingsV4Theme.blend(
+                        tokens.surfaceContainerHigh,
+                        tokens.primaryContainer,
+                        tokens.dark ? 0.64f : 0.54f
+                ),
+                52
+        ));
+
+        LinearLayout text = new LinearLayout(context);
+        text.setOrientation(LinearLayout.VERTICAL);
+        LinearLayout.LayoutParams textParams = new LinearLayout.LayoutParams(
+                0,
+                ViewGroup.LayoutParams.WRAP_CONTENT,
+                1.0f
+        );
+        textParams.setMarginStart(dp(16));
+        card.addView(text, textParams);
+
+        TextView badge = textView("MORPHE · V4 PREVIEW", 11, tokens.primary);
+        badge.setTypeface(Typeface.DEFAULT_BOLD);
+        text.addView(badge);
+
+        TextView title = textView("Morphe settings", 21, tokens.textPrimary);
+        title.setTypeface(Typeface.create("sans-serif-medium", Typeface.NORMAL));
+        LinearLayout.LayoutParams titleParams = wrapParams();
+        titleParams.topMargin = dp(4);
+        text.addView(title, titleParams);
+
+        TextView summary = textView(
+                "Patches, previews, recovery, and interface controls",
+                14,
+                tokens.textSecondary
+        );
+        summary.setLineSpacing(0, 1.08f);
+        LinearLayout.LayoutParams summaryParams = wrapParams();
+        summaryParams.topMargin = dp(3);
+        text.addView(summary, summaryParams);
+
+        TextView chevron = textView("›", 32, tokens.primary);
+        chevron.setGravity(Gravity.CENTER);
+        card.addView(chevron, new LinearLayout.LayoutParams(dp(28), dp(52)));
+
+        parent.addView(card, new LinearLayout.LayoutParams(
+                ViewGroup.LayoutParams.MATCH_PARENT,
+                ViewGroup.LayoutParams.WRAP_CONTENT
+        ));
+    }
+
+    private void addSearchField(LinearLayout parent) {
+        Context context = requireContext();
+        searchField = new EditText(context);
+        searchField.setSingleLine(true);
+        searchField.setTextSize(16);
+        searchField.setTextColor(tokens.textPrimary);
+        searchField.setHintTextColor(tokens.textSecondary);
+        searchField.setHint("Search all settings");
+        searchField.setImeOptions(EditorInfo.IME_ACTION_SEARCH);
+        searchField.setPadding(dp(18), 0, dp(18), 0);
+        searchField.setBackground(MorpheSettingsV4Theme.rounded(
+                context,
+                MorpheSettingsV4Theme.blend(
+                        tokens.surfaceContainerHigh,
+                        tokens.primaryContainer,
+                        tokens.dark ? 0.06f : 0.08f
+                ),
+                28
+        ));
+
+        Drawable searchIcon = icon("ic_search_color_24dp", tokens.primary);
+        if (searchIcon != null) {
+            searchIcon.setBounds(0, 0, dp(22), dp(22));
+            searchField.setCompoundDrawablePadding(dp(12));
+            searchField.setCompoundDrawables(searchIcon, null, null, null);
+        }
+
+        parent.addView(searchField, new LinearLayout.LayoutParams(
+                ViewGroup.LayoutParams.MATCH_PARENT,
+                dp(56)
+        ));
+
+        searchField.addTextChangedListener(new TextWatcher() {
+            @Override
+            public void beforeTextChanged(
+                    CharSequence value,
+                    int start,
+                    int count,
+                    int after
+            ) {
+            }
+
+            @Override
+            public void onTextChanged(
+                    CharSequence value,
+                    int start,
+                    int before,
+                    int count
+            ) {
+                renderRootContent(value == null ? "" : value.toString());
+            }
+
+            @Override
+            public void afterTextChanged(Editable value) {
+            }
+        });
+    }
+
+    private void renderRootContent(String query) {
+        if (dynamicContent == null) {
+            return;
+        }
+        dynamicContent.removeAllViews();
+
+        String normalized = MorpheSettingsV4Catalog.normalize(query);
+        if (TextUtils.isEmpty(normalized)) {
+            renderCategories();
+        } else {
+            renderSearchResults(normalized);
+        }
+    }
+
+    private void renderCategories() {
+        addSectionLabel(dynamicContent, "Browse by task");
+        addSpace(dynamicContent, 10);
+
+        for (MorpheSettingsV4Catalog.Category category
+                : MorpheSettingsV4Catalog.categories()) {
+            View card = createNavigationCard(
+                    category.title,
+                    category.summary,
+                    category.iconName,
+                    false,
+                    view -> navigateToHub(category)
+            );
+            dynamicContent.addView(card, cardLayoutParams());
+        }
+
+        addSpace(dynamicContent, 10);
+        TextView classic = textView(
+                "Open classic Boost settings",
+                14,
+                tokens.primary
+        );
+        classic.setTypeface(Typeface.create("sans-serif-medium", Typeface.NORMAL));
+        classic.setGravity(Gravity.CENTER);
+        classic.setPadding(dp(16), dp(14), dp(16), dp(14));
+        classic.setBackground(MorpheSettingsV4Theme.interactive(
+                requireContext(),
+                Color.TRANSPARENT,
+                22,
+                tokens.primary
+        ));
+        classic.setOnClickListener(view -> openClassicSettings());
+        dynamicContent.addView(classic, new LinearLayout.LayoutParams(
+                ViewGroup.LayoutParams.MATCH_PARENT,
+                ViewGroup.LayoutParams.WRAP_CONTENT
+        ));
+    }
+
+    private void renderSearchResults(String normalizedQuery) {
+        if (searchIndex == null) {
+            searchIndex = MorpheSettingsV4Catalog.buildSearchIndex(requireContext());
+        }
+
+        List<MorpheSettingsV4Catalog.SearchItem> matches = new ArrayList<>();
+        for (MorpheSettingsV4Catalog.SearchItem item : searchIndex) {
+            if (item.matches(normalizedQuery)) {
+                matches.add(item);
+            }
+        }
+
+        addSectionLabel(
+                dynamicContent,
+                matches.isEmpty()
+                        ? "No matching settings"
+                        : matches.size() + (matches.size() == 1 ? " result" : " results")
+        );
+        addSpace(dynamicContent, 10);
+
+        if (matches.isEmpty()) {
+            addBodyText(
+                    dynamicContent,
+                    "Try a setting name, category, summary, or preference key."
+            );
+            return;
+        }
+
+        int limit = Math.min(matches.size(), 80);
+        for (int index = 0; index < limit; index++) {
+            MorpheSettingsV4Catalog.SearchItem item = matches.get(index);
+            String secondary = item.category;
+            if (!TextUtils.isEmpty(item.summary)) {
+                secondary += "\n" + item.summary;
+            }
+            View card = createNavigationCard(
+                    item.title,
+                    secondary,
+                    item.iconName,
+                    false,
+                    view -> openSearchItem(item)
+            );
+            dynamicContent.addView(card, cardLayoutParams());
+        }
+
+        if (matches.size() > limit) {
+            addBodyText(
+                    dynamicContent,
+                    "Showing the first " + limit + " results. Keep typing to narrow the search."
+            );
+        }
+    }
+
+    private void addHubHeader(
+            LinearLayout parent,
+            MorpheSettingsV4Catalog.Category category
+    ) {
+        Context context = requireContext();
+        MorpheSettingsV4Theme.Accent accent =
+                tokens.navigationAccent();
+        LinearLayout header = new LinearLayout(context);
+        header.setOrientation(LinearLayout.HORIZONTAL);
+        header.setGravity(Gravity.CENTER_VERTICAL);
+        header.setPadding(dp(18), dp(18), dp(18), dp(18));
+        header.setBackground(MorpheSettingsV4Theme.rounded(
+                context,
+                MorpheSettingsV4Theme.blend(
+                        tokens.surfaceContainerHigh,
+                        accent.container,
+                        tokens.dark ? 0.34f : 0.28f
+                ),
+                28
+        ));
+        header.addView(createIconContainer(
+                category.iconName,
+                accent.color,
+                MorpheSettingsV4Theme.blend(
+                        tokens.surfaceContainerHigh,
+                        accent.container,
+                        tokens.dark ? 0.54f : 0.46f
+                ),
+                52
+        ));
+
+        LinearLayout labels = new LinearLayout(context);
+        labels.setOrientation(LinearLayout.VERTICAL);
+        LinearLayout.LayoutParams labelsParams = new LinearLayout.LayoutParams(
+                0,
+                ViewGroup.LayoutParams.WRAP_CONTENT,
+                1.0f
+        );
+        labelsParams.setMarginStart(dp(16));
+        header.addView(labels, labelsParams);
+
+        TextView title = textView(category.title, 21, tokens.textPrimary);
+        title.setTypeface(Typeface.create("sans-serif-medium", Typeface.NORMAL));
+        labels.addView(title);
+
+        TextView summary = textView(
+                category.summary,
+                14,
+                tokens.textSecondary
+        );
+        LinearLayout.LayoutParams summaryParams = wrapParams();
+        summaryParams.topMargin = dp(4);
+        labels.addView(summary, summaryParams);
+
+        parent.addView(header, new LinearLayout.LayoutParams(
+                ViewGroup.LayoutParams.MATCH_PARENT,
+                ViewGroup.LayoutParams.WRAP_CONTENT
+        ));
+    }
+
+    private View createNavigationCard(
+            String titleValue,
+            String summaryValue,
+            String iconName,
+            boolean highlighted,
+            View.OnClickListener clickListener
+    ) {
+        Context context = requireContext();
+        MorpheSettingsV4Theme.Accent accent = tokens.navigationAccent();
+        int cardColor = highlighted
+                ? MorpheSettingsV4Theme.blend(
+                        tokens.surfaceContainerHigh,
+                        accent.container,
+                        tokens.dark ? 0.18f : 0.14f
+                )
+                : MorpheSettingsV4Theme.blend(
+                        tokens.surfaceContainer,
+                        accent.container,
+                        tokens.dark ? 0.06f : 0.05f
+                );
+        int iconBackground = highlighted
+                ? MorpheSettingsV4Theme.blend(
+                        tokens.surfaceContainerHigh,
+                        accent.container,
+                        tokens.dark ? 0.42f : 0.34f
+                )
+                : MorpheSettingsV4Theme.blend(
+                        tokens.surfaceContainerHigh,
+                        accent.container,
+                        tokens.dark ? 0.34f : 0.28f
+                );
+        int iconColor = accent.color;
+
+        LinearLayout card = new LinearLayout(context);
+        card.setOrientation(LinearLayout.HORIZONTAL);
+        card.setGravity(Gravity.CENTER_VERTICAL);
+        card.setMinimumHeight(dp(84));
+        card.setPadding(dp(16), dp(13), dp(12), dp(13));
+        card.setBackground(MorpheSettingsV4Theme.interactive(
+                context,
+                cardColor,
+                22,
+                accent.color
+        ));
+        card.setClickable(true);
+        card.setFocusable(true);
+        card.setOnClickListener(clickListener);
+
+        card.addView(createIconContainer(
+                iconName,
+                iconColor,
+                iconBackground,
+                46
+        ));
+
+        LinearLayout labels = new LinearLayout(context);
+        labels.setOrientation(LinearLayout.VERTICAL);
+        LinearLayout.LayoutParams labelsParams = new LinearLayout.LayoutParams(
+                0,
+                ViewGroup.LayoutParams.WRAP_CONTENT,
+                1.0f
+        );
+        labelsParams.setMarginStart(dp(15));
+        card.addView(labels, labelsParams);
+
+        TextView title = textView(titleValue, 17, tokens.textPrimary);
+        title.setTypeface(Typeface.create("sans-serif-medium", Typeface.NORMAL));
+        labels.addView(title);
+
+        if (!TextUtils.isEmpty(summaryValue)) {
+            TextView summary = textView(summaryValue, 14, tokens.textSecondary);
+            summary.setLineSpacing(0, 1.08f);
+            summary.setMaxLines(3);
+            summary.setEllipsize(TextUtils.TruncateAt.END);
+            LinearLayout.LayoutParams summaryParams = wrapParams();
+            summaryParams.topMargin = dp(3);
+            labels.addView(summary, summaryParams);
+        }
+
+        TextView chevron = textView(
+                "›",
+                30,
+                MorpheSettingsV4Theme.withAlpha(accent.color, 184)
+        );
+        chevron.setGravity(Gravity.CENTER);
+        card.addView(chevron, new LinearLayout.LayoutParams(dp(28), dp(48)));
+        return card;
+    }
+
+    private View createIconContainer(
+            String iconName,
+            int iconColor,
+            int backgroundColor,
+            int sizeDp
+    ) {
+        Context context = requireContext();
+        FrameLayout container = new FrameLayout(context);
+        container.setBackground(MorpheSettingsV4Theme.rounded(
+                context,
+                backgroundColor,
+                sizeDp / 2.0f
+        ));
+
+        ImageView iconView = new ImageView(context);
+        Drawable drawable = icon(iconName, iconColor);
+        if (drawable != null) {
+            iconView.setImageDrawable(drawable);
+        } else {
+            iconView.setImageResource(android.R.drawable.ic_menu_preferences);
+            iconView.setColorFilter(iconColor);
+        }
+        iconView.setScaleType(ImageView.ScaleType.CENTER_INSIDE);
+
+        int iconSize = dp(24);
+        FrameLayout.LayoutParams iconParams = new FrameLayout.LayoutParams(
+                iconSize,
+                iconSize,
+                Gravity.CENTER
+        );
+        container.addView(iconView, iconParams);
+        container.setLayoutParams(new LinearLayout.LayoutParams(dp(sizeDp), dp(sizeDp)));
+        return container;
+    }
+
+    private void navigateToHub(MorpheSettingsV4Catalog.Category category) {
+        Activity activity = hostActivity();
+        if (activity == null) {
+            showUnavailable();
+            return;
+        }
+
+        Intent intent = new Intent(activity, activity.getClass());
+        intent.putExtra(
+                EXTRA_SHOW_FRAGMENT,
+                MorpheSettingsV4Fragment.class.getName()
+        );
+        intent.putExtra(ARGUMENT_PAGE, category.id);
+        activity.startActivity(intent);
+    }
+
+    private void openSearchItem(MorpheSettingsV4Catalog.SearchItem item) {
+        if (!TextUtils.isEmpty(item.activityName)) {
+            openActivity(item.activityName);
+            return;
+        }
+        openFragment(item.fragmentName, item.title);
+    }
+
+    private void openLeaf(
+            MorpheSettingsV4Catalog.Leaf leaf,
+            String preferenceKey
+    ) {
+        if (!TextUtils.isEmpty(leaf.activityName)) {
+            openActivity(leaf.activityName);
+            return;
+        }
+        openFragment(leaf.fragmentName, leaf.title);
+    }
+
+    private void openFragment(String fragmentName, String title) {
+        if (TextUtils.isEmpty(fragmentName)) {
+            showUnavailable();
+            return;
+        }
+
+        Activity activity = hostActivity();
+        if (activity == null) {
+            showUnavailable();
+            return;
+        }
+
+        Intent intent = new Intent(activity, activity.getClass());
+        intent.putExtra(EXTRA_SHOW_FRAGMENT, fragmentName);
+        activity.startActivity(intent);
+    }
+
+    private void openActivity(String activityName) {
+        try {
+            Context context = requireContext();
+            Intent intent = new Intent();
+            intent.setClassName(context.getPackageName(), activityName);
+            context.startActivity(intent);
+        } catch (Exception exception) {
+            showUnavailable();
+        }
+    }
+
+    private void openClassicSettings() {
+        Activity activity = hostActivity();
+        if (activity == null) {
+            showUnavailable();
+            return;
+        }
+
+        Intent intent = new Intent(activity, activity.getClass());
+        intent.putExtra(EXTRA_SHOW_FRAGMENT, CLASSIC_HEADER_FRAGMENT);
+        activity.startActivity(intent);
+    }
+
+    private void styleHostAndTitle() {
+        Activity activity = hostActivity();
+        if (activity == null || tokens == null) {
+            return;
+        }
+
+        String title = "Settings";
+        if (!PAGE_ROOT.equals(page)) {
+            MorpheSettingsV4Catalog.Category category =
+                    MorpheSettingsV4Catalog.findCategory(page);
+            if (category != null) {
+                title = category.title;
+            }
+        }
+        activity.setTitle(title);
+        styleSystemBars(activity);
+
+        int toolbarId = MorpheSettingsV4Catalog.resourceId(
+                activity,
+                "id",
+                "toolbar"
+        );
+        View toolbar = activity.findViewById(toolbarId);
+        if (toolbar != null) {
+            toolbar.setBackgroundColor(tokens.background);
+            toolbar.setElevation(0);
+        }
+    }
+
+    private void styleSystemBars(Activity activity) {
+        BoostSystemBarInsetsFix.applyMorpheSettingsV4SystemBars(
+                activity,
+                tokens.background,
+                tokens.dark
+        );
+    }
+
+    private Activity hostActivity() {
+        Context context = requireContext();
+        return context instanceof Activity ? (Activity) context : null;
+    }
+
+    private void hideMenuItem(Menu menu, String resourceName) {
+        int resourceId = MorpheSettingsV4Catalog.resourceId(
+                requireContext(),
+                "id",
+                resourceName
+        );
+        if (resourceId == 0) {
+            return;
+        }
+        MenuItem item = menu.findItem(resourceId);
+        if (item != null) {
+            item.setVisible(false);
+        }
+    }
+
+    private Drawable icon(String resourceName, int color) {
+        int resourceId = MorpheSettingsV4Catalog.resourceId(
+                requireContext(),
+                "drawable",
+                resourceName
+        );
+        if (resourceId == 0) {
+            return null;
+        }
+        Drawable drawable = requireContext().getDrawable(resourceId);
+        if (drawable != null) {
+            drawable = drawable.mutate();
+            drawable.setTintList(ColorStateList.valueOf(color));
+        }
+        return drawable;
+    }
+
+    private void addSectionLabel(LinearLayout parent, String value) {
+        TextView label = textView(value, 14, tokens.primary);
+        label.setTypeface(Typeface.create("sans-serif-medium", Typeface.NORMAL));
+        label.setLetterSpacing(0.02f);
+        parent.addView(label);
+    }
+
+    private void addBodyText(LinearLayout parent, String value) {
+        TextView text = textView(value, 15, tokens.textSecondary);
+        text.setLineSpacing(0, 1.12f);
+        text.setPadding(dp(4), dp(8), dp(4), dp(16));
+        parent.addView(text);
+    }
+
+    private TextView textView(String value, int sizeSp, int color) {
+        TextView textView = new TextView(requireContext());
+        textView.setText(value);
+        textView.setTextSize(sizeSp);
+        textView.setTextColor(color);
+        return textView;
+    }
+
+    private LinearLayout.LayoutParams cardLayoutParams() {
+        LinearLayout.LayoutParams params = new LinearLayout.LayoutParams(
+                ViewGroup.LayoutParams.MATCH_PARENT,
+                ViewGroup.LayoutParams.WRAP_CONTENT
+        );
+        params.bottomMargin = dp(10);
+        return params;
+    }
+
+    private LinearLayout.LayoutParams wrapParams() {
+        return new LinearLayout.LayoutParams(
+                ViewGroup.LayoutParams.WRAP_CONTENT,
+                ViewGroup.LayoutParams.WRAP_CONTENT
+        );
+    }
+
+    private void addSpace(LinearLayout parent, int heightDp) {
+        View space = new View(requireContext());
+        parent.addView(space, new LinearLayout.LayoutParams(1, dp(heightDp)));
+    }
+
+    private int dp(float value) {
+        return MorpheSettingsV4Theme.dp(requireContext(), value);
+    }
+
+    private void showUnavailable() {
+        Toast.makeText(
+                requireContext(),
+                "This settings page is unavailable in the current Boost build.",
+                Toast.LENGTH_SHORT
+        ).show();
+    }
+}

--- a/extensions/boostforreddit/src/main/java/app/morphe/extension/boostforreddit/settings/MorpheSettingsV4NativePages.java
+++ b/extensions/boostforreddit/src/main/java/app/morphe/extension/boostforreddit/settings/MorpheSettingsV4NativePages.java
@@ -1,0 +1,3036 @@
+package app.morphe.extension.boostforreddit.settings;
+
+import android.app.Activity;
+import android.content.ComponentName;
+import android.content.Context;
+import android.content.Intent;
+import android.content.SharedPreferences;
+import android.content.pm.PackageInfo;
+import android.content.res.ColorStateList;
+import android.content.res.Resources;
+import android.content.res.XmlResourceParser;
+import android.graphics.Typeface;
+import android.net.Uri;
+import android.os.Build;
+import android.os.Bundle;
+import android.preference.PreferenceManager;
+import android.provider.Settings;
+import android.text.InputType;
+import android.text.TextUtils;
+import android.view.Gravity;
+import android.view.LayoutInflater;
+import android.view.Menu;
+import android.view.MenuItem;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.EditText;
+import android.widget.FrameLayout;
+import android.widget.LinearLayout;
+import android.widget.ScrollView;
+import android.widget.SeekBar;
+import android.widget.TextView;
+import android.widget.Toast;
+
+import androidx.fragment.app.Fragment;
+
+import app.morphe.extension.boostforreddit.utils.BoostSystemBarInsetsFix;
+
+import org.xmlpull.v1.XmlPullParser;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.lang.reflect.Proxy;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Morphe-native destinations for the remaining Boost v2 preference pages.
+ *
+ * <p>The page model is read from Boost's packaged XML so titles, summaries,
+ * defaults, arrays, dependencies, and localization remain canonical. Unlike
+ * the discarded V8 experiment, no Boost Fragment is created as a hidden
+ * delegate. Morphe owns every visible control and writes the canonical Boost
+ * preference keys directly. Special actions are bound explicitly below.</p>
+ */
+public final class MorpheSettingsV4NativePages {
+    public static final String CONTRACT_MARKER =
+            "MORPHE_BOOST_SETTINGS_V4_NATIVE_REST_ISSUE106_V1";
+    public static final String NO_DELEGATE_MARKER =
+            "MORPHE_BOOST_SETTINGS_V4_NATIVE_NO_HIDDEN_DELEGATE_ISSUE106_V1";
+    public static final String SPECIAL_ACTION_MARKER =
+            "MORPHE_BOOST_SETTINGS_V4_NATIVE_SPECIAL_ACTIONS_ISSUE106_V1";
+    public static final String NESTED_EDITOR_MARKER =
+            "MORPHE_BOOST_SETTINGS_V4_NATIVE_NESTED_EDITORS_ISSUE106_V10";
+    public static final String LEGACY_PRUNING_MARKER =
+            "MORPHE_BOOST_SETTINGS_V4_LEGACY_PRUNING_ISSUE106_V10";
+    public static final String M3_SORT_PILOT_MARKER =
+            "MORPHE_BOOST_SETTINGS_V4_M3_SORT_PILOT_ISSUE106_V11";
+    public static final String MATERIAL_EDITOR_MARKER =
+            "MORPHE_BOOST_SETTINGS_V4_MATERIAL_EDITOR_PAGES_ISSUE106_V12";
+    public static final String MATERIAL_ABI_MARKER =
+            "MORPHE_BOOST_SETTINGS_V4_MATERIAL_ABI_SAFE_ISSUE106_V12";
+    public static final String EDITOR_BACK_STACK_MARKER =
+            "MORPHE_BOOST_SETTINGS_V4_FRAGMENT_BACK_STACK_ISSUE106_V13";
+    public static final String V14_EDITOR_MARKER =
+            "MORPHE_BOOST_SETTINGS_V14_EDITOR_SYSTEM_ISSUE106_V1";
+    public static final String V14_NO_COMPILE_ONLY_UI_MARKER =
+            "MORPHE_BOOST_SETTINGS_V14_NO_COMPILE_ONLY_UI_ABI_ISSUE106_V1";
+
+    private static final String PREFIX =
+            "app.morphe.extension.boostforreddit.settings."
+                    + "MorpheSettingsV4NativePages$";
+
+    private MorpheSettingsV4NativePages() {
+    }
+
+    public static String nativeDestination(String legacyDestination) {
+        if (TextUtils.isEmpty(legacyDestination)) {
+            return legacyDestination;
+        }
+        if (legacyDestination.endsWith("PreferenceFragmentPostsCompat")) {
+            return PREFIX + "Posts";
+        }
+        if (legacyDestination.endsWith("PreferenceFragmentCommentsCompat")) {
+            return PREFIX + "Comments";
+        }
+        if (legacyDestination.endsWith("PreferenceFragmentBottomNavigationCompat")) {
+            return PREFIX + "BottomNavigation";
+        }
+        if (legacyDestination.endsWith("PreferenceFragmentDrawerCompat")) {
+            return PREFIX + "Drawer";
+        }
+        if (legacyDestination.endsWith("PreferenceFragmentMediaCompat")) {
+            return PREFIX + "Media";
+        }
+        if (legacyDestination.endsWith("PreferenceFragmentLinksCompat")) {
+            return PREFIX + "Links";
+        }
+        if (legacyDestination.endsWith("PreferenceFragmentSearchCompat")) {
+            return PREFIX + "Search";
+        }
+        if (legacyDestination.endsWith("PreferenceFragmentFiltersCompat")) {
+            return PREFIX + "Filters";
+        }
+        if (legacyDestination.endsWith("PreferenceFragmentMessagesCompat")) {
+            return PREFIX + "Messages";
+        }
+        if (legacyDestination.endsWith("PreferenceFragmentPrivacyCompat")) {
+            return PREFIX + "Privacy";
+        }
+        if (legacyDestination.endsWith("PreferenceFragmentGeneralCompat")) {
+            return PREFIX + "General";
+        }
+        if (legacyDestination.endsWith("PreferenceFragmentMiscCompat")) {
+            return PREFIX + "Misc";
+        }
+        if (legacyDestination.endsWith("PreferenceFragmentAboutCompat")) {
+            return PREFIX + "About";
+        }
+        if (legacyDestination.endsWith("PreferenceFragmentViewsCompat")) {
+            return MorpheSettingsV4Catalog.V4_POST_VIEWS_FRAGMENT;
+        }
+        if (legacyDestination.endsWith("PreferenceFragmentToolbarCompat")) {
+            return MorpheSettingsV4Catalog.V4_TOOLBAR_FRAGMENT;
+        }
+        return legacyDestination;
+    }
+
+    public static final class Posts extends NativePage {
+        public Posts() {
+            super("Posts", "pref_posts_v2");
+        }
+    }
+
+    public static final class Comments extends NativePage {
+        public Comments() {
+            super("Comments", "pref_comments_v2");
+        }
+    }
+
+    public static final class BottomNavigation extends NativePage {
+        public BottomNavigation() {
+            super("Bottom navigation", "pref_bottom_navigation_v2");
+        }
+    }
+
+    public static final class Drawer extends NativePage {
+        public Drawer() {
+            super("Navigation drawer", "pref_drawer_v2");
+        }
+    }
+
+    public static final class Media extends NativePage {
+        public Media() {
+            super("Media viewer", "pref_media_v2");
+        }
+    }
+
+    public static final class Links extends NativePage {
+        public Links() {
+            super("Link handling", "pref_links_v2");
+        }
+    }
+
+    public static final class Search extends NativePage {
+        public Search() {
+            super("Search", "pref_search_v2");
+        }
+    }
+
+    public static final class Filters extends NativePage {
+        public Filters() {
+            super("Content filters", "pref_filters_v2");
+        }
+    }
+
+    public static final class Messages extends NativePage {
+        public Messages() {
+            super("Notifications", "pref_messages_v2");
+        }
+    }
+
+    public static final class Privacy extends NativePage {
+        public Privacy() {
+            super("History & privacy", "pref_privacy_v2");
+        }
+    }
+
+    public static final class General extends NativePage {
+        public General() {
+            super("General", "pref_general_v2");
+        }
+    }
+
+    public static final class Misc extends NativePage {
+        public Misc() {
+            super("Legacy features", "pref_misc_v2");
+        }
+    }
+
+    public static final class About extends NativePage {
+        public About() {
+            super("About Boost", "pref_about_v2");
+        }
+    }
+
+    public static final class Morphe extends NativePage {
+        public static final String MATERIAL_TOGGLE_LAST_MARKER =
+                "MORPHE_BOOST_SETTINGS_V14_3_MATERIAL_TOGGLE_LAST_ISSUE106_V1";
+
+        public Morphe() {
+            super("Morphe", "morphe_boost_settings_skeleton");
+        }
+    }
+
+    public abstract static class NativePage extends Fragment {
+        private static final String ANDROID_NS =
+                "http://schemas.android.com/apk/res/android";
+        private static final String APP_NS =
+                "http://schemas.android.com/apk/res-auto";
+        private static final String EXTRA_SHOW_FRAGMENT = "extra_show_fragment";
+        private static final String BOOST_FRAGMENT_PREFIX =
+                "com.rubenmayayo.reddit.ui.preferences.v2.";
+        private static final int REQUEST_SYNCCIT_DEVICE = 1001;
+        private static final int REQUEST_SYNCCIT_ACCOUNT = 1002;
+
+        private final String pageTitle;
+        private final String resourceName;
+        private final List<Binding> bindings = new ArrayList<>();
+        private final Map<String, Control> controlsByKey = new LinkedHashMap<>();
+
+        private MorpheSettingsV4Theme.Tokens tokens;
+        private SharedPreferences preferences;
+        private EditText synccitUsernameInput;
+        private EditText synccitAuthInput;
+        private Object savedSearchObserver;
+        private FrameLayout pageHost;
+        private View settingsPage;
+        private final List<EditorPage> editorPages = new ArrayList<>();
+        private Object editorFragmentManager;
+        private Object editorBackStackListener;
+        private int editorBackStackBaseCount = -1;
+        private int editorBackStackSequence;
+
+        protected NativePage(String pageTitle, String resourceName) {
+            this.pageTitle = pageTitle;
+            this.resourceName = resourceName;
+        }
+
+        @Override
+        public View onCreateView(
+                LayoutInflater inflater,
+                ViewGroup container,
+                Bundle savedInstanceState
+        ) {
+            Context context = inflater.getContext();
+            tokens = MorpheSettingsV4Theme.resolve(context);
+            preferences = PreferenceManager.getDefaultSharedPreferences(context);
+            setHasOptionsMenu(true);
+
+            pageHost = new FrameLayout(context);
+            pageHost.setBackgroundColor(tokens.background);
+
+            ScrollView scrollView = new ScrollView(context);
+            scrollView.setFillViewport(true);
+            scrollView.setClipToPadding(false);
+            scrollView.setBackgroundColor(tokens.background);
+            settingsPage = scrollView;
+            pageHost.addView(scrollView, new FrameLayout.LayoutParams(
+                    ViewGroup.LayoutParams.MATCH_PARENT,
+                    ViewGroup.LayoutParams.MATCH_PARENT
+            ));
+
+            LinearLayout content = new LinearLayout(context);
+            content.setOrientation(LinearLayout.VERTICAL);
+            content.setPadding(dp(16), dp(10), dp(16), dp(32));
+            scrollView.addView(content, new ScrollView.LayoutParams(
+                    ViewGroup.LayoutParams.MATCH_PARENT,
+                    ViewGroup.LayoutParams.WRAP_CONTENT
+            ));
+
+            List<Control> controls = readControls(context);
+            if (controls.isEmpty()) {
+                addSectionLabel(content, pageTitle);
+                addSpace(content, 8);
+                LinearLayout group = addGroup(content);
+                addActionRow(
+                        group,
+                        "This settings page is unavailable",
+                        "Boost's packaged preference contract could not be read.",
+                        view -> showUnavailable()
+                );
+                return pageHost;
+            }
+
+            renderControls(content, controls);
+            updateDependencies();
+            return pageHost;
+        }
+
+        @Override
+        public void onResume() {
+            super.onResume();
+            syncRows();
+            styleHost();
+        }
+
+        @Override
+        public void onPause() {
+            Activity activity = hostActivity();
+            if (activity != null) {
+                BoostSystemBarInsetsFix.clearMorpheSettingsV4SystemBars(activity);
+            }
+            super.onPause();
+        }
+
+        @Override
+        public void onDestroyView() {
+            bindings.clear();
+            controlsByKey.clear();
+            synccitUsernameInput = null;
+            synccitAuthInput = null;
+            savedSearchObserver = null;
+            editorPages.clear();
+            pageHost = null;
+            settingsPage = null;
+            editorFragmentManager = null;
+            editorBackStackListener = null;
+            editorBackStackBaseCount = -1;
+            super.onDestroyView();
+        }
+
+        @Override
+        public void onActivityResult(
+                int requestCode,
+                int resultCode,
+                Intent data
+        ) {
+            super.onActivityResult(requestCode, resultCode, data);
+            if ((requestCode != REQUEST_SYNCCIT_DEVICE
+                    && requestCode != REQUEST_SYNCCIT_ACCOUNT)
+                    || resultCode != Activity.RESULT_OK
+                    || data == null) {
+                return;
+            }
+            String username = data.getStringExtra("username");
+            String auth = data.getStringExtra("auth");
+            if (username == null || auth == null) {
+                return;
+            }
+            saveSynccitCredentials(username, auth);
+            if (synccitUsernameInput != null) {
+                synccitUsernameInput.setText(username);
+            }
+            if (synccitAuthInput != null) {
+                synccitAuthInput.setText(auth);
+            }
+        }
+
+        @Override
+        public void onPrepareOptionsMenu(Menu menu) {
+            super.onPrepareOptionsMenu(menu);
+            hideMenuItem(menu, "action_generic_search");
+            hideMenuItem(menu, "action_search");
+            hideMenuItem(menu, "search");
+            hideMenuItem(menu, "menu_search");
+        }
+
+        private List<Control> readControls(Context context) {
+            int resourceId = MorpheSettingsV4Catalog.resourceId(
+                    context,
+                    "xml",
+                    resourceName
+            );
+            if (resourceId == 0) {
+                return Collections.emptyList();
+            }
+
+            Resources resources = context.getResources();
+            List<Control> result = new ArrayList<>();
+            XmlResourceParser parser = null;
+            String section = pageTitle;
+            int categoryDepth = -1;
+            int hiddenDepth = -1;
+            try {
+                parser = resources.getXml(resourceId);
+                int event;
+                while ((event = parser.next()) != XmlPullParser.END_DOCUMENT) {
+                    int depth = parser.getDepth();
+                    if (event == XmlPullParser.END_TAG) {
+                        if (depth == hiddenDepth) {
+                            hiddenDepth = -1;
+                        }
+                        if (depth == categoryDepth) {
+                            section = pageTitle;
+                            categoryDepth = -1;
+                        }
+                        continue;
+                    }
+                    if (event != XmlPullParser.START_TAG) {
+                        continue;
+                    }
+                    if (hiddenDepth >= 0 && depth > hiddenDepth) {
+                        continue;
+                    }
+
+                    String rawTag = parser.getName();
+                    String tag = simpleTag(rawTag);
+                    if ("PreferenceScreen".equals(tag)
+                            || "intent".equalsIgnoreCase(tag)) {
+                        continue;
+                    }
+                    boolean visible = parser.getAttributeBooleanValue(
+                            APP_NS,
+                            "isPreferenceVisible",
+                            true
+                    );
+                    if ("PreferenceCategory".equals(tag)) {
+                        if (!visible) {
+                            hiddenDepth = depth;
+                            continue;
+                        }
+                        String categoryTitle = attributeText(
+                                resources,
+                                parser,
+                                "title"
+                        );
+                        section = TextUtils.isEmpty(categoryTitle)
+                                ? pageTitle
+                                : categoryTitle;
+                        categoryDepth = depth;
+                        continue;
+                    }
+                    if (!visible) {
+                        continue;
+                    }
+
+                    Control control = new Control();
+                    control.tag = tag;
+                    control.section = section;
+                    control.key = attributeText(resources, parser, "key");
+                    control.title = attributeText(resources, parser, "title");
+                    control.summary = attributeText(resources, parser, "summary");
+                    control.summaryOn = attributeText(resources, parser, "summaryOn");
+                    control.summaryOff = attributeText(resources, parser, "summaryOff");
+                    control.defaultValue = attributeText(
+                            resources,
+                            parser,
+                            "defaultValue"
+                    );
+                    control.dependency = attributeText(
+                            resources,
+                            parser,
+                            "dependency"
+                    );
+                    control.fragmentName = parser.getAttributeValue(
+                            ANDROID_NS,
+                            "fragment"
+                    );
+                    control.disableDependentsState =
+                            parser.getAttributeBooleanValue(
+                                    ANDROID_NS,
+                                    "disableDependentsState",
+                                    false
+                            );
+                    control.min = parser.getAttributeIntValue(
+                            ANDROID_NS,
+                            "min",
+                            0
+                    );
+                    control.max = parser.getAttributeIntValue(
+                            ANDROID_NS,
+                            "max",
+                            100
+                    );
+                    control.entries = attributeArray(
+                            resources,
+                            parser,
+                            "entries"
+                    );
+                    control.entryValues = attributeArray(
+                            resources,
+                            parser,
+                            "entryValues"
+                    );
+                    configureMorpheControl(control);
+                    if ("pref_general_v2".equals(resourceName)
+                            && !TextUtils.isEmpty(control.fragmentName)) {
+                        // These six routes duplicate the dedicated Morphe hubs.
+                        // Classic Boost settings remains available separately.
+                        continue;
+                    }
+                    if (!TextUtils.isEmpty(control.title)) {
+                        result.add(control);
+                        if (!TextUtils.isEmpty(control.key)) {
+                            controlsByKey.put(control.key, control);
+                        }
+                    }
+                }
+            } catch (Exception ignored) {
+                return Collections.emptyList();
+            } finally {
+                if (parser != null) {
+                    parser.close();
+                }
+            }
+            return result;
+        }
+
+        private void renderControls(
+                LinearLayout content,
+                List<Control> controls
+        ) {
+            String currentSection = null;
+            LinearLayout group = null;
+            for (Control control : controls) {
+                if (!TextUtils.equals(currentSection, control.section)) {
+                    if (content.getChildCount() > 0) {
+                        addSpace(content, 24);
+                    }
+                    currentSection = control.section;
+                    addSectionLabel(content, currentSection);
+                    addSpace(content, 8);
+                    group = addGroup(content);
+                }
+                if (isToggle(control)) {
+                    addToggle(group, control);
+                } else if (isChoice(control)) {
+                    addChoice(group, control);
+                } else if ("SeekBarPreference".equals(control.tag)) {
+                    addSeek(group, control);
+                } else {
+                    addAction(group, control);
+                }
+            }
+        }
+
+        private void addToggle(LinearLayout group, Control control) {
+            boolean checked = preferences.getBoolean(
+                    control.key,
+                    booleanDefault(control)
+            );
+            LinearLayout row = baseRow();
+            TextView summary = addLabels(
+                    row,
+                    control.title,
+                    toggleSummary(control, checked)
+            );
+
+            MorpheSettingsV14Ui.Toggle toggle =
+                    new MorpheSettingsV14Ui.Toggle(
+                            requireContext(),
+                            tokens,
+                            checked
+                    );
+            toggle.setOnCheckedChangeListener((button, value) -> {
+                preferences.edit().putBoolean(control.key, value).apply();
+                applySideEffects(control.key);
+                summary.setText(toggleSummary(control, value));
+                summary.setVisibility(
+                        TextUtils.isEmpty(summary.getText())
+                                ? View.GONE
+                                : View.VISIBLE
+                );
+                updateDependencies();
+            });
+            row.setOnClickListener(view -> {
+                if (row.isEnabled()) {
+                    toggle.toggle();
+                }
+            });
+            row.addView(toggle, wrapParams());
+            addGroupedRow(group, row);
+            bindings.add(new Binding(control, row, summary, toggle, null));
+        }
+
+        private void addChoice(LinearLayout group, Control control) {
+            LinearLayout row = baseRow();
+            TextView summary = addLabels(
+                    row,
+                    control.title,
+                    selectedTitle(control)
+            );
+            addChevron(row);
+            row.setOnClickListener(view -> {
+                if (row.isEnabled()) {
+                    showChoiceDialog(control, summary);
+                }
+            });
+            addGroupedRow(group, row);
+            bindings.add(new Binding(control, row, summary, null, null));
+        }
+
+        private void addSeek(LinearLayout group, Control control) {
+            LinearLayout row = new LinearLayout(requireContext());
+            row.setOrientation(LinearLayout.VERTICAL);
+            row.setPadding(dp(16), dp(10), dp(16), dp(12));
+            row.setMinimumHeight(dp(82));
+            row.setBackground(MorpheSettingsV4Theme.interactive(
+                    requireContext(),
+                    0x00000000,
+                    0,
+                    tokens.navigationAccent().color
+            ));
+
+            LinearLayout labels = new LinearLayout(requireContext());
+            labels.setOrientation(LinearLayout.HORIZONTAL);
+            labels.setGravity(Gravity.CENTER_VERTICAL);
+            TextView title = textView(control.title, 16, tokens.textPrimary);
+            title.setTypeface(Typeface.create(
+                    "sans-serif-medium",
+                    Typeface.NORMAL
+            ));
+            labels.addView(title, labelsParams());
+            int value = preferences.getInt(control.key, intDefault(control));
+            TextView summary = textView(String.valueOf(value), 14, tokens.textSecondary);
+            labels.addView(summary, wrapParams());
+            row.addView(labels, matchWrapParams());
+
+            SeekBar seek = new SeekBar(requireContext());
+            seek.setMax(Math.max(0, control.max - control.min));
+            seek.setProgress(Math.max(0, value - control.min));
+            if (Build.VERSION.SDK_INT >= 21) {
+                seek.setProgressTintList(ColorStateList.valueOf(
+                        tokens.navigationAccent().color
+                ));
+                seek.setThumbTintList(ColorStateList.valueOf(
+                        tokens.navigationAccent().color
+                ));
+            }
+            seek.setOnSeekBarChangeListener(new SeekBar.OnSeekBarChangeListener() {
+                @Override
+                public void onProgressChanged(
+                        SeekBar seekBar,
+                        int progress,
+                        boolean fromUser
+                ) {
+                    summary.setText(String.valueOf(control.min + progress));
+                }
+
+                @Override
+                public void onStartTrackingTouch(SeekBar seekBar) {
+                }
+
+                @Override
+                public void onStopTrackingTouch(SeekBar seekBar) {
+                    int selected = control.min + seekBar.getProgress();
+                    preferences.edit().putInt(control.key, selected).apply();
+                    applySideEffects(control.key);
+                }
+            });
+            row.addView(seek, matchWrapParams());
+            addGroupedRow(group, row);
+            bindings.add(new Binding(control, row, summary, null, seek));
+        }
+
+        private void addAction(LinearLayout group, Control control) {
+            LinearLayout row = baseRow();
+            TextView summary = addLabels(
+                    row,
+                    control.title,
+                    actionSummary(control)
+            );
+            addChevron(row);
+            row.setOnClickListener(view -> {
+                if (row.isEnabled()) {
+                    performAction(control);
+                }
+            });
+            addGroupedRow(group, row);
+            bindings.add(new Binding(control, row, summary, null, null));
+        }
+
+        private void addActionRow(
+                LinearLayout group,
+                String title,
+                String summary,
+                View.OnClickListener listener
+        ) {
+            LinearLayout row = baseRow();
+            addLabels(row, title, summary);
+            addChevron(row);
+            row.setOnClickListener(listener);
+            addGroupedRow(group, row);
+        }
+
+        private void performAction(Control control) {
+            if ("FilterPreference".equals(control.tag)) {
+                showFilterEditor(control);
+                return;
+            }
+            if (control.tag.startsWith("Delete")) {
+                confirmDelete(control);
+                return;
+            }
+            if ("ColorPatternPreference".equals(control.tag)) {
+                showColorPatternEditor();
+                return;
+            }
+            if ("RevokeGDPRConsentPreference".equals(control.tag)) {
+                openClassic("PreferenceFragmentAboutCompat");
+                return;
+            }
+
+            String key = control.key;
+            if ("synncit_config".equals(key)) {
+                showSynccitEditor();
+            } else if ("pref_sort_per_sub".equals(key)) {
+                showSavedSortsEditor();
+            } else if ("pref_frontpage_sort".equals(key)) {
+                showSortEditor(false, frontpageSubscription(), null);
+            } else if ("pref_default_sort".equals(key)) {
+                showSortEditor(true, emptySubscription(), null);
+            } else if ("pref_saved_searches".equals(key)) {
+                showSavedSearchesEditor();
+            } else if ("pref_search_advanced_help".equals(key)) {
+                showFieldSearchHelp();
+            } else if ("pref_notifications_configure".equals(key)) {
+                openNotificationSettings();
+            } else if ("pref_edit_subscriptions".equals(key)) {
+                invokeActivityHelper("t0", Activity.class, hostActivity());
+            } else if ("pref_manage_drafts".equals(key)) {
+                invokeActivityHelper("P", Context.class, requireContext());
+            } else if ("pref_imgur_uploads".equals(key)) {
+                invokeActivityHelper("n0", Context.class, requireContext());
+            } else if ("reset_tips".equals(key)) {
+                resetTips();
+            } else if ("support_launch".equals(key)) {
+                invokeActivityHelper("c1", Context.class, requireContext());
+            } else if ("rate_app".equals(key)) {
+                invokeActivityHelper("u1", Context.class, requireContext());
+            } else if ("about_subreddit".equals(key)) {
+                invokeActivityHelper(
+                        "Y0",
+                        new Class<?>[]{Activity.class, String.class},
+                        new Object[]{hostActivity(), "BoostForReddit"}
+                );
+            } else if ("about_faq".equals(key)) {
+                invokeActivityHelper(
+                        "m1",
+                        new Class<?>[]{Activity.class, String.class, String.class},
+                        new Object[]{hostActivity(), "boostforreddit", "index"}
+                );
+            } else if ("licenses_preference".equals(key)) {
+                invokeActivityHelper("i0", Context.class, requireContext());
+            } else if ("privacy_policy".equals(key)) {
+                openUrl("https://www.iubenda.com/privacy-policy/7976518");
+            } else if ("about_reddit".equals(key)) {
+                invokeActivityHelper(
+                        "y0",
+                        new Class<?>[]{Context.class, String.class},
+                        new Object[]{requireContext(), "rmayayo"}
+                );
+            } else if ("about_twitter".equals(key)) {
+                openUrl("https://twitter.com/rmayayo");
+            } else if ("contact_dev_key".equals(key)) {
+                openEmail("mayayo.dev@gmail.com");
+            } else if ("about_version".equals(key)) {
+                showVersion();
+            } else if (!TextUtils.isEmpty(control.fragmentName)) {
+                openFragment(nativeDestination(control.fragmentName));
+            } else {
+                showUnavailable();
+            }
+        }
+
+        private void showChoiceDialog(Control control, TextView summaryView) {
+            if (control.entries.length == 0
+                    || control.entries.length != control.entryValues.length) {
+                showUnavailable();
+                return;
+            }
+            EditorPage page = openEditorPage(control.title);
+
+            String selected = preferences.getString(
+                    control.key,
+                    stringDefault(control)
+            );
+            LinearLayout group = addGroup(page.content);
+            for (int index = 0; index < control.entries.length; index++) {
+                final String value = control.entryValues[index];
+                boolean checked = TextUtils.equals(value, selected);
+                LinearLayout row = materialChoiceRow(
+                        control.entries[index],
+                        "",
+                        checked
+                );
+                row.setOnClickListener(view -> {
+                    preferences.edit().putString(control.key, value).apply();
+                    applySideEffects(control.key);
+                    summaryView.setText(selectedTitle(control));
+                    updateDependencies();
+                    page.dismiss();
+                });
+                addGroupedRow(group, row);
+            }
+        }
+
+        private void showFilterEditor(Control control) {
+            List<String> values = loadFilters(control.key);
+            EditorPage page = openEditorPage(control.title);
+            LinearLayout content = page.content;
+            EditText input = addEditorInput(content, "Add filter", "", 4);
+
+            TextView add = actionLabel("Add", true);
+            content.addView(add, spacedMatchWrapParams(10));
+
+            LinearLayout list = new LinearLayout(materialContext());
+            list.setOrientation(LinearLayout.VERTICAL);
+            content.addView(list, spacedMatchWrapParams(14));
+
+            Runnable render = () -> renderFilterRows(
+                    list,
+                    values,
+                    control.key
+            );
+            render.run();
+            add.setOnClickListener(view -> {
+                String value = input.getText().toString().trim();
+                if (!TextUtils.isEmpty(value) && !values.contains(value)) {
+                    values.add(0, value);
+                    persistFilters(control.key, values);
+                    input.setText("");
+                    render.run();
+                }
+            });
+
+        }
+
+        private void renderFilterRows(
+                LinearLayout list,
+                List<String> values,
+                String key
+        ) {
+            list.removeAllViews();
+            if (values.isEmpty()) {
+                TextView empty = textView(
+                        "No filters yet",
+                        14,
+                        tokens.textSecondary
+                );
+                empty.setPadding(dp(4), dp(12), dp(4), dp(12));
+                list.addView(empty);
+                return;
+            }
+            LinearLayout group = addGroup(list);
+            for (String value : new ArrayList<>(values)) {
+                LinearLayout row = new LinearLayout(requireContext());
+                row.setOrientation(LinearLayout.HORIZONTAL);
+                row.setGravity(Gravity.CENTER_VERTICAL);
+                row.setPadding(dp(4), dp(5), dp(2), dp(5));
+                TextView label = textView(value, 16, tokens.textPrimary);
+                row.addView(label, labelsParams());
+                TextView remove = actionLabel("Remove", false);
+                remove.setOnClickListener(view -> {
+                    values.remove(value);
+                    persistFilters(key, values);
+                    renderFilterRows(list, values, key);
+                });
+                row.addView(remove, wrapParams());
+                addGroupedRow(group, row);
+            }
+        }
+
+        @SuppressWarnings("unchecked")
+        private List<String> loadFilters(String key) {
+            try {
+                Object settingsObject = invokeStatic("id.b", "v0");
+                Method method = settingsObject.getClass().getMethod(
+                        "j0",
+                        String.class
+                );
+                Object value = method.invoke(settingsObject, key);
+                if (value instanceof List) {
+                    return new ArrayList<>((List<String>) value);
+                }
+            } catch (Throwable ignored) {
+            }
+            return new ArrayList<>();
+        }
+
+        private void persistFilters(String key, List<String> values) {
+            try {
+                Object settingsObject = invokeStatic("id.b", "v0");
+                Method method = settingsObject.getClass().getMethod(
+                        "d6",
+                        String.class,
+                        List.class
+                );
+                method.invoke(settingsObject, key, new ArrayList<>(values));
+                applySideEffects(key);
+            } catch (Throwable throwable) {
+                showUnavailable();
+            }
+        }
+
+        private void showColorPatternEditor() {
+            Context context = requireContext();
+            EditorPage page = openEditorPage("Color patterns");
+            LinearLayout content = page.content;
+
+            String[][] palettes = new String[][]{
+                    {"Standard", "standard"},
+                    {"Secondary", "secondary"},
+                    {"Diverging", "diverging"},
+                    {"Diverging translucent", "divergingTrans"},
+                    {"Pain", "pain"},
+                    {"Rainbow", "Rainbow"},
+                    {"Viridis", "viridis2"},
+                    {"Blues", "blues"},
+                    {"Yellow to red", "YlOrRd"},
+                    {"Grayscale", "gradient_gray"},
+                    {"Transparent", "transparent"}
+            };
+            LinearLayout group = addGroup(content);
+            int available = 0;
+            for (String[] palette : palettes) {
+                int resourceId = MorpheSettingsV4Catalog.resourceId(
+                        context,
+                        "array",
+                        palette[1]
+                );
+                if (resourceId == 0) {
+                    continue;
+                }
+                int[] colors;
+                try {
+                    colors = context.getResources().getIntArray(resourceId);
+                } catch (Resources.NotFoundException ignored) {
+                    continue;
+                }
+                available++;
+                LinearLayout row = baseRow();
+                addLabels(row, palette[0], "");
+                LinearLayout preview = new LinearLayout(context);
+                preview.setOrientation(LinearLayout.HORIZONTAL);
+                preview.setGravity(Gravity.CENTER_VERTICAL);
+                int shown = Math.min(colors.length, 7);
+                for (int index = 0; index < shown; index++) {
+                    View swatch = new View(context);
+                    swatch.setBackground(MorpheSettingsV4Theme.rounded(
+                            context,
+                            colors[index],
+                            5
+                    ));
+                    LinearLayout.LayoutParams swatchParams =
+                            new LinearLayout.LayoutParams(dp(18), dp(30));
+                    if (index > 0) {
+                        swatchParams.setMarginStart(dp(3));
+                    }
+                    preview.addView(swatch, swatchParams);
+                }
+                row.addView(preview, wrapParams());
+                row.setOnClickListener(view -> {
+                    Object settingsObject = invokeStatic("id.b", "v0");
+                    Object result = invokeInstance(
+                            settingsObject,
+                            "x6",
+                            new Class<?>[]{int[].class},
+                            new Object[]{colors}
+                    );
+                    if (result == InvocationFailure.INSTANCE) {
+                        showUnavailable();
+                        return;
+                    }
+                    setBoostStaticBoolean("j");
+                    page.dismiss();
+                });
+                addGroupedRow(group, row);
+            }
+            if (available == 0) {
+                page.dismiss();
+                showUnavailable();
+                return;
+            }
+        }
+
+        private Object frontpageSubscription() {
+            return invokeStatic(
+                    "com.rubenmayayo.reddit.models.reddit.SubscriptionViewModel",
+                    "m"
+            );
+        }
+
+        private Object emptySubscription() {
+            return newInstance(
+                    "com.rubenmayayo.reddit.models.reddit.SubscriptionViewModel",
+                    new Class<?>[]{String.class},
+                    new Object[]{""}
+            );
+        }
+
+        @SuppressWarnings("unchecked")
+        private void showSortEditor(
+                boolean defaultSort,
+                Object subscription,
+                Runnable afterSelection
+        ) {
+            if (subscription == InvocationFailure.INSTANCE
+                    || subscription == null) {
+                showUnavailable();
+                return;
+            }
+            try {
+                Class<?> subscriptionType = Class.forName(
+                        "com.rubenmayayo.reddit.models.reddit."
+                                + "SubscriptionViewModel"
+                );
+                Object rawOptions = invokeStatic(
+                        "qc.a",
+                        "j",
+                        new Class<?>[]{subscriptionType},
+                        new Object[]{subscription}
+                );
+                if (!(rawOptions instanceof List)) {
+                    showUnavailable();
+                    return;
+                }
+                List<Object> options = (List<Object>) rawOptions;
+                List<Integer> optionIds = new ArrayList<>();
+                List<CharSequence> optionLabels = new ArrayList<>();
+                for (Object option : options) {
+                    int id = intResult(invokeInstance(option, "q"), -1);
+                    String title = menuOptionTitle(option);
+                    if (TextUtils.isEmpty(title) || id < 0) {
+                        continue;
+                    }
+                    String supporting = stringResult(invokeInstance(option, "t"));
+                    optionIds.add(id);
+                    optionLabels.add(TextUtils.isEmpty(supporting)
+                            ? title
+                            : title + " — " + supporting);
+                }
+                if (optionIds.isEmpty()) {
+                    showUnavailable();
+                    return;
+                }
+
+                Integer selectedId = currentSortOptionId(
+                        defaultSort,
+                        subscription
+                );
+                EditorPage page = openEditorPage(
+                        defaultSort ? "Default sort" : "Sort home by"
+                );
+                if (!defaultSort && Integer.valueOf(100).equals(selectedId)) {
+                    page.content.addView(MorpheSettingsV14Ui.supportingText(
+                            requireContext(),
+                            tokens,
+                            "Using the default sort"
+                    ));
+                    addSpace(page.content, 10);
+                }
+                LinearLayout group = addGroup(page.content);
+                boolean hasReset = false;
+                for (int index = 0; index < optionIds.size(); index++) {
+                    int optionId = optionIds.get(index);
+                    if (!defaultSort && optionId == 100) {
+                        hasReset = true;
+                        continue;
+                    }
+                    final int which = index;
+                    MorpheSettingsV14Ui.ChoiceRow row = materialChoiceRow(
+                            optionLabels.get(index).toString(),
+                            "",
+                            Integer.valueOf(optionId).equals(selectedId)
+                    );
+                    row.setOnClickListener(view -> {
+                        int id = optionIds.get(which);
+                        boolean saved = defaultSort
+                                ? saveDefaultSort(id)
+                                : saveSubscriptionSort(subscription, id);
+                        if (!saved) {
+                            showUnavailable();
+                            return;
+                        }
+                        applySideEffects(defaultSort
+                                ? "pref_default_sort"
+                                : "pref_frontpage_sort");
+                        page.dismiss();
+                        if (afterSelection != null) {
+                            afterSelection.run();
+                        }
+                    });
+                    addGroupedRow(group, row);
+                }
+                if (hasReset) {
+                    addSpace(page.content, 12);
+                    TextView reset = actionLabel("Reset to default", false);
+                    boolean resetEnabled = !Integer.valueOf(100).equals(
+                            selectedId
+                    );
+                    reset.setEnabled(resetEnabled);
+                    reset.setAlpha(resetEnabled ? 1.0f : 0.42f);
+                    reset.setOnClickListener(view -> {
+                        if (!saveSubscriptionSort(subscription, 100)) {
+                            showUnavailable();
+                            return;
+                        }
+                        applySideEffects("pref_frontpage_sort");
+                        page.dismiss();
+                        if (afterSelection != null) {
+                            afterSelection.run();
+                        }
+                    });
+                    page.content.addView(reset, wrapParams());
+                }
+            } catch (Throwable throwable) {
+                showUnavailable();
+            }
+        }
+
+        private int selectedSortIndex(
+                boolean defaultSort,
+                Object subscription,
+                List<Integer> optionIds
+        ) {
+            Integer selectedId = currentSortOptionId(
+                    defaultSort,
+                    subscription
+            );
+            return selectedId == null ? -1 : optionIds.indexOf(selectedId);
+        }
+
+        private Integer currentSortOptionId(
+                boolean defaultSort,
+                Object subscription
+        ) {
+            try {
+                Object sorting;
+                Object period;
+                if (defaultSort) {
+                    Object settingsObject = invokeStatic("id.b", "v0");
+                    sorting = invokeInstance(settingsObject, "Y1");
+                    period = invokeInstance(settingsObject, "V1");
+                } else {
+                    Class<?> subscriptionType = Class.forName(
+                            "com.rubenmayayo.reddit.models.reddit."
+                                    + "SubscriptionViewModel"
+                    );
+                    Object manager = invokeStatic("he.c0", "e");
+                    Object saved = invokeInstance(
+                            manager,
+                            "j",
+                            new Class<?>[]{subscriptionType},
+                            new Object[]{subscription}
+                    );
+                    if (saved == null || saved == InvocationFailure.INSTANCE) {
+                        return 100;
+                    }
+                    sorting = invokeInstance(saved, "a");
+                    period = invokeInstance(saved, "b");
+                }
+                if (sorting == InvocationFailure.INSTANCE
+                        || sorting == null
+                        || period == InvocationFailure.INSTANCE) {
+                    return null;
+                }
+                String sortingName = enumName(sorting);
+                if ("HOT".equals(sortingName)) {
+                    return 0;
+                }
+                if ("NEW".equals(sortingName)) {
+                    return 1;
+                }
+                if ("RISING".equals(sortingName)) {
+                    return 2;
+                }
+                if ("GILDED".equals(sortingName)) {
+                    return 5;
+                }
+                int periodIndex = timePeriodIndex(enumName(period));
+                if (periodIndex < 0) {
+                    return null;
+                }
+                if ("TOP".equals(sortingName)) {
+                    return 30 + periodIndex;
+                }
+                if ("CONTROVERSIAL".equals(sortingName)) {
+                    return 40 + periodIndex;
+                }
+                return null;
+            } catch (Throwable throwable) {
+                return null;
+            }
+        }
+
+        private String enumName(Object value) {
+            return value instanceof Enum
+                    ? ((Enum<?>) value).name()
+                    : "";
+        }
+
+        private int timePeriodIndex(String name) {
+            String[] names = {"HOUR", "DAY", "WEEK", "MONTH", "YEAR", "ALL"};
+            for (int index = 0; index < names.length; index++) {
+                if (names[index].equals(name)) {
+                    return index;
+                }
+            }
+            return -1;
+        }
+
+        private boolean saveDefaultSort(int id) {
+            String sort = null;
+            String period = null;
+            if (id == 0 || id == 1 || id == 2 || id == 5) {
+                sort = String.valueOf(id);
+            } else if (id >= 30 && id <= 35) {
+                sort = "3";
+                period = String.valueOf(id - 30);
+            } else if (id >= 40 && id <= 45) {
+                sort = "4";
+                period = String.valueOf(id - 40);
+            }
+            if (sort == null) {
+                return false;
+            }
+            Object settingsObject = invokeStatic("id.b", "v0");
+            if (invokeInstance(
+                    settingsObject,
+                    "B6",
+                    new Class<?>[]{String.class},
+                    new Object[]{sort}
+            ) == InvocationFailure.INSTANCE) {
+                return false;
+            }
+            return period == null || invokeInstance(
+                    settingsObject,
+                    "A6",
+                    new Class<?>[]{String.class},
+                    new Object[]{period}
+            ) != InvocationFailure.INSTANCE;
+        }
+
+        private boolean saveSubscriptionSort(Object subscription, int id) {
+            try {
+                Class<?> subscriptionType = Class.forName(
+                        "com.rubenmayayo.reddit.models.reddit."
+                                + "SubscriptionViewModel"
+                );
+                Object manager = invokeStatic("he.c0", "e");
+                String method = id == 100 ? "a" : "m";
+                Class<?>[] types = id == 100
+                        ? new Class<?>[]{subscriptionType}
+                        : new Class<?>[]{subscriptionType, int.class};
+                Object[] values = id == 100
+                        ? new Object[]{subscription}
+                        : new Object[]{subscription, id};
+                return invokeInstance(manager, method, types, values)
+                        != InvocationFailure.INSTANCE;
+            } catch (Throwable throwable) {
+                return false;
+            }
+        }
+
+        private String menuOptionTitle(Object option) {
+            String title = stringResult(invokeInstance(option, "v"));
+            if (!TextUtils.isEmpty(title)) {
+                return title;
+            }
+            int resourceId = intResult(invokeInstance(option, "x"), 0);
+            if (resourceId == 0) {
+                return "";
+            }
+            try {
+                return requireContext().getString(resourceId);
+            } catch (Resources.NotFoundException ignored) {
+                return "";
+            }
+        }
+
+        @SuppressWarnings("unchecked")
+        private void showSavedSortsEditor() {
+            Object manager = invokeStatic("he.c0", "e");
+            if (manager == InvocationFailure.INSTANCE) {
+                showUnavailable();
+                return;
+            }
+            EditorPage page = openEditorPage("Manage saved sorts");
+            LinearLayout content = page.content;
+            LinearLayout list = new LinearLayout(materialContext());
+            list.setOrientation(LinearLayout.VERTICAL);
+            content.addView(list, matchWrapParams());
+
+            Runnable[] render = new Runnable[1];
+            render[0] = () -> {
+                list.removeAllViews();
+                Object raw = invokeInstance(manager, "k");
+                if (!(raw instanceof List) || ((List<?>) raw).isEmpty()) {
+                    TextView empty = textView(
+                            "No community-specific sorts yet.",
+                            15,
+                            tokens.textSecondary
+                    );
+                    empty.setPadding(dp(8), dp(16), dp(8), dp(16));
+                    list.addView(empty, matchWrapParams());
+                    return;
+                }
+                LinearLayout group = addGroup(list);
+                for (Object subscription : (List<Object>) raw) {
+                    String name = stringResult(
+                            invokeInstance(subscription, "z")
+                    );
+                    if (TextUtils.isEmpty(name)) {
+                        name = "Community";
+                    }
+                    LinearLayout row = baseRow();
+                    addLabels(row, name, "Tap to change its saved sort");
+                    TextView remove = actionLabel("Remove", false);
+                    remove.setOnClickListener(view -> {
+                        saveSubscriptionSort(subscription, 100);
+                        render[0].run();
+                    });
+                    row.addView(remove, wrapParams());
+                    row.setOnClickListener(view -> showSortEditor(
+                            false,
+                            subscription,
+                            render[0]
+                    ));
+                    addGroupedRow(group, row);
+                }
+            };
+            render[0].run();
+
+            LinearLayout actions = endAlignedActions();
+            TextView clear = actionLabel("Clear all", false);
+            clear.setOnClickListener(view -> showConfirmationPage(
+                    "Clear saved sorts?",
+                    "Community-specific sort choices will be removed.",
+                    "Clear",
+                    () -> {
+                        invokeInstance(manager, "c");
+                        render[0].run();
+                    }
+            ));
+            actions.addView(clear, wrapParams());
+            content.addView(actions, matchWrapParams());
+        }
+
+        private void showSavedSearchesEditor() {
+            Object model = savedSearchesViewModel();
+            if (model == InvocationFailure.INSTANCE) {
+                showUnavailable();
+                return;
+            }
+            EditorPage page = openEditorPage("Saved searches");
+            LinearLayout content = page.content;
+
+            LinearLayout list = new LinearLayout(materialContext());
+            list.setOrientation(LinearLayout.VERTICAL);
+            content.addView(list, matchWrapParams());
+
+            SavedSearchRenderer renderer = values -> {
+                if (!page.isShowing()) {
+                    return;
+                }
+                renderSavedSearches(list, model, values);
+            };
+            Object liveData = invokeInstance(model, "g");
+            Object current = invokeInstance(liveData, "e");
+            if (current instanceof List) {
+                renderer.render((List<?>) current);
+            } else {
+                renderer.render(Collections.emptyList());
+            }
+            observeSavedSearches(liveData, renderer);
+
+            LinearLayout actions = endAlignedActions();
+            TextView add = actionLabel("Add saved search", true);
+            add.setOnClickListener(view -> showSavedSearchEditor(
+                    model,
+                    null
+            ));
+            actions.addView(add, wrapParams());
+            content.addView(actions, matchWrapParams());
+        }
+
+        private Object savedSearchesViewModel() {
+            Activity activity = hostActivity();
+            if (activity == null) {
+                return InvocationFailure.INSTANCE;
+            }
+            try {
+                Object factory = invokeStatic(
+                        "hc.d",
+                        "e",
+                        new Class<?>[]{Context.class},
+                        new Object[]{activity}
+                );
+                if (factory == InvocationFailure.INSTANCE) {
+                    return InvocationFailure.INSTANCE;
+                }
+                Class<?> ownerType = Class.forName("androidx.lifecycle.r0");
+                Class<?> factoryType = Class.forName("androidx.lifecycle.n0$b");
+                Class<?> providerType = Class.forName("androidx.lifecycle.n0");
+                Object provider = providerType
+                        .getConstructor(ownerType, factoryType)
+                        .newInstance(activity, factory);
+                Method get = providerType.getMethod("a", Class.class);
+                return get.invoke(provider, Class.forName("hc.i"));
+            } catch (Throwable throwable) {
+                return InvocationFailure.INSTANCE;
+            }
+        }
+
+        private void observeSavedSearches(
+                Object liveData,
+                SavedSearchRenderer renderer
+        ) {
+            Activity activity = hostActivity();
+            if (activity == null || liveData == InvocationFailure.INSTANCE) {
+                return;
+            }
+            try {
+                Class<?> ownerType = Class.forName("androidx.lifecycle.q");
+                Class<?> observerType = Class.forName("androidx.lifecycle.y");
+                savedSearchObserver = Proxy.newProxyInstance(
+                        observerType.getClassLoader(),
+                        new Class<?>[]{observerType},
+                        (proxy, method, arguments) -> {
+                            if ("a".equals(method.getName())
+                                    && arguments != null
+                                    && arguments.length == 1
+                                    && arguments[0] instanceof List) {
+                                List<?> values = new ArrayList<>(
+                                        (List<?>) arguments[0]
+                                );
+                                activity.runOnUiThread(
+                                        () -> renderer.render(values)
+                                );
+                            }
+                            return null;
+                        }
+                );
+                Method observe = liveData.getClass().getMethod(
+                        "h",
+                        ownerType,
+                        observerType
+                );
+                observe.invoke(liveData, activity, savedSearchObserver);
+            } catch (Throwable ignored) {
+                savedSearchObserver = null;
+            }
+        }
+
+        private void renderSavedSearches(
+                LinearLayout list,
+                Object model,
+                List<?> values
+        ) {
+            list.removeAllViews();
+            if (values.isEmpty()) {
+                TextView empty = textView(
+                        "No saved searches yet.",
+                        15,
+                        tokens.textSecondary
+                );
+                empty.setPadding(dp(8), dp(16), dp(8), dp(16));
+                list.addView(empty, matchWrapParams());
+                return;
+            }
+            LinearLayout group = addGroup(list);
+            for (Object entity : values) {
+                String name = stringField(entity, "b");
+                String query = stringField(entity, "e");
+                if (TextUtils.isEmpty(name)) {
+                    name = query;
+                }
+                String scope = stringField(entity, "c");
+                String summary = TextUtils.isEmpty(scope)
+                        ? query
+                        : query + "  ·  r/" + scope;
+                LinearLayout row = baseRow();
+                addLabels(row, name, summary);
+                TextView remove = actionLabel("Remove", false);
+                remove.setOnClickListener(view -> deleteSavedSearch(
+                        model,
+                        entity
+                ));
+                row.addView(remove, wrapParams());
+                row.setOnClickListener(view -> showSavedSearchEditor(
+                        model,
+                        entity
+                ));
+                addGroupedRow(group, row);
+            }
+        }
+
+        private void deleteSavedSearch(Object model, Object entity) {
+            try {
+                Class<?> entityType = Class.forName("hc.e");
+                if (invokeInstance(
+                        model,
+                        "f",
+                        new Class<?>[]{entityType},
+                        new Object[]{entity}
+                ) == InvocationFailure.INSTANCE) {
+                    showUnavailable();
+                }
+            } catch (Throwable throwable) {
+                showUnavailable();
+            }
+        }
+
+        private void showSavedSearchEditor(Object model, Object existing) {
+            SearchDraft draft = searchDraft(existing);
+            EditorPage page = openEditorPage(
+                    existing == null ? "Add saved search" : "Edit saved search"
+            );
+            LinearLayout content = page.content;
+
+            EditText name = addEditorInput(
+                    content,
+                    "Name (optional)",
+                    draft.name,
+                    4
+            );
+            EditText query = addEditorInput(
+                    content,
+                    "Search query",
+                    draft.query,
+                    12
+            );
+            EditText community = addEditorInput(
+                    content,
+                    "Community (optional)",
+                    draft.community,
+                    12
+            );
+
+            addSpace(content, 18);
+            LinearLayout choices = addGroup(content);
+            LinearLayout sortRow = baseRow();
+            TextView sortSummary = addLabels(
+                    sortRow,
+                    "Sort",
+                    searchSortLabel(draft.sort)
+            );
+            addChevron(sortRow);
+            sortRow.setOnClickListener(view -> showValueChoice(
+                    "Sort",
+                    new String[]{"Relevance", "New", "Top", "Hot", "Comments"},
+                    new String[]{"relevance", "new", "top", "hot", "comments"},
+                    draft.sort,
+                    value -> {
+                        draft.sort = value;
+                        sortSummary.setText(searchSortLabel(value));
+                    }
+            ));
+            addGroupedRow(choices, sortRow);
+
+            LinearLayout periodRow = baseRow();
+            TextView periodSummary = addLabels(
+                    periodRow,
+                    "Time period",
+                    searchPeriodLabel(draft.period)
+            );
+            addChevron(periodRow);
+            periodRow.setOnClickListener(view -> showValueChoice(
+                    "Time period",
+                    new String[]{"Hour", "Day", "Week", "Month", "Year", "All"},
+                    new String[]{"hour", "day", "week", "month", "year", "all"},
+                    draft.period,
+                    value -> {
+                        draft.period = value;
+                        periodSummary.setText(searchPeriodLabel(value));
+                    }
+            ));
+            addGroupedRow(choices, periodRow);
+
+            LinearLayout actions = endAlignedActions();
+            TextView cancel = actionLabel("Cancel", false);
+            cancel.setOnClickListener(view -> page.dismiss());
+            actions.addView(cancel, wrapParams());
+            TextView save = actionLabel("Save", true);
+            LinearLayout.LayoutParams saveParams = wrapParams();
+            saveParams.setMarginStart(dp(8));
+            actions.addView(save, saveParams);
+            save.setOnClickListener(view -> {
+                draft.name = name.getText().toString().trim();
+                draft.query = query.getText().toString().trim();
+                String previousCommunity = draft.community;
+                draft.community = community.getText().toString().trim();
+                if (!TextUtils.equals(previousCommunity, draft.community)) {
+                    draft.scopeId = "";
+                }
+                if (TextUtils.isEmpty(draft.query)) {
+                    query.setError("A search query is required");
+                    return;
+                }
+                if (saveSavedSearch(model, existing, draft)) {
+                    page.dismiss();
+                } else {
+                    showUnavailable();
+                }
+            });
+            content.addView(actions, matchWrapParams());
+        }
+
+        private SearchDraft searchDraft(Object entity) {
+            SearchDraft draft = new SearchDraft();
+            if (entity == null) {
+                int sortIndex = integerPreference(
+                        "pref_default_search_sorting",
+                        0
+                );
+                int periodIndex = integerPreference(
+                        "pref_default_search_period",
+                        5
+                );
+                String[] sorts = new String[]{
+                        "relevance", "new", "top", "hot", "comments"
+                };
+                String[] periods = new String[]{
+                        "hour", "day", "week", "month", "year", "all"
+                };
+                draft.sort = sorts[Math.max(0, Math.min(sortIndex, 4))];
+                draft.period = periods[Math.max(0, Math.min(periodIndex, 5))];
+                return draft;
+            }
+            draft.id = intField(entity, "a", 0);
+            draft.name = stringField(entity, "b");
+            draft.community = stringField(entity, "c");
+            draft.scopeId = stringField(entity, "d");
+            draft.query = stringField(entity, "e");
+            draft.sort = stringField(entity, "f");
+            draft.period = stringField(entity, "g");
+            if (TextUtils.isEmpty(draft.sort)) {
+                draft.sort = "relevance";
+            }
+            if (TextUtils.isEmpty(draft.period)) {
+                draft.period = "all";
+            }
+            return draft;
+        }
+
+        private boolean saveSavedSearch(
+                Object model,
+                Object existing,
+                SearchDraft draft
+        ) {
+            try {
+                Class<?> entityType = Class.forName("hc.e");
+                Object entity = entityType.getConstructor().newInstance();
+                setField(entity, "a", draft.id);
+                setField(
+                        entity,
+                        "b",
+                        TextUtils.isEmpty(draft.name) ? draft.query : draft.name
+                );
+                setField(entity, "c", draft.community);
+                setField(entity, "d", draft.scopeId);
+                setField(entity, "e", draft.query);
+                setField(entity, "f", draft.sort.toLowerCase());
+                setField(entity, "g", draft.period.toLowerCase());
+                String method = existing == null ? "h" : "i";
+                return invokeInstance(
+                        model,
+                        method,
+                        new Class<?>[]{entityType},
+                        new Object[]{entity}
+                ) != InvocationFailure.INSTANCE;
+            } catch (Throwable throwable) {
+                return false;
+            }
+        }
+
+        private int integerPreference(String key, int fallback) {
+            String value = preferences.getString(key, String.valueOf(fallback));
+            try {
+                return Integer.parseInt(value);
+            } catch (NumberFormatException ignored) {
+                return fallback;
+            }
+        }
+
+        private String searchSortLabel(String value) {
+            if ("new".equals(value)) return "New";
+            if ("top".equals(value)) return "Top";
+            if ("hot".equals(value)) return "Hot";
+            if ("comments".equals(value)) return "Comments";
+            return "Relevance";
+        }
+
+        private String searchPeriodLabel(String value) {
+            if ("hour".equals(value)) return "Hour";
+            if ("day".equals(value)) return "Day";
+            if ("week".equals(value)) return "Week";
+            if ("month".equals(value)) return "Month";
+            if ("year".equals(value)) return "Year";
+            return "All";
+        }
+
+        private void showValueChoice(
+                String title,
+                String[] labels,
+                String[] values,
+                String current,
+                ValueConsumer consumer
+        ) {
+            EditorPage page = openEditorPage(title);
+            LinearLayout group = addGroup(page.content);
+            for (int index = 0; index < labels.length; index++) {
+                LinearLayout option = materialChoiceRow(
+                        labels[index],
+                        "",
+                        TextUtils.equals(values[index], current)
+                );
+                final String value = values[index];
+                option.setOnClickListener(view -> {
+                    consumer.accept(value);
+                    page.dismiss();
+                });
+                addGroupedRow(group, option);
+            }
+        }
+
+        private void showSynccitEditor() {
+            Context context = requireContext();
+            EditorPage page = openEditorPage("Configure Synccit");
+            LinearLayout content = page.content;
+
+            TextView explanation = textView(
+                    "Synchronize read posts between supported Reddit clients. "
+                            + "Credentials are stored in Boost on this device.",
+                    14,
+                    tokens.textSecondary
+            );
+            explanation.setLineSpacing(0, 1.08f);
+            content.addView(explanation, spacedMatchWrapParams(4));
+
+            synccitUsernameInput = addEditorInput(
+                    content,
+                    "Synccit username",
+                    settingsString("k4"),
+                    14
+            );
+            synccitAuthInput = addEditorInput(
+                    content,
+                    "Device auth token",
+                    settingsString("i4"),
+                    12
+            );
+
+            addSpace(content, 18);
+            LinearLayout registration = addGroup(content);
+            LinearLayout account = baseRow();
+            addLabels(
+                    account,
+                    "Create Synccit account",
+                    "Register a new account through Boost"
+            );
+            addChevron(account);
+            account.setOnClickListener(view -> startSynccitCreate(true));
+            addGroupedRow(registration, account);
+
+            LinearLayout device = baseRow();
+            addLabels(
+                    device,
+                    "Add this device",
+                    "Generate a device auth token for the username above"
+            );
+            addChevron(device);
+            device.setOnClickListener(view -> startSynccitCreate(false));
+            addGroupedRow(registration, device);
+
+            LinearLayout actions = endAlignedActions();
+            TextView disconnect = actionLabel("Disconnect", false);
+            disconnect.setOnClickListener(view -> showConfirmationPage(
+                    "Disconnect Synccit?",
+                    "The saved Synccit username and token will be removed.",
+                    "Disconnect",
+                    () -> {
+                        saveSynccitCredentials("", "");
+                        synccitUsernameInput.setText("");
+                        synccitAuthInput.setText("");
+                    }
+            ));
+            actions.addView(disconnect, wrapParams());
+
+            TextView save = actionLabel("Save", true);
+            LinearLayout.LayoutParams saveParams = wrapParams();
+            saveParams.setMarginStart(dp(8));
+            actions.addView(save, saveParams);
+            save.setOnClickListener(view -> {
+                saveSynccitCredentials(
+                        synccitUsernameInput.getText().toString().trim(),
+                        synccitAuthInput.getText().toString().trim()
+                );
+                Toast.makeText(context, "Synccit settings saved", Toast.LENGTH_SHORT)
+                        .show();
+                page.dismiss();
+            });
+            content.addView(actions, matchWrapParams());
+        }
+
+        private void startSynccitCreate(boolean accountMode) {
+            try {
+                Class<?> type = Class.forName(
+                        "com.rubenmayayo.reddit.ui.synccit."
+                                + "SynccitCreateActivity"
+                );
+                Intent intent = new Intent(requireContext(), type);
+                int requestCode;
+                if (accountMode) {
+                    intent.putExtra("account_mode", true);
+                    requestCode = REQUEST_SYNCCIT_ACCOUNT;
+                } else {
+                    String username = synccitUsernameInput == null
+                            ? settingsString("k4")
+                            : synccitUsernameInput.getText().toString().trim();
+                    intent.putExtra("username", username);
+                    requestCode = REQUEST_SYNCCIT_DEVICE;
+                }
+                startActivityForResult(intent, requestCode);
+            } catch (Throwable throwable) {
+                showUnavailable();
+            }
+        }
+
+        private void saveSynccitCredentials(String username, String auth) {
+            Object settingsObject = invokeStatic("id.b", "v0");
+            invokeInstance(
+                    settingsObject,
+                    "y7",
+                    new Class<?>[]{String.class},
+                    new Object[]{username}
+            );
+            invokeInstance(
+                    settingsObject,
+                    "x7",
+                    new Class<?>[]{String.class},
+                    new Object[]{auth}
+            );
+        }
+
+        private String settingsString(String method) {
+            Object settingsObject = invokeStatic("id.b", "v0");
+            return stringResult(invokeInstance(settingsObject, method));
+        }
+
+        private void showFieldSearchHelp() {
+            EditorPage page = openEditorPage("Field search help");
+            LinearLayout content = page.content;
+            LinearLayout group = addGroup(content);
+            TextView help = textView(
+                    "Use a field followed by a colon:\n\n"
+                            + "author:username\n"
+                            + "subreddit:android\n"
+                            + "title:keyword\n"
+                            + "selftext:keyword\n"
+                            + "url:example.com\n"
+                            + "site:example.com\n"
+                            + "self:yes  or  self:no\n"
+                            + "nsfw:yes  or  nsfw:no\n\n"
+                            + "Combine terms with AND, OR and NOT. "
+                            + "Use parentheses to group expressions.",
+                    15,
+                    tokens.textPrimary
+            );
+            help.setTextIsSelectable(true);
+            help.setLineSpacing(0, 1.12f);
+            help.setPadding(dp(18), dp(16), dp(18), dp(18));
+            group.addView(help, matchWrapParams());
+        }
+
+        private boolean notificationAccessGranted() {
+            String enabled = Settings.Secure.getString(
+                    requireContext().getContentResolver(),
+                    "enabled_notification_listeners"
+            );
+            if (TextUtils.isEmpty(enabled)) {
+                return false;
+            }
+            String packageName = requireContext().getPackageName();
+            for (String flat : enabled.split(":")) {
+                ComponentName component = ComponentName.unflattenFromString(flat);
+                if (component != null
+                        && packageName.equals(component.getPackageName())) {
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        private void reconcileNotificationAccess() {
+            boolean pushEnabled = preferences.getBoolean(
+                    "pref_check_messages_push",
+                    false
+            );
+            boolean accessGranted = notificationAccessGranted();
+            if (pushEnabled == accessGranted) {
+                return;
+            }
+            String message = pushEnabled
+                    ? "Reddit push needs Android notification access. "
+                            + "Enable access for Boost on the next screen."
+                    : "Boost still has Android notification access. "
+                            + "You can revoke it on the next screen.";
+            showConfirmationPage(
+                    "Reddit push",
+                    message,
+                    "Open settings",
+                    () -> {
+                        try {
+                            startActivity(new Intent(
+                                    Settings.ACTION_NOTIFICATION_LISTENER_SETTINGS
+                            ));
+                        } catch (Exception exception) {
+                            showUnavailable();
+                        }
+                    }
+            );
+        }
+
+        private void confirmDelete(Control control) {
+            showConfirmationPage(
+                    control.title,
+                    "Delete the selected local history data?",
+                    "Delete",
+                    () -> {
+                        deleteForKey(control.key);
+                        Toast.makeText(
+                                requireContext(),
+                                "Deleted",
+                                Toast.LENGTH_SHORT
+                        ).show();
+                    }
+            );
+        }
+
+        private void deleteForKey(String key) {
+            if ("pref_history_delete_read".equals(key)) {
+                factoryCall("he.a0", "b", "a");
+            } else if ("pref_recent_posts_delete".equals(key)) {
+                factoryCall("he.z", "e", "c");
+            } else if ("pref_history_delete".equals(key)) {
+                factoryCall("he.d0", "d", "c");
+            } else if ("pref_searches_delete".equals(key)) {
+                factoryCall("ld.c", "a", "clear");
+            } else if ("pref_all_delete".equals(key)) {
+                factoryCall("he.z", "e", "c");
+                factoryCall("he.d0", "d", "c");
+                factoryCall("ld.c", "a", "clear");
+            }
+        }
+
+        private void applySideEffects(String key) {
+            // These are Boost's existing invalidation flags. Setting a broader
+            // superset is safe and keeps changes visible without a hidden
+            // PreferenceFragment listener.
+            setBoostStaticBoolean("e");
+            setBoostStaticBoolean("f");
+            setBoostStaticBoolean("h");
+            setBoostStaticBoolean("i");
+            setBoostStaticBoolean("j");
+
+            if ("pref_subscriptions_drawer".equals(key)
+                    || "pref_subscriptions_drawer_show_icon".equals(key)
+                    || "pref_subscriptions_only_casual".equals(key)) {
+                invokeStatic(
+                        "he.h0",
+                        "m0",
+                        new Class<?>[]{Context.class},
+                        new Object[]{requireContext()}
+                );
+            }
+            if ("pref_check_messages".equals(key)) {
+                String method = preferences.getBoolean(key, true) ? "b" : "c";
+                invokeStatic(
+                        "pe.b",
+                        method,
+                        new Class<?>[]{Context.class},
+                        new Object[]{requireContext()}
+                );
+            } else if ("pref_check_messages_interval".equals(key)) {
+                invokeStatic(
+                        "pe.b",
+                        "b",
+                        new Class<?>[]{Context.class},
+                        new Object[]{requireContext()}
+                );
+            } else if ("pref_check_messages_push".equals(key)) {
+                reconcileNotificationAccess();
+            } else if ("pref_search_show_trending_searches".equals(key)
+                    && preferences.getBoolean(key, false)) {
+                invokeStatic(
+                        "com.rubenmayayo.reddit.work.trending.TrendingWorker",
+                        "a",
+                        new Class<?>[]{Context.class, int.class},
+                        new Object[]{requireContext(), 2}
+                );
+            }
+        }
+
+        private void syncRows() {
+            if (preferences == null) {
+                return;
+            }
+            for (Binding binding : bindings) {
+                Control control = binding.control;
+                if (binding.toggle != null) {
+                    boolean checked = preferences.getBoolean(
+                            control.key,
+                            booleanDefault(control)
+                    );
+                    binding.toggle.setCheckedSilently(checked);
+                    binding.summary.setText(toggleSummary(control, checked));
+                } else if (isChoice(control)) {
+                    binding.summary.setText(selectedTitle(control));
+                } else if (binding.seekBar != null) {
+                    int value = preferences.getInt(
+                            control.key,
+                            intDefault(control)
+                    );
+                    binding.seekBar.setProgress(value - control.min);
+                    binding.summary.setText(String.valueOf(value));
+                }
+            }
+            updateDependencies();
+        }
+
+        private void updateDependencies() {
+            for (Binding binding : bindings) {
+                Control control = binding.control;
+                if (TextUtils.isEmpty(control.dependency)) {
+                    setRowEnabled(binding.row, true);
+                    continue;
+                }
+                Control parent = controlsByKey.get(control.dependency);
+                boolean enabled = true;
+                if (parent != null && isToggle(parent)) {
+                    boolean parentValue = preferences.getBoolean(
+                            parent.key,
+                            booleanDefault(parent)
+                    );
+                    enabled = parent.disableDependentsState
+                            ? !parentValue
+                            : parentValue;
+                }
+                setRowEnabled(binding.row, enabled);
+            }
+        }
+
+        private void setRowEnabled(View row, boolean enabled) {
+            row.setEnabled(enabled);
+            row.setAlpha(enabled ? 1.0f : 0.44f);
+            if (row instanceof ViewGroup) {
+                setChildrenEnabled((ViewGroup) row, enabled);
+            }
+        }
+
+        private void setChildrenEnabled(ViewGroup group, boolean enabled) {
+            for (int index = 0; index < group.getChildCount(); index++) {
+                View child = group.getChildAt(index);
+                child.setEnabled(enabled);
+                if (child instanceof ViewGroup) {
+                    setChildrenEnabled((ViewGroup) child, enabled);
+                }
+            }
+        }
+
+        private String actionSummary(Control control) {
+            if (!TextUtils.isEmpty(control.summary)) {
+                return control.summary;
+            }
+            if (control.tag.startsWith("Delete")) {
+                return "Remove local history data";
+            }
+            if ("ColorPatternPreference".equals(control.tag)) {
+                return "Choose comment thread colors";
+            }
+            if ("RevokeGDPRConsentPreference".equals(control.tag)) {
+                return "Open Boost's consent controls";
+            }
+            return "";
+        }
+
+        private String toggleSummary(Control control, boolean checked) {
+            if (checked && !TextUtils.isEmpty(control.summaryOn)) {
+                return control.summaryOn;
+            }
+            if (!checked && !TextUtils.isEmpty(control.summaryOff)) {
+                return control.summaryOff;
+            }
+            return control.summary;
+        }
+
+        private String selectedTitle(Control control) {
+            String value = preferences.getString(
+                    control.key,
+                    stringDefault(control)
+            );
+            for (int index = 0; index < control.entryValues.length; index++) {
+                if (TextUtils.equals(value, control.entryValues[index])) {
+                    return control.entries[index];
+                }
+            }
+            return value;
+        }
+
+        private boolean booleanDefault(Control control) {
+            return "true".equalsIgnoreCase(control.defaultValue);
+        }
+
+        private int intDefault(Control control) {
+            try {
+                return Integer.parseInt(control.defaultValue);
+            } catch (NumberFormatException ignored) {
+                return control.min;
+            }
+        }
+
+        private String stringDefault(Control control) {
+            return TextUtils.isEmpty(control.defaultValue)
+                    ? ""
+                    : control.defaultValue;
+        }
+
+        private boolean isToggle(Control control) {
+            return "CheckBoxPreference".equals(control.tag)
+                    || "SwitchPreference".equals(control.tag)
+                    || "SwitchPreferenceCompat".equals(control.tag);
+        }
+
+        private boolean isChoice(Control control) {
+            return "ListPreference".equals(control.tag)
+                    || "PreviewSizePreference".equals(control.tag)
+                    || "PreviewAlignmentPreference".equals(control.tag)
+                    || "MediaTapActionPreference".equals(control.tag);
+        }
+
+        private void configureMorpheControl(Control control) {
+            if ("PreviewSizePreference".equals(control.tag)) {
+                control.entries = new String[]{"Compact", "Balanced", "Large"};
+                control.entryValues = new String[]{"compact", "balanced", "large"};
+            } else if ("PreviewAlignmentPreference".equals(control.tag)) {
+                control.entries = new String[]{"Left", "Center", "Right"};
+                control.entryValues = new String[]{"left", "center", "right"};
+            } else if ("MediaTapActionPreference".equals(control.tag)) {
+                control.entries = new String[]{
+                        "Image viewer",
+                        "Video viewer",
+                        "Browser",
+                        "Disabled"
+                };
+                control.entryValues = new String[]{
+                        "image_viewer",
+                        "video_viewer",
+                        "browser",
+                        "disabled"
+                };
+            }
+        }
+
+        private void openClassic(String simpleName) {
+            openFragment(BOOST_FRAGMENT_PREFIX + simpleName);
+        }
+
+        private void openFragment(String destination) {
+            Activity activity = hostActivity();
+            if (activity == null || TextUtils.isEmpty(destination)) {
+                showUnavailable();
+                return;
+            }
+            Intent intent = new Intent(activity, activity.getClass());
+            intent.putExtra(EXTRA_SHOW_FRAGMENT, destination);
+            activity.startActivity(intent);
+        }
+
+        private void openNotificationSettings() {
+            try {
+                Intent intent = new Intent(Settings.ACTION_APP_NOTIFICATION_SETTINGS);
+                intent.putExtra(Settings.EXTRA_APP_PACKAGE, requireContext().getPackageName());
+                startActivity(intent);
+            } catch (Exception exception) {
+                showUnavailable();
+            }
+        }
+
+        private void openUrl(String url) {
+            try {
+                startActivity(new Intent(Intent.ACTION_VIEW, Uri.parse(url)));
+            } catch (Exception exception) {
+                showUnavailable();
+            }
+        }
+
+        private void openEmail(String address) {
+            try {
+                startActivity(new Intent(
+                        Intent.ACTION_SENDTO,
+                        Uri.parse("mailto:" + address)
+                ));
+            } catch (Exception exception) {
+                showUnavailable();
+            }
+        }
+
+        private void showVersion() {
+            String version = "Unknown";
+            try {
+                PackageInfo info = requireContext()
+                        .getPackageManager()
+                        .getPackageInfo(requireContext().getPackageName(), 0);
+                version = info.versionName;
+            } catch (Exception ignored) {
+            }
+            EditorPage page = openEditorPage("Boost version");
+            LinearLayout group = addGroup(page.content);
+            TextView value = textView(version, 18, tokens.textPrimary);
+            value.setPadding(dp(18), dp(16), dp(18), dp(18));
+            group.addView(value, matchWrapParams());
+        }
+
+        private void resetTips() {
+            factoryCall("he.f", "b", "f");
+            Toast.makeText(
+                    requireContext(),
+                    "Tips reset",
+                    Toast.LENGTH_SHORT
+            ).show();
+        }
+
+        private void invokeActivityHelper(
+                String method,
+                Class<?> parameterType,
+                Object value
+        ) {
+            invokeActivityHelper(
+                    method,
+                    new Class<?>[]{parameterType},
+                    new Object[]{value}
+            );
+        }
+
+        private void invokeActivityHelper(
+                String method,
+                Class<?>[] parameterTypes,
+                Object[] values
+        ) {
+            Object result = invokeStatic(
+                    "com.rubenmayayo.reddit.ui.activities.i",
+                    method,
+                    parameterTypes,
+                    values
+            );
+            if (result == InvocationFailure.INSTANCE) {
+                showUnavailable();
+            }
+        }
+
+        private void factoryCall(
+                String className,
+                String factory,
+                String method
+        ) {
+            try {
+                Object target = invokeStatic(className, factory);
+                Method action = target.getClass().getMethod(method);
+                action.invoke(target);
+            } catch (Throwable throwable) {
+                showUnavailable();
+            }
+        }
+
+        private Object invokeStatic(String className, String method) {
+            return invokeStatic(className, method, new Class<?>[0], new Object[0]);
+        }
+
+        private Object invokeStatic(
+                String className,
+                String method,
+                Class<?>[] parameterTypes,
+                Object[] values
+        ) {
+            try {
+                Class<?> type = Class.forName(className);
+                Method target = type.getMethod(method, parameterTypes);
+                return target.invoke(null, values);
+            } catch (Throwable throwable) {
+                return InvocationFailure.INSTANCE;
+            }
+        }
+
+        private Object invokeInstance(Object target, String method) {
+            return invokeInstance(
+                    target,
+                    method,
+                    new Class<?>[0],
+                    new Object[0]
+            );
+        }
+
+        private Object invokeInstance(
+                Object target,
+                String method,
+                Class<?>[] parameterTypes,
+                Object[] values
+        ) {
+            if (target == null || target == InvocationFailure.INSTANCE) {
+                return InvocationFailure.INSTANCE;
+            }
+            try {
+                Method action = target.getClass().getMethod(
+                        method,
+                        parameterTypes
+                );
+                return action.invoke(target, values);
+            } catch (Throwable throwable) {
+                return InvocationFailure.INSTANCE;
+            }
+        }
+
+        private Object newInstance(
+                String className,
+                Class<?>[] parameterTypes,
+                Object[] values
+        ) {
+            try {
+                Class<?> type = Class.forName(className);
+                return type.getConstructor(parameterTypes).newInstance(values);
+            } catch (Throwable throwable) {
+                return InvocationFailure.INSTANCE;
+            }
+        }
+
+        private String stringResult(Object value) {
+            return value instanceof String ? (String) value : "";
+        }
+
+        private int intResult(Object value, int fallback) {
+            return value instanceof Number
+                    ? ((Number) value).intValue()
+                    : fallback;
+        }
+
+        private String stringField(Object target, String name) {
+            Object value = fieldValue(target, name);
+            return value instanceof String ? (String) value : "";
+        }
+
+        private int intField(Object target, String name, int fallback) {
+            return intResult(fieldValue(target, name), fallback);
+        }
+
+        private Object fieldValue(Object target, String name) {
+            if (target == null) {
+                return null;
+            }
+            try {
+                Field field = target.getClass().getDeclaredField(name);
+                field.setAccessible(true);
+                return field.get(target);
+            } catch (Throwable throwable) {
+                return null;
+            }
+        }
+
+        private void setField(Object target, String name, Object value)
+                throws ReflectiveOperationException {
+            Field field = target.getClass().getDeclaredField(name);
+            field.setAccessible(true);
+            field.set(target, value);
+        }
+
+        private void setBoostStaticBoolean(String fieldName) {
+            try {
+                Class<?> settingsClass = Class.forName("id.b");
+                Field field = settingsClass.getDeclaredField(fieldName);
+                field.setAccessible(true);
+                field.setBoolean(null, true);
+            } catch (Throwable ignored) {
+            }
+        }
+
+        private void styleHost() {
+            Activity activity = hostActivity();
+            if (activity == null || tokens == null) {
+                return;
+            }
+            activity.setTitle(editorPages.isEmpty()
+                    ? pageTitle
+                    : editorPages.get(editorPages.size() - 1).title);
+            BoostSystemBarInsetsFix.applyMorpheSettingsV4SystemBars(
+                    activity,
+                    tokens.background,
+                    tokens.dark
+            );
+            int toolbarId = MorpheSettingsV4Catalog.resourceId(
+                    activity,
+                    "id",
+                    "toolbar"
+            );
+            View toolbar = activity.findViewById(toolbarId);
+            if (toolbar != null) {
+                toolbar.setBackgroundColor(tokens.background);
+                toolbar.setElevation(0);
+            }
+        }
+
+        private Activity hostActivity() {
+            Context context = getContext();
+            return context instanceof Activity ? (Activity) context : null;
+        }
+
+        private LinearLayout addGroup(LinearLayout parent) {
+            LinearLayout group = MorpheSettingsV14Ui.group(requireContext());
+            parent.addView(group, matchWrapParams());
+            return group;
+        }
+
+        private LinearLayout baseRow() {
+            return MorpheSettingsV14Ui.baseRow(requireContext(), tokens);
+        }
+
+        private MorpheSettingsV14Ui.ChoiceRow materialChoiceRow(
+                String title,
+                String summary,
+                boolean selected
+        ) {
+            return MorpheSettingsV14Ui.choiceRow(
+                    requireContext(),
+                    tokens,
+                    title,
+                    summary,
+                    selected
+            );
+        }
+
+        private TextView addLabels(
+                LinearLayout row,
+                String titleValue,
+                String summaryValue
+        ) {
+            LinearLayout labels = new LinearLayout(requireContext());
+            labels.setOrientation(LinearLayout.VERTICAL);
+            TextView title = textView(titleValue, 16, tokens.textPrimary);
+            labels.addView(title);
+
+            TextView summary = textView(
+                    summaryValue,
+                    14,
+                    tokens.textSecondary
+            );
+            summary.setLineSpacing(0, 1.04f);
+            summary.setMaxLines(4);
+            summary.setVisibility(
+                    TextUtils.isEmpty(summaryValue) ? View.GONE : View.VISIBLE
+            );
+            LinearLayout.LayoutParams summaryParams = wrapParams();
+            summaryParams.topMargin = dp(3);
+            labels.addView(summary, summaryParams);
+            row.addView(labels, labelsParams());
+            return summary;
+        }
+
+        private void addChevron(LinearLayout row) {
+            row.addView(MorpheSettingsV14Ui.chevron(
+                    requireContext(),
+                    tokens
+            ));
+        }
+
+        private void addGroupedRow(LinearLayout group, View row) {
+            MorpheSettingsV14Ui.addSegmentedRow(group, row, tokens);
+        }
+
+        private Context materialContext() {
+            return requireContext();
+        }
+
+        private EditorPage openEditorPage(String title) {
+            if (pageHost == null) {
+                throw new IllegalStateException("Settings page is not attached");
+            }
+            if (!editorPages.isEmpty()) {
+                editorPages.get(editorPages.size() - 1).view.setVisibility(
+                        View.GONE
+                );
+            } else if (settingsPage != null) {
+                settingsPage.setVisibility(View.GONE);
+            }
+
+            ScrollView scroll = new ScrollView(materialContext());
+            scroll.setFillViewport(true);
+            scroll.setClipToPadding(false);
+            scroll.setBackgroundColor(tokens.background);
+
+            LinearLayout content = new LinearLayout(materialContext());
+            content.setOrientation(LinearLayout.VERTICAL);
+            content.setPadding(dp(16), dp(10), dp(16), dp(36));
+            scroll.addView(content, new ScrollView.LayoutParams(
+                    ViewGroup.LayoutParams.MATCH_PARENT,
+                    ViewGroup.LayoutParams.WRAP_CONTENT
+            ));
+
+            EditorPage page = new EditorPage(title, scroll, content);
+            editorPages.add(page);
+            pageHost.addView(scroll, new FrameLayout.LayoutParams(
+                    ViewGroup.LayoutParams.MATCH_PARENT,
+                    ViewGroup.LayoutParams.MATCH_PARENT
+            ));
+            try {
+                pushEditorBackStackEntry();
+            } catch (Throwable throwable) {
+                removeTopEditorView();
+                throw new IllegalStateException(
+                        "Morphe V13 editor back-stack bridge failed",
+                        throwable
+                );
+            }
+            styleHost();
+            return page;
+        }
+
+        private void closeTopEditorPage() {
+            if (editorPages.isEmpty()) {
+                return;
+            }
+            if (!popEditorBackStackEntry()) {
+                throw new IllegalStateException(
+                        "Morphe V13 editor back-stack pop failed"
+                );
+            }
+            syncEditorPagesWithBackStack();
+        }
+
+        private void removeTopEditorView() {
+            if (editorPages.isEmpty()) {
+                return;
+            }
+            EditorPage page = editorPages.remove(editorPages.size() - 1);
+            if (pageHost != null) {
+                pageHost.removeView(page.view);
+            }
+            if (editorPages.isEmpty()) {
+                if (settingsPage != null) {
+                    settingsPage.setVisibility(View.VISIBLE);
+                }
+                syncRows();
+            } else {
+                editorPages.get(editorPages.size() - 1).view.setVisibility(
+                        View.VISIBLE
+                );
+            }
+            styleHost();
+        }
+
+        private void ensureEditorBackStackBridge() throws Exception {
+            if (editorFragmentManager != null
+                    && editorBackStackListener != null) {
+                return;
+            }
+            editorFragmentManager = getParentFragmentManager();
+            editorBackStackBaseCount = editorBackStackCount();
+
+            Method addListener = findBackStackListenerMethod();
+            Class<?> listenerType = addListener.getParameterTypes()[0];
+            if (!listenerType.isInterface()) {
+                throw new NoSuchMethodException(
+                        "Boost FragmentManager listener ABI unavailable"
+                );
+            }
+            editorBackStackListener = Proxy.newProxyInstance(
+                    listenerType.getClassLoader(),
+                    new Class<?>[]{listenerType},
+                    (proxy, method, args) -> {
+                        if (method.getDeclaringClass() == Object.class) {
+                            if ("hashCode".equals(method.getName())) {
+                                return System.identityHashCode(proxy);
+                            }
+                            if ("equals".equals(method.getName())) {
+                                return proxy == args[0];
+                            }
+                            if ("toString".equals(method.getName())) {
+                                return EDITOR_BACK_STACK_MARKER;
+                            }
+                        }
+                        if ("onBackStackChanged".equals(method.getName())) {
+                            syncEditorPagesWithBackStack();
+                        }
+                        return null;
+                    }
+            );
+            addListener.invoke(editorFragmentManager, editorBackStackListener);
+        }
+
+        private Method findBackStackListenerMethod()
+                throws NoSuchMethodException {
+            for (Method method
+                    : editorFragmentManager.getClass().getMethods()) {
+                if (("addOnBackStackChangedListener".equals(method.getName())
+                        || "i".equals(method.getName()))
+                        && method.getParameterTypes().length == 1
+                        && method.getParameterTypes()[0].isInterface()) {
+                    for (Method callback
+                            : method.getParameterTypes()[0].getMethods()) {
+                        if ("onBackStackChanged".equals(callback.getName())
+                                && callback.getParameterTypes().length == 0) {
+                            method.setAccessible(true);
+                            return method;
+                        }
+                    }
+                }
+            }
+            throw new NoSuchMethodException(
+                    "Boost FragmentManager back-stack listener unavailable"
+            );
+        }
+
+        private void pushEditorBackStackEntry() throws Exception {
+            ensureEditorBackStackBridge();
+            Object transaction = invokeRuntimeMethod(
+                    editorFragmentManager,
+                    "beginTransaction",
+                    "n",
+                    new Class<?>[0],
+                    new Object[0]
+            );
+            String name = "morphe-v13-editor-" + (++editorBackStackSequence);
+            invokeRuntimeMethod(
+                    transaction,
+                    "addToBackStack",
+                    "g",
+                    new Class<?>[]{String.class},
+                    new Object[]{name}
+            );
+            invokeRuntimeMethod(
+                    transaction,
+                    "commit",
+                    "i",
+                    new Class<?>[0],
+                    new Object[0]
+            );
+        }
+
+        private boolean popEditorBackStackEntry() {
+            if (editorFragmentManager == null) {
+                return false;
+            }
+            try {
+                Object result = invokeRuntimeMethod(
+                        editorFragmentManager,
+                        "popBackStackImmediate",
+                        "Z0",
+                        new Class<?>[0],
+                        new Object[0]
+                );
+                return Boolean.TRUE.equals(result);
+            } catch (Throwable throwable) {
+                return false;
+            }
+        }
+
+        private void syncEditorPagesWithBackStack() {
+            if (editorFragmentManager == null
+                    || editorBackStackBaseCount < 0) {
+                return;
+            }
+            try {
+                int depth = Math.max(
+                        0,
+                        editorBackStackCount() - editorBackStackBaseCount
+                );
+                while (editorPages.size() > depth) {
+                    removeTopEditorView();
+                }
+            } catch (Throwable ignored) {
+            }
+        }
+
+        private int editorBackStackCount() throws Exception {
+            Object value = invokeRuntimeMethod(
+                    editorFragmentManager,
+                    "getBackStackEntryCount",
+                    "n0",
+                    new Class<?>[0],
+                    new Object[0]
+            );
+            if (!(value instanceof Number)) {
+                throw new IllegalStateException(
+                        "Boost FragmentManager back-stack count unavailable"
+                );
+            }
+            return ((Number) value).intValue();
+        }
+
+        private Object invokeRuntimeMethod(
+                Object target,
+                String canonicalName,
+                String boostName,
+                Class<?>[] parameterTypes,
+                Object[] values
+        ) throws Exception {
+            Method method = findRuntimeMethod(
+                    target,
+                    canonicalName,
+                    boostName,
+                    parameterTypes.length,
+                    parameterTypes
+            );
+            return method.invoke(target, values);
+        }
+
+        private Method findRuntimeMethod(
+                Object target,
+                String canonicalName,
+                String boostName,
+                int parameterCount,
+                Class<?>[] parameterTypes
+        ) throws NoSuchMethodException {
+            for (Method method : target.getClass().getMethods()) {
+                if ((!canonicalName.equals(method.getName())
+                        && !boostName.equals(method.getName()))
+                        || method.getParameterTypes().length != parameterCount) {
+                    continue;
+                }
+                if (parameterTypes != null) {
+                    Class<?>[] actual = method.getParameterTypes();
+                    boolean matches = true;
+                    for (int index = 0; index < actual.length; index++) {
+                        if (actual[index] != parameterTypes[index]) {
+                            matches = false;
+                            break;
+                        }
+                    }
+                    if (!matches) {
+                        continue;
+                    }
+                }
+                method.setAccessible(true);
+                return method;
+            }
+            throw new NoSuchMethodException(
+                    target.getClass().getName()
+                            + "." + canonicalName
+                            + "/" + boostName
+            );
+        }
+
+        private EditText addEditorInput(
+                LinearLayout parent,
+                String hint,
+                String value,
+                int topMarginDp
+        ) {
+            MorpheSettingsV14Ui.Field field = MorpheSettingsV14Ui.outlinedField(
+                    materialContext(),
+                    tokens,
+                    hint,
+                    value
+            );
+            EditText input = field.input;
+            input.setInputType(InputType.TYPE_CLASS_TEXT);
+
+            LinearLayout.LayoutParams params = matchWrapParams();
+            params.topMargin = dp(topMarginDp);
+            parent.addView(field.root, params);
+            return input;
+        }
+
+        private TextView actionLabel(String value, boolean filled) {
+            return MorpheSettingsV14Ui.action(
+                    materialContext(),
+                    tokens,
+                    value,
+                    filled
+            );
+        }
+
+        private LinearLayout endAlignedActions() {
+            LinearLayout actions = new LinearLayout(requireContext());
+            actions.setOrientation(LinearLayout.HORIZONTAL);
+            actions.setGravity(Gravity.END | Gravity.CENTER_VERTICAL);
+            actions.setPadding(0, dp(14), 0, 0);
+            return actions;
+        }
+
+        private LinearLayout.LayoutParams spacedMatchWrapParams(int topDp) {
+            LinearLayout.LayoutParams params = matchWrapParams();
+            params.topMargin = dp(topDp);
+            return params;
+        }
+
+        private void showConfirmationPage(
+                String title,
+                String message,
+                String confirmLabel,
+                Runnable confirmation
+        ) {
+            EditorPage page = openEditorPage(title);
+            TextView body = textView(message, 16, tokens.textPrimary);
+            body.setLineSpacing(0, 1.12f);
+            body.setPadding(dp(4), dp(12), dp(4), dp(12));
+            page.content.addView(body, matchWrapParams());
+
+            LinearLayout actions = endAlignedActions();
+            TextView cancel = actionLabel("Cancel", false);
+            cancel.setOnClickListener(view -> page.dismiss());
+            actions.addView(cancel, wrapParams());
+            TextView confirm = actionLabel(confirmLabel, true);
+            LinearLayout.LayoutParams confirmParams = wrapParams();
+            confirmParams.setMarginStart(dp(8));
+            actions.addView(confirm, confirmParams);
+            confirm.setOnClickListener(view -> {
+                confirmation.run();
+                page.dismiss();
+            });
+            page.content.addView(actions, matchWrapParams());
+        }
+
+        private final class EditorPage {
+            final String title;
+            final View view;
+            final LinearLayout content;
+
+            EditorPage(String title, View view, LinearLayout content) {
+                this.title = title;
+                this.view = view;
+                this.content = content;
+            }
+
+            boolean isShowing() {
+                return pageHost != null && view.getParent() == pageHost;
+            }
+
+            void dismiss() {
+                if (!editorPages.isEmpty()
+                        && editorPages.get(editorPages.size() - 1) == this) {
+                    closeTopEditorPage();
+                }
+            }
+        }
+
+        private void hideMenuItem(Menu menu, String resourceName) {
+            int id = MorpheSettingsV4Catalog.resourceId(
+                    requireContext(),
+                    "id",
+                    resourceName
+            );
+            if (id != 0) {
+                MenuItem item = menu.findItem(id);
+                if (item != null) {
+                    item.setVisible(false);
+                }
+            }
+        }
+
+        private void showUnavailable() {
+            Toast.makeText(
+                    requireContext(),
+                    "This Boost setting is currently unavailable.",
+                    Toast.LENGTH_SHORT
+            ).show();
+        }
+
+        private void addSectionLabel(LinearLayout parent, String value) {
+            parent.addView(MorpheSettingsV14Ui.sectionLabel(
+                    requireContext(),
+                    tokens,
+                    value
+            ));
+        }
+
+        private TextView textView(String value, int sizeSp, int color) {
+            TextView view = new TextView(requireContext());
+            view.setText(value);
+            view.setTextSize(sizeSp);
+            view.setTextColor(color);
+            return view;
+        }
+
+        private LinearLayout.LayoutParams labelsParams() {
+            return new LinearLayout.LayoutParams(
+                    0,
+                    ViewGroup.LayoutParams.WRAP_CONTENT,
+                    1.0f
+            );
+        }
+
+        private LinearLayout.LayoutParams wrapParams() {
+            return new LinearLayout.LayoutParams(
+                    ViewGroup.LayoutParams.WRAP_CONTENT,
+                    ViewGroup.LayoutParams.WRAP_CONTENT
+            );
+        }
+
+        private LinearLayout.LayoutParams matchWrapParams() {
+            return new LinearLayout.LayoutParams(
+                    ViewGroup.LayoutParams.MATCH_PARENT,
+                    ViewGroup.LayoutParams.WRAP_CONTENT
+            );
+        }
+
+        private void addSpace(LinearLayout parent, int heightDp) {
+            parent.addView(new View(requireContext()), new LinearLayout.LayoutParams(
+                    1,
+                    dp(heightDp)
+            ));
+        }
+
+        private int dp(float value) {
+            return MorpheSettingsV4Theme.dp(requireContext(), value);
+        }
+
+        private static String simpleTag(String value) {
+            if (value == null) {
+                return "";
+            }
+            int index = value.lastIndexOf('.');
+            return index < 0 ? value : value.substring(index + 1);
+        }
+
+        private static String attributeText(
+                Resources resources,
+                XmlResourceParser parser,
+                String name
+        ) {
+            int resourceId = parser.getAttributeResourceValue(
+                    ANDROID_NS,
+                    name,
+                    0
+            );
+            if (resourceId != 0) {
+                try {
+                    return resources.getText(resourceId).toString();
+                } catch (Resources.NotFoundException ignored) {
+                    return "";
+                }
+            }
+            String value = parser.getAttributeValue(ANDROID_NS, name);
+            return value == null || "@null".equals(value) ? "" : value;
+        }
+
+        private static String[] attributeArray(
+                Resources resources,
+                XmlResourceParser parser,
+                String name
+        ) {
+            int resourceId = parser.getAttributeResourceValue(
+                    ANDROID_NS,
+                    name,
+                    0
+            );
+            if (resourceId == 0) {
+                return new String[0];
+            }
+            try {
+                CharSequence[] values = resources.getTextArray(resourceId);
+                String[] result = new String[values.length];
+                for (int index = 0; index < values.length; index++) {
+                    result[index] = values[index].toString();
+                }
+                return result;
+            } catch (Resources.NotFoundException ignored) {
+                return new String[0];
+            }
+        }
+
+        private static final class Control {
+            String tag = "";
+            String section = "";
+            String key = "";
+            String title = "";
+            String summary = "";
+            String summaryOn = "";
+            String summaryOff = "";
+            String defaultValue = "";
+            String dependency = "";
+            String fragmentName = "";
+            boolean disableDependentsState;
+            int min;
+            int max;
+            String[] entries = new String[0];
+            String[] entryValues = new String[0];
+        }
+
+        private static final class Binding {
+            final Control control;
+            final View row;
+            final TextView summary;
+            final MorpheSettingsV14Ui.Toggle toggle;
+            final SeekBar seekBar;
+
+            Binding(
+                    Control control,
+                    View row,
+                    TextView summary,
+                    MorpheSettingsV14Ui.Toggle toggle,
+                    SeekBar seekBar
+            ) {
+                this.control = control;
+                this.row = row;
+                this.summary = summary;
+                this.toggle = toggle;
+                this.seekBar = seekBar;
+            }
+        }
+
+        private static final class SearchDraft {
+            int id;
+            String name = "";
+            String community = "";
+            String scopeId = "";
+            String query = "";
+            String sort = "relevance";
+            String period = "all";
+        }
+
+        private interface SavedSearchRenderer {
+            void render(List<?> values);
+        }
+
+        private interface ValueConsumer {
+            void accept(String value);
+        }
+
+        private enum InvocationFailure {
+            INSTANCE
+        }
+    }
+}

--- a/extensions/boostforreddit/src/main/java/app/morphe/extension/boostforreddit/settings/MorpheSettingsV4PostViewsFragment.java
+++ b/extensions/boostforreddit/src/main/java/app/morphe/extension/boostforreddit/settings/MorpheSettingsV4PostViewsFragment.java
@@ -1,0 +1,772 @@
+package app.morphe.extension.boostforreddit.settings;
+
+import android.app.Activity;
+import android.app.Dialog;
+import android.content.Context;
+import android.content.Intent;
+import android.content.SharedPreferences;
+import android.content.res.ColorStateList;
+import android.graphics.Color;
+import android.graphics.Typeface;
+import android.graphics.drawable.ColorDrawable;
+import android.os.Build;
+import android.os.Bundle;
+import android.preference.PreferenceManager;
+import android.text.TextUtils;
+import android.view.Gravity;
+import android.view.LayoutInflater;
+import android.view.Menu;
+import android.view.MenuItem;
+import android.view.View;
+import android.view.ViewGroup;
+import android.view.Window;
+import android.widget.LinearLayout;
+import android.widget.RadioButton;
+import android.widget.ScrollView;
+import android.widget.SeekBar;
+import android.widget.Switch;
+import android.widget.TextView;
+import android.widget.Toast;
+
+import androidx.fragment.app.Fragment;
+
+import app.morphe.extension.boostforreddit.utils.BoostSystemBarInsetsFix;
+
+import java.lang.reflect.Field;
+
+/** Morphe-owned post-view controls backed by Boost's canonical preferences. */
+public final class MorpheSettingsV4PostViewsFragment extends Fragment {
+    public static final String CONTRACT_MARKER =
+            "MORPHE_BOOST_SETTINGS_V4_POST_VIEWS_ISSUE106_V1";
+
+    private static final String EXTRA_SHOW_FRAGMENT = "extra_show_fragment";
+
+    private static final String KEY_DEFAULT_VIEW = "pref_view";
+    private static final String KEY_REMEMBER_PER_COMMUNITY =
+            "pref_view_per_subscription";
+    private static final String KEY_LEFT_HANDED = "pref_left_handed";
+    private static final String KEY_SUBREDDIT_PREFIX =
+            "pref_show_subreddit_prefix";
+    private static final String KEY_CARDS_ROUNDED =
+            "pref_cards_rounded_corners";
+    private static final String KEY_CARDS_FULL_PREVIEW =
+            "pref_cards_full_preview";
+    private static final String KEY_CARDS_SUBREDDIT_ICON =
+            "pref_cards_subreddit_icon";
+    private static final String KEY_CARDS_GALLERY_CAROUSEL =
+            "pref_cards_gallery_carousel";
+    private static final String KEY_CARDS_LINK_THUMBNAILS =
+            "pref_cards_links_as_thumbnails";
+    private static final String KEY_CARDS_PREVIEW_TEXT =
+            "pref_cards_preview_self";
+    private static final String KEY_CARDS_PREVIEW_LINES =
+            "pref_cards_preview_self_lines";
+    private static final String KEY_MINI_ROUNDED =
+            "pref_mini_cards_rounded_corners";
+    private static final String KEY_MINI_TRUNCATE_TITLE =
+            "pref_mini_cards_truncate_title";
+    private static final String KEY_MINI_BUTTONS =
+            "pref_mini_cards_buttons_visible";
+    private static final String KEY_DENSE_BUTTONS =
+            "pref_dense_buttons_visible";
+    private static final String KEY_PREVIEW_EXTERNAL_LINKS =
+            "pref_load_readability";
+    private static final String KEY_LOCK_SIDEBAR = "pref_lock_sidebar";
+
+    private static final String[] VIEW_TITLES = new String[]{
+            "Cards",
+            "Cards 2.0",
+            "Compact",
+            "Small cards",
+            "Dense",
+            "Columns",
+            "Images",
+            "Swipe",
+    };
+    private static final String[] VIEW_VALUES = new String[]{
+            "0", "7", "1", "4", "5", "2", "6", "3",
+    };
+
+    private MorpheSettingsV4Theme.Tokens tokens;
+    private SharedPreferences preferences;
+    private TextView defaultViewSummary;
+    private LinearLayout manageSavedViewsRow;
+    private LinearLayout previewLinesRow;
+    private SeekBar previewLinesSeekBar;
+
+    public MorpheSettingsV4PostViewsFragment() {
+    }
+
+    @Override
+    public View onCreateView(
+            LayoutInflater inflater,
+            ViewGroup container,
+            Bundle savedInstanceState
+    ) {
+        Context context = inflater.getContext();
+        tokens = MorpheSettingsV4Theme.resolve(context);
+        preferences = PreferenceManager.getDefaultSharedPreferences(context);
+        setHasOptionsMenu(true);
+
+        ScrollView scrollView = new ScrollView(context);
+        scrollView.setFillViewport(true);
+        scrollView.setClipToPadding(false);
+        scrollView.setBackgroundColor(tokens.background);
+
+        LinearLayout content = new LinearLayout(context);
+        content.setOrientation(LinearLayout.VERTICAL);
+        int horizontal = dp(18);
+        content.setPadding(horizontal, dp(12), horizontal, dp(32));
+        scrollView.addView(
+                content,
+                new ScrollView.LayoutParams(
+                        ViewGroup.LayoutParams.MATCH_PARENT,
+                        ViewGroup.LayoutParams.WRAP_CONTENT
+                )
+        );
+
+        addSectionLabel(content, "Layout");
+        addSpace(content, 8);
+        LinearLayout layoutGroup = addGroup(content);
+        LinearLayout defaultViewRow = addNavigationRow(
+                layoutGroup,
+                "Default view",
+                viewTitle(preferences.getString(KEY_DEFAULT_VIEW, "0")),
+                true,
+                view -> showDefaultViewDialog()
+        );
+        defaultViewSummary = rowSummary(defaultViewRow);
+        addSwitchRow(
+                layoutGroup,
+                "Remember per community",
+                "Use the last selected view for each community",
+                preferences.getBoolean(KEY_REMEMBER_PER_COMMUNITY, false),
+                checked -> {
+                    putBoolean(KEY_REMEMBER_PER_COMMUNITY, checked, null);
+                    setRowEnabled(manageSavedViewsRow, checked);
+                }
+        );
+        manageSavedViewsRow = addNavigationRow(
+                layoutGroup,
+                "Manage saved views",
+                "Review or clear community-specific views",
+                preferences.getBoolean(KEY_REMEMBER_PER_COMMUNITY, false),
+                view -> openMorpheFragment(
+                        MorpheSettingsV4Catalog.V4_SAVED_VIEWS_FRAGMENT
+                )
+        );
+        addSwitchRow(
+                layoutGroup,
+                "Thumbnails on left",
+                "Place post thumbnails on the left side",
+                preferences.getBoolean(KEY_LEFT_HANDED, false),
+                checked -> putBoolean(KEY_LEFT_HANDED, checked, "h")
+        );
+        addSwitchRow(
+                layoutGroup,
+                "Communities start with r/",
+                "Show Reddit's r/ prefix before community names",
+                preferences.getBoolean(KEY_SUBREDDIT_PREFIX, false),
+                this::updateSubredditPrefix
+        );
+
+        addSpace(content, 24);
+        addSectionLabel(content, "Cards");
+        addSpace(content, 8);
+        LinearLayout cardsGroup = addGroup(content);
+        addSwitchRow(cardsGroup, "Rounded corners", null,
+                preferences.getBoolean(KEY_CARDS_ROUNDED, false),
+                checked -> putBoolean(KEY_CARDS_ROUNDED, checked, "g"));
+        addSwitchRow(cardsGroup, "Full height images",
+                "Turn off to use fixed-height images",
+                preferences.getBoolean(KEY_CARDS_FULL_PREVIEW, false),
+                checked -> putBoolean(KEY_CARDS_FULL_PREVIEW, checked, "g"));
+        addSwitchRow(cardsGroup, "Show community icon", null,
+                preferences.getBoolean(KEY_CARDS_SUBREDDIT_ICON, true),
+                checked -> putBoolean(KEY_CARDS_SUBREDDIT_ICON, checked, "g"));
+        addSwitchRow(cardsGroup, "Carousel for multiple images", null,
+                preferences.getBoolean(KEY_CARDS_GALLERY_CAROUSEL, true),
+                checked -> putBoolean(KEY_CARDS_GALLERY_CAROUSEL, checked, "g"));
+        addSwitchRow(cardsGroup, "Show thumbnails for link posts",
+                "Turn off to use large image previews",
+                preferences.getBoolean(KEY_CARDS_LINK_THUMBNAILS, true),
+                checked -> putBoolean(KEY_CARDS_LINK_THUMBNAILS, checked, "g"));
+        addSwitchRow(cardsGroup, "Preview text from posts", null,
+                preferences.getBoolean(KEY_CARDS_PREVIEW_TEXT, true),
+                checked -> {
+                    putBoolean(KEY_CARDS_PREVIEW_TEXT, checked, "g");
+                    setPreviewLinesEnabled(checked);
+                });
+        previewLinesRow = addSeekBarRow(
+                cardsGroup,
+                "Lines to preview",
+                preferences.getInt(KEY_CARDS_PREVIEW_LINES, 5)
+        );
+        setPreviewLinesEnabled(
+                preferences.getBoolean(KEY_CARDS_PREVIEW_TEXT, true)
+        );
+
+        addSpace(content, 24);
+        addSectionLabel(content, "Small cards");
+        addSpace(content, 8);
+        LinearLayout miniCardsGroup = addGroup(content);
+        addSwitchRow(miniCardsGroup, "Rounded corners", null,
+                preferences.getBoolean(KEY_MINI_ROUNDED, true),
+                checked -> putBoolean(KEY_MINI_ROUNDED, checked, "g"));
+        addSwitchRow(miniCardsGroup, "Truncate title",
+                "Limit the post title to two lines",
+                preferences.getBoolean(KEY_MINI_TRUNCATE_TITLE, true),
+                checked -> putBoolean(KEY_MINI_TRUNCATE_TITLE, checked, "g"));
+        addSwitchRow(miniCardsGroup, "Buttons always visible",
+                "When off, long-press to show buttons",
+                preferences.getBoolean(KEY_MINI_BUTTONS, false),
+                checked -> putBoolean(KEY_MINI_BUTTONS, checked, "g"));
+
+        addSpace(content, 24);
+        addSectionLabel(content, "Dense");
+        addSpace(content, 8);
+        LinearLayout denseGroup = addGroup(content);
+        addSwitchRow(denseGroup, "Buttons always visible",
+                "When off, long-press to show buttons",
+                preferences.getBoolean(KEY_DENSE_BUTTONS, false),
+                checked -> putBoolean(KEY_DENSE_BUTTONS, checked, "h"));
+
+        addSpace(content, 24);
+        addSectionLabel(content, "Swipe");
+        addSpace(content, 8);
+        LinearLayout swipeGroup = addGroup(content);
+        addSwitchRow(swipeGroup, "Preview external links",
+                "Automatically load a text preview for external links",
+                preferences.getBoolean(KEY_PREVIEW_EXTERNAL_LINKS, false),
+                checked -> putBoolean(KEY_PREVIEW_EXTERNAL_LINKS, checked, null));
+        addSwitchRow(swipeGroup, "Lock sidebar",
+                "Disable opening the sidebar with a swipe",
+                preferences.getBoolean(KEY_LOCK_SIDEBAR, false),
+                checked -> putBoolean(KEY_LOCK_SIDEBAR, checked, "i"));
+
+        return scrollView;
+    }
+
+    @Override
+    public void onResume() {
+        super.onResume();
+        styleHost();
+    }
+
+    @Override
+    public void onPause() {
+        Activity activity = hostActivity();
+        if (activity != null) {
+            BoostSystemBarInsetsFix.clearMorpheSettingsV4SystemBars(activity);
+        }
+        super.onPause();
+    }
+
+    @Override
+    public void onPrepareOptionsMenu(Menu menu) {
+        super.onPrepareOptionsMenu(menu);
+        hideMenuItem(menu, "action_generic_search");
+        hideMenuItem(menu, "action_search");
+        hideMenuItem(menu, "search");
+    }
+
+    private LinearLayout addGroup(LinearLayout parent) {
+        Context context = requireContext();
+        MorpheSettingsV4Theme.Accent accent = tokens.navigationAccent();
+        int groupColor = MorpheSettingsV4Theme.blend(
+                tokens.surfaceContainer,
+                accent.container,
+                tokens.dark ? 0.035f : 0.025f
+        );
+        LinearLayout group = new LinearLayout(context);
+        group.setOrientation(LinearLayout.VERTICAL);
+        group.setBackground(MorpheSettingsV4Theme.rounded(
+                context,
+                groupColor,
+                24
+        ));
+        group.setClipToOutline(true);
+        parent.addView(group, new LinearLayout.LayoutParams(
+                ViewGroup.LayoutParams.MATCH_PARENT,
+                ViewGroup.LayoutParams.WRAP_CONTENT
+        ));
+        return group;
+    }
+
+    private LinearLayout addNavigationRow(
+            LinearLayout parent,
+            String titleValue,
+            String summaryValue,
+            boolean enabled,
+            View.OnClickListener listener
+    ) {
+        Context context = requireContext();
+        MorpheSettingsV4Theme.Accent accent = tokens.navigationAccent();
+        LinearLayout row = baseRow(context);
+        row.addView(createLabels(titleValue, summaryValue), labelsParams());
+
+        TextView chevron = textView("›", 28, accent.color);
+        chevron.setGravity(Gravity.CENTER);
+        row.addView(chevron, new LinearLayout.LayoutParams(dp(28), dp(44)));
+        row.setOnClickListener(listener);
+        setRowEnabled(row, enabled);
+        addGroupedRow(parent, row);
+        return row;
+    }
+
+    private void addSwitchRow(
+            LinearLayout parent,
+            String titleValue,
+            String summaryValue,
+            boolean checked,
+            CheckedChange change
+    ) {
+        Context context = requireContext();
+        MorpheSettingsV4Theme.Accent accent = tokens.navigationAccent();
+        LinearLayout row = baseRow(context);
+        row.setClickable(true);
+        row.setFocusable(true);
+        row.addView(createLabels(titleValue, summaryValue), labelsParams());
+
+        Switch toggle = new Switch(context);
+        toggle.setChecked(checked);
+        tintSwitch(toggle, accent);
+        toggle.setOnCheckedChangeListener(
+                (button, value) -> change.onChanged(value)
+        );
+        row.setOnClickListener(view -> toggle.toggle());
+        row.addView(toggle, new LinearLayout.LayoutParams(
+                ViewGroup.LayoutParams.WRAP_CONTENT,
+                ViewGroup.LayoutParams.WRAP_CONTENT
+        ));
+        addGroupedRow(parent, row);
+    }
+
+    private LinearLayout addSeekBarRow(
+            LinearLayout parent,
+            String titleValue,
+            int progress
+    ) {
+        Context context = requireContext();
+        LinearLayout row = new LinearLayout(context);
+        row.setOrientation(LinearLayout.VERTICAL);
+        row.setPadding(dp(18), dp(12), dp(18), dp(10));
+        row.setMinimumHeight(dp(92));
+
+        LinearLayout heading = new LinearLayout(context);
+        heading.setOrientation(LinearLayout.HORIZONTAL);
+        heading.setGravity(Gravity.CENTER_VERTICAL);
+        TextView title = textView(titleValue, 16, tokens.textPrimary);
+        title.setTypeface(Typeface.create("sans-serif-medium", Typeface.NORMAL));
+        heading.addView(title, labelsParams());
+        TextView value = textView(linesSummary(progress), 14, tokens.textSecondary);
+        heading.addView(value);
+        row.addView(heading);
+
+        previewLinesSeekBar = new SeekBar(context);
+        previewLinesSeekBar.setMax(100);
+        previewLinesSeekBar.setProgress(progress);
+        if (Build.VERSION.SDK_INT >= 21) {
+            previewLinesSeekBar.setProgressTintList(
+                    ColorStateList.valueOf(tokens.navigationAccent().color)
+            );
+            previewLinesSeekBar.setThumbTintList(
+                    ColorStateList.valueOf(tokens.navigationAccent().color)
+            );
+        }
+        previewLinesSeekBar.setOnSeekBarChangeListener(
+                new SeekBar.OnSeekBarChangeListener() {
+                    @Override
+                    public void onProgressChanged(
+                            SeekBar seekBar,
+                            int current,
+                            boolean fromUser
+                    ) {
+                        value.setText(linesSummary(current));
+                        if (fromUser) {
+                            preferences.edit()
+                                    .putInt(KEY_CARDS_PREVIEW_LINES, current)
+                                    .apply();
+                            setBoostStaticBoolean("g");
+                        }
+                    }
+
+                    @Override
+                    public void onStartTrackingTouch(SeekBar seekBar) {
+                    }
+
+                    @Override
+                    public void onStopTrackingTouch(SeekBar seekBar) {
+                    }
+                }
+        );
+        row.addView(previewLinesSeekBar, new LinearLayout.LayoutParams(
+                ViewGroup.LayoutParams.MATCH_PARENT,
+                ViewGroup.LayoutParams.WRAP_CONTENT
+        ));
+        addGroupedRow(parent, row);
+        return row;
+    }
+
+    private void showDefaultViewDialog() {
+        Context context = requireContext();
+        Dialog dialog = new Dialog(context);
+        LinearLayout content = new LinearLayout(context);
+        content.setOrientation(LinearLayout.VERTICAL);
+        content.setPadding(dp(20), dp(20), dp(20), dp(14));
+        content.setBackground(MorpheSettingsV4Theme.rounded(
+                context,
+                tokens.surfaceContainerHigh,
+                28
+        ));
+
+        TextView heading = textView("Default view", 20, tokens.textPrimary);
+        heading.setTypeface(Typeface.create("sans-serif-medium", Typeface.NORMAL));
+        LinearLayout.LayoutParams headingParams = wrapParams();
+        headingParams.setMarginStart(dp(8));
+        headingParams.bottomMargin = dp(8);
+        content.addView(heading, headingParams);
+
+        String selected = preferences.getString(KEY_DEFAULT_VIEW, "0");
+        for (int index = 0; index < VIEW_TITLES.length; index++) {
+            final int choice = index;
+            LinearLayout row = new LinearLayout(context);
+            row.setOrientation(LinearLayout.HORIZONTAL);
+            row.setGravity(Gravity.CENTER_VERTICAL);
+            row.setMinimumHeight(dp(52));
+            row.setPadding(dp(4), 0, dp(8), 0);
+            row.setBackground(MorpheSettingsV4Theme.interactive(
+                    context,
+                    Color.TRANSPARENT,
+                    16,
+                    tokens.navigationAccent().color
+            ));
+
+            RadioButton radio = new RadioButton(context);
+            radio.setChecked(VIEW_VALUES[index].equals(selected));
+            radio.setClickable(false);
+            radio.setFocusable(false);
+            if (Build.VERSION.SDK_INT >= 21) {
+                radio.setButtonTintList(new ColorStateList(
+                        new int[][]{
+                                new int[]{android.R.attr.state_checked},
+                                new int[]{-android.R.attr.state_checked},
+                        },
+                        new int[]{
+                                tokens.navigationAccent().color,
+                                tokens.textSecondary,
+                        }
+                ));
+            }
+            row.addView(radio);
+
+            TextView label = textView(VIEW_TITLES[index], 16, tokens.textPrimary);
+            row.addView(label, labelsParams());
+            row.setOnClickListener(view -> {
+                preferences.edit()
+                        .putString(KEY_DEFAULT_VIEW, VIEW_VALUES[choice])
+                        .apply();
+                if (defaultViewSummary != null) {
+                    defaultViewSummary.setText(VIEW_TITLES[choice]);
+                }
+                dialog.dismiss();
+            });
+            content.addView(row, new LinearLayout.LayoutParams(
+                    ViewGroup.LayoutParams.MATCH_PARENT,
+                    ViewGroup.LayoutParams.WRAP_CONTENT
+            ));
+        }
+
+        TextView cancel = textView("Cancel", 14, tokens.navigationAccent().color);
+        cancel.setTypeface(Typeface.create("sans-serif-medium", Typeface.NORMAL));
+        cancel.setGravity(Gravity.CENTER);
+        cancel.setAllCaps(false);
+        cancel.setPadding(dp(14), dp(10), dp(14), dp(10));
+        cancel.setOnClickListener(view -> dialog.dismiss());
+        LinearLayout.LayoutParams cancelParams = wrapParams();
+        cancelParams.gravity = Gravity.END;
+        cancelParams.topMargin = dp(4);
+        content.addView(cancel, cancelParams);
+
+        dialog.setContentView(content);
+        Window window = dialog.getWindow();
+        if (window != null) {
+            window.setBackgroundDrawable(new ColorDrawable(Color.TRANSPARENT));
+        }
+        dialog.show();
+        window = dialog.getWindow();
+        if (window != null) {
+            int width = context.getResources().getDisplayMetrics().widthPixels
+                    - dp(40);
+            window.setLayout(width, ViewGroup.LayoutParams.WRAP_CONTENT);
+        }
+    }
+
+    private void putBoolean(String key, boolean value, String refreshFlag) {
+        preferences.edit().putBoolean(key, value).apply();
+        if (refreshFlag != null) {
+            setBoostStaticBoolean(refreshFlag);
+        }
+    }
+
+    private void updateSubredditPrefix(boolean enabled) {
+        preferences.edit().putBoolean(KEY_SUBREDDIT_PREFIX, enabled).apply();
+        setBoostStaticString("c", enabled ? "r/" : "");
+        setBoostStaticBoolean("i");
+    }
+
+    private void setBoostStaticBoolean(String fieldName) {
+        try {
+            Class<?> settings = Class.forName("id.b");
+            Field field = settings.getDeclaredField(fieldName);
+            field.setAccessible(true);
+            field.setBoolean(null, true);
+        } catch (Throwable ignored) {
+        }
+    }
+
+    private void setBoostStaticString(String fieldName, String value) {
+        try {
+            Class<?> settings = Class.forName("id.b");
+            Field field = settings.getDeclaredField(fieldName);
+            field.setAccessible(true);
+            field.set(null, value);
+        } catch (Throwable ignored) {
+        }
+    }
+
+    private void openMorpheFragment(String fragmentName) {
+        Activity activity = hostActivity();
+        if (activity == null) {
+            showUnavailable();
+            return;
+        }
+        try {
+            Intent intent = new Intent(activity, activity.getClass());
+            intent.putExtra(EXTRA_SHOW_FRAGMENT, fragmentName);
+            activity.startActivity(intent);
+        } catch (Throwable ignored) {
+            showUnavailable();
+        }
+    }
+
+    private void styleHost() {
+        Activity activity = hostActivity();
+        if (activity == null || tokens == null) {
+            return;
+        }
+        activity.setTitle("Post views");
+        BoostSystemBarInsetsFix.applyMorpheSettingsV4SystemBars(
+                activity,
+                tokens.background,
+                tokens.dark
+        );
+        int toolbarId = MorpheSettingsV4Catalog.resourceId(
+                activity,
+                "id",
+                "toolbar"
+        );
+        View toolbar = activity.findViewById(toolbarId);
+        if (toolbar != null) {
+            toolbar.setBackgroundColor(tokens.background);
+            toolbar.setElevation(0);
+        }
+    }
+
+    private Activity hostActivity() {
+        Context context = requireContext();
+        return context instanceof Activity ? (Activity) context : null;
+    }
+
+    private void hideMenuItem(Menu menu, String resourceName) {
+        int resourceId = MorpheSettingsV4Catalog.resourceId(
+                requireContext(),
+                "id",
+                resourceName
+        );
+        if (resourceId == 0) {
+            return;
+        }
+        MenuItem item = menu.findItem(resourceId);
+        if (item != null) {
+            item.setVisible(false);
+        }
+    }
+
+    private LinearLayout baseRow(Context context) {
+        LinearLayout row = new LinearLayout(context);
+        row.setOrientation(LinearLayout.HORIZONTAL);
+        row.setGravity(Gravity.CENTER_VERTICAL);
+        row.setMinimumHeight(dp(68));
+        row.setPadding(dp(18), dp(10), dp(14), dp(10));
+        row.setBackground(MorpheSettingsV4Theme.interactive(
+                context,
+                Color.TRANSPARENT,
+                0,
+                tokens.navigationAccent().color
+        ));
+        return row;
+    }
+
+    private void addGroupedRow(LinearLayout group, LinearLayout row) {
+        if (group.getChildCount() > 0) {
+            addGroupDivider(group);
+        }
+        group.addView(row, new LinearLayout.LayoutParams(
+                ViewGroup.LayoutParams.MATCH_PARENT,
+                ViewGroup.LayoutParams.WRAP_CONTENT
+        ));
+    }
+
+    private void addGroupDivider(LinearLayout group) {
+        View divider = new View(requireContext());
+        divider.setBackgroundColor(MorpheSettingsV4Theme.blend(
+                tokens.surfaceContainer,
+                tokens.outline,
+                tokens.dark ? 0.22f : 0.16f
+        ));
+        LinearLayout.LayoutParams params = new LinearLayout.LayoutParams(
+                ViewGroup.LayoutParams.MATCH_PARENT,
+                dp(1)
+        );
+        params.setMarginStart(dp(18));
+        params.setMarginEnd(dp(18));
+        group.addView(divider, params);
+    }
+
+    private LinearLayout createLabels(String titleValue, String summaryValue) {
+        LinearLayout labels = new LinearLayout(requireContext());
+        labels.setOrientation(LinearLayout.VERTICAL);
+        TextView title = textView(titleValue, 16, tokens.textPrimary);
+        title.setTypeface(Typeface.create("sans-serif-medium", Typeface.NORMAL));
+        labels.addView(title);
+        if (!TextUtils.isEmpty(summaryValue)) {
+            TextView summary = textView(summaryValue, 14, tokens.textSecondary);
+            summary.setLineSpacing(0, 1.04f);
+            summary.setMaxLines(3);
+            LinearLayout.LayoutParams params = wrapParams();
+            params.topMargin = dp(3);
+            labels.addView(summary, params);
+        }
+        return labels;
+    }
+
+    private TextView rowSummary(LinearLayout row) {
+        if (row.getChildCount() == 0 || !(row.getChildAt(0) instanceof LinearLayout)) {
+            return null;
+        }
+        LinearLayout labels = (LinearLayout) row.getChildAt(0);
+        return labels.getChildCount() > 1 && labels.getChildAt(1) instanceof TextView
+                ? (TextView) labels.getChildAt(1)
+                : null;
+    }
+
+    private void setRowEnabled(View row, boolean enabled) {
+        if (row == null) {
+            return;
+        }
+        row.setEnabled(enabled);
+        row.setClickable(enabled);
+        row.setFocusable(enabled);
+        row.setAlpha(enabled ? 1.0f : 0.44f);
+    }
+
+    private void setPreviewLinesEnabled(boolean enabled) {
+        setRowEnabled(previewLinesRow, enabled);
+        if (previewLinesSeekBar != null) {
+            previewLinesSeekBar.setEnabled(enabled);
+        }
+    }
+
+    private void tintSwitch(
+            Switch toggle,
+            MorpheSettingsV4Theme.Accent accent
+    ) {
+        if (Build.VERSION.SDK_INT < 21) {
+            return;
+        }
+        int[][] states = new int[][]{
+                new int[]{android.R.attr.state_checked},
+                new int[]{-android.R.attr.state_checked},
+        };
+        toggle.setThumbTintList(new ColorStateList(
+                states,
+                new int[]{accent.color, tokens.textSecondary}
+        ));
+        toggle.setTrackTintList(new ColorStateList(
+                states,
+                new int[]{
+                        MorpheSettingsV4Theme.blend(
+                                tokens.surfaceContainerHigh,
+                                accent.container,
+                                0.72f
+                        ),
+                        tokens.surfaceContainerHigh,
+                }
+        ));
+    }
+
+    private String viewTitle(String value) {
+        for (int index = 0; index < VIEW_VALUES.length; index++) {
+            if (VIEW_VALUES[index].equals(value)) {
+                return VIEW_TITLES[index];
+            }
+        }
+        return VIEW_TITLES[0];
+    }
+
+    private String linesSummary(int value) {
+        return value == 1 ? "1 line" : value + " lines";
+    }
+
+    private void addSectionLabel(LinearLayout parent, String value) {
+        TextView label = textView(value, 14, tokens.primary);
+        label.setTypeface(Typeface.create("sans-serif-medium", Typeface.NORMAL));
+        label.setLetterSpacing(0.02f);
+        parent.addView(label);
+    }
+
+    private TextView textView(String value, int sizeSp, int color) {
+        TextView textView = new TextView(requireContext());
+        textView.setText(value);
+        textView.setTextSize(sizeSp);
+        textView.setTextColor(color);
+        return textView;
+    }
+
+    private LinearLayout.LayoutParams labelsParams() {
+        return new LinearLayout.LayoutParams(
+                0,
+                ViewGroup.LayoutParams.WRAP_CONTENT,
+                1.0f
+        );
+    }
+
+    private LinearLayout.LayoutParams wrapParams() {
+        return new LinearLayout.LayoutParams(
+                ViewGroup.LayoutParams.WRAP_CONTENT,
+                ViewGroup.LayoutParams.WRAP_CONTENT
+        );
+    }
+
+    private void addSpace(LinearLayout parent, int heightDp) {
+        View space = new View(requireContext());
+        parent.addView(space, new LinearLayout.LayoutParams(1, dp(heightDp)));
+    }
+
+    private int dp(float value) {
+        return MorpheSettingsV4Theme.dp(requireContext(), value);
+    }
+
+    private void showUnavailable() {
+        Toast.makeText(
+                requireContext(),
+                "This post-view control is unavailable in the current Boost build.",
+                Toast.LENGTH_SHORT
+        ).show();
+    }
+
+    private interface CheckedChange {
+        void onChanged(boolean checked);
+    }
+}

--- a/extensions/boostforreddit/src/main/java/app/morphe/extension/boostforreddit/settings/MorpheSettingsV4PostViewsFragment.java
+++ b/extensions/boostforreddit/src/main/java/app/morphe/extension/boostforreddit/settings/MorpheSettingsV4PostViewsFragment.java
@@ -384,10 +384,7 @@ public final class MorpheSettingsV4PostViewsFragment extends Fragment {
                     ) {
                         value.setText(linesSummary(current));
                         if (fromUser) {
-                            preferences.edit()
-                                    .putInt(KEY_CARDS_PREVIEW_LINES, current)
-                                    .apply();
-                            setBoostStaticBoolean("g");
+                            applyPreviewLinesPreference(preferences, current);
                         }
                     }
 
@@ -463,9 +460,10 @@ public final class MorpheSettingsV4PostViewsFragment extends Fragment {
             TextView label = textView(VIEW_TITLES[index], 16, tokens.textPrimary);
             row.addView(label, labelsParams());
             row.setOnClickListener(view -> {
-                preferences.edit()
-                        .putString(KEY_DEFAULT_VIEW, VIEW_VALUES[choice])
-                        .apply();
+                applyDefaultViewPreference(
+                        preferences,
+                        VIEW_VALUES[choice]
+                );
                 if (defaultViewSummary != null) {
                     defaultViewSummary.setText(VIEW_TITLES[choice]);
                 }
@@ -503,6 +501,15 @@ public final class MorpheSettingsV4PostViewsFragment extends Fragment {
     }
 
     private void putBoolean(String key, boolean value, String refreshFlag) {
+        applyBooleanPreference(preferences, key, value, refreshFlag);
+    }
+
+    static void applyBooleanPreference(
+            SharedPreferences preferences,
+            String key,
+            boolean value,
+            String refreshFlag
+    ) {
         preferences.edit().putBoolean(key, value).apply();
         if (refreshFlag != null) {
             setBoostStaticBoolean(refreshFlag);
@@ -510,12 +517,49 @@ public final class MorpheSettingsV4PostViewsFragment extends Fragment {
     }
 
     private void updateSubredditPrefix(boolean enabled) {
+        applySubredditPrefix(preferences, enabled);
+    }
+
+    static void applySubredditPrefix(
+            SharedPreferences preferences,
+            boolean enabled
+    ) {
         preferences.edit().putBoolean(KEY_SUBREDDIT_PREFIX, enabled).apply();
         setBoostStaticString("c", enabled ? "r/" : "");
         setBoostStaticBoolean("i");
     }
 
-    private void setBoostStaticBoolean(String fieldName) {
+    static void applyDefaultViewPreference(
+            SharedPreferences preferences,
+            String value
+    ) {
+        if (indexOf(VIEW_VALUES, value) < 0) {
+            throw new IllegalArgumentException("unsupported view " + value);
+        }
+        preferences.edit().putString(KEY_DEFAULT_VIEW, value).apply();
+    }
+
+    static void applyPreviewLinesPreference(
+            SharedPreferences preferences,
+            int value
+    ) {
+        if (value < 0 || value > 100) {
+            throw new IllegalArgumentException("preview lines outside 0..100");
+        }
+        preferences.edit().putInt(KEY_CARDS_PREVIEW_LINES, value).apply();
+        setBoostStaticBoolean("g");
+    }
+
+    private static int indexOf(String[] values, String target) {
+        for (int index = 0; index < values.length; index++) {
+            if (values[index].equals(target)) {
+                return index;
+            }
+        }
+        return -1;
+    }
+
+    private static void setBoostStaticBoolean(String fieldName) {
         try {
             Class<?> settings = Class.forName("id.b");
             Field field = settings.getDeclaredField(fieldName);
@@ -525,7 +569,7 @@ public final class MorpheSettingsV4PostViewsFragment extends Fragment {
         }
     }
 
-    private void setBoostStaticString(String fieldName, String value) {
+    private static void setBoostStaticString(String fieldName, String value) {
         try {
             Class<?> settings = Class.forName("id.b");
             Field field = settings.getDeclaredField(fieldName);
@@ -662,19 +706,30 @@ public final class MorpheSettingsV4PostViewsFragment extends Fragment {
     }
 
     private void setRowEnabled(View row, boolean enabled) {
-        if (row == null) {
-            return;
-        }
-        row.setEnabled(enabled);
-        row.setClickable(enabled);
-        row.setFocusable(enabled);
-        row.setAlpha(enabled ? 1.0f : 0.44f);
+        applyDependentRowState(row, null, enabled);
     }
 
     private void setPreviewLinesEnabled(boolean enabled) {
-        setRowEnabled(previewLinesRow, enabled);
-        if (previewLinesSeekBar != null) {
-            previewLinesSeekBar.setEnabled(enabled);
+        applyDependentRowState(
+                previewLinesRow,
+                previewLinesSeekBar,
+                enabled
+        );
+    }
+
+    static void applyDependentRowState(
+            View row,
+            View control,
+            boolean enabled
+    ) {
+        if (row != null) {
+            row.setEnabled(enabled);
+            row.setClickable(enabled);
+            row.setFocusable(enabled);
+            row.setAlpha(enabled ? 1.0f : 0.44f);
+        }
+        if (control != null) {
+            control.setEnabled(enabled);
         }
     }
 
@@ -706,7 +761,7 @@ public final class MorpheSettingsV4PostViewsFragment extends Fragment {
         ));
     }
 
-    private String viewTitle(String value) {
+    static String viewTitle(String value) {
         for (int index = 0; index < VIEW_VALUES.length; index++) {
             if (VIEW_VALUES[index].equals(value)) {
                 return VIEW_TITLES[index];

--- a/extensions/boostforreddit/src/main/java/app/morphe/extension/boostforreddit/settings/MorpheSettingsV4PostViewsFragment.java
+++ b/extensions/boostforreddit/src/main/java/app/morphe/extension/boostforreddit/settings/MorpheSettingsV4PostViewsFragment.java
@@ -21,10 +21,8 @@ import android.view.View;
 import android.view.ViewGroup;
 import android.view.Window;
 import android.widget.LinearLayout;
-import android.widget.RadioButton;
 import android.widget.ScrollView;
 import android.widget.SeekBar;
-import android.widget.Switch;
 import android.widget.TextView;
 import android.widget.Toast;
 
@@ -115,8 +113,8 @@ public final class MorpheSettingsV4PostViewsFragment extends Fragment {
 
         LinearLayout content = new LinearLayout(context);
         content.setOrientation(LinearLayout.VERTICAL);
-        int horizontal = dp(18);
-        content.setPadding(horizontal, dp(12), horizontal, dp(32));
+        int horizontal = dp(16);
+        content.setPadding(horizontal, dp(10), horizontal, dp(32));
         scrollView.addView(
                 content,
                 new ScrollView.LayoutParams(
@@ -271,21 +269,7 @@ public final class MorpheSettingsV4PostViewsFragment extends Fragment {
     }
 
     private LinearLayout addGroup(LinearLayout parent) {
-        Context context = requireContext();
-        MorpheSettingsV4Theme.Accent accent = tokens.navigationAccent();
-        int groupColor = MorpheSettingsV4Theme.blend(
-                tokens.surfaceContainer,
-                accent.container,
-                tokens.dark ? 0.035f : 0.025f
-        );
-        LinearLayout group = new LinearLayout(context);
-        group.setOrientation(LinearLayout.VERTICAL);
-        group.setBackground(MorpheSettingsV4Theme.rounded(
-                context,
-                groupColor,
-                24
-        ));
-        group.setClipToOutline(true);
+        LinearLayout group = MorpheSettingsV14Ui.group(requireContext());
         parent.addView(group, new LinearLayout.LayoutParams(
                 ViewGroup.LayoutParams.MATCH_PARENT,
                 ViewGroup.LayoutParams.WRAP_CONTENT
@@ -301,13 +285,10 @@ public final class MorpheSettingsV4PostViewsFragment extends Fragment {
             View.OnClickListener listener
     ) {
         Context context = requireContext();
-        MorpheSettingsV4Theme.Accent accent = tokens.navigationAccent();
         LinearLayout row = baseRow(context);
         row.addView(createLabels(titleValue, summaryValue), labelsParams());
 
-        TextView chevron = textView("›", 28, accent.color);
-        chevron.setGravity(Gravity.CENTER);
-        row.addView(chevron, new LinearLayout.LayoutParams(dp(28), dp(44)));
+        row.addView(MorpheSettingsV14Ui.chevron(context, tokens));
         row.setOnClickListener(listener);
         setRowEnabled(row, enabled);
         addGroupedRow(parent, row);
@@ -328,9 +309,8 @@ public final class MorpheSettingsV4PostViewsFragment extends Fragment {
         row.setFocusable(true);
         row.addView(createLabels(titleValue, summaryValue), labelsParams());
 
-        Switch toggle = new Switch(context);
-        toggle.setChecked(checked);
-        tintSwitch(toggle, accent);
+        MorpheSettingsV14Ui.Toggle toggle =
+                new MorpheSettingsV14Ui.Toggle(context, tokens, checked);
         toggle.setOnCheckedChangeListener(
                 (button, value) -> change.onChanged(value)
         );
@@ -425,40 +405,21 @@ public final class MorpheSettingsV4PostViewsFragment extends Fragment {
         content.addView(heading, headingParams);
 
         String selected = preferences.getString(KEY_DEFAULT_VIEW, "0");
+        LinearLayout choiceGroup = MorpheSettingsV14Ui.group(context);
+        content.addView(choiceGroup, new LinearLayout.LayoutParams(
+                ViewGroup.LayoutParams.MATCH_PARENT,
+                ViewGroup.LayoutParams.WRAP_CONTENT
+        ));
         for (int index = 0; index < VIEW_TITLES.length; index++) {
             final int choice = index;
-            LinearLayout row = new LinearLayout(context);
-            row.setOrientation(LinearLayout.HORIZONTAL);
-            row.setGravity(Gravity.CENTER_VERTICAL);
-            row.setMinimumHeight(dp(52));
-            row.setPadding(dp(4), 0, dp(8), 0);
-            row.setBackground(MorpheSettingsV4Theme.interactive(
+            MorpheSettingsV14Ui.ChoiceRow row =
+                    MorpheSettingsV14Ui.choiceRow(
                     context,
-                    Color.TRANSPARENT,
-                    16,
-                    tokens.navigationAccent().color
-            ));
-
-            RadioButton radio = new RadioButton(context);
-            radio.setChecked(VIEW_VALUES[index].equals(selected));
-            radio.setClickable(false);
-            radio.setFocusable(false);
-            if (Build.VERSION.SDK_INT >= 21) {
-                radio.setButtonTintList(new ColorStateList(
-                        new int[][]{
-                                new int[]{android.R.attr.state_checked},
-                                new int[]{-android.R.attr.state_checked},
-                        },
-                        new int[]{
-                                tokens.navigationAccent().color,
-                                tokens.textSecondary,
-                        }
-                ));
-            }
-            row.addView(radio);
-
-            TextView label = textView(VIEW_TITLES[index], 16, tokens.textPrimary);
-            row.addView(label, labelsParams());
+                    tokens,
+                    VIEW_TITLES[index],
+                    "",
+                    VIEW_VALUES[index].equals(selected)
+            );
             row.setOnClickListener(view -> {
                 applyDefaultViewPreference(
                         preferences,
@@ -469,10 +430,7 @@ public final class MorpheSettingsV4PostViewsFragment extends Fragment {
                 }
                 dialog.dismiss();
             });
-            content.addView(row, new LinearLayout.LayoutParams(
-                    ViewGroup.LayoutParams.MATCH_PARENT,
-                    ViewGroup.LayoutParams.WRAP_CONTENT
-            ));
+            MorpheSettingsV14Ui.addSegmentedRow(choiceGroup, row, tokens);
         }
 
         TextView cancel = textView("Cancel", 14, tokens.navigationAccent().color);
@@ -638,28 +596,11 @@ public final class MorpheSettingsV4PostViewsFragment extends Fragment {
     }
 
     private LinearLayout baseRow(Context context) {
-        LinearLayout row = new LinearLayout(context);
-        row.setOrientation(LinearLayout.HORIZONTAL);
-        row.setGravity(Gravity.CENTER_VERTICAL);
-        row.setMinimumHeight(dp(68));
-        row.setPadding(dp(18), dp(10), dp(14), dp(10));
-        row.setBackground(MorpheSettingsV4Theme.interactive(
-                context,
-                Color.TRANSPARENT,
-                0,
-                tokens.navigationAccent().color
-        ));
-        return row;
+        return MorpheSettingsV14Ui.baseRow(context, tokens);
     }
 
     private void addGroupedRow(LinearLayout group, LinearLayout row) {
-        if (group.getChildCount() > 0) {
-            addGroupDivider(group);
-        }
-        group.addView(row, new LinearLayout.LayoutParams(
-                ViewGroup.LayoutParams.MATCH_PARENT,
-                ViewGroup.LayoutParams.WRAP_CONTENT
-        ));
+        MorpheSettingsV14Ui.addSegmentedRow(group, row, tokens);
     }
 
     private void addGroupDivider(LinearLayout group) {
@@ -679,20 +620,12 @@ public final class MorpheSettingsV4PostViewsFragment extends Fragment {
     }
 
     private LinearLayout createLabels(String titleValue, String summaryValue) {
-        LinearLayout labels = new LinearLayout(requireContext());
-        labels.setOrientation(LinearLayout.VERTICAL);
-        TextView title = textView(titleValue, 16, tokens.textPrimary);
-        title.setTypeface(Typeface.create("sans-serif-medium", Typeface.NORMAL));
-        labels.addView(title);
-        if (!TextUtils.isEmpty(summaryValue)) {
-            TextView summary = textView(summaryValue, 14, tokens.textSecondary);
-            summary.setLineSpacing(0, 1.04f);
-            summary.setMaxLines(3);
-            LinearLayout.LayoutParams params = wrapParams();
-            params.topMargin = dp(3);
-            labels.addView(summary, params);
-        }
-        return labels;
+        return MorpheSettingsV14Ui.labels(
+                requireContext(),
+                tokens,
+                titleValue,
+                summaryValue
+        );
     }
 
     private TextView rowSummary(LinearLayout row) {
@@ -733,34 +666,6 @@ public final class MorpheSettingsV4PostViewsFragment extends Fragment {
         }
     }
 
-    private void tintSwitch(
-            Switch toggle,
-            MorpheSettingsV4Theme.Accent accent
-    ) {
-        if (Build.VERSION.SDK_INT < 21) {
-            return;
-        }
-        int[][] states = new int[][]{
-                new int[]{android.R.attr.state_checked},
-                new int[]{-android.R.attr.state_checked},
-        };
-        toggle.setThumbTintList(new ColorStateList(
-                states,
-                new int[]{accent.color, tokens.textSecondary}
-        ));
-        toggle.setTrackTintList(new ColorStateList(
-                states,
-                new int[]{
-                        MorpheSettingsV4Theme.blend(
-                                tokens.surfaceContainerHigh,
-                                accent.container,
-                                0.72f
-                        ),
-                        tokens.surfaceContainerHigh,
-                }
-        ));
-    }
-
     static String viewTitle(String value) {
         for (int index = 0; index < VIEW_VALUES.length; index++) {
             if (VIEW_VALUES[index].equals(value)) {
@@ -775,10 +680,11 @@ public final class MorpheSettingsV4PostViewsFragment extends Fragment {
     }
 
     private void addSectionLabel(LinearLayout parent, String value) {
-        TextView label = textView(value, 14, tokens.primary);
-        label.setTypeface(Typeface.create("sans-serif-medium", Typeface.NORMAL));
-        label.setLetterSpacing(0.02f);
-        parent.addView(label);
+        parent.addView(MorpheSettingsV14Ui.sectionLabel(
+                requireContext(),
+                tokens,
+                value
+        ));
     }
 
     private TextView textView(String value, int sizeSp, int color) {

--- a/extensions/boostforreddit/src/main/java/app/morphe/extension/boostforreddit/settings/MorpheSettingsV4SavedViewsFragment.java
+++ b/extensions/boostforreddit/src/main/java/app/morphe/extension/boostforreddit/settings/MorpheSettingsV4SavedViewsFragment.java
@@ -4,11 +4,9 @@ import android.app.Activity;
 import android.app.Dialog;
 import android.content.Context;
 import android.content.SharedPreferences;
-import android.content.res.ColorStateList;
 import android.graphics.Color;
 import android.graphics.Typeface;
 import android.graphics.drawable.ColorDrawable;
-import android.os.Build;
 import android.os.Bundle;
 import android.text.TextUtils;
 import android.view.inputmethod.EditorInfo;
@@ -22,9 +20,7 @@ import android.view.Window;
 import android.widget.EditText;
 import android.widget.ImageView;
 import android.widget.LinearLayout;
-import android.widget.RadioButton;
 import android.widget.ScrollView;
-import android.widget.Switch;
 import android.widget.TextView;
 
 import androidx.fragment.app.Fragment;
@@ -94,7 +90,7 @@ public final class MorpheSettingsV4SavedViewsFragment extends Fragment {
 
         entriesHost = new LinearLayout(context);
         entriesHost.setOrientation(LinearLayout.VERTICAL);
-        entriesHost.setPadding(dp(18), dp(12), dp(18), dp(32));
+        entriesHost.setPadding(dp(16), dp(10), dp(16), dp(32));
         scrollView.addView(
                 entriesHost,
                 new ScrollView.LayoutParams(
@@ -262,8 +258,12 @@ public final class MorpheSettingsV4SavedViewsFragment extends Fragment {
                 tokens.textPrimary
         );
         customFeedRow.addView(customFeedLabel, labelsParams());
-        Switch customFeed = new Switch(context);
-        tintSwitch(customFeed);
+        MorpheSettingsV14Ui.Toggle customFeed =
+                new MorpheSettingsV14Ui.Toggle(
+                        context,
+                        tokens,
+                        false
+                );
         customFeedRow.addView(customFeed);
         customFeedRow.setOnClickListener(
                 view -> customFeed.setChecked(!customFeed.isChecked())
@@ -473,16 +473,14 @@ public final class MorpheSettingsV4SavedViewsFragment extends Fragment {
 
         for (int index = 0; index < VIEW_TITLES.length; index++) {
             final int choice = index;
-            LinearLayout row = dialogChoiceRow();
-            RadioButton radio = new RadioButton(context);
-            radio.setChecked(VIEW_VALUES[index] == entry.viewType);
-            radio.setClickable(false);
-            radio.setFocusable(false);
-            tintRadioButton(radio);
-            row.addView(radio);
-
-            TextView label = textView(VIEW_TITLES[index], 16, tokens.textPrimary);
-            row.addView(label, labelsParams());
+            MorpheSettingsV14Ui.ChoiceRow row =
+                    MorpheSettingsV14Ui.choiceRow(
+                    context,
+                    tokens,
+                    VIEW_TITLES[index],
+                    "",
+                    VIEW_VALUES[index] == entry.viewType
+            );
             row.setOnClickListener(view -> {
                 applySavedView(
                         savedViews,
@@ -492,10 +490,7 @@ public final class MorpheSettingsV4SavedViewsFragment extends Fragment {
                 dialog.dismiss();
                 rebuildEntries();
             });
-            content.addView(row, new LinearLayout.LayoutParams(
-                    ViewGroup.LayoutParams.MATCH_PARENT,
-                    ViewGroup.LayoutParams.WRAP_CONTENT
-            ));
+            MorpheSettingsV14Ui.addSegmentedRow(content, row, tokens);
         }
 
         addDialogAction(content, "Cancel", () -> dialog.dismiss());
@@ -718,21 +713,7 @@ public final class MorpheSettingsV4SavedViewsFragment extends Fragment {
     }
 
     private LinearLayout addGroup(LinearLayout parent) {
-        Context context = requireContext();
-        MorpheSettingsV4Theme.Accent accent = tokens.navigationAccent();
-        int groupColor = MorpheSettingsV4Theme.blend(
-                tokens.surfaceContainer,
-                accent.container,
-                tokens.dark ? 0.035f : 0.025f
-        );
-        LinearLayout group = new LinearLayout(context);
-        group.setOrientation(LinearLayout.VERTICAL);
-        group.setBackground(MorpheSettingsV4Theme.rounded(
-                context,
-                groupColor,
-                24
-        ));
-        group.setClipToOutline(true);
+        LinearLayout group = MorpheSettingsV14Ui.group(requireContext());
         parent.addView(group, new LinearLayout.LayoutParams(
                 ViewGroup.LayoutParams.MATCH_PARENT,
                 ViewGroup.LayoutParams.WRAP_CONTENT
@@ -741,82 +722,16 @@ public final class MorpheSettingsV4SavedViewsFragment extends Fragment {
     }
 
     private void addGroupedRow(LinearLayout group, LinearLayout row) {
-        if (group.getChildCount() > 0) {
-            View divider = new View(requireContext());
-            divider.setBackgroundColor(MorpheSettingsV4Theme.blend(
-                    tokens.surfaceContainer,
-                    tokens.outline,
-                    tokens.dark ? 0.22f : 0.16f
-            ));
-            LinearLayout.LayoutParams dividerParams = new LinearLayout.LayoutParams(
-                    ViewGroup.LayoutParams.MATCH_PARENT,
-                    dp(1)
-            );
-            dividerParams.setMarginStart(dp(18));
-            dividerParams.setMarginEnd(dp(18));
-            group.addView(divider, dividerParams);
-        }
-        group.addView(row, new LinearLayout.LayoutParams(
-                ViewGroup.LayoutParams.MATCH_PARENT,
-                ViewGroup.LayoutParams.WRAP_CONTENT
-        ));
+        MorpheSettingsV14Ui.addSegmentedRow(group, row, tokens);
     }
 
     private LinearLayout createLabels(String titleValue, String summaryValue) {
-        LinearLayout labels = new LinearLayout(requireContext());
-        labels.setOrientation(LinearLayout.VERTICAL);
-        TextView title = textView(titleValue, 16, tokens.textPrimary);
-        title.setTypeface(Typeface.create("sans-serif-medium", Typeface.NORMAL));
-        labels.addView(title);
-        TextView summary = textView(summaryValue, 14, tokens.textSecondary);
-        LinearLayout.LayoutParams summaryParams = wrapParams();
-        summaryParams.topMargin = dp(3);
-        labels.addView(summary, summaryParams);
-        return labels;
-    }
-
-    private void tintRadioButton(RadioButton radio) {
-        if (Build.VERSION.SDK_INT < 21) {
-            return;
-        }
-        radio.setButtonTintList(new ColorStateList(
-                new int[][]{
-                        new int[]{android.R.attr.state_checked},
-                        new int[]{-android.R.attr.state_checked},
-                },
-                new int[]{
-                        tokens.navigationAccent().color,
-                        tokens.textSecondary,
-                }
-        ));
-    }
-
-    private void tintSwitch(Switch toggle) {
-        if (Build.VERSION.SDK_INT < 21) {
-            return;
-        }
-        int accent = tokens.navigationAccent().color;
-        toggle.setThumbTintList(new ColorStateList(
-                new int[][]{
-                        new int[]{android.R.attr.state_checked},
-                        new int[]{-android.R.attr.state_checked},
-                },
-                new int[]{accent, tokens.textSecondary}
-        ));
-        toggle.setTrackTintList(new ColorStateList(
-                new int[][]{
-                        new int[]{android.R.attr.state_checked},
-                        new int[]{-android.R.attr.state_checked},
-                },
-                new int[]{
-                        MorpheSettingsV4Theme.blend(
-                                tokens.surfaceContainer,
-                                accent,
-                                0.45f
-                        ),
-                        tokens.surfaceContainerHigh,
-                }
-        ));
+        return MorpheSettingsV14Ui.labels(
+                requireContext(),
+                tokens,
+                titleValue,
+                summaryValue
+        );
     }
 
     private void styleHost() {
@@ -863,10 +778,11 @@ public final class MorpheSettingsV4SavedViewsFragment extends Fragment {
     }
 
     private void addSectionLabel(LinearLayout parent, String value) {
-        TextView label = textView(value, 14, tokens.primary);
-        label.setTypeface(Typeface.create("sans-serif-medium", Typeface.NORMAL));
-        label.setLetterSpacing(0.02f);
-        parent.addView(label);
+        parent.addView(MorpheSettingsV14Ui.sectionLabel(
+                requireContext(),
+                tokens,
+                value
+        ));
     }
 
     private TextView textView(String value, int sizeSp, int color) {

--- a/extensions/boostforreddit/src/main/java/app/morphe/extension/boostforreddit/settings/MorpheSettingsV4SavedViewsFragment.java
+++ b/extensions/boostforreddit/src/main/java/app/morphe/extension/boostforreddit/settings/MorpheSettingsV4SavedViewsFragment.java
@@ -1,0 +1,882 @@
+package app.morphe.extension.boostforreddit.settings;
+
+import android.app.Activity;
+import android.app.Dialog;
+import android.content.Context;
+import android.content.SharedPreferences;
+import android.content.res.ColorStateList;
+import android.graphics.Color;
+import android.graphics.Typeface;
+import android.graphics.drawable.ColorDrawable;
+import android.os.Build;
+import android.os.Bundle;
+import android.text.TextUtils;
+import android.view.inputmethod.EditorInfo;
+import android.view.Gravity;
+import android.view.LayoutInflater;
+import android.view.Menu;
+import android.view.MenuItem;
+import android.view.View;
+import android.view.ViewGroup;
+import android.view.Window;
+import android.widget.EditText;
+import android.widget.ImageView;
+import android.widget.LinearLayout;
+import android.widget.RadioButton;
+import android.widget.ScrollView;
+import android.widget.Switch;
+import android.widget.TextView;
+
+import androidx.fragment.app.Fragment;
+
+import app.morphe.extension.boostforreddit.utils.BoostSystemBarInsetsFix;
+
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+/** Material 3 editor for Boost's per-community saved post views. */
+public final class MorpheSettingsV4SavedViewsFragment extends Fragment {
+    public static final String CONTRACT_MARKER =
+            "MORPHE_BOOST_SETTINGS_V4_SAVED_VIEWS_ISSUE106_V1";
+
+    private static final String SAVED_VIEWS_PREFERENCES =
+            "com.rubenmayayo.reddit.VIEW_PER_SUBSCRIPTION";
+    private static final String MULTI_SUFFIX = ".multi";
+    private static final String FRONT_PAGE_KEY =
+            "_load_front_page_this_is_not_a_subreddit";
+    private static final String SAVED_KEY =
+            "_load_saved_this_is_not_a_subreddit";
+    private static final String HISTORY_KEY =
+            "_load_history_this_is_not_a_subreddit";
+
+    private static final String[] VIEW_TITLES = new String[]{
+            "Cards",
+            "Cards 2.0",
+            "Compact",
+            "Small cards",
+            "Dense",
+            "Columns",
+            "Images",
+            "Swipe",
+    };
+    private static final int[] VIEW_VALUES = new int[]{
+            0, 7, 1, 4, 5, 2, 6, 3,
+    };
+
+    private MorpheSettingsV4Theme.Tokens tokens;
+    private SharedPreferences savedViews;
+    private LinearLayout entriesHost;
+
+    public MorpheSettingsV4SavedViewsFragment() {
+    }
+
+    @Override
+    public View onCreateView(
+            LayoutInflater inflater,
+            ViewGroup container,
+            Bundle savedInstanceState
+    ) {
+        Context context = inflater.getContext();
+        tokens = MorpheSettingsV4Theme.resolve(context);
+        savedViews = context.getSharedPreferences(
+                SAVED_VIEWS_PREFERENCES,
+                Context.MODE_PRIVATE
+        );
+        setHasOptionsMenu(true);
+
+        ScrollView scrollView = new ScrollView(context);
+        scrollView.setFillViewport(true);
+        scrollView.setClipToPadding(false);
+        scrollView.setBackgroundColor(tokens.background);
+
+        entriesHost = new LinearLayout(context);
+        entriesHost.setOrientation(LinearLayout.VERTICAL);
+        entriesHost.setPadding(dp(18), dp(12), dp(18), dp(32));
+        scrollView.addView(
+                entriesHost,
+                new ScrollView.LayoutParams(
+                        ViewGroup.LayoutParams.MATCH_PARENT,
+                        ViewGroup.LayoutParams.WRAP_CONTENT
+                )
+        );
+        rebuildEntries();
+        return scrollView;
+    }
+
+    @Override
+    public void onResume() {
+        super.onResume();
+        if (entriesHost != null) {
+            rebuildEntries();
+        }
+        styleHost();
+    }
+
+    @Override
+    public void onPause() {
+        Activity activity = hostActivity();
+        if (activity != null) {
+            BoostSystemBarInsetsFix.clearMorpheSettingsV4SystemBars(activity);
+        }
+        super.onPause();
+    }
+
+    @Override
+    public void onPrepareOptionsMenu(Menu menu) {
+        super.onPrepareOptionsMenu(menu);
+        hideMenuItem(menu, "action_generic_search");
+        hideMenuItem(menu, "action_search");
+        hideMenuItem(menu, "search");
+    }
+
+    private void rebuildEntries() {
+        if (entriesHost == null || savedViews == null) {
+            return;
+        }
+        entriesHost.removeAllViews();
+        addSectionLabel(entriesHost, "Community views");
+        addSpace(entriesHost, 8);
+
+        addAddSavedViewCard(entriesHost);
+        addSpace(entriesHost, 12);
+
+        List<SavedView> entries = readEntries();
+        if (entries.isEmpty()) {
+            addEmptyState(entriesHost);
+            addSpace(entriesHost, 18);
+            addExplanation(entriesHost);
+            return;
+        }
+
+        LinearLayout group = addGroup(entriesHost);
+        for (SavedView entry : entries) {
+            addSavedViewRow(group, entry);
+        }
+
+        addSpace(entriesHost, 18);
+        TextView clearAll = actionText("Clear all saved views");
+        clearAll.setOnClickListener(view -> showConfirmation(
+                "Clear saved views?",
+                "This removes the saved view for every community.",
+                "Clear all",
+                () -> {
+                    savedViews.edit().clear().apply();
+                    rebuildEntries();
+                }
+        ));
+        LinearLayout.LayoutParams clearParams = wrapParams();
+        clearParams.gravity = Gravity.CENTER_HORIZONTAL;
+        entriesHost.addView(clearAll, clearParams);
+
+        addSpace(entriesHost, 14);
+        addExplanation(entriesHost);
+    }
+
+    private void addAddSavedViewCard(LinearLayout parent) {
+        Context context = requireContext();
+        MorpheSettingsV4Theme.Accent accent = tokens.navigationAccent();
+        LinearLayout action = new LinearLayout(context);
+        action.setOrientation(LinearLayout.HORIZONTAL);
+        action.setGravity(Gravity.CENTER_VERTICAL);
+        action.setMinimumHeight(dp(72));
+        action.setPadding(dp(18), dp(10), dp(14), dp(10));
+        action.setClickable(true);
+        action.setFocusable(true);
+        action.setBackground(MorpheSettingsV4Theme.interactive(
+                context,
+                MorpheSettingsV4Theme.blend(
+                        tokens.surfaceContainer,
+                        accent.container,
+                        tokens.dark ? 0.12f : 0.08f
+                ),
+                24,
+                accent.color
+        ));
+        action.setOnClickListener(view -> showAddSavedViewDialog());
+
+        TextView plus = textView("+", 26, accent.color);
+        plus.setGravity(Gravity.CENTER);
+        plus.setTypeface(Typeface.create("sans-serif-medium", Typeface.NORMAL));
+        action.addView(plus, new LinearLayout.LayoutParams(dp(44), dp(44)));
+
+        LinearLayout labels = createLabels(
+                "Add saved view",
+                "Choose a community or custom feed and its view"
+        );
+        LinearLayout.LayoutParams labelsLayout = labelsParams();
+        labelsLayout.setMarginStart(dp(10));
+        action.addView(labels, labelsLayout);
+        parent.addView(action, new LinearLayout.LayoutParams(
+                ViewGroup.LayoutParams.MATCH_PARENT,
+                ViewGroup.LayoutParams.WRAP_CONTENT
+        ));
+    }
+
+    private void showAddSavedViewDialog() {
+        Context context = requireContext();
+        Dialog dialog = new Dialog(context);
+        LinearLayout content = dialogContent();
+
+        TextView heading = textView("Add saved view", 20, tokens.textPrimary);
+        heading.setTypeface(Typeface.create("sans-serif-medium", Typeface.NORMAL));
+        content.addView(heading);
+
+        TextView description = textView(
+                "Enter a community name, then choose the view Boost should remember.",
+                14,
+                tokens.textSecondary
+        );
+        description.setLineSpacing(0, 1.08f);
+        LinearLayout.LayoutParams descriptionParams = wrapParams();
+        descriptionParams.topMargin = dp(6);
+        content.addView(description, descriptionParams);
+
+        EditText name = new EditText(context);
+        name.setSingleLine(true);
+        name.setHint("Community name");
+        name.setTextColor(tokens.textPrimary);
+        name.setHintTextColor(tokens.textSecondary);
+        name.setTextSize(16);
+        name.setImeOptions(EditorInfo.IME_ACTION_NEXT);
+        name.setPadding(dp(14), dp(11), dp(14), dp(11));
+        name.setBackground(MorpheSettingsV4Theme.interactive(
+                context,
+                tokens.surfaceContainer,
+                16,
+                tokens.navigationAccent().color
+        ));
+        LinearLayout.LayoutParams nameParams = new LinearLayout.LayoutParams(
+                ViewGroup.LayoutParams.MATCH_PARENT,
+                ViewGroup.LayoutParams.WRAP_CONTENT
+        );
+        nameParams.topMargin = dp(14);
+        content.addView(name, nameParams);
+
+        LinearLayout customFeedRow = dialogChoiceRow();
+        TextView customFeedLabel = textView(
+                "Custom feed",
+                15,
+                tokens.textPrimary
+        );
+        customFeedRow.addView(customFeedLabel, labelsParams());
+        Switch customFeed = new Switch(context);
+        tintSwitch(customFeed);
+        customFeedRow.addView(customFeed);
+        customFeedRow.setOnClickListener(
+                view -> customFeed.setChecked(!customFeed.isChecked())
+        );
+        LinearLayout.LayoutParams customParams = new LinearLayout.LayoutParams(
+                ViewGroup.LayoutParams.MATCH_PARENT,
+                ViewGroup.LayoutParams.WRAP_CONTENT
+        );
+        customParams.topMargin = dp(6);
+        content.addView(customFeedRow, customParams);
+
+        LinearLayout actions = new LinearLayout(context);
+        actions.setGravity(Gravity.END | Gravity.CENTER_VERTICAL);
+        TextView cancel = dialogAction("Cancel");
+        cancel.setOnClickListener(view -> dialog.dismiss());
+        actions.addView(cancel);
+        TextView continueButton = dialogAction("Choose view");
+        continueButton.setOnClickListener(view -> {
+            String key = normalizeSavedViewKey(
+                    name.getText().toString(),
+                    customFeed.isChecked()
+            );
+            if (TextUtils.isEmpty(key)) {
+                name.setError("Enter a community name");
+                return;
+            }
+            int current = savedViews.contains(key)
+                    ? parseViewType(savedViews.getAll().get(key))
+                    : 0;
+            dialog.dismiss();
+            showViewTypeDialog(new SavedView(
+                    key,
+                    displayName(key),
+                    current
+            ));
+        });
+        actions.addView(continueButton);
+        LinearLayout.LayoutParams actionParams = new LinearLayout.LayoutParams(
+                ViewGroup.LayoutParams.MATCH_PARENT,
+                ViewGroup.LayoutParams.WRAP_CONTENT
+        );
+        actionParams.topMargin = dp(8);
+        content.addView(actions, actionParams);
+        showDialog(dialog, content);
+    }
+
+    private String normalizeSavedViewKey(String rawValue, boolean customFeed) {
+        String value = rawValue == null ? "" : rawValue.trim();
+        while (value.startsWith("/")) {
+            value = value.substring(1);
+        }
+        if (value.regionMatches(true, 0, "r/", 0, 2)) {
+            value = value.substring(2);
+        }
+        if (value.regionMatches(true, 0, "u/", 0, 2)) {
+            int multi = value.toLowerCase().indexOf("/m/");
+            value = multi >= 0 ? value.substring(multi + 3) : value.substring(2);
+        }
+        value = value.trim();
+        if (TextUtils.isEmpty(value)) {
+            return null;
+        }
+        if (customFeed) {
+            return value.endsWith(MULTI_SUFFIX)
+                    ? value
+                    : value + MULTI_SUFFIX;
+        }
+        if ("home".equalsIgnoreCase(value)
+                || "front page".equalsIgnoreCase(value)
+                || "frontpage".equalsIgnoreCase(value)) {
+            return FRONT_PAGE_KEY;
+        }
+        if ("saved".equalsIgnoreCase(value)) {
+            return SAVED_KEY;
+        }
+        if ("history".equalsIgnoreCase(value)) {
+            return HISTORY_KEY;
+        }
+        return value;
+    }
+
+    private List<SavedView> readEntries() {
+        List<SavedView> result = new ArrayList<>();
+        for (Map.Entry<String, ?> entry : savedViews.getAll().entrySet()) {
+            int viewType = parseViewType(entry.getValue());
+            result.add(new SavedView(
+                    entry.getKey(),
+                    displayName(entry.getKey()),
+                    viewType
+            ));
+        }
+        Collections.sort(
+                result,
+                (left, right) -> left.key.compareToIgnoreCase(right.key)
+        );
+        return result;
+    }
+
+    private int parseViewType(Object value) {
+        if (value instanceof Number) {
+            return ((Number) value).intValue();
+        }
+        try {
+            return Integer.parseInt(String.valueOf(value));
+        } catch (NumberFormatException ignored) {
+            return 0;
+        }
+    }
+
+    private void addEmptyState(LinearLayout parent) {
+        LinearLayout group = addGroup(parent);
+        group.setPadding(dp(22), dp(22), dp(22), dp(22));
+
+        TextView title = textView("No saved views yet", 18, tokens.textPrimary);
+        title.setTypeface(Typeface.create("sans-serif-medium", Typeface.NORMAL));
+        group.addView(title);
+
+        TextView summary = textView(
+                "Choose a different view inside a community and Boost will "
+                        + "remember it here.",
+                15,
+                tokens.textSecondary
+        );
+        summary.setLineSpacing(0, 1.08f);
+        LinearLayout.LayoutParams summaryParams = wrapParams();
+        summaryParams.topMargin = dp(6);
+        group.addView(summary, summaryParams);
+    }
+
+    private void addExplanation(LinearLayout parent) {
+        TextView note = textView(
+                "Saved views are used when Remember per community is enabled.",
+                14,
+                tokens.textSecondary
+        );
+        note.setLineSpacing(0, 1.08f);
+        LinearLayout.LayoutParams noteParams = new LinearLayout.LayoutParams(
+                ViewGroup.LayoutParams.MATCH_PARENT,
+                ViewGroup.LayoutParams.WRAP_CONTENT
+        );
+        noteParams.setMarginStart(dp(18));
+        noteParams.setMarginEnd(dp(18));
+        parent.addView(note, noteParams);
+    }
+
+    private void addSavedViewRow(LinearLayout group, SavedView entry) {
+        Context context = requireContext();
+        MorpheSettingsV4Theme.Accent accent = tokens.navigationAccent();
+        LinearLayout row = new LinearLayout(context);
+        row.setOrientation(LinearLayout.HORIZONTAL);
+        row.setGravity(Gravity.CENTER_VERTICAL);
+        row.setMinimumHeight(dp(72));
+        row.setPadding(dp(18), dp(9), dp(8), dp(9));
+        row.setClickable(true);
+        row.setFocusable(true);
+        row.setBackground(MorpheSettingsV4Theme.interactive(
+                context,
+                Color.TRANSPARENT,
+                0,
+                accent.color
+        ));
+        row.setOnClickListener(view -> showViewTypeDialog(entry));
+
+        row.addView(
+                createLabels(entry.title, viewTitle(entry.viewType)),
+                labelsParams()
+        );
+
+        ImageView delete = new ImageView(context);
+        delete.setImageResource(android.R.drawable.ic_menu_delete);
+        delete.setColorFilter(tokens.textSecondary);
+        delete.setScaleType(ImageView.ScaleType.CENTER_INSIDE);
+        delete.setContentDescription("Delete " + entry.title);
+        delete.setClickable(true);
+        delete.setFocusable(true);
+        delete.setBackground(MorpheSettingsV4Theme.interactive(
+                context,
+                Color.TRANSPARENT,
+                22,
+                accent.color
+        ));
+        delete.setOnClickListener(view -> showConfirmation(
+                "Remove saved view?",
+                entry.title + " will use the default view again.",
+                "Remove",
+                () -> {
+                    savedViews.edit().remove(entry.key).apply();
+                    rebuildEntries();
+                }
+        ));
+        row.addView(delete, new LinearLayout.LayoutParams(dp(48), dp(48)));
+
+        addGroupedRow(group, row);
+    }
+
+    private void showViewTypeDialog(SavedView entry) {
+        Context context = requireContext();
+        Dialog dialog = new Dialog(context);
+        LinearLayout content = dialogContent();
+
+        TextView heading = textView(entry.title, 20, tokens.textPrimary);
+        heading.setTypeface(Typeface.create("sans-serif-medium", Typeface.NORMAL));
+        LinearLayout.LayoutParams headingParams = wrapParams();
+        headingParams.setMarginStart(dp(8));
+        headingParams.bottomMargin = dp(8);
+        content.addView(heading, headingParams);
+
+        for (int index = 0; index < VIEW_TITLES.length; index++) {
+            final int choice = index;
+            LinearLayout row = dialogChoiceRow();
+            RadioButton radio = new RadioButton(context);
+            radio.setChecked(VIEW_VALUES[index] == entry.viewType);
+            radio.setClickable(false);
+            radio.setFocusable(false);
+            tintRadioButton(radio);
+            row.addView(radio);
+
+            TextView label = textView(VIEW_TITLES[index], 16, tokens.textPrimary);
+            row.addView(label, labelsParams());
+            row.setOnClickListener(view -> {
+                savedViews.edit()
+                        .putInt(entry.key, VIEW_VALUES[choice])
+                        .apply();
+                dialog.dismiss();
+                rebuildEntries();
+            });
+            content.addView(row, new LinearLayout.LayoutParams(
+                    ViewGroup.LayoutParams.MATCH_PARENT,
+                    ViewGroup.LayoutParams.WRAP_CONTENT
+            ));
+        }
+
+        addDialogAction(content, "Cancel", () -> dialog.dismiss());
+        showDialog(dialog, content);
+    }
+
+    private void showConfirmation(
+            String titleValue,
+            String message,
+            String confirmLabel,
+            Runnable confirmation
+    ) {
+        Dialog dialog = new Dialog(requireContext());
+        LinearLayout content = dialogContent();
+
+        TextView title = textView(titleValue, 20, tokens.textPrimary);
+        title.setTypeface(Typeface.create("sans-serif-medium", Typeface.NORMAL));
+        content.addView(title);
+
+        TextView body = textView(message, 15, tokens.textSecondary);
+        body.setLineSpacing(0, 1.08f);
+        LinearLayout.LayoutParams bodyParams = wrapParams();
+        bodyParams.topMargin = dp(8);
+        bodyParams.bottomMargin = dp(14);
+        content.addView(body, bodyParams);
+
+        LinearLayout actions = new LinearLayout(requireContext());
+        actions.setGravity(Gravity.END | Gravity.CENTER_VERTICAL);
+        TextView cancel = dialogAction("Cancel");
+        cancel.setOnClickListener(view -> dialog.dismiss());
+        actions.addView(cancel);
+        TextView confirm = dialogAction(confirmLabel);
+        confirm.setOnClickListener(view -> {
+            dialog.dismiss();
+            confirmation.run();
+        });
+        actions.addView(confirm);
+        content.addView(actions, new LinearLayout.LayoutParams(
+                ViewGroup.LayoutParams.MATCH_PARENT,
+                ViewGroup.LayoutParams.WRAP_CONTENT
+        ));
+        showDialog(dialog, content);
+    }
+
+    private LinearLayout dialogContent() {
+        LinearLayout content = new LinearLayout(requireContext());
+        content.setOrientation(LinearLayout.VERTICAL);
+        content.setPadding(dp(20), dp(20), dp(20), dp(14));
+        content.setBackground(MorpheSettingsV4Theme.rounded(
+                requireContext(),
+                tokens.surfaceContainerHigh,
+                28
+        ));
+        return content;
+    }
+
+    private LinearLayout dialogChoiceRow() {
+        LinearLayout row = new LinearLayout(requireContext());
+        row.setOrientation(LinearLayout.HORIZONTAL);
+        row.setGravity(Gravity.CENTER_VERTICAL);
+        row.setMinimumHeight(dp(52));
+        row.setPadding(dp(4), 0, dp(8), 0);
+        row.setBackground(MorpheSettingsV4Theme.interactive(
+                requireContext(),
+                Color.TRANSPARENT,
+                16,
+                tokens.navigationAccent().color
+        ));
+        return row;
+    }
+
+    private void addDialogAction(
+            LinearLayout content,
+            String value,
+            Runnable action
+    ) {
+        TextView button = dialogAction(value);
+        button.setOnClickListener(view -> action.run());
+        LinearLayout.LayoutParams params = wrapParams();
+        params.gravity = Gravity.END;
+        params.topMargin = dp(4);
+        content.addView(button, params);
+    }
+
+    private TextView dialogAction(String value) {
+        TextView button = textView(value, 14, tokens.navigationAccent().color);
+        button.setTypeface(Typeface.create("sans-serif-medium", Typeface.NORMAL));
+        button.setGravity(Gravity.CENTER);
+        button.setAllCaps(false);
+        button.setPadding(dp(14), dp(10), dp(14), dp(10));
+        button.setBackground(MorpheSettingsV4Theme.interactive(
+                requireContext(),
+                Color.TRANSPARENT,
+                18,
+                tokens.navigationAccent().color
+        ));
+        return button;
+    }
+
+    private TextView actionText(String value) {
+        TextView action = dialogAction(value);
+        action.setTextSize(15);
+        return action;
+    }
+
+    private void showDialog(Dialog dialog, LinearLayout content) {
+        Context context = requireContext();
+        dialog.setContentView(content);
+        Window window = dialog.getWindow();
+        if (window != null) {
+            window.setBackgroundDrawable(new ColorDrawable(Color.TRANSPARENT));
+        }
+        dialog.show();
+        window = dialog.getWindow();
+        if (window != null) {
+            int width = context.getResources().getDisplayMetrics().widthPixels
+                    - dp(40);
+            window.setLayout(width, ViewGroup.LayoutParams.WRAP_CONTENT);
+        }
+    }
+
+    private String displayName(String key) {
+        String nativeTitle = nativeDisplayName(key);
+        if (!TextUtils.isEmpty(nativeTitle)) {
+            return nativeTitle;
+        }
+        if ("_load_front_page_this_is_not_a_subreddit".equals(key)) {
+            return "Front page";
+        }
+        if ("_load_saved_this_is_not_a_subreddit".equals(key)) {
+            return "Saved";
+        }
+        if ("_load_history_this_is_not_a_subreddit".equals(key)) {
+            return "History";
+        }
+        if ("all".equalsIgnoreCase(key) || "popular".equalsIgnoreCase(key)) {
+            return "r/" + key;
+        }
+        if (key.endsWith(MULTI_SUFFIX)) {
+            return "Custom feed · "
+                    + key.substring(0, key.length() - MULTI_SUFFIX.length());
+        }
+        return key.startsWith("r/") ? key : "r/" + key;
+    }
+
+    private String nativeDisplayName(String key) {
+        try {
+            Class<?> managerClass = Class.forName("he.k0");
+            Object manager = managerClass.getDeclaredMethod("e").invoke(null);
+            Method createModel = managerClass.getDeclaredMethod(
+                    "i",
+                    String.class
+            );
+            Object model = createModel.invoke(manager, key);
+            Class<?> modelClass = Class.forName(
+                    "com.rubenmayayo.reddit.models.reddit.SubscriptionViewModel"
+            );
+            Method display = Class.forName("he.h0").getDeclaredMethod(
+                    "Z0",
+                    Context.class,
+                    modelClass
+            );
+            Object value = display.invoke(null, requireContext(), model);
+            return value instanceof String ? (String) value : null;
+        } catch (Throwable ignored) {
+            return null;
+        }
+    }
+
+    private String viewTitle(int viewType) {
+        try {
+            Method display = Class.forName("he.h0").getDeclaredMethod(
+                    "a1",
+                    Context.class,
+                    int.class
+            );
+            Object value = display.invoke(null, requireContext(), viewType);
+            if (value instanceof String && !TextUtils.isEmpty((String) value)) {
+                return (String) value;
+            }
+        } catch (Throwable ignored) {
+        }
+        for (int index = 0; index < VIEW_VALUES.length; index++) {
+            if (VIEW_VALUES[index] == viewType) {
+                return VIEW_TITLES[index];
+            }
+        }
+        return "View " + viewType;
+    }
+
+    private LinearLayout addGroup(LinearLayout parent) {
+        Context context = requireContext();
+        MorpheSettingsV4Theme.Accent accent = tokens.navigationAccent();
+        int groupColor = MorpheSettingsV4Theme.blend(
+                tokens.surfaceContainer,
+                accent.container,
+                tokens.dark ? 0.035f : 0.025f
+        );
+        LinearLayout group = new LinearLayout(context);
+        group.setOrientation(LinearLayout.VERTICAL);
+        group.setBackground(MorpheSettingsV4Theme.rounded(
+                context,
+                groupColor,
+                24
+        ));
+        group.setClipToOutline(true);
+        parent.addView(group, new LinearLayout.LayoutParams(
+                ViewGroup.LayoutParams.MATCH_PARENT,
+                ViewGroup.LayoutParams.WRAP_CONTENT
+        ));
+        return group;
+    }
+
+    private void addGroupedRow(LinearLayout group, LinearLayout row) {
+        if (group.getChildCount() > 0) {
+            View divider = new View(requireContext());
+            divider.setBackgroundColor(MorpheSettingsV4Theme.blend(
+                    tokens.surfaceContainer,
+                    tokens.outline,
+                    tokens.dark ? 0.22f : 0.16f
+            ));
+            LinearLayout.LayoutParams dividerParams = new LinearLayout.LayoutParams(
+                    ViewGroup.LayoutParams.MATCH_PARENT,
+                    dp(1)
+            );
+            dividerParams.setMarginStart(dp(18));
+            dividerParams.setMarginEnd(dp(18));
+            group.addView(divider, dividerParams);
+        }
+        group.addView(row, new LinearLayout.LayoutParams(
+                ViewGroup.LayoutParams.MATCH_PARENT,
+                ViewGroup.LayoutParams.WRAP_CONTENT
+        ));
+    }
+
+    private LinearLayout createLabels(String titleValue, String summaryValue) {
+        LinearLayout labels = new LinearLayout(requireContext());
+        labels.setOrientation(LinearLayout.VERTICAL);
+        TextView title = textView(titleValue, 16, tokens.textPrimary);
+        title.setTypeface(Typeface.create("sans-serif-medium", Typeface.NORMAL));
+        labels.addView(title);
+        TextView summary = textView(summaryValue, 14, tokens.textSecondary);
+        LinearLayout.LayoutParams summaryParams = wrapParams();
+        summaryParams.topMargin = dp(3);
+        labels.addView(summary, summaryParams);
+        return labels;
+    }
+
+    private void tintRadioButton(RadioButton radio) {
+        if (Build.VERSION.SDK_INT < 21) {
+            return;
+        }
+        radio.setButtonTintList(new ColorStateList(
+                new int[][]{
+                        new int[]{android.R.attr.state_checked},
+                        new int[]{-android.R.attr.state_checked},
+                },
+                new int[]{
+                        tokens.navigationAccent().color,
+                        tokens.textSecondary,
+                }
+        ));
+    }
+
+    private void tintSwitch(Switch toggle) {
+        if (Build.VERSION.SDK_INT < 21) {
+            return;
+        }
+        int accent = tokens.navigationAccent().color;
+        toggle.setThumbTintList(new ColorStateList(
+                new int[][]{
+                        new int[]{android.R.attr.state_checked},
+                        new int[]{-android.R.attr.state_checked},
+                },
+                new int[]{accent, tokens.textSecondary}
+        ));
+        toggle.setTrackTintList(new ColorStateList(
+                new int[][]{
+                        new int[]{android.R.attr.state_checked},
+                        new int[]{-android.R.attr.state_checked},
+                },
+                new int[]{
+                        MorpheSettingsV4Theme.blend(
+                                tokens.surfaceContainer,
+                                accent,
+                                0.45f
+                        ),
+                        tokens.surfaceContainerHigh,
+                }
+        ));
+    }
+
+    private void styleHost() {
+        Activity activity = hostActivity();
+        if (activity == null || tokens == null) {
+            return;
+        }
+        activity.setTitle("Saved views");
+        BoostSystemBarInsetsFix.applyMorpheSettingsV4SystemBars(
+                activity,
+                tokens.background,
+                tokens.dark
+        );
+        int toolbarId = MorpheSettingsV4Catalog.resourceId(
+                activity,
+                "id",
+                "toolbar"
+        );
+        View toolbar = activity.findViewById(toolbarId);
+        if (toolbar != null) {
+            toolbar.setBackgroundColor(tokens.background);
+            toolbar.setElevation(0);
+        }
+    }
+
+    private Activity hostActivity() {
+        Context context = requireContext();
+        return context instanceof Activity ? (Activity) context : null;
+    }
+
+    private void hideMenuItem(Menu menu, String resourceName) {
+        int resourceId = MorpheSettingsV4Catalog.resourceId(
+                requireContext(),
+                "id",
+                resourceName
+        );
+        if (resourceId == 0) {
+            return;
+        }
+        MenuItem item = menu.findItem(resourceId);
+        if (item != null) {
+            item.setVisible(false);
+        }
+    }
+
+    private void addSectionLabel(LinearLayout parent, String value) {
+        TextView label = textView(value, 14, tokens.primary);
+        label.setTypeface(Typeface.create("sans-serif-medium", Typeface.NORMAL));
+        label.setLetterSpacing(0.02f);
+        parent.addView(label);
+    }
+
+    private TextView textView(String value, int sizeSp, int color) {
+        TextView textView = new TextView(requireContext());
+        textView.setText(value);
+        textView.setTextSize(sizeSp);
+        textView.setTextColor(color);
+        return textView;
+    }
+
+    private LinearLayout.LayoutParams labelsParams() {
+        return new LinearLayout.LayoutParams(
+                0,
+                ViewGroup.LayoutParams.WRAP_CONTENT,
+                1.0f
+        );
+    }
+
+    private LinearLayout.LayoutParams wrapParams() {
+        return new LinearLayout.LayoutParams(
+                ViewGroup.LayoutParams.WRAP_CONTENT,
+                ViewGroup.LayoutParams.WRAP_CONTENT
+        );
+    }
+
+    private void addSpace(LinearLayout parent, int heightDp) {
+        View space = new View(requireContext());
+        parent.addView(space, new LinearLayout.LayoutParams(1, dp(heightDp)));
+    }
+
+    private int dp(float value) {
+        return MorpheSettingsV4Theme.dp(requireContext(), value);
+    }
+
+    private static final class SavedView {
+        final String key;
+        final String title;
+        final int viewType;
+
+        SavedView(String key, String title, int viewType) {
+            this.key = key;
+            this.title = title;
+            this.viewType = viewType;
+        }
+    }
+}

--- a/extensions/boostforreddit/src/main/java/app/morphe/extension/boostforreddit/settings/MorpheSettingsV4SavedViewsFragment.java
+++ b/extensions/boostforreddit/src/main/java/app/morphe/extension/boostforreddit/settings/MorpheSettingsV4SavedViewsFragment.java
@@ -163,7 +163,7 @@ public final class MorpheSettingsV4SavedViewsFragment extends Fragment {
                 "This removes the saved view for every community.",
                 "Clear all",
                 () -> {
-                    savedViews.edit().clear().apply();
+                    clearSavedViews(savedViews);
                     rebuildEntries();
                 }
         ));
@@ -450,7 +450,7 @@ public final class MorpheSettingsV4SavedViewsFragment extends Fragment {
                 entry.title + " will use the default view again.",
                 "Remove",
                 () -> {
-                    savedViews.edit().remove(entry.key).apply();
+                    removeSavedView(savedViews, entry.key);
                     rebuildEntries();
                 }
         ));
@@ -484,9 +484,11 @@ public final class MorpheSettingsV4SavedViewsFragment extends Fragment {
             TextView label = textView(VIEW_TITLES[index], 16, tokens.textPrimary);
             row.addView(label, labelsParams());
             row.setOnClickListener(view -> {
-                savedViews.edit()
-                        .putInt(entry.key, VIEW_VALUES[choice])
-                        .apply();
+                applySavedView(
+                        savedViews,
+                        entry.key,
+                        VIEW_VALUES[choice]
+                );
                 dialog.dismiss();
                 rebuildEntries();
             });
@@ -498,6 +500,37 @@ public final class MorpheSettingsV4SavedViewsFragment extends Fragment {
 
         addDialogAction(content, "Cancel", () -> dialog.dismiss());
         showDialog(dialog, content);
+    }
+
+    static void applySavedView(
+            SharedPreferences savedViews,
+            String key,
+            int viewType
+    ) {
+        if (TextUtils.isEmpty(key) || indexOfViewType(viewType) < 0) {
+            throw new IllegalArgumentException("invalid saved view");
+        }
+        savedViews.edit().putInt(key, viewType).apply();
+    }
+
+    static void removeSavedView(
+            SharedPreferences savedViews,
+            String key
+    ) {
+        savedViews.edit().remove(key).apply();
+    }
+
+    static void clearSavedViews(SharedPreferences savedViews) {
+        savedViews.edit().clear().apply();
+    }
+
+    private static int indexOfViewType(int viewType) {
+        for (int index = 0; index < VIEW_VALUES.length; index++) {
+            if (VIEW_VALUES[index] == viewType) {
+                return index;
+            }
+        }
+        return -1;
     }
 
     private void showConfirmation(

--- a/extensions/boostforreddit/src/main/java/app/morphe/extension/boostforreddit/settings/MorpheSettingsV4Theme.java
+++ b/extensions/boostforreddit/src/main/java/app/morphe/extension/boostforreddit/settings/MorpheSettingsV4Theme.java
@@ -1,0 +1,369 @@
+package app.morphe.extension.boostforreddit.settings;
+
+import android.content.Context;
+import android.content.res.ColorStateList;
+import android.content.res.Configuration;
+import android.content.res.Resources;
+import android.content.res.TypedArray;
+import android.graphics.Color;
+import android.graphics.drawable.Drawable;
+import android.graphics.drawable.GradientDrawable;
+import android.graphics.drawable.RippleDrawable;
+import android.os.Build;
+import android.util.TypedValue;
+
+final class MorpheSettingsV4Theme {
+    static final class Accent {
+        final int color;
+        final int container;
+        final int onContainer;
+
+        Accent(int color, int container, int onContainer) {
+            this.color = color;
+            this.container = container;
+            this.onContainer = onContainer;
+        }
+    }
+
+    static final class Tokens {
+        final boolean dark;
+        final int background;
+        final int surface;
+        final int surfaceContainer;
+        final int surfaceContainerHigh;
+        final int primary;
+        final int primaryContainer;
+        final int onPrimaryContainer;
+        final int secondary;
+        final int secondaryContainer;
+        final int onSecondaryContainer;
+        final int tertiary;
+        final int tertiaryContainer;
+        final int onTertiaryContainer;
+        final int textPrimary;
+        final int textSecondary;
+        final int outline;
+
+        Tokens(
+                boolean dark,
+                int background,
+                int surface,
+                int surfaceContainer,
+                int surfaceContainerHigh,
+                int primary,
+                int primaryContainer,
+                int onPrimaryContainer,
+                int secondary,
+                int secondaryContainer,
+                int onSecondaryContainer,
+                int tertiary,
+                int tertiaryContainer,
+                int onTertiaryContainer,
+                int textPrimary,
+                int textSecondary,
+                int outline
+        ) {
+            this.dark = dark;
+            this.background = background;
+            this.surface = surface;
+            this.surfaceContainer = surfaceContainer;
+            this.surfaceContainerHigh = surfaceContainerHigh;
+            this.primary = primary;
+            this.primaryContainer = primaryContainer;
+            this.onPrimaryContainer = onPrimaryContainer;
+            this.secondary = secondary;
+            this.secondaryContainer = secondaryContainer;
+            this.onSecondaryContainer = onSecondaryContainer;
+            this.tertiary = tertiary;
+            this.tertiaryContainer = tertiaryContainer;
+            this.onTertiaryContainer = onTertiaryContainer;
+            this.textPrimary = textPrimary;
+            this.textSecondary = textSecondary;
+            this.outline = outline;
+        }
+
+        Accent navigationAccent() {
+            return new Accent(
+                    secondary,
+                    secondaryContainer,
+                    onSecondaryContainer
+            );
+        }
+    }
+
+    private MorpheSettingsV4Theme() {
+    }
+
+    static Tokens resolve(Context context) {
+        boolean dark = (context.getResources().getConfiguration().uiMode
+                & Configuration.UI_MODE_NIGHT_MASK)
+                == Configuration.UI_MODE_NIGHT_YES;
+
+        int fallbackBackground = themeColor(
+                context,
+                android.R.attr.colorBackground,
+                dark ? Color.rgb(28, 27, 30) : Color.rgb(255, 251, 254)
+        );
+        int fallbackTextPrimary = themeColor(
+                context,
+                android.R.attr.textColorPrimary,
+                dark ? Color.rgb(231, 225, 229) : Color.rgb(29, 27, 30)
+        );
+        int fallbackTextSecondary = themeColor(
+                context,
+                android.R.attr.textColorSecondary,
+                dark ? Color.rgb(202, 196, 208) : Color.rgb(73, 69, 79)
+        );
+        int fallbackPrimary = themeColor(
+                context,
+                android.R.attr.colorAccent,
+                dark ? Color.rgb(208, 188, 255) : Color.rgb(103, 80, 164)
+        );
+
+        int paletteBackground = paletteColor(
+                context,
+                dark ? "system_neutral1_900" : "system_neutral1_10",
+                fallbackBackground
+        );
+        int background = blend(
+                dark ? Color.rgb(18, 18, 18) : Color.rgb(250, 249, 252),
+                paletteBackground,
+                dark ? 0.28f : 0.18f
+        );
+        int paletteSurface = paletteColor(
+                context,
+                dark ? "system_neutral1_900" : "system_neutral1_10",
+                fallbackBackground
+        );
+        int surface = blend(background, paletteSurface, 0.10f);
+        int paletteSurfaceContainer = paletteColor(
+                context,
+                dark ? "system_neutral1_800" : "system_neutral1_50",
+                blend(background, fallbackTextPrimary, dark ? 0.075f : 0.055f)
+        );
+        int surfaceContainer = blend(
+                blend(
+                        background,
+                        dark ? Color.WHITE : Color.BLACK,
+                        dark ? 0.07f : 0.035f
+                ),
+                paletteSurfaceContainer,
+                dark ? 0.20f : 0.15f
+        );
+        int paletteSurfaceContainerHigh = paletteColor(
+                context,
+                dark ? "system_neutral1_700" : "system_neutral1_100",
+                blend(background, fallbackTextPrimary, dark ? 0.12f : 0.09f)
+        );
+        int surfaceContainerHigh = blend(
+                blend(
+                        background,
+                        dark ? Color.WHITE : Color.BLACK,
+                        dark ? 0.11f : 0.065f
+                ),
+                paletteSurfaceContainerHigh,
+                dark ? 0.20f : 0.15f
+        );
+        int paletteTextPrimary = paletteColor(
+                context,
+                dark ? "system_neutral1_100" : "system_neutral1_900",
+                fallbackTextPrimary
+        );
+        int textPrimary = blend(
+                dark ? Color.rgb(242, 239, 242) : Color.rgb(33, 31, 33),
+                paletteTextPrimary,
+                dark ? 0.18f : 0.12f
+        );
+        int paletteTextSecondary = paletteColor(
+                context,
+                dark ? "system_neutral2_200" : "system_neutral2_700",
+                fallbackTextSecondary
+        );
+        int textSecondary = blend(
+                dark ? Color.rgb(199, 195, 199) : Color.rgb(91, 87, 92),
+                paletteTextSecondary,
+                dark ? 0.20f : 0.14f
+        );
+        int paletteOutline = paletteColor(
+                context,
+                dark ? "system_neutral2_400" : "system_neutral2_500",
+                withAlpha(fallbackTextSecondary, dark ? 150 : 135)
+        );
+        int outline = blend(
+                dark ? Color.rgb(146, 142, 147) : Color.rgb(120, 116, 121),
+                paletteOutline,
+                0.18f
+        );
+
+        int primary = paletteColor(
+                context,
+                dark ? "system_accent1_200" : "system_accent1_600",
+                fallbackPrimary
+        );
+        int primaryContainer = paletteColor(
+                context,
+                dark ? "system_accent1_700" : "system_accent1_100",
+                blend(background, primary, dark ? 0.34f : 0.18f)
+        );
+        int onPrimaryContainer = paletteColor(
+                context,
+                dark ? "system_accent1_100" : "system_accent1_900",
+                bestTextColor(primaryContainer, textPrimary)
+        );
+
+        int secondary = paletteColor(
+                context,
+                dark ? "system_accent2_200" : "system_accent2_600",
+                dark ? Color.rgb(204, 194, 220) : Color.rgb(98, 91, 113)
+        );
+        int secondaryContainer = paletteColor(
+                context,
+                dark ? "system_accent2_700" : "system_accent2_100",
+                dark ? Color.rgb(74, 68, 88) : Color.rgb(232, 222, 248)
+        );
+        int onSecondaryContainer = paletteColor(
+                context,
+                dark ? "system_accent2_100" : "system_accent2_900",
+                bestTextColor(secondaryContainer, textPrimary)
+        );
+
+        int tertiary = paletteColor(
+                context,
+                dark ? "system_accent3_200" : "system_accent3_600",
+                dark ? Color.rgb(239, 184, 200) : Color.rgb(125, 82, 96)
+        );
+        int tertiaryContainer = paletteColor(
+                context,
+                dark ? "system_accent3_700" : "system_accent3_100",
+                dark ? Color.rgb(99, 59, 72) : Color.rgb(255, 216, 228)
+        );
+        int onTertiaryContainer = paletteColor(
+                context,
+                dark ? "system_accent3_100" : "system_accent3_900",
+                bestTextColor(tertiaryContainer, textPrimary)
+        );
+
+        return new Tokens(
+                dark,
+                background,
+                surface,
+                surfaceContainer,
+                surfaceContainerHigh,
+                primary,
+                primaryContainer,
+                onPrimaryContainer,
+                secondary,
+                secondaryContainer,
+                onSecondaryContainer,
+                tertiary,
+                tertiaryContainer,
+                onTertiaryContainer,
+                textPrimary,
+                textSecondary,
+                outline
+        );
+    }
+
+    static Drawable rounded(Context context, int color, float radiusDp) {
+        GradientDrawable drawable = new GradientDrawable();
+        drawable.setColor(color);
+        drawable.setCornerRadius(dp(context, radiusDp));
+        return drawable;
+    }
+
+    static Drawable interactive(
+            Context context,
+            int color,
+            float radiusDp,
+            int rippleColor
+    ) {
+        Drawable content = rounded(context, color, radiusDp);
+        if (Build.VERSION.SDK_INT < 21) {
+            return content;
+        }
+        return new RippleDrawable(
+                ColorStateList.valueOf(withAlpha(rippleColor, 46)),
+                content,
+                null
+        );
+    }
+
+    static int dp(Context context, float value) {
+        return Math.round(TypedValue.applyDimension(
+                TypedValue.COMPLEX_UNIT_DIP,
+                value,
+                context.getResources().getDisplayMetrics()
+        ));
+    }
+
+    static int blend(int base, int overlay, float amount) {
+        float inverse = 1.0f - amount;
+        return Color.rgb(
+                Math.round(Color.red(base) * inverse + Color.red(overlay) * amount),
+                Math.round(Color.green(base) * inverse + Color.green(overlay) * amount),
+                Math.round(Color.blue(base) * inverse + Color.blue(overlay) * amount)
+        );
+    }
+
+    static int withAlpha(int color, int alpha) {
+        return Color.argb(
+                alpha,
+                Color.red(color),
+                Color.green(color),
+                Color.blue(color)
+        );
+    }
+
+    private static int themeColor(Context context, int attribute, int fallback) {
+        TypedArray values = context.obtainStyledAttributes(new int[]{attribute});
+        try {
+            return values.getColor(0, fallback);
+        } finally {
+            values.recycle();
+        }
+    }
+
+    private static int paletteColor(
+            Context context,
+            String resourceName,
+            int fallback
+    ) {
+        if (Build.VERSION.SDK_INT < 31) {
+            return fallback;
+        }
+
+        Resources resources = context.getResources();
+        int resourceId = resources.getIdentifier(resourceName, "color", "android");
+        if (resourceId == 0) {
+            return fallback;
+        }
+        return resources.getColor(resourceId, context.getTheme());
+    }
+
+    private static int bestTextColor(int background, int preferred) {
+        double backgroundLuminance = luminance(background);
+        double preferredContrast = contrast(backgroundLuminance, luminance(preferred));
+        int alternative = backgroundLuminance > 0.45 ? Color.BLACK : Color.WHITE;
+        double alternativeContrast = contrast(backgroundLuminance, luminance(alternative));
+        return preferredContrast >= alternativeContrast ? preferred : alternative;
+    }
+
+    private static double luminance(int color) {
+        double red = channel(Color.red(color) / 255.0);
+        double green = channel(Color.green(color) / 255.0);
+        double blue = channel(Color.blue(color) / 255.0);
+        return red * 0.2126 + green * 0.7152 + blue * 0.0722;
+    }
+
+    private static double channel(double value) {
+        return value <= 0.03928
+                ? value / 12.92
+                : Math.pow((value + 0.055) / 1.055, 2.4);
+    }
+
+    private static double contrast(double first, double second) {
+        double light = Math.max(first, second);
+        double dark = Math.min(first, second);
+        return (light + 0.05) / (dark + 0.05);
+    }
+}

--- a/extensions/boostforreddit/src/main/java/app/morphe/extension/boostforreddit/settings/MorpheSettingsV4Theme.java
+++ b/extensions/boostforreddit/src/main/java/app/morphe/extension/boostforreddit/settings/MorpheSettingsV4Theme.java
@@ -4,15 +4,17 @@ import android.content.Context;
 import android.content.res.ColorStateList;
 import android.content.res.Configuration;
 import android.content.res.Resources;
-import android.content.res.TypedArray;
 import android.graphics.Color;
 import android.graphics.drawable.Drawable;
 import android.graphics.drawable.GradientDrawable;
 import android.graphics.drawable.RippleDrawable;
 import android.os.Build;
+import android.preference.PreferenceManager;
 import android.util.TypedValue;
 
 final class MorpheSettingsV4Theme {
+    private static final String KEY_DYNAMIC_COLORS = "pref_dynamic_colors";
+
     static final class Accent {
         final int color;
         final int container;
@@ -99,26 +101,18 @@ final class MorpheSettingsV4Theme {
                 & Configuration.UI_MODE_NIGHT_MASK)
                 == Configuration.UI_MODE_NIGHT_YES;
 
-        int fallbackBackground = themeColor(
-                context,
-                android.R.attr.colorBackground,
-                dark ? Color.rgb(28, 27, 30) : Color.rgb(255, 251, 254)
-        );
-        int fallbackTextPrimary = themeColor(
-                context,
-                android.R.attr.textColorPrimary,
-                dark ? Color.rgb(231, 225, 229) : Color.rgb(29, 27, 30)
-        );
-        int fallbackTextSecondary = themeColor(
-                context,
-                android.R.attr.textColorSecondary,
-                dark ? Color.rgb(202, 196, 208) : Color.rgb(73, 69, 79)
-        );
-        int fallbackPrimary = themeColor(
-                context,
-                android.R.attr.colorAccent,
-                dark ? Color.rgb(208, 188, 255) : Color.rgb(103, 80, 164)
-        );
+        int fallbackBackground = dark
+                ? Color.rgb(28, 27, 30)
+                : Color.rgb(255, 251, 254);
+        int fallbackTextPrimary = dark
+                ? Color.rgb(231, 225, 229)
+                : Color.rgb(29, 27, 30);
+        int fallbackTextSecondary = dark
+                ? Color.rgb(202, 196, 208)
+                : Color.rgb(73, 69, 79);
+        int fallbackPrimary = dark
+                ? Color.rgb(208, 188, 255)
+                : Color.rgb(103, 80, 164);
 
         int paletteBackground = paletteColor(
                 context,
@@ -314,21 +308,14 @@ final class MorpheSettingsV4Theme {
         );
     }
 
-    private static int themeColor(Context context, int attribute, int fallback) {
-        TypedArray values = context.obtainStyledAttributes(new int[]{attribute});
-        try {
-            return values.getColor(0, fallback);
-        } finally {
-            values.recycle();
-        }
-    }
-
     private static int paletteColor(
             Context context,
             String resourceName,
             int fallback
     ) {
-        if (Build.VERSION.SDK_INT < 31) {
+        if (Build.VERSION.SDK_INT < 31
+                || !PreferenceManager.getDefaultSharedPreferences(context)
+                .getBoolean(KEY_DYNAMIC_COLORS, false)) {
             return fallback;
         }
 

--- a/extensions/boostforreddit/src/main/java/app/morphe/extension/boostforreddit/settings/MorpheSettingsV4ToolbarFragment.java
+++ b/extensions/boostforreddit/src/main/java/app/morphe/extension/boostforreddit/settings/MorpheSettingsV4ToolbarFragment.java
@@ -1,0 +1,565 @@
+package app.morphe.extension.boostforreddit.settings;
+
+import android.app.Activity;
+import android.app.Dialog;
+import android.content.Context;
+import android.content.SharedPreferences;
+import android.graphics.Typeface;
+import android.graphics.drawable.ColorDrawable;
+import android.os.Bundle;
+import android.preference.PreferenceManager;
+import android.text.TextUtils;
+import android.view.Gravity;
+import android.view.LayoutInflater;
+import android.view.Menu;
+import android.view.MenuItem;
+import android.view.View;
+import android.view.ViewGroup;
+import android.view.Window;
+import android.widget.LinearLayout;
+import android.widget.ScrollView;
+import android.widget.TextView;
+
+import androidx.fragment.app.Fragment;
+
+import app.morphe.extension.boostforreddit.utils.BoostSystemBarInsetsFix;
+
+import java.lang.reflect.Field;
+
+/**
+ * Morphe-native pilot for Boost's toolbar preferences.
+ *
+ * <p>This fragment deliberately owns only the five controls from
+ * {@code pref_toolbar_v2}. It writes Boost's canonical preference keys and
+ * mirrors the refresh flags used by PreferenceFragmentToolbarCompat.</p>
+ */
+public final class MorpheSettingsV4ToolbarFragment extends Fragment {
+    public static final String CONTRACT_MARKER =
+            "MORPHE_BOOST_SETTINGS_V4_TOOLBAR_PILOT_ISSUE106_V1";
+    public static final String SIDE_EFFECT_MARKER =
+            "MORPHE_BOOST_SETTINGS_V4_TOOLBAR_REFRESH_FLAGS_ISSUE106_V1";
+
+    private static final String KEY_MAIN_ACTION = "pref_toolbar_main_action";
+    private static final String KEY_HIDE_ON_SCROLL = "pref_toolbar";
+    private static final String KEY_SHOW_HEADER = "pref_show_subreddit_header";
+    private static final String KEY_HEADER_TYPE = "pref_toolbar_header_type";
+    private static final String KEY_SHOW_DESCRIPTION =
+            "pref_header_show_description";
+
+    private static final String[] MAIN_ACTION_TITLES = new String[]{
+            "Search",
+            "Post view",
+            "Refresh",
+    };
+    private static final String[] MAIN_ACTION_VALUES = new String[]{
+            "0",
+            "1",
+            "2",
+    };
+    private static final String[] HEADER_TYPE_TITLES = new String[]{
+            "Center",
+            "Left",
+    };
+    private static final String[] HEADER_TYPE_VALUES = new String[]{
+            "center",
+            "left",
+    };
+
+    private MorpheSettingsV4Theme.Tokens tokens;
+    private SharedPreferences preferences;
+    private TextView mainActionSummary;
+    private TextView headerTypeSummary;
+    private LinearLayout headerTypeRow;
+    private LinearLayout showDescriptionRow;
+
+    public MorpheSettingsV4ToolbarFragment() {
+    }
+
+    @Override
+    public View onCreateView(
+            LayoutInflater inflater,
+            ViewGroup container,
+            Bundle savedInstanceState
+    ) {
+        Context context = inflater.getContext();
+        tokens = MorpheSettingsV4Theme.resolve(context);
+        preferences = PreferenceManager.getDefaultSharedPreferences(context);
+        setHasOptionsMenu(true);
+
+        ScrollView scrollView = new ScrollView(context);
+        scrollView.setFillViewport(true);
+        scrollView.setClipToPadding(false);
+        scrollView.setBackgroundColor(tokens.background);
+
+        LinearLayout content = new LinearLayout(context);
+        content.setOrientation(LinearLayout.VERTICAL);
+        content.setPadding(dp(16), dp(10), dp(16), dp(32));
+        scrollView.addView(content, new ScrollView.LayoutParams(
+                ViewGroup.LayoutParams.MATCH_PARENT,
+                ViewGroup.LayoutParams.WRAP_CONTENT
+        ));
+
+        addSectionLabel(content, "Toolbar actions");
+        addSpace(content, 8);
+        LinearLayout actions = addGroup(content);
+
+        LinearLayout mainActionRow = addChoiceRow(
+                actions,
+                "Main action",
+                mainActionTitle(preferences.getString(KEY_MAIN_ACTION, "1")),
+                view -> showChoiceDialog(
+                        "Main action",
+                        KEY_MAIN_ACTION,
+                        MAIN_ACTION_TITLES,
+                        MAIN_ACTION_VALUES,
+                        "1"
+                )
+        );
+        mainActionSummary = rowSummary(mainActionRow);
+
+        addSwitchRow(
+                actions,
+                "Hide on scroll",
+                "Hide the top toolbar while scrolling feeds",
+                preferences.getBoolean(KEY_HIDE_ON_SCROLL, true),
+                checked -> applyBooleanPreference(KEY_HIDE_ON_SCROLL, checked)
+        );
+
+        addSpace(content, 24);
+        addSectionLabel(content, "Community header");
+        addSpace(content, 8);
+        LinearLayout communityHeader = addGroup(content);
+
+        addSwitchRow(
+                communityHeader,
+                "Show community header",
+                "Show banner and icon in communities",
+                preferences.getBoolean(KEY_SHOW_HEADER, false),
+                checked -> {
+                    applyBooleanPreference(KEY_SHOW_HEADER, checked);
+                    updateHeaderDependencies(checked);
+                }
+        );
+
+        headerTypeRow = addChoiceRow(
+                communityHeader,
+                "Community info alignment",
+                headerTypeTitle(preferences.getString(KEY_HEADER_TYPE, "center")),
+                view -> showChoiceDialog(
+                        "Community info alignment",
+                        KEY_HEADER_TYPE,
+                        HEADER_TYPE_TITLES,
+                        HEADER_TYPE_VALUES,
+                        "center"
+                )
+        );
+        headerTypeSummary = rowSummary(headerTypeRow);
+
+        showDescriptionRow = addSwitchRow(
+                communityHeader,
+                "Show community description",
+                "Display the community description below its header",
+                preferences.getBoolean(KEY_SHOW_DESCRIPTION, true),
+                checked -> applyBooleanPreference(KEY_SHOW_DESCRIPTION, checked)
+        );
+
+        updateHeaderDependencies(preferences.getBoolean(KEY_SHOW_HEADER, false));
+        return scrollView;
+    }
+
+    @Override
+    public void onResume() {
+        super.onResume();
+        updateSummaries();
+        if (preferences != null) {
+            updateHeaderDependencies(
+                    preferences.getBoolean(KEY_SHOW_HEADER, false)
+            );
+        }
+        styleHost();
+    }
+
+    @Override
+    public void onPause() {
+        Activity activity = hostActivity();
+        if (activity != null) {
+            BoostSystemBarInsetsFix.clearMorpheSettingsV4SystemBars(activity);
+        }
+        super.onPause();
+    }
+
+    @Override
+    public void onPrepareOptionsMenu(Menu menu) {
+        super.onPrepareOptionsMenu(menu);
+        hideMenuItem(menu, "action_generic_search");
+        hideMenuItem(menu, "action_search");
+        hideMenuItem(menu, "search");
+    }
+
+    private LinearLayout addGroup(LinearLayout parent) {
+        LinearLayout group = MorpheSettingsV14Ui.group(requireContext());
+        parent.addView(group, new LinearLayout.LayoutParams(
+                ViewGroup.LayoutParams.MATCH_PARENT,
+                ViewGroup.LayoutParams.WRAP_CONTENT
+        ));
+        return group;
+    }
+
+    private LinearLayout addChoiceRow(
+            LinearLayout parent,
+            String titleValue,
+            String summaryValue,
+            View.OnClickListener listener
+    ) {
+        LinearLayout row = baseRow();
+        row.setClickable(true);
+        row.setFocusable(true);
+        row.setOnClickListener(listener);
+        row.addView(createLabels(titleValue, summaryValue), labelsParams());
+
+        row.addView(MorpheSettingsV14Ui.chevron(requireContext(), tokens));
+        addGroupedRow(parent, row);
+        return row;
+    }
+
+    private LinearLayout addSwitchRow(
+            LinearLayout parent,
+            String titleValue,
+            String summaryValue,
+            boolean checked,
+            CheckedChange change
+    ) {
+        LinearLayout row = baseRow();
+        row.setClickable(true);
+        row.setFocusable(true);
+        row.addView(createLabels(titleValue, summaryValue), labelsParams());
+
+        MorpheSettingsV14Ui.Toggle toggle =
+                new MorpheSettingsV14Ui.Toggle(
+                        requireContext(),
+                        tokens,
+                        checked
+                );
+        toggle.setOnCheckedChangeListener(
+                (button, value) -> change.onChanged(value)
+        );
+        row.setOnClickListener(view -> toggle.toggle());
+        row.addView(toggle, new LinearLayout.LayoutParams(
+                ViewGroup.LayoutParams.WRAP_CONTENT,
+                ViewGroup.LayoutParams.WRAP_CONTENT
+        ));
+        addGroupedRow(parent, row);
+        return row;
+    }
+
+    private LinearLayout baseRow() {
+        return MorpheSettingsV14Ui.baseRow(requireContext(), tokens);
+    }
+
+    private void addGroupedRow(LinearLayout group, LinearLayout row) {
+        MorpheSettingsV14Ui.addSegmentedRow(group, row, tokens);
+    }
+
+    private void addGroupDivider(LinearLayout group) {
+        View divider = new View(requireContext());
+        divider.setBackgroundColor(MorpheSettingsV4Theme.blend(
+                tokens.surfaceContainer,
+                tokens.outline,
+                tokens.dark ? 0.22f : 0.16f
+        ));
+        LinearLayout.LayoutParams params = new LinearLayout.LayoutParams(
+                ViewGroup.LayoutParams.MATCH_PARENT,
+                dp(1)
+        );
+        params.setMarginStart(dp(18));
+        params.setMarginEnd(dp(18));
+        group.addView(divider, params);
+    }
+
+    private LinearLayout createLabels(String titleValue, String summaryValue) {
+        return MorpheSettingsV14Ui.labels(
+                requireContext(),
+                tokens,
+                titleValue,
+                summaryValue
+        );
+    }
+
+    private TextView rowSummary(LinearLayout row) {
+        if (row == null || row.getChildCount() == 0) {
+            return null;
+        }
+        View labelsView = row.getChildAt(0);
+        if (!(labelsView instanceof LinearLayout)) {
+            return null;
+        }
+        LinearLayout labels = (LinearLayout) labelsView;
+        if (labels.getChildCount() < 2
+                || !(labels.getChildAt(1) instanceof TextView)) {
+            return null;
+        }
+        return (TextView) labels.getChildAt(1);
+    }
+
+    private void showChoiceDialog(
+            String titleValue,
+            String key,
+            String[] titles,
+            String[] values,
+            String defaultValue
+    ) {
+        Context context = requireContext();
+        Dialog dialog = new Dialog(context);
+        LinearLayout content = new LinearLayout(context);
+        content.setOrientation(LinearLayout.VERTICAL);
+        content.setPadding(dp(12), dp(12), dp(12), dp(12));
+        content.setBackground(MorpheSettingsV4Theme.rounded(
+                context,
+                tokens.surfaceContainerHigh,
+                28
+        ));
+
+        TextView title = textView(titleValue, 20, tokens.textPrimary);
+        title.setTypeface(Typeface.create("sans-serif-medium", Typeface.NORMAL));
+        title.setPadding(dp(12), dp(8), dp(12), dp(10));
+        content.addView(title);
+
+        String current = preferences.getString(key, defaultValue);
+        LinearLayout choiceGroup = MorpheSettingsV14Ui.group(context);
+        content.addView(choiceGroup, new LinearLayout.LayoutParams(
+                ViewGroup.LayoutParams.MATCH_PARENT,
+                ViewGroup.LayoutParams.WRAP_CONTENT
+        ));
+        for (int index = 0; index < values.length; index++) {
+            final String selectedValue = values[index];
+            MorpheSettingsV14Ui.ChoiceRow option =
+                    MorpheSettingsV14Ui.choiceRow(
+                    context,
+                    tokens,
+                    titles[index],
+                    "",
+                    selectedValue.equals(current)
+            );
+            option.setOnClickListener(view -> {
+                applyChoicePreference(key, selectedValue);
+                updateSummaries();
+                dialog.dismiss();
+            });
+            MorpheSettingsV14Ui.addSegmentedRow(
+                    choiceGroup,
+                    option,
+                    tokens
+            );
+        }
+
+        dialog.setContentView(content);
+        Window window = dialog.getWindow();
+        if (window != null) {
+            window.setBackgroundDrawable(new ColorDrawable(0x00000000));
+        }
+        dialog.setOnShowListener(ignored -> {
+            Window shownWindow = dialog.getWindow();
+            if (shownWindow != null) {
+                int width = context.getResources().getDisplayMetrics().widthPixels
+                        - dp(40);
+                shownWindow.setLayout(width, ViewGroup.LayoutParams.WRAP_CONTENT);
+            }
+        });
+        dialog.show();
+    }
+
+    private void applyChoicePreference(String key, String value) {
+        if (KEY_MAIN_ACTION.equals(key)) {
+            requireValue(MAIN_ACTION_VALUES, value, key);
+            preferences.edit().putString(key, value).apply();
+            setBoostStaticBoolean("i");
+            return;
+        }
+        if (KEY_HEADER_TYPE.equals(key)) {
+            requireValue(HEADER_TYPE_VALUES, value, key);
+            preferences.edit().putString(key, value).apply();
+            setBoostStaticBoolean("e");
+            return;
+        }
+        throw new IllegalArgumentException("unsupported toolbar choice " + key);
+    }
+
+    private void applyBooleanPreference(String key, boolean value) {
+        if (!KEY_HIDE_ON_SCROLL.equals(key)
+                && !KEY_SHOW_HEADER.equals(key)
+                && !KEY_SHOW_DESCRIPTION.equals(key)) {
+            throw new IllegalArgumentException("unsupported toolbar boolean " + key);
+        }
+        preferences.edit().putBoolean(key, value).apply();
+        setBoostStaticBoolean("e");
+    }
+
+    private void updateSummaries() {
+        if (preferences == null) {
+            return;
+        }
+        if (mainActionSummary != null) {
+            mainActionSummary.setText(mainActionTitle(
+                    preferences.getString(KEY_MAIN_ACTION, "1")
+            ));
+        }
+        if (headerTypeSummary != null) {
+            headerTypeSummary.setText(headerTypeTitle(
+                    preferences.getString(KEY_HEADER_TYPE, "center")
+            ));
+        }
+    }
+
+    private void updateHeaderDependencies(boolean enabled) {
+        setRowEnabled(headerTypeRow, enabled);
+        setRowEnabled(showDescriptionRow, enabled);
+    }
+
+    private void setRowEnabled(LinearLayout row, boolean enabled) {
+        if (row == null) {
+            return;
+        }
+        row.setEnabled(enabled);
+        row.setAlpha(enabled ? 1.0f : 0.44f);
+        setChildrenEnabled(row, enabled);
+    }
+
+    private void setChildrenEnabled(ViewGroup parent, boolean enabled) {
+        for (int index = 0; index < parent.getChildCount(); index++) {
+            View child = parent.getChildAt(index);
+            child.setEnabled(enabled);
+            if (child instanceof ViewGroup) {
+                setChildrenEnabled((ViewGroup) child, enabled);
+            }
+        }
+    }
+
+    private String mainActionTitle(String value) {
+        return titleFor(MAIN_ACTION_TITLES, MAIN_ACTION_VALUES, value, "Post view");
+    }
+
+    private String headerTypeTitle(String value) {
+        return titleFor(HEADER_TYPE_TITLES, HEADER_TYPE_VALUES, value, "Center");
+    }
+
+    private String titleFor(
+            String[] titles,
+            String[] values,
+            String value,
+            String fallback
+    ) {
+        for (int index = 0; index < values.length; index++) {
+            if (values[index].equals(value)) {
+                return titles[index];
+            }
+        }
+        return fallback;
+    }
+
+    private void requireValue(String[] values, String value, String key) {
+        for (String candidate : values) {
+            if (candidate.equals(value)) {
+                return;
+            }
+        }
+        throw new IllegalArgumentException("unsupported value for " + key);
+    }
+
+    private static void setBoostStaticBoolean(String fieldName) {
+        try {
+            Class<?> settings = Class.forName("id.b");
+            Field field = settings.getDeclaredField(fieldName);
+            field.setAccessible(true);
+            field.setBoolean(null, true);
+        } catch (Throwable ignored) {
+        }
+    }
+
+    private void styleHost() {
+        Activity activity = hostActivity();
+        if (activity == null || tokens == null) {
+            return;
+        }
+        activity.setTitle("Toolbar");
+        BoostSystemBarInsetsFix.applyMorpheSettingsV4SystemBars(
+                activity,
+                tokens.background,
+                tokens.dark
+        );
+
+        int toolbarId = MorpheSettingsV4Catalog.resourceId(
+                activity,
+                "id",
+                "toolbar"
+        );
+        View toolbar = activity.findViewById(toolbarId);
+        if (toolbar != null) {
+            toolbar.setBackgroundColor(tokens.background);
+            toolbar.setElevation(0);
+        }
+    }
+
+    private Activity hostActivity() {
+        Context context = requireContext();
+        return context instanceof Activity ? (Activity) context : null;
+    }
+
+    private void hideMenuItem(Menu menu, String resourceName) {
+        int resourceId = MorpheSettingsV4Catalog.resourceId(
+                requireContext(),
+                "id",
+                resourceName
+        );
+        if (resourceId == 0) {
+            return;
+        }
+        MenuItem item = menu.findItem(resourceId);
+        if (item != null) {
+            item.setVisible(false);
+        }
+    }
+
+    private void addSectionLabel(LinearLayout parent, String value) {
+        parent.addView(MorpheSettingsV14Ui.sectionLabel(
+                requireContext(),
+                tokens,
+                value
+        ));
+    }
+
+    private TextView textView(String value, int sizeSp, int color) {
+        TextView textView = new TextView(requireContext());
+        textView.setText(value);
+        textView.setTextSize(sizeSp);
+        textView.setTextColor(color);
+        return textView;
+    }
+
+    private LinearLayout.LayoutParams labelsParams() {
+        return new LinearLayout.LayoutParams(
+                0,
+                ViewGroup.LayoutParams.WRAP_CONTENT,
+                1.0f
+        );
+    }
+
+    private LinearLayout.LayoutParams wrapParams() {
+        return new LinearLayout.LayoutParams(
+                ViewGroup.LayoutParams.WRAP_CONTENT,
+                ViewGroup.LayoutParams.WRAP_CONTENT
+        );
+    }
+
+    private void addSpace(LinearLayout parent, int heightDp) {
+        View space = new View(requireContext());
+        parent.addView(space, new LinearLayout.LayoutParams(1, dp(heightDp)));
+    }
+
+    private int dp(float value) {
+        return MorpheSettingsV4Theme.dp(requireContext(), value);
+    }
+
+    private interface CheckedChange {
+        void onChanged(boolean checked);
+    }
+}

--- a/extensions/boostforreddit/src/main/java/app/morphe/extension/boostforreddit/utils/BoostSystemBarInsetsFix.java
+++ b/extensions/boostforreddit/src/main/java/app/morphe/extension/boostforreddit/utils/BoostSystemBarInsetsFix.java
@@ -43,6 +43,10 @@ public final class BoostSystemBarInsetsFix {
     private static final String EXTENDED_ACTIVITY_SURFACE_SCOPE_MARKER_V5 = "MORPHE_BOOST_EXTENDED_ACTIVITY_SURFACE_SCOPE_V5";
     private static final String DRAWER_STICKY_FOOTER_CLEARANCE_MARKER =
             "MORPHE_BOOST_DRAWER_STICKY_FOOTER_CLEARANCE_V10031";
+    private static final String MORPHE_SETTINGS_V4_SYSTEM_BAR_OWNER_MARKER =
+            "MORPHE_BOOST_SETTINGS_V4_SYSTEM_BAR_OWNER_ISSUE106_V2";
+    private static final String MORPHE_SETTINGS_V4_NAVIGATION_SURFACE_MARKER =
+            "MORPHE_BOOST_SETTINGS_V4_NAVIGATION_SURFACE_ISSUE106_V3";
     private static final String DECOR_NAVIGATION_CONTAINER_TAG =
             "morphe_boost_decor_owned_navigation_container";
     private static final String COMMENTS_ACTIVITY_NAME = "com.rubenmayayo.reddit.ui.comments.CommentsActivity";
@@ -53,6 +57,8 @@ public final class BoostSystemBarInsetsFix {
     private static final WeakHashMap<View, Boolean> WATCHERS = new WeakHashMap<>();
     private static final WeakHashMap<View, Integer> STICKY_FOOTER_CLEARANCE =
             new WeakHashMap<>();
+    private static final WeakHashMap<Activity, MorpheSettingsV4SystemBars>
+            MORPHE_SETTINGS_V4_SYSTEM_BARS = new WeakHashMap<>();
 
     private BoostSystemBarInsetsFix() {
     }
@@ -383,6 +389,35 @@ public final class BoostSystemBarInsetsFix {
         scheduleCommentsSystemBars(activity);
     }
 
+    public static void applyMorpheSettingsV4SystemBars(
+            Activity activity,
+            int color,
+            boolean dark
+    ) {
+        try {
+            if (!shouldApply(activity)) return;
+
+            MorpheSettingsV4SystemBars state =
+                    new MorpheSettingsV4SystemBars(color, dark);
+            MORPHE_SETTINGS_V4_SYSTEM_BARS.put(activity, state);
+            applyMorpheSettingsV4SystemBarsNow(activity, state);
+        } catch (Throwable ignored) {
+        }
+    }
+
+    public static void clearMorpheSettingsV4SystemBars(Activity activity) {
+        try {
+            if (activity == null) return;
+
+            MORPHE_SETTINGS_V4_SYSTEM_BARS.remove(activity);
+            Window window = activity.getWindow();
+            View decor = window == null ? null : window.getDecorView();
+            removeMorpheSettingsV4NavigationBarSurface(decor);
+            scheduleCommentsSystemBars(activity);
+        } catch (Throwable ignored) {
+        }
+    }
+
     private static void scheduleCommentsSystemBars(final Activity activity) {
         try {
             if (!shouldApply(activity) || !isToolbarSurfaceActivity(activity)) return;
@@ -468,6 +503,13 @@ public final class BoostSystemBarInsetsFix {
         try {
             if (!shouldApply(activity) || !isToolbarSurfaceActivity(activity)) return;
 
+            MorpheSettingsV4SystemBars v4State =
+                    MORPHE_SETTINGS_V4_SYSTEM_BARS.get(activity);
+            if (v4State != null) {
+                applyMorpheSettingsV4SystemBarsNow(activity, v4State);
+                return;
+            }
+
             Window window = activity.getWindow();
             if (window == null) return;
 
@@ -490,6 +532,119 @@ public final class BoostSystemBarInsetsFix {
             applyLightStatusBarFlag(decor, color);
             applyMainActivityNavigationBarSurface(activity, window, decor, color);
             applyCommentsToolbarForeground(activity, decor, statusHeight, color);
+        } catch (Throwable ignored) {
+        }
+    }
+
+    private static void applyMorpheSettingsV4SystemBarsNow(
+            Activity activity,
+            MorpheSettingsV4SystemBars state
+    ) {
+        if (activity == null || state == null) return;
+
+        Window window = activity.getWindow();
+        if (window == null) return;
+
+        View decor = window.getDecorView();
+        if (decor == null) return;
+
+        int statusHeight = getStatusBarTopInset(decor);
+        if (statusHeight <= 0) {
+            statusHeight = getStatusBarHeight(activity);
+        }
+        if (statusHeight > 0) {
+            installStatusBarSurface(decor, statusHeight, state.color);
+        }
+
+        decor.setBackgroundColor(state.color);
+        if (Build.VERSION.SDK_INT >= 21) {
+            window.setStatusBarColor(state.color);
+            // Keep the requested color as a fallback for devices that do not let
+            // app content draw behind the gesture/navigation area.
+            window.setNavigationBarColor(state.color);
+        }
+        if (Build.VERSION.SDK_INT >= 28) {
+            window.setNavigationBarDividerColor(Color.TRANSPARENT);
+        }
+        if (Build.VERSION.SDK_INT >= 29) {
+            window.setStatusBarContrastEnforced(false);
+            window.setNavigationBarContrastEnforced(false);
+        }
+
+        int bottomInset = getEffectiveNavigationBottomInset(
+                decor,
+                getBestCurrentInsets(decor)
+        );
+        if (bottomInset <= 0) {
+            bottomInset = getNavigationBarHeight(decor);
+        }
+        installMorpheSettingsV4NavigationBarSurface(
+                decor,
+                bottomInset,
+                state.color
+        );
+        applyLightStatusBarFlag(decor, state.color);
+        applyLightNavigationBarFlag(decor, state.color);
+
+        if (MORPHE_SETTINGS_V4_SYSTEM_BAR_OWNER_MARKER.length() == 0
+                || MORPHE_SETTINGS_V4_NAVIGATION_SURFACE_MARKER.length() == 0
+                || state.dark && state.color == Color.TRANSPARENT) {
+            decor.invalidate();
+        }
+    }
+
+    private static void removeMorpheSettingsV4NavigationBarSurface(View decor) {
+        if (decor == null) return;
+
+        View surface = decor.findViewWithTag(
+                MORPHE_SETTINGS_V4_NAVIGATION_SURFACE_MARKER
+        );
+        if (surface == null || !(surface.getParent() instanceof ViewGroup)) return;
+
+        ((ViewGroup) surface.getParent()).removeView(surface);
+    }
+
+    private static void installMorpheSettingsV4NavigationBarSurface(
+            View decor,
+            int bottomInset,
+            int color
+    ) {
+        try {
+            if (!(decor instanceof FrameLayout) || bottomInset <= 0) return;
+
+            FrameLayout group = (FrameLayout) decor;
+            View surface = decor.findViewWithTag(
+                    MORPHE_SETTINGS_V4_NAVIGATION_SURFACE_MARKER
+            );
+
+            if (surface == null) {
+                surface = new View(decor.getContext());
+                surface.setTag(MORPHE_SETTINGS_V4_NAVIGATION_SURFACE_MARKER);
+                surface.setClickable(false);
+                surface.setFocusable(false);
+                if (Build.VERSION.SDK_INT >= 16) {
+                    surface.setImportantForAccessibility(
+                            View.IMPORTANT_FOR_ACCESSIBILITY_NO
+                    );
+                }
+
+                FrameLayout.LayoutParams params = new FrameLayout.LayoutParams(
+                        ViewGroup.LayoutParams.MATCH_PARENT,
+                        bottomInset,
+                        Gravity.BOTTOM
+                );
+                group.addView(surface, params);
+            }
+
+            ViewGroup.LayoutParams params = surface.getLayoutParams();
+            if (params != null && params.height != bottomInset) {
+                params.height = bottomInset;
+                surface.setLayoutParams(params);
+            }
+
+            surface.setBackgroundColor(color);
+            surface.bringToFront();
+            surface.invalidate();
         } catch (Throwable ignored) {
         }
     }
@@ -1112,6 +1267,16 @@ public final class BoostSystemBarInsetsFix {
         }
 
         return 0;
+    }
+
+    private static final class MorpheSettingsV4SystemBars {
+        final int color;
+        final boolean dark;
+
+        MorpheSettingsV4SystemBars(int color, boolean dark) {
+            this.color = color;
+            this.dark = dark;
+        }
     }
 
     private static final class Padding {

--- a/patches-list.json
+++ b/patches-list.json
@@ -147,9 +147,12 @@
     },
     {
       "name": "Boost Morphe settings",
-      "description": "Adds Boost Morphe settings for Search keyboard behavior, inline media previews, undelete toggles, adaptive refresh rate, source text visibility, and preview alignment.",
+      "description": "Adds dedicated Morphe settings and Morphe-owned Material-style Settings v4 pages with a classic fallback.",
       "default": false,
-      "dependencies": [],
+      "dependencies": [
+        "BytecodePatch",
+        "ResourcePatch"
+      ],
       "compatiblePackages": [
         {
           "packageName": "com.rubenmayayo.reddit",
@@ -1608,7 +1611,7 @@
       "default": false,
       "dependencies": [
         "BytecodePatch",
-        "ResourcePatch"
+        "BytecodePatch"
       ],
       "compatiblePackages": [
         {

--- a/patches/src/main/kotlin/app/morphe/patches/reddit/customclients/boostforreddit/misc/settings/BoostMorpheSettingsSkeletonPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/reddit/customclients/boostforreddit/misc/settings/BoostMorpheSettingsSkeletonPatch.kt
@@ -1,13 +1,52 @@
 package app.morphe.patches.reddit.customclients.boostforreddit.misc.settings
 
+import app.morphe.patcher.Fingerprint
+import app.morphe.patcher.extensions.InstructionExtensions.addInstructions
+import app.morphe.patcher.patch.bytecodePatch
 import app.morphe.patcher.patch.resourcePatch
 import app.morphe.patcher.resource.utf8Writer
 import app.morphe.patches.reddit.customclients.boostforreddit.BoostCompatible
+import app.morphe.patches.reddit.customclients.boostforreddit.misc.extension.sharedExtensionPatch
+import app.morphe.util.getReference
+import app.morphe.util.indexOfFirstInstructionOrThrow
+import com.android.tools.smali.dexlib2.Opcode
+import com.android.tools.smali.dexlib2.iface.reference.MethodReference
 
-@Suppress("unused")
-val boostMorpheSettingsSkeletonPatch = resourcePatch(
-    name = "Boost Morphe settings",
-    description = "Adds a dedicated top-level Morphe settings screen for Search behavior, inline media previews, undelete toggles, and adaptive refresh rate.",
+private const val SETTINGS_LAYOUT_EXTENSION_DESCRIPTOR =
+    "Lapp/morphe/extension/boostforreddit/settings/MorpheSettingsLayout;"
+
+private const val SETTINGS_V4_EXTENSION_DESCRIPTOR =
+    "Lapp/morphe/extension/boostforreddit/settings/MorpheSettingsV4;"
+
+private const val SET_PREFERENCES_FROM_RESOURCE_REFERENCE =
+    "Landroidx/preference/PreferenceFragmentCompat;->setPreferencesFromResource(ILjava/lang/String;)V"
+
+private const val GET_INTENT_REFERENCE =
+    "Landroid/app/Activity;->getIntent()Landroid/content/Intent;"
+
+private val settingsHeaderOnCreatePreferencesFingerprint = Fingerprint(
+    returnType = "V",
+    parameters = listOf("Landroid/os/Bundle;", "Ljava/lang/String;"),
+    custom = { method, classDef ->
+        classDef.type ==
+            "Lcom/rubenmayayo/reddit/ui/preferences/v2/SettingsActivityCompat\$HeaderFragment;" &&
+            method.name == "onCreatePreferences"
+    },
+)
+
+private val settingsActivityOnCreateFingerprint = Fingerprint(
+    returnType = "V",
+    parameters = listOf("Landroid/os/Bundle;"),
+    custom = { method, classDef ->
+        classDef.type ==
+            "Lcom/rubenmayayo/reddit/ui/preferences/v2/SettingsActivityCompat;" &&
+            method.name == "onCreate"
+    },
+)
+
+private val boostMorpheSettingsResourcesPatch = resourcePatch(
+    name = "Boost Morphe settings resources",
+    description = "Adds resources for Morphe settings, Settings v4, and its compatibility fallback.",
     default = false
 ) {
     compatibleWith(*BoostCompatible)
@@ -18,6 +57,14 @@ val boostMorpheSettingsSkeletonPatch = resourcePatch(
                 """
                 <?xml version="1.0" encoding="utf-8"?>
                 <PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android">
+                    <PreferenceCategory android:title="Settings">
+                        <CheckBoxPreference
+                            android:key="morphe_boost_settings_v4_enabled"
+                            android:title="Settings v4 (preview)"
+                            android:summary="Use Morphe's modern task-based settings. Close and reopen Settings to apply."
+                            android:defaultValue="false" />
+                    </PreferenceCategory>
+
                     <PreferenceCategory android:title="Media previews">
                         <CheckBoxPreference
                             android:key="morphe_boost_inline_media_previews_enabled"
@@ -183,6 +230,300 @@ val boostMorpheSettingsSkeletonPatch = resourcePatch(
                         app:allowDividerAbove="true" />
                 </PreferenceScreen>
                 """.trimIndent()
+            )
+        }
+
+        mapOf(
+            "morphe_boost_settings_layout_v2" to
+                """
+                <?xml version="1.0" encoding="utf-8"?>
+                <PreferenceScreen
+                  xmlns:android="http://schemas.android.com/apk/res/android"
+                  xmlns:app="http://schemas.android.com/apk/res-auto">
+                    <Preference
+                        android:icon="@drawable/ic_puzzle_24dp"
+                        android:key="morphe_boost_settings_entry"
+                        android:title="Morphe"
+                        android:summary="Features added by Morphe patches"
+                        android:fragment="app.morphe.extension.boostforreddit.settings.MorpheSettingsFragment"
+                        app:allowDividerBelow="true" />
+                    <Preference
+                        android:icon="@drawable/ic_color_lens_24dp"
+                        android:key="morphe_boost_settings_v2_appearance_layout"
+                        android:title="Appearance &amp; layout"
+                        android:summary="Theme, post layout, and fonts"
+                        android:fragment="app.morphe.extension.boostforreddit.settings.MorpheSettingsHubFragment"
+                        app:allowDividerAbove="true">
+                        <extra
+                            android:name="morphe_boost_settings_hub_resource"
+                            android:value="morphe_boost_settings_hub_appearance_layout" />
+                    </Preference>
+                    <Preference
+                        android:icon="@drawable/ic_post_24dp"
+                        android:key="morphe_boost_settings_v2_posts_comments"
+                        android:title="Posts &amp; comments"
+                        android:summary="Post and comment behavior"
+                        android:fragment="app.morphe.extension.boostforreddit.settings.MorpheSettingsHubFragment">
+                        <extra
+                            android:name="morphe_boost_settings_hub_resource"
+                            android:value="morphe_boost_settings_hub_posts_comments" />
+                    </Preference>
+                    <Preference
+                        android:icon="@drawable/ic_menu_24dp"
+                        android:key="morphe_boost_settings_v2_navigation"
+                        android:title="Navigation"
+                        android:summary="Toolbar, bottom navigation, and drawer"
+                        android:fragment="app.morphe.extension.boostforreddit.settings.MorpheSettingsHubFragment">
+                        <extra
+                            android:name="morphe_boost_settings_hub_resource"
+                            android:value="morphe_boost_settings_hub_navigation" />
+                    </Preference>
+                    <Preference
+                        android:icon="@drawable/ic_photo_outline_24dp"
+                        android:key="morphe_boost_settings_v2_media_links"
+                        android:title="Media &amp; links"
+                        android:summary="Viewers, players, and link handling"
+                        android:fragment="app.morphe.extension.boostforreddit.settings.MorpheSettingsHubFragment">
+                        <extra
+                            android:name="morphe_boost_settings_hub_resource"
+                            android:value="morphe_boost_settings_hub_media_links" />
+                    </Preference>
+                    <Preference
+                        android:icon="@drawable/ic_search_color_24dp"
+                        android:key="morphe_boost_settings_v2_search_filters"
+                        android:title="Search &amp; filters"
+                        android:summary="Search behavior and content filters"
+                        android:fragment="app.morphe.extension.boostforreddit.settings.MorpheSettingsHubFragment">
+                        <extra
+                            android:name="morphe_boost_settings_hub_resource"
+                            android:value="morphe_boost_settings_hub_search_filters" />
+                    </Preference>
+                    <Preference
+                        android:icon="@drawable/ic_notifications_black_24dp"
+                        android:key="morphe_boost_settings_v2_notifications"
+                        android:title="@string/pref_header_messages"
+                        android:summary="@string/pref_header_messages_summary"
+                        android:fragment="com.rubenmayayo.reddit.ui.preferences.v2.PreferenceFragmentMessagesCompat" />
+                    <Preference
+                        android:icon="@drawable/outline_data_usage_24"
+                        android:key="morphe_boost_settings_v2_data_storage"
+                        android:title="Data &amp; storage"
+                        android:summary="Bandwidth, cache, downloads, and backup"
+                        android:fragment="app.morphe.extension.boostforreddit.settings.MorpheSettingsHubFragment">
+                        <extra
+                            android:name="morphe_boost_settings_hub_resource"
+                            android:value="morphe_boost_settings_hub_data_storage" />
+                    </Preference>
+                    <Preference
+                        android:icon="@drawable/ic_person_24dp"
+                        android:key="morphe_boost_settings_v2_account_privacy"
+                        android:title="Account &amp; privacy"
+                        android:summary="Reddit preferences, history, and privacy"
+                        android:fragment="app.morphe.extension.boostforreddit.settings.MorpheSettingsHubFragment">
+                        <extra
+                            android:name="morphe_boost_settings_hub_resource"
+                            android:value="morphe_boost_settings_hub_account_privacy" />
+                    </Preference>
+                    <Preference
+                        android:icon="@drawable/ic_settings_24dp"
+                        android:key="morphe_boost_settings_v2_app_legacy"
+                        android:title="App behavior &amp; legacy"
+                        android:summary="General and old features"
+                        android:fragment="app.morphe.extension.boostforreddit.settings.MorpheSettingsHubFragment">
+                        <extra
+                            android:name="morphe_boost_settings_hub_resource"
+                            android:value="morphe_boost_settings_hub_app_legacy" />
+                    </Preference>
+                    <Preference
+                        android:icon="@drawable/ic_help_24dp"
+                        android:key="morphe_boost_settings_v2_about"
+                        android:title="@string/pref_header_about"
+                        android:summary="@string/pref_header_about_summary"
+                        android:fragment="com.rubenmayayo.reddit.ui.preferences.v2.PreferenceFragmentAboutCompat" />
+                </PreferenceScreen>
+                """,
+            "morphe_boost_settings_hub_appearance_layout" to
+                """
+                <?xml version="1.0" encoding="utf-8"?>
+                <PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android">
+                    <Preference
+                        android:icon="@drawable/ic_color_lens_24dp"
+                        android:title="@string/theme"
+                        android:summary="Theme, dark mode, and app icon"
+                        android:fragment="com.rubenmayayo.reddit.ui.preferences.v2.PreferenceFragmentAppearanceCompat" />
+                    <Preference
+                        android:icon="@drawable/ic_view_carousel_24dp"
+                        android:title="@string/view_settings"
+                        android:summary="@string/view_settings_summary"
+                        android:fragment="com.rubenmayayo.reddit.ui.preferences.v2.PreferenceFragmentViewsCompat" />
+                    <Preference
+                        android:icon="@drawable/ic_format_size_24dp"
+                        android:title="@string/pref_appearance_category_fonts"
+                        android:fragment="com.rubenmayayo.reddit.ui.preferences.v2.PreferenceFragmentFontsCompat" />
+                </PreferenceScreen>
+                """,
+            "morphe_boost_settings_hub_posts_comments" to
+                """
+                <?xml version="1.0" encoding="utf-8"?>
+                <PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android">
+                    <Preference
+                        android:icon="@drawable/ic_post_24dp"
+                        android:title="@string/pref_header_posts"
+                        android:summary="@string/pref_header_posts_summary"
+                        android:fragment="com.rubenmayayo.reddit.ui.preferences.v2.PreferenceFragmentPostsCompat" />
+                    <Preference
+                        android:icon="@drawable/ic_comment_outline_white_24dp"
+                        android:title="@string/pref_header_comments"
+                        android:summary="@string/pref_header_comments_summary"
+                        android:fragment="com.rubenmayayo.reddit.ui.preferences.v2.PreferenceFragmentCommentsCompat" />
+                </PreferenceScreen>
+                """,
+            "morphe_boost_settings_hub_navigation" to
+                """
+                <?xml version="1.0" encoding="utf-8"?>
+                <PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android">
+                    <Preference
+                        android:icon="@drawable/ic_toolbar_24dp"
+                        android:title="@string/toolbar"
+                        android:summary="@string/pref_toolbar_summary"
+                        android:fragment="com.rubenmayayo.reddit.ui.preferences.v2.PreferenceFragmentToolbarCompat" />
+                    <Preference
+                        android:icon="@drawable/ic_bottomnav_24dp"
+                        android:title="@string/pref_bottom_navigation_title"
+                        android:summary="@string/pref_bottom_navigation_summary"
+                        android:fragment="com.rubenmayayo.reddit.ui.preferences.v2.PreferenceFragmentBottomNavigationCompat" />
+                    <Preference
+                        android:icon="@drawable/ic_dock_left_24dp"
+                        android:title="@string/pref_drawer_items"
+                        android:summary="@string/pref_header_drawer_summary"
+                        android:fragment="com.rubenmayayo.reddit.ui.preferences.v2.PreferenceFragmentDrawerCompat" />
+                </PreferenceScreen>
+                """,
+            "morphe_boost_settings_hub_media_links" to
+                """
+                <?xml version="1.0" encoding="utf-8"?>
+                <PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android">
+                    <Preference
+                        android:icon="@drawable/ic_photo_outline_24dp"
+                        android:title="@string/pref_media_viewer_title"
+                        android:summary="@string/pref_header_media_summary"
+                        android:fragment="com.rubenmayayo.reddit.ui.preferences.v2.PreferenceFragmentMediaCompat" />
+                    <Preference
+                        android:icon="@drawable/ic_link_24dp"
+                        android:title="@string/pref_header_links"
+                        android:summary="@string/pref_header_links_summary"
+                        android:fragment="com.rubenmayayo.reddit.ui.preferences.v2.PreferenceFragmentLinksCompat" />
+                </PreferenceScreen>
+                """,
+            "morphe_boost_settings_hub_search_filters" to
+                """
+                <?xml version="1.0" encoding="utf-8"?>
+                <PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android">
+                    <Preference
+                        android:icon="@drawable/ic_search_color_24dp"
+                        android:title="@string/search"
+                        android:summary="@string/search_summary"
+                        android:fragment="com.rubenmayayo.reddit.ui.preferences.v2.PreferenceFragmentSearchCompat" />
+                    <Preference
+                        android:icon="@drawable/ic_filter_list_24dp"
+                        android:title="@string/content_filters"
+                        android:fragment="com.rubenmayayo.reddit.ui.preferences.v2.PreferenceFragmentFiltersCompat" />
+                </PreferenceScreen>
+                """,
+            "morphe_boost_settings_hub_data_storage" to
+                """
+                <?xml version="1.0" encoding="utf-8"?>
+                <PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android">
+                    <Preference
+                        android:icon="@drawable/outline_data_usage_24"
+                        android:title="@string/pref_category_data_usage"
+                        android:summary="@string/pref_header_bandwidth_summary"
+                        android:fragment="com.rubenmayayo.reddit.ui.preferences.v2.PreferenceFragmentDataSavingCompat" />
+                    <Preference
+                        android:icon="@drawable/ic_save_24dp"
+                        android:key="morphe_boost_settings_backup"
+                        android:title="@string/pref_header_backup"
+                        android:summary="@string/pref_header_backup_summary" />
+                </PreferenceScreen>
+                """,
+            "morphe_boost_settings_hub_account_privacy" to
+                """
+                <?xml version="1.0" encoding="utf-8"?>
+                <PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android">
+                    <Preference
+                        android:icon="@drawable/ic_subreddit_24dp"
+                        android:title="@string/pref_header_account"
+                        android:summary="@string/pref_header_account_summary"
+                        android:fragment="com.rubenmayayo.reddit.ui.preferences.v2.PreferenceFragmentAccountCompat" />
+                    <Preference
+                        android:icon="@drawable/ic_restore_black_24dp"
+                        android:title="@string/history"
+                        android:fragment="com.rubenmayayo.reddit.ui.preferences.v2.PreferenceFragmentPrivacyCompat" />
+                </PreferenceScreen>
+                """,
+            "morphe_boost_settings_hub_app_legacy" to
+                """
+                <?xml version="1.0" encoding="utf-8"?>
+                <PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android">
+                    <Preference
+                        android:icon="@drawable/ic_settings_24dp"
+                        android:title="@string/pref_header_general"
+                        android:summary="@string/pref_header_general_summary"
+                        android:fragment="com.rubenmayayo.reddit.ui.preferences.v2.PreferenceFragmentGeneralCompat" />
+                    <Preference
+                        android:icon="@drawable/ic_restore_black_24dp"
+                        android:title="@string/pref_header_legacy"
+                        android:summary="@string/pref_header_legacy_summary"
+                        android:fragment="com.rubenmayayo.reddit.ui.preferences.v2.PreferenceFragmentMiscCompat" />
+                </PreferenceScreen>
+                """,
+        ).forEach { (resourceName, xml) ->
+            get("res/xml/$resourceName.xml").utf8Writer().use { writer ->
+                writer.write(xml.trimIndent())
+            }
+        }
+    }
+}
+
+@Suppress("unused")
+val boostMorpheSettingsSkeletonPatch = bytecodePatch(
+    name = "Boost Morphe settings",
+    description = "Adds dedicated Morphe settings and an optional Morphe-owned Settings v4 interface.",
+    default = false,
+) {
+    dependsOn(sharedExtensionPatch, boostMorpheSettingsResourcesPatch)
+    compatibleWith(*BoostCompatible)
+
+    execute {
+        settingsHeaderOnCreatePreferencesFingerprint.method.apply {
+            val loadPreferencesIndex = indexOfFirstInstructionOrThrow {
+                opcode == Opcode.INVOKE_VIRTUAL &&
+                    getReference<MethodReference>()?.toString() ==
+                    SET_PREFERENCES_FROM_RESOURCE_REFERENCE
+            }
+
+            addInstructions(
+                loadPreferencesIndex,
+                """
+                    invoke-static {p0, p1}, $SETTINGS_LAYOUT_EXTENSION_DESCRIPTOR->resolveRootResource(Landroidx/preference/PreferenceFragmentCompat;I)I
+
+                    move-result p1
+                """.trimIndent(),
+            )
+        }
+
+        settingsActivityOnCreateFingerprint.method.apply {
+            val getIntentIndex = indexOfFirstInstructionOrThrow {
+                opcode == Opcode.INVOKE_VIRTUAL &&
+                    getReference<MethodReference>()?.toString() ==
+                    GET_INTENT_REFERENCE
+            }
+
+            addInstructions(
+                getIntentIndex,
+                """
+                    invoke-static {p0}, $SETTINGS_V4_EXTENSION_DESCRIPTOR->prepareIntent(Landroid/app/Activity;)V
+                """.trimIndent(),
             )
         }
     }

--- a/patches/src/main/kotlin/app/morphe/patches/reddit/customclients/boostforreddit/misc/settings/BoostMorpheSettingsSkeletonPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/reddit/customclients/boostforreddit/misc/settings/BoostMorpheSettingsSkeletonPatch.kt
@@ -7,7 +7,7 @@ import app.morphe.patches.reddit.customclients.boostforreddit.BoostCompatible
 @Suppress("unused")
 val boostMorpheSettingsSkeletonPatch = resourcePatch(
     name = "Boost Morphe settings",
-    description = "Adds Boost Morphe settings for Search keyboard behavior, inline media previews, undelete toggles, adaptive refresh rate, source text visibility, and preview alignment.",
+    description = "Adds a dedicated top-level Morphe settings screen for Search behavior, inline media previews, undelete toggles, and adaptive refresh rate.",
     default = false
 ) {
     compatibleWith(*BoostCompatible)
@@ -18,32 +18,12 @@ val boostMorpheSettingsSkeletonPatch = resourcePatch(
                 """
                 <?xml version="1.0" encoding="utf-8"?>
                 <PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android">
-                    <PreferenceCategory android:title="Morphe">
-                        <CheckBoxPreference
-                            android:key="morphe_boost_prefer_high_refresh_rate"
-                            android:title="Prefer high refresh rate"
-                            android:summary="Ask Android to use a high refresh rate for Boost windows on adaptive-refresh displays."
-                            android:defaultValue="true" />
-
-                        <CheckBoxPreference
-                            android:key="morphe_boost_search_open_keyboard_on_entry"
-                            android:title="Open keyboard when entering Search"
-                            android:summary="Focus the search field and show the keyboard immediately. When disabled, tap Search again to start typing."
-                            android:defaultValue="false" />
-
+                    <PreferenceCategory android:title="Media previews">
                         <CheckBoxPreference
                             android:key="morphe_boost_inline_media_previews_enabled"
                             android:title="Enable inline media previews"
                             android:summary="Show supported media previews directly in comments."
                             android:defaultValue="true" />
-
-                        <app.morphe.extension.boostforreddit.giphy.PreviewAlignmentPreference
-                            android:icon="@drawable/ic_photo_outline_24dp"
-                            android:key="morphe_boost_inline_media_preview_alignment"
-                            android:title="Preview alignment"
-                            android:summary="Center"
-                            android:dialogTitle="Preview alignment"
-                            android:defaultValue="center" />
 
                         <app.morphe.extension.boostforreddit.giphy.PreviewSizePreference
                             android:icon="@drawable/ic_photo_outline_24dp"
@@ -53,6 +33,22 @@ val boostMorpheSettingsSkeletonPatch = resourcePatch(
                             android:dialogTitle="Preview size"
                             android:defaultValue="balanced" />
 
+                        <app.morphe.extension.boostforreddit.giphy.PreviewAlignmentPreference
+                            android:icon="@drawable/ic_photo_outline_24dp"
+                            android:key="morphe_boost_inline_media_preview_alignment"
+                            android:title="Preview alignment"
+                            android:summary="Center"
+                            android:dialogTitle="Preview alignment"
+                            android:defaultValue="center" />
+
+                        <CheckBoxPreference
+                            android:key="morphe_boost_inline_media_preview_show_source_text"
+                            android:title="Show source text with preview"
+                            android:summary="Keep the original link text visible with the preview."
+                            android:defaultValue="false" />
+                    </PreferenceCategory>
+
+                    <PreferenceCategory android:title="Open behavior">
                         <app.morphe.extension.boostforreddit.giphy.MediaTapActionPreference
                             android:icon="@drawable/ic_photo_outline_24dp"
                             android:key="morphe_boost_direct_reddit_gif_tap_action"
@@ -76,13 +72,25 @@ val boostMorpheSettingsSkeletonPatch = resourcePatch(
                             android:summary="Image viewer"
                             android:dialogTitle="Static preview tap action"
                             android:defaultValue="image_viewer" />
+                    </PreferenceCategory>
 
+                    <PreferenceCategory android:title="Search">
                         <CheckBoxPreference
-                            android:key="morphe_boost_inline_media_preview_show_source_text"
-                            android:title="Show source text with preview"
-                            android:summary="Keep the original link text visible with the preview."
+                            android:key="morphe_boost_search_open_keyboard_on_entry"
+                            android:title="Open keyboard when entering Search"
+                            android:summary="Focus the search field and show the keyboard immediately. When disabled, tap Search again to start typing."
                             android:defaultValue="false" />
+                    </PreferenceCategory>
 
+                    <PreferenceCategory android:title="Display &amp; performance">
+                        <CheckBoxPreference
+                            android:key="morphe_boost_prefer_high_refresh_rate"
+                            android:title="Prefer high refresh rate"
+                            android:summary="Ask Android to use a high refresh rate for Boost windows on adaptive-refresh displays."
+                            android:defaultValue="true" />
+                    </PreferenceCategory>
+
+                    <PreferenceCategory android:title="Recovery &amp; archives">
                         <CheckBoxPreference
                             android:key="morphe_boost_reddit_undelete_enabled"
                             android:title="Automatically undelete Reddit content"
@@ -100,123 +108,79 @@ val boostMorpheSettingsSkeletonPatch = resourcePatch(
             )
         }
 
-        get("res/xml/pref_advanced_v2.xml").utf8Writer().use { writer ->
+        get("res/xml/pref_headers_v2.xml").utf8Writer().use { writer ->
             writer.write(
                 """
                 <?xml version="1.0" encoding="utf-8"?>
                 <PreferenceScreen
-                  xmlns:android="http://schemas.android.com/apk/res/android">
+                  xmlns:android="http://schemas.android.com/apk/res/android"
+                  xmlns:app="http://schemas.android.com/apk/res-auto">
                     <Preference
-                        android:icon="@drawable/ic_photo_outline_24dp"
-                        android:title="@string/pref_media_viewer_title"
-                        android:summary="@string/pref_header_media_summary"
-                        android:fragment="com.rubenmayayo.reddit.ui.preferences.v2.PreferenceFragmentMediaCompat" />
+                        android:icon="@drawable/ic_puzzle_24dp"
+                        android:key="morphe_boost_settings_entry"
+                        android:title="Morphe"
+                        android:summary="Features added by Morphe patches"
+                        android:fragment="app.morphe.extension.boostforreddit.settings.MorpheSettingsFragment"
+                        app:allowDividerBelow="true" />
                     <Preference
-                        android:icon="@drawable/ic_link_24dp"
-                        android:title="@string/pref_header_links"
-                        android:summary="@string/pref_header_links_summary"
-                        android:fragment="com.rubenmayayo.reddit.ui.preferences.v2.PreferenceFragmentLinksCompat" />
+                        android:icon="@drawable/ic_settings_24dp"
+                        android:title="@string/pref_header_general"
+                        android:fragment="com.rubenmayayo.reddit.ui.preferences.v2.PreferenceFragmentGeneralCompat"
+                        app:allowDividerAbove="true" />
                     <Preference
-                        android:icon="@drawable/ic_subreddit_24dp"
-                        android:title="@string/pref_header_account"
-                        android:summary="@string/pref_header_account_summary"
-                        android:fragment="com.rubenmayayo.reddit.ui.preferences.v2.PreferenceFragmentAccountCompat" />
+                        android:icon="@drawable/ic_color_lens_24dp"
+                        android:title="@string/theme"
+                        android:fragment="com.rubenmayayo.reddit.ui.preferences.v2.PreferenceFragmentAppearanceCompat" />
                     <Preference
-                        android:icon="@drawable/ic_search_color_24dp"
-                        android:title="@string/search"
-                        android:summary="@string/search_summary"
-                        android:fragment="com.rubenmayayo.reddit.ui.preferences.v2.PreferenceFragmentSearchCompat" />
+                        android:icon="@drawable/ic_notifications_black_24dp"
+                        android:title="@string/pref_header_messages"
+                        android:fragment="com.rubenmayayo.reddit.ui.preferences.v2.PreferenceFragmentMessagesCompat" />
                     <Preference
-                        android:icon="@drawable/ic_save_24dp"
-                        android:title="@string/pref_header_backup"
-                        android:summary="@string/pref_header_backup_summary">
-                        <intent
-                            android:targetPackage="com.rubenmayayo.reddit"
-                            android:targetClass="com.rubenmayayo.reddit.BackupActivity" />
-                    </Preference>
+                        android:icon="@drawable/ic_filter_list_24dp"
+                        android:title="@string/content_filters"
+                        android:fragment="com.rubenmayayo.reddit.ui.preferences.v2.PreferenceFragmentFiltersCompat" />
+                    <Preference
+                        android:icon="@drawable/outline_data_usage_24"
+                        android:title="@string/pref_category_data_usage"
+                        android:fragment="com.rubenmayayo.reddit.ui.preferences.v2.PreferenceFragmentDataSavingCompat" />
                     <Preference
                         android:icon="@drawable/ic_restore_black_24dp"
-                        android:title="@string/pref_header_legacy"
-                        android:summary="@string/pref_header_legacy_summary"
-                        android:fragment="com.rubenmayayo.reddit.ui.preferences.v2.PreferenceFragmentMiscCompat" />
-
-                    <PreferenceCategory android:title="Morphe">
-                        <CheckBoxPreference
-                            android:key="morphe_boost_prefer_high_refresh_rate"
-                            android:title="Prefer high refresh rate"
-                            android:summary="Ask Android to use a high refresh rate for Boost windows on adaptive-refresh displays."
-                            android:defaultValue="true" />
-
-                        <CheckBoxPreference
-                            android:key="morphe_boost_search_open_keyboard_on_entry"
-                            android:title="Open keyboard when entering Search"
-                            android:summary="Focus the search field and show the keyboard immediately. When disabled, tap Search again to start typing."
-                            android:defaultValue="false" />
-
-                        <CheckBoxPreference
-                            android:key="morphe_boost_inline_media_previews_enabled"
-                            android:title="Enable inline media previews"
-                            android:summary="Show supported media previews directly in comments."
-                            android:defaultValue="true" />
-
-                        <app.morphe.extension.boostforreddit.giphy.PreviewAlignmentPreference
-                            android:icon="@drawable/ic_photo_outline_24dp"
-                            android:key="morphe_boost_inline_media_preview_alignment"
-                            android:title="Preview alignment"
-                            android:summary="Center"
-                            android:dialogTitle="Preview alignment"
-                            android:defaultValue="center" />
-
-                        <app.morphe.extension.boostforreddit.giphy.PreviewSizePreference
-                            android:icon="@drawable/ic_photo_outline_24dp"
-                            android:key="morphe_boost_inline_media_preview_size"
-                            android:title="Preview size"
-                            android:summary="Balanced"
-                            android:dialogTitle="Preview size"
-                            android:defaultValue="balanced" />
-
-                        <app.morphe.extension.boostforreddit.giphy.MediaTapActionPreference
-                            android:icon="@drawable/ic_photo_outline_24dp"
-                            android:key="morphe_boost_direct_reddit_gif_tap_action"
-                            android:title="Direct Reddit GIF tap action"
-                            android:summary="Image viewer"
-                            android:dialogTitle="Direct Reddit GIF tap action"
-                            android:defaultValue="image_viewer" />
-
-                        <app.morphe.extension.boostforreddit.giphy.MediaTapActionPreference
-                            android:icon="@drawable/ic_photo_outline_24dp"
-                            android:key="morphe_boost_giphy_preview_tap_action"
-                            android:title="Giphy preview tap action"
-                            android:summary="Video viewer"
-                            android:dialogTitle="Giphy preview tap action"
-                            android:defaultValue="video_viewer" />
-
-                        <app.morphe.extension.boostforreddit.giphy.MediaTapActionPreference
-                            android:icon="@drawable/ic_photo_outline_24dp"
-                            android:key="morphe_boost_static_preview_tap_action"
-                            android:title="Static preview tap action"
-                            android:summary="Image viewer"
-                            android:dialogTitle="Static preview tap action"
-                            android:defaultValue="image_viewer" />
-
-                        <CheckBoxPreference
-                            android:key="morphe_boost_inline_media_preview_show_source_text"
-                            android:title="Show source text with preview"
-                            android:summary="Keep the original link text visible with the preview."
-                            android:defaultValue="false" />
-
-                        <CheckBoxPreference
-                            android:key="morphe_boost_reddit_undelete_enabled"
-                            android:title="Automatically undelete Reddit content"
-                            android:summary="Try to restore supported deleted Reddit posts/comments from archive sources. Disabled by default to keep normal browsing stable."
-                            android:defaultValue="false" />
-
-                        <CheckBoxPreference
-                            android:key="morphe_boost_imgur_undelete_enabled"
-                            android:title="Automatically undelete Imgur images"
-                            android:summary="Try to restore supported missing Imgur media from archive sources. Disabled by default."
-                            android:defaultValue="false" />
-                    </PreferenceCategory>
+                        android:title="@string/history"
+                        android:fragment="com.rubenmayayo.reddit.ui.preferences.v2.PreferenceFragmentPrivacyCompat" />
+                    <Preference
+                        android:icon="@drawable/ic_settings_24dp"
+                        android:title="@string/pref_category_advanced"
+                        android:fragment="com.rubenmayayo.reddit.ui.preferences.v2.PreferenceFragmentAdvancedCompat" />
+                    <Preference
+                        android:icon="@drawable/ic_help_24dp"
+                        android:title="@string/pref_header_about"
+                        android:fragment="com.rubenmayayo.reddit.ui.preferences.v2.PreferenceFragmentAboutCompat" />
+                    <Preference
+                        android:icon="@drawable/ic_baseline_favorite_border_24"
+                        android:title="@string/action_remove_ads"
+                        android:key="remove_ads"
+                        android:summary="@string/support_boost"
+                        app:allowDividerAbove="true"
+                        app:allowDividerBelow="true" />
+                    <Preference
+                        android:icon="@drawable/ic_baseline_favorite_border_24"
+                        android:title="@string/action_buy_pro"
+                        android:key="buy_pro"
+                        app:allowDividerAbove="true"
+                        app:allowDividerBelow="true" />
+                    <Preference
+                        android:icon="@drawable/ic_gas_station"
+                        android:visible="false"
+                        android:title="@string/support_pref"
+                        android:key="support_launch"
+                        android:summary="@string/support_explanation"
+                        app:allowDividerAbove="true"
+                        app:allowDividerBelow="true" />
+                    <Preference
+                        android:icon="@drawable/ic_info_outline_24dp"
+                        android:title="@string/about_privacy_policy"
+                        android:key="privacy_policy"
+                        app:allowDividerAbove="true" />
                 </PreferenceScreen>
                 """.trimIndent()
             )

--- a/patches/src/main/kotlin/app/morphe/patches/reddit/customclients/boostforreddit/misc/settings/BoostMorpheSettingsSkeletonPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/reddit/customclients/boostforreddit/misc/settings/BoostMorpheSettingsSkeletonPatch.kt
@@ -57,14 +57,6 @@ private val boostMorpheSettingsResourcesPatch = resourcePatch(
                 """
                 <?xml version="1.0" encoding="utf-8"?>
                 <PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android">
-                    <PreferenceCategory android:title="Settings">
-                        <CheckBoxPreference
-                            android:key="morphe_boost_settings_v4_enabled"
-                            android:title="Settings v4 (preview)"
-                            android:summary="Use Morphe's modern task-based settings. Close and reopen Settings to apply."
-                            android:defaultValue="false" />
-                    </PreferenceCategory>
-
                     <PreferenceCategory android:title="Media previews">
                         <CheckBoxPreference
                             android:key="morphe_boost_inline_media_previews_enabled"
@@ -149,6 +141,13 @@ private val boostMorpheSettingsResourcesPatch = resourcePatch(
                             android:title="Automatically undelete Imgur images"
                             android:summary="Try to restore supported missing Imgur media from archive sources. Disabled by default."
                             android:defaultValue="false" />
+                    </PreferenceCategory>
+                    <PreferenceCategory android:title="Settings">
+                        <CheckBoxPreference
+                            android:key="morphe_boost_settings_v4_enabled"
+                            android:title="Material settings"
+                            android:summary="Use Morphe's modern task-based settings. Reopen Settings to apply."
+                            android:defaultValue="true" />
                     </PreferenceCategory>
                 </PreferenceScreen>
                 """.trimIndent()
@@ -488,7 +487,7 @@ private val boostMorpheSettingsResourcesPatch = resourcePatch(
 @Suppress("unused")
 val boostMorpheSettingsSkeletonPatch = bytecodePatch(
     name = "Boost Morphe settings",
-    description = "Adds dedicated Morphe settings and an optional Morphe-owned Settings v4 interface.",
+    description = "Adds dedicated Morphe settings and Morphe-owned Material-style Settings v4 pages with a classic fallback.",
     default = false,
 ) {
     dependsOn(sharedExtensionPatch, boostMorpheSettingsResourcesPatch)
@@ -526,5 +525,6 @@ val boostMorpheSettingsSkeletonPatch = bytecodePatch(
                 """.trimIndent(),
             )
         }
+
     }
 }

--- a/tests/tools/fixtures/boost_morphe_settings_bindings.json
+++ b/tests/tools/fixtures/boost_morphe_settings_bindings.json
@@ -1,0 +1,77 @@
+{
+  "schema": 2,
+  "scope": "appearance-layout",
+  "harness_version": 56,
+  "safety": {
+    "classification": "reversible_dev_only",
+    "network": false,
+    "destructive": false,
+    "secrets": false
+  },
+  "render_probes": [
+    {"name": "title_typography", "keys": ["pref_title_font", "pref_font_size_title"]},
+    {"name": "comment_typography", "keys": ["pref_comments_font", "pref_font_size"]},
+    {"name": "saved_views_enabled", "keys": ["pref_view_per_subscription"]},
+    {"name": "preview_lines_enabled", "keys": ["pref_cards_preview_self"]},
+    {"name": "default_view_summary", "keys": ["pref_view"]},
+    {"name": "settings_shell_system_bars", "keys": []}
+  ],
+  "provenance": {
+    "preferences": [
+      "res/xml/pref_appearance_v2.xml",
+      "res/xml/pref_appearance_advanced_v2.xml",
+      "res/xml/pref_views_v2.xml",
+      "res/xml/pref_fonts_v2.xml"
+    ],
+    "native_listeners": [
+      "PreferenceFragmentAppearanceCompat",
+      "PreferenceFragmentViewsCompat",
+      "PreferenceFragmentFontsCompat"
+    ]
+  },
+  "appearance": [
+    {"constant": "KEY_DYNAMIC_COLORS", "key": "pref_dynamic_colors", "type": "boolean", "default": false, "writer": "dynamic", "consumer": "m2", "side_effects": ["i", "activity_recreate"]},
+    {"constant": "KEY_COLORED_STATUS_BAR", "key": "pref_colored_status_bar", "type": "boolean", "default": true, "writer": "system_bar", "consumer": "r1", "side_effects": ["h", "system_bars_apply"]},
+    {"constant": "KEY_COLORED_NAV_BAR", "key": "pref_colored_nav_bar", "type": "boolean", "default": false, "writer": "system_bar", "consumer": "m1", "side_effects": ["h", "system_bars_apply"]}
+  ],
+  "post_views": [
+    {"constant": "KEY_DEFAULT_VIEW", "key": "pref_view", "type": "string", "default": "0", "writer": "view", "consumer": "Y3", "domain": ["0", "7", "1", "4", "5", "2", "6", "3"], "side_effects": []},
+    {"constant": "KEY_REMEMBER_PER_COMMUNITY", "key": "pref_view_per_subscription", "type": "boolean", "default": false, "writer": "boolean", "consumer": "L2", "side_effects": []},
+    {"constant": "KEY_LEFT_HANDED", "key": "pref_left_handed", "type": "boolean", "default": false, "writer": "boolean", "consumer": "s2", "side_effects": ["h"]},
+    {"constant": "KEY_SUBREDDIT_PREFIX", "key": "pref_show_subreddit_prefix", "type": "boolean", "default": false, "writer": "subreddit_prefix", "consumer": "S7", "side_effects": ["c", "i"]},
+    {"constant": "KEY_CARDS_ROUNDED", "key": "pref_cards_rounded_corners", "type": "boolean", "default": false, "writer": "boolean", "consumer": "Y0", "side_effects": ["g"]},
+    {"constant": "KEY_CARDS_FULL_PREVIEW", "key": "pref_cards_full_preview", "type": "boolean", "default": false, "writer": "boolean", "consumer": "V0", "side_effects": ["g"]},
+    {"constant": "KEY_CARDS_SUBREDDIT_ICON", "key": "pref_cards_subreddit_icon", "type": "boolean", "default": true, "writer": "boolean", "consumer": "e3", "side_effects": ["g"]},
+    {"constant": "KEY_CARDS_GALLERY_CAROUSEL", "key": "pref_cards_gallery_carousel", "type": "boolean", "default": true, "writer": "boolean", "consumer": "L3", "side_effects": ["g"]},
+    {"constant": "KEY_CARDS_LINK_THUMBNAILS", "key": "pref_cards_links_as_thumbnails", "type": "boolean", "default": true, "writer": "boolean", "consumer": "Q", "side_effects": ["g"]},
+    {"constant": "KEY_CARDS_PREVIEW_TEXT", "key": "pref_cards_preview_self", "type": "boolean", "default": true, "writer": "boolean", "consumer": "f4", "side_effects": ["g"]},
+    {"constant": "KEY_CARDS_PREVIEW_LINES", "key": "pref_cards_preview_self_lines", "type": "integer", "default": 5, "writer": "preview_lines", "consumer": "g4", "domain": {"minimum": 0, "maximum": 100}, "side_effects": ["g"]},
+    {"constant": "KEY_MINI_ROUNDED", "key": "pref_mini_cards_rounded_corners", "type": "boolean", "default": true, "writer": "boolean", "consumer": "D2", "side_effects": ["g"]},
+    {"constant": "KEY_MINI_TRUNCATE_TITLE", "key": "pref_mini_cards_truncate_title", "type": "boolean", "default": true, "writer": "boolean", "consumer": "Y7", "side_effects": ["g"]},
+    {"constant": "KEY_MINI_BUTTONS", "key": "pref_mini_cards_buttons_visible", "type": "boolean", "default": false, "writer": "boolean", "consumer": "B2", "side_effects": ["g"]},
+    {"constant": "KEY_DENSE_BUTTONS", "key": "pref_dense_buttons_visible", "type": "boolean", "default": false, "writer": "boolean", "consumer": "h2", "side_effects": ["h"]},
+    {"constant": "KEY_PREVIEW_EXTERNAL_LINKS", "key": "pref_load_readability", "type": "boolean", "default": false, "writer": "boolean", "consumer": "I0", "side_effects": []},
+    {"constant": "KEY_LOCK_SIDEBAR", "key": "pref_lock_sidebar", "type": "boolean", "default": false, "writer": "boolean", "consumer": "w2", "side_effects": ["i"]}
+  ],
+  "fonts": [
+    {"constant": "KEY_TITLE_FONT", "key": "pref_title_font", "type": "string", "default": "", "writer": "font", "consumer": "m4", "side_effects": ["h"]},
+    {"constant": "KEY_TITLE_SIZE", "key": "pref_font_size_title", "type": "string", "default": "Medium", "writer": "size", "consumer": "q0", "side_effects": ["d"]},
+    {"constant": "KEY_COMMENTS_FONT", "key": "pref_comments_font", "type": "string", "default": "", "writer": "font", "consumer": "W", "side_effects": []},
+    {"constant": "KEY_COMMENTS_SIZE", "key": "pref_font_size", "type": "string", "default": "Medium", "writer": "size", "consumer": "p0", "side_effects": ["d"]}
+  ],
+  "font_domain": ["", "sans-serif-thin", "sans-serif-light", "sans-serif", "sans-serif-medium", "sans-serif-black", "sans-serif-condensed-light", "sans-serif-condensed", "serif", "monospace", "serif-monospace", "sans-serif-smallcaps", "RobotoSlab-Regular.ttf"],
+  "font_size_domain": ["XSmall", "Small", "Medium", "Large", "XLarge", "XXLarge"],
+  "app_icons": [
+    {"title": "Default", "resource": "ic_launcher", "alias": null},
+    {"title": "Grey", "resource": "ic_launcher_grey", "alias": "grey"},
+    {"title": "Vivid", "resource": "ic_launcher_vivid", "alias": "vivid"},
+    {"title": "Metal", "resource": "ic_launcher_metal", "alias": "metal"},
+    {"title": "Yellow", "resource": "ic_launcher_yellow", "alias": "yellow"}
+  ],
+  "saved_views": {
+    "preferences": "com.rubenmayayo.reddit.VIEW_PER_SUBSCRIPTION",
+    "domain": [0, 7, 1, 4, 5, 2, 6, 3],
+    "special_keys": ["_load_front_page_this_is_not_a_subreddit", "_load_saved_this_is_not_a_subreddit", "_load_history_this_is_not_a_subreddit"],
+    "custom_feed_suffix": ".multi"
+  }
+}

--- a/tests/tools/test_boost_morphe_settings_binding_runtime_source_contract.py
+++ b/tests/tools/test_boost_morphe_settings_binding_runtime_source_contract.py
@@ -1,0 +1,369 @@
+#!/usr/bin/env python3
+"""Source contract for the reversible DEV-only settings binding runtime audit."""
+
+import json
+import os
+import re
+import unittest
+from pathlib import Path
+
+
+TEST_PATH = Path(__file__).resolve()
+REPO_ROOT = Path(os.environ.get("MORPHE_REPO_ROOT", TEST_PATH.parents[2]))
+FIXTURE = TEST_PATH.parent / "fixtures" / "boost_morphe_settings_bindings.json"
+JAVA = (
+    REPO_ROOT
+    / "extensions/boostforreddit/src/main/java/app/morphe/extension/boostforreddit/settings"
+    / "MorpheSettingsV4BindingRuntimeAuditFragment.java"
+)
+TOOL = REPO_ROOT / "tools/boost-morphe-settings-binding-runtime.sh"
+REPORT_WRITER = REPO_ROOT / "tools/write-boost-morphe-settings-audit-report.py"
+
+
+def string_array(source, name):
+    match = re.search(
+        rf"{name}\s*=\s*new String\[\]\s*\{{(.*?)\}};", source, re.S
+    )
+    if match is None:
+        raise AssertionError(f"missing String array {name}")
+    return re.findall(r'"([^"]*)"', match.group(1))
+
+
+def int_array(source, name):
+    match = re.search(
+        rf"{name}\s*=\s*new int\[\]\s*\{{(.*?)\}};", source, re.S
+    )
+    if match is None:
+        raise AssertionError(f"missing int array {name}")
+    return [int(value) for value in re.findall(r"-?\d+", match.group(1))]
+
+
+def method_block(source, signature):
+    start = source.index(signature)
+    end = source.find("\n    private static ", start + len(signature))
+    return source[start:] if end < 0 else source[start:end]
+
+
+def switch_string_returns(source, signature):
+    block = method_block(source, signature)
+    result = {}
+    pending = []
+    for line in block.splitlines():
+        case = re.search(r'case "([^"]+)":', line)
+        if case:
+            pending.append(case.group(1))
+        returned = re.search(r'return "([^"]+)";', line)
+        if returned:
+            for key in pending:
+                result[key] = returned.group(1)
+            pending = []
+    return result
+
+
+class MorpheSettingsBindingRuntimeSourceContract(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.manifest = json.loads(FIXTURE.read_text(encoding="utf-8"))
+        cls.java = JAVA.read_text(encoding="utf-8")
+        cls.tool = TOOL.read_text(encoding="utf-8")
+        cls.report_writer = REPORT_WRITER.read_text(encoding="utf-8")
+
+    def test_runtime_key_registry_exactly_matches_static_binding_manifest(self):
+        specs = (
+            self.manifest["appearance"]
+            + self.manifest["post_views"]
+            + self.manifest["fonts"]
+        )
+        expected_boolean = {spec["key"] for spec in specs if spec["type"] == "boolean"}
+        expected_string = {spec["key"] for spec in specs if spec["type"] == "string"}
+        expected_integer = {spec["key"] for spec in specs if spec["type"] == "integer"}
+        self.assertEqual(expected_boolean, set(string_array(self.java, "BOOLEAN_KEYS")))
+        self.assertEqual(expected_string, set(string_array(self.java, "STRING_KEYS")))
+        self.assertEqual(expected_integer, set(string_array(self.java, "INTEGER_KEYS")))
+        self.assertEqual(
+            {
+                spec["key"]
+                for spec in specs
+                if spec["type"] == "boolean" and spec["default"] is True
+            },
+            set(string_array(self.java, "BOOLEAN_DEFAULT_TRUE_KEYS")),
+        )
+        self.assertEqual(
+            {
+                spec["key"]
+                for spec in specs
+                if spec["type"] == "boolean" and spec["default"] is True
+            },
+            set(string_array(self.java, "BOOLEAN_DEFAULT_TRUE_KEYS")),
+        )
+
+    def test_runtime_exercises_every_declared_domain(self):
+        self.assertEqual(2, self.manifest["schema"])
+        self.assertEqual("appearance-layout", self.manifest["scope"])
+        self.assertEqual(56, self.manifest["harness_version"])
+        self.assertEqual(
+            "reversible_dev_only",
+            self.manifest["safety"]["classification"],
+        )
+        self.assertFalse(self.manifest["safety"]["network"])
+        self.assertFalse(self.manifest["safety"]["destructive"])
+        self.assertFalse(self.manifest["safety"]["secrets"])
+        view_spec = next(
+            spec for spec in self.manifest["post_views"] if spec["key"] == "pref_view"
+        )
+        integer_spec = next(
+            spec
+            for spec in self.manifest["post_views"]
+            if spec["key"] == "pref_cards_preview_self_lines"
+        )
+        self.assertEqual(view_spec["domain"], string_array(self.java, "VIEW_VALUES"))
+        self.assertEqual(self.manifest["font_domain"], string_array(self.java, "FONT_VALUES"))
+        self.assertEqual(
+            self.manifest["font_size_domain"],
+            string_array(self.java, "FONT_SIZE_VALUES"),
+        )
+        self.assertEqual(
+            self.manifest["saved_views"]["domain"],
+            int_array(self.java, "SAVED_VIEW_VALUES"),
+        )
+        self.assertIn(
+            f'INTEGER_MINIMUM = {integer_spec["domain"]["minimum"]};', self.java
+        )
+        self.assertIn(
+            f'INTEGER_MAXIMUM = {integer_spec["domain"]["maximum"]};', self.java
+        )
+        self.assertIn(
+            f'"{self.manifest["saved_views"]["preferences"]}"', self.java
+        )
+        self.assertEqual(
+            [""]
+            + [option["alias"] for option in self.manifest["app_icons"] if option["alias"]],
+            string_array(self.java, "ICON_AUDIT_VALUES"),
+        )
+        self.assertIn("DOMAIN_ACTION_COUNT = 196", self.java)
+        for probe in self.manifest["render_probes"]:
+            self.assertIn(f'"{probe["name"]}"', self.java)
+        self.assertIn('if ("pref_view".equals(key)) {\n            return "0";', self.java)
+        self.assertIn('return "Medium";', self.java)
+        self.assertIn('return "";', self.java)
+        self.assertIn('snapshot.getBoolean("present:" + identity, false)', self.java)
+
+    def test_runtime_app_icon_inventory_matches_static_binding_manifest(self):
+        self.assertEqual(
+            [option["resource"] for option in self.manifest["app_icons"]],
+            string_array(self.java, "ICON_RESOURCES"),
+        )
+        self.assertEqual(
+            [option["alias"] for option in self.manifest["app_icons"] if option["alias"]],
+            string_array(self.java, "ICON_ALIASES"),
+        )
+        self.assertIn("PackageManager.MATCH_DISABLED_COMPONENTS", self.java)
+        self.assertIn("enabledAliases <= 1", self.java)
+
+    def test_effect_audit_maps_every_binding_to_the_native_consumer_and_cache(self):
+        specs = (
+            self.manifest["appearance"]
+            + self.manifest["post_views"]
+            + self.manifest["fonts"]
+        )
+        expected_consumers = {spec["key"]: spec["consumer"] for spec in specs}
+        actual_consumers = switch_string_returns(
+            self.java,
+            "private static String nativeConsumerForKey(String key)",
+        )
+        self.assertEqual(expected_consumers, actual_consumers)
+
+        cache_fields = {"d", "g", "h", "i"}
+        expected_effects = {
+            spec["key"]: next(
+                (effect for effect in reversed(spec["side_effects"]) if effect in cache_fields),
+                None,
+            )
+            for spec in specs
+        }
+        expected_effects = {
+            key: effect for key, effect in expected_effects.items() if effect is not None
+        }
+        actual_effects = switch_string_returns(
+            self.java,
+            "private static String effectFieldForKey(String key)",
+        )
+        self.assertEqual(expected_effects, actual_effects)
+        self.assertIn("AUDIT_ITEM_COUNT = 26", self.java)
+        self.assertIn("EFFECT_AUDIT_RELOAD_COUNT = 26", self.java)
+
+    def test_app_transaction_is_dev_only_reload_verified_and_restored(self):
+        required = (
+            'DEV_PACKAGE = "com.rubenmayayo.reddit.dev"',
+            "if (!DEV_PACKAGE.equals(context.getPackageName()))",
+            "MORPHE_BINDING_AUDIT_REFUSED_NON_DEV_PACKAGE",
+            'SCOPE_APPEARANCE_LAYOUT = "appearance-layout"',
+            "SNAPSHOT_LOCK_TIMEOUT_MS",
+            '"MORPHE_BINDING_AUDIT_FAIL phase=write active_lock"',
+            'PHASE_RECOVER_FORCE = "recover_force"',
+            "recoverIfNeeded(context, nonce, scope, true)",
+            "MORPHE_BINDING_AUDIT_ORPHAN_RECOVERY_FORCED",
+            "createSnapshot(",
+            "exerciseFullDomainsViaUiActions(",
+            "exerciseBooleanDomain(defaults, snapshot, key)",
+            "exerciseStringDomain(defaults, snapshot, key)",
+            "exerciseIntegerDomain(",
+            "exerciseSavedViewDomain(savedViews, snapshot)",
+            "exerciseAppIconDomain(context, snapshot)",
+            "verifyPersistedAuditValues(context, snapshot)",
+            "verifyNativeConsumersAfterReload(context, snapshot)",
+            "MorpheSettingsV4AppearanceFragment.applyDynamicColors(",
+            "MorpheSettingsV4AppearanceFragment.applySystemBarPreference(",
+            "MorpheSettingsV4PostViewsFragment.applyBooleanPreference(",
+            "MorpheSettingsV4PostViewsFragment.applySubredditPrefix(",
+            "MorpheSettingsV4PostViewsFragment.applyDefaultViewPreference(",
+            "MorpheSettingsV4PostViewsFragment.applyPreviewLinesPreference(",
+            "MorpheSettingsV4FontsFragment.applyFontPreference(",
+            "MorpheSettingsV4SavedViewsFragment.applySavedView(",
+            "MorpheSettingsV4AppIconFragment.applyIconSelection(",
+            "MorpheSettingsV4FontsFragment.applyPreviewTypography(",
+            "MorpheSettingsV4PostViewsFragment.applyDependentRowState(",
+            "BoostSystemBarInsetsFix.applyMorpheSettingsV4SystemBars(",
+            "invokeNativeConsumer(nativeConsumerForKey(key))",
+            "MORPHE_DOMAIN_AUDIT_OK items=",
+            "MORPHE_RENDER_AUDIT_OK count=",
+            "MORPHE_DOMAIN_AUDIT_RELOAD_OK count=",
+            "snapshotIconComponents(context, editor)",
+            '"icon_state:" + alias',
+            "restoreIconComponents(context, snapshot)",
+            "verifyExpectedAuditIcon(context, snapshot)",
+            "restoreOriginalValues(context, snapshot)",
+            "MORPHE_BINDING_AUDIT_RELOAD_OK",
+            "MORPHE_BINDING_AUDIT_RESTORE_OK",
+            "MORPHE_BOOST_SETTINGS_APPEARANCE_LAYOUT_AUDIT_V56_APP_PASS",
+        )
+        for snippet in required:
+            self.assertIn(snippet, self.java)
+        for forbidden in (
+            "exerciseBooleanBindings(",
+            "exerciseStringBindings(",
+            "exerciseIntegerBindings(",
+            "commitBoolean(",
+            "commitString(",
+            "commitInteger(",
+        ):
+            self.assertNotIn(forbidden, self.java)
+
+    def test_render_probes_share_the_same_helpers_as_the_visible_ui(self):
+        fonts = (
+            JAVA.parent / "MorpheSettingsV4FontsFragment.java"
+        ).read_text(encoding="utf-8")
+        post_views = (
+            JAVA.parent / "MorpheSettingsV4PostViewsFragment.java"
+        ).read_text(encoding="utf-8")
+        self.assertIn("applyPreviewTypography(", fonts)
+        self.assertIn("preview.setTypeface(typefaceFor(fontValue))", fonts)
+        self.assertIn("preview.setTextSize(previewSizeSp(sizeValue, title))", fonts)
+        self.assertIn("applyDependentRowState(", post_views)
+        self.assertIn("row.setAlpha(enabled ? 1.0f : 0.44f)", post_views)
+        self.assertIn("RENDER_PROBE_COUNT = 6", self.java)
+        self.assertIn(
+            "MORPHE_BOOST_SETTINGS_AUDIT_SYSTEM_BARS_ANDROID15_V56_1",
+            self.java,
+        )
+        self.assertIn("assertSettingsSystemBarRendering(", self.java)
+        self.assertIn(
+            "MORPHE_BOOST_COMMENTS_SYSTEM_BAR_SURFACE_V1",
+            self.java,
+        )
+        self.assertIn(
+            "MORPHE_BOOST_SETTINGS_V4_NAVIGATION_SURFACE_ISSUE106_V3",
+            self.java,
+        )
+        self.assertIn("Build.VERSION.SDK_INT >= 35", self.java)
+        self.assertNotIn(
+            "window.getStatusBarColor() != tokens.background",
+            self.java,
+        )
+
+    def test_runtime_entry_avoids_fragment_activity_api_missing_from_boost(self):
+        self.assertNotIn("getActivity()", self.java)
+        self.assertNotIn("requireActivity()", self.java)
+        self.assertIn(
+            "Activity activity = activityFromContext(inflater.getContext());",
+            self.java,
+        )
+        self.assertIn("current instanceof ContextWrapper", self.java)
+
+    def test_shell_orchestrator_fails_closed_and_never_mutates_normal_boost(self):
+        required = (
+            "MORPHE_RUNTIME_AUDIT_MUTATE_DEV",
+            "--scope appearance-layout",
+            "tools/boost-adb-serial.sh",
+            "ADB=(env -u ANDROID_SERIAL adb -s \"$SERIAL\")",
+            "AUDIT_ACTIVE=1",
+            "another settings audit owns",
+            "flock -n 9",
+            "MORPHE_RUNTIME_AUDIT_RECOVER_ORPHANED_DEV",
+            "--recover-orphaned",
+            "start_phase recover_force",
+            "MORPHE_BOOST_SETTINGS_AUDIT_V56_ORPHAN_RECOVERY_PASS",
+            "DEV_AUDIT_HOST_LOCK=PASS",
+            "trap recover_on_exit EXIT",
+            "start_phase write",
+            "MorpheSettingsV4BindingRuntimeAuditFragment",
+            "userId\\|appId",
+            'shell pm list packages -U "$DEV_PACKAGE"',
+            "could not resolve Boost DEV uid from userId, appId, or pm -U",
+            "pkgFlags=.*DEBUGGABLE",
+            "--debuggable-dev",
+            'shell am start -W',
+            'rg -q "^uid=${DEV_UID}\\\\("',
+            "DEV_DEBUGGABLE=PASS",
+            "DEV_RUN_AS_UID=PASS",
+            "DEV_AUDIT_GATEWAY_LAUNCH=ARMED",
+            "shell am force-stop \"$DEV_PACKAGE\"",
+            "start_phase verify_restore",
+            'logcat --uid="$DEV_UID"',
+            "MORPHE_BINDING_AUDIT_RELOAD_OK",
+            "MORPHE_BINDING_AUDIT_RESTORE_OK",
+            "MORPHE_DOMAIN_AUDIT_OK items=26 actions=196",
+            "MORPHE_RENDER_AUDIT_OK count=6",
+            "MORPHE_DOMAIN_AUDIT_RELOAD_OK count=26",
+            "DEV_ALL_REGISTERED_DOMAINS_VIA_UI_ACTIONS=PASS",
+            "DEV_APPEARANCE_LAYOUT_NATIVE_CONSUMERS=PASS",
+            "DEV_RENDERED_EFFECT_PROBES=PASS",
+            "DEV_APP_ICON_DURABLE_SNAPSHOT=PASS",
+            "DEV_NATIVE_CONSUMERS_AND_ICON_AFTER_COLD_RELOAD=PASS",
+            "tools/write-boost-morphe-settings-audit-report.py",
+            "STRUCTURED_AUDIT_REPORT=PASS",
+            "RESULT=MORPHE_BOOST_SETTINGS_APPEARANCE_LAYOUT_AUDIT_V56_RUNTIME_PASS",
+            "NORMAL_BOOST_UNTOUCHED=PASS",
+        )
+        for snippet in required:
+            self.assertIn(snippet, self.tool)
+        forbidden = (
+            'force-stop "$NORMAL_PACKAGE"',
+            "pm clear",
+            " uninstall ",
+            " install ",
+            'shell run-as "$DEV_PACKAGE" /system/bin/am start',
+        )
+        for snippet in forbidden:
+            self.assertNotIn(snippet, self.tool)
+
+        for snippet in (
+            "manifest_sha256",
+            '"items": items',
+            '"render_probes": render_probes',
+            '"apk_sha256": args.apk_sha256',
+            '"status": status',
+        ):
+            self.assertIn(snippet, self.report_writer)
+
+
+if __name__ == "__main__":
+    suite = unittest.defaultTestLoader.loadTestsFromTestCase(
+        MorpheSettingsBindingRuntimeSourceContract
+    )
+    result = unittest.TextTestRunner(verbosity=2).run(suite)
+    if result.wasSuccessful():
+        relative = TEST_PATH.relative_to(REPO_ROOT)
+        print(f"SOURCE_CONTRACT=PASS path={relative}")
+        print("RESULT=MORPHE_ISSUE106_SETTINGS_BINDING_RUNTIME_SOURCE_OK")
+    raise SystemExit(0 if result.wasSuccessful() else 1)

--- a/tests/tools/test_boost_morphe_settings_bindings_source_contract.py
+++ b/tests/tools/test_boost_morphe_settings_bindings_source_contract.py
@@ -1,0 +1,319 @@
+#!/usr/bin/env python3
+"""Exhaustive source contract for Morphe Settings v4 preference bindings."""
+
+import json
+import os
+import re
+import unittest
+from collections import Counter
+from pathlib import Path
+
+
+TEST_PATH = Path(__file__).resolve()
+REPO_ROOT = Path(os.environ.get("MORPHE_REPO_ROOT", TEST_PATH.parents[2]))
+FIXTURE = TEST_PATH.parent / "fixtures" / "boost_morphe_settings_bindings.json"
+JAVA_ROOT = Path(
+    os.environ.get(
+        "MORPHE_JAVA_ROOT",
+        REPO_ROOT
+        / "extensions/boostforreddit/src/main/java/app/morphe/extension/boostforreddit/settings",
+    )
+)
+
+
+def compact(text):
+    return re.sub(r"\s+", " ", text).strip()
+
+
+def string_constants(text):
+    return dict(
+        re.findall(
+            r"private static final String (KEY_[A-Z0-9_]+)\s*=\s*\"([^\"]*)\";",
+            text,
+            re.S,
+        )
+    )
+
+
+def string_array(text, name):
+    match = re.search(
+        rf"{name}\s*=\s*new String\[\]\s*\{{(.*?)\}};", text, re.S
+    )
+    if match is None:
+        raise AssertionError(f"missing String array {name}")
+    return re.findall(r'\"([^\"]*)\"', match.group(1))
+
+
+def int_array(text, name):
+    match = re.search(
+        rf"{name}\s*=\s*new int\[\]\s*\{{(.*?)\}};", text, re.S
+    )
+    if match is None:
+        raise AssertionError(f"missing int array {name}")
+    return [int(value) for value in re.findall(r"-?\d+", match.group(1))]
+
+
+class MorpheSettingsBindingsSourceContract(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.manifest = json.loads(FIXTURE.read_text(encoding="utf-8"))
+        cls.sources = {}
+        for short_name in (
+            "Appearance",
+            "PostViews",
+            "Fonts",
+            "AppIcon",
+            "SavedViews",
+        ):
+            path = JAVA_ROOT / f"MorpheSettingsV4{short_name}Fragment.java"
+            cls.sources[short_name] = path.read_text(encoding="utf-8")
+        cls.compact_sources = {
+            name: compact(source) for name, source in cls.sources.items()
+        }
+
+    def assert_contains(self, source_name, snippet):
+        self.assertIn(compact(snippet), self.compact_sources[source_name])
+
+    def assert_occurs_once(self, source_name, snippet):
+        self.assertEqual(
+            1,
+            self.compact_sources[source_name].count(compact(snippet)),
+            snippet,
+        )
+
+    def assert_exact_key_set(self, source_name, specs):
+        expected = {spec["constant"]: spec["key"] for spec in specs}
+        actual = string_constants(self.sources[source_name])
+        self.assertEqual(expected, actual)
+        literal_keys = set(re.findall(r'\"(pref_[^\"]+)\"', self.sources[source_name]))
+        self.assertEqual(set(expected.values()), literal_keys)
+
+    def assert_read(self, source_name, spec):
+        constant = spec["constant"]
+        default = spec["default"]
+        if spec["type"] == "boolean":
+            literal = "true" if default else "false"
+            self.assert_contains(
+                source_name, f"preferences.getBoolean({constant}, {literal})"
+            )
+        elif spec["type"] == "integer":
+            self.assert_contains(
+                source_name, f"preferences.getInt({constant}, {default})"
+            )
+        else:
+            self.assert_contains(
+                source_name,
+                f'preferences.getString({constant}, "{default}")',
+            )
+
+    def test_appearance_rows_have_exact_read_write_and_effect_bindings(self):
+        specs = self.manifest["appearance"]
+        self.assert_exact_key_set("Appearance", specs)
+        for spec in specs:
+            self.assert_read("Appearance", spec)
+
+        self.assert_occurs_once("Appearance", "checked -> updateDynamicColors(checked)")
+        self.assert_contains(
+            "Appearance", "applyDynamicColors(preferences, enabled)"
+        )
+        self.assert_contains(
+            "Appearance",
+            "preferences.edit().putBoolean(KEY_DYNAMIC_COLORS, enabled).apply()",
+        )
+        self.assert_contains("Appearance", 'setBoostStaticBoolean("i")')
+        self.assert_occurs_once(
+            "Appearance",
+            "checked -> updateSystemBarPreference( KEY_COLORED_STATUS_BAR, checked )",
+        )
+        self.assert_occurs_once(
+            "Appearance",
+            "checked -> updateSystemBarPreference( KEY_COLORED_NAV_BAR, checked )",
+        )
+        self.assert_contains(
+            "Appearance", "applySystemBarPreference(preferences, key, enabled)"
+        )
+        self.assert_contains(
+            "Appearance", "preferences.edit().putBoolean(key, enabled).apply()"
+        )
+        self.assert_contains("Appearance", 'setBoostStaticBoolean("h")')
+        self.assert_contains("Appearance", "activity.recreate()")
+        self.assert_contains(
+            "Appearance", "BoostSystemBarInsetsFix.applyMorpheSettingsV4SystemBars("
+        )
+
+    def test_post_view_rows_have_exact_read_write_and_effect_bindings(self):
+        specs = self.manifest["post_views"]
+        self.assert_exact_key_set("PostViews", specs)
+        self.assertEqual(
+            self.manifest["post_views"][0]["domain"],
+            string_array(self.sources["PostViews"], "VIEW_VALUES"),
+        )
+        actual_reads = Counter(
+            re.findall(
+                r"preferences\.get(?:Boolean|String|Int)\(\s*(KEY_[A-Z0-9_]+)\s*,",
+                self.compact_sources["PostViews"],
+            )
+        )
+        expected_reads = Counter(spec["constant"] for spec in specs)
+        expected_reads["KEY_DEFAULT_VIEW"] += 1
+        expected_reads["KEY_REMEMBER_PER_COMMUNITY"] += 1
+        expected_reads["KEY_CARDS_PREVIEW_TEXT"] += 1
+        self.assertEqual(expected_reads, actual_reads)
+
+        for spec in specs:
+            self.assert_read("PostViews", spec)
+            constant = spec["constant"]
+            writer = spec["writer"]
+            effects = spec["side_effects"]
+            if writer == "boolean":
+                flag = next((value for value in effects if value in {"g", "h", "i"}), None)
+                flag_literal = f'"{flag}"' if flag else "null"
+                self.assert_occurs_once(
+                    "PostViews",
+                    f"putBoolean({constant}, checked, {flag_literal})",
+                )
+            elif writer == "subreddit_prefix":
+                self.assert_contains("PostViews", "this::updateSubredditPrefix")
+            elif writer == "view":
+                self.assert_contains(
+                    "PostViews",
+                    "applyDefaultViewPreference( preferences, VIEW_VALUES[choice] )",
+                )
+            elif writer == "preview_lines":
+                self.assert_contains(
+                    "PostViews",
+                    "applyPreviewLinesPreference(preferences, current)",
+                )
+
+        self.assert_contains(
+            "PostViews", "preferences.edit().putBoolean(key, value).apply()"
+        )
+        self.assert_contains(
+            "PostViews",
+            "applyBooleanPreference(preferences, key, value, refreshFlag)",
+        )
+        self.assert_contains(
+            "PostViews",
+            "preferences.edit().putBoolean(KEY_SUBREDDIT_PREFIX, enabled).apply()",
+        )
+        self.assert_contains(
+            "PostViews", 'setBoostStaticString("c", enabled ? "r/" : "")'
+        )
+        self.assert_contains("PostViews", 'setBoostStaticBoolean("i")')
+        self.assert_contains("PostViews", "previewLinesSeekBar.setMax(100)")
+        self.assert_contains(
+            "PostViews", "setRowEnabled(manageSavedViewsRow, checked)"
+        )
+        self.assert_contains(
+            "PostViews", "setPreviewLinesEnabled(checked)"
+        )
+
+    def test_font_rows_have_exact_read_write_domain_and_cache_bindings(self):
+        specs = self.manifest["fonts"]
+        self.assert_exact_key_set("Fonts", specs)
+        self.assertEqual(
+            self.manifest["font_domain"],
+            string_array(self.sources["Fonts"], "FONT_VALUES"),
+        )
+        self.assertEqual(
+            self.manifest["font_size_domain"],
+            string_array(self.sources["Fonts"], "SIZE_VALUES"),
+        )
+        actual_constant_reads = Counter(
+            re.findall(
+                r"preferences\.getString\(\s*(KEY_[A-Z0-9_]+)\s*,",
+                self.compact_sources["Fonts"],
+            )
+        )
+        self.assertEqual(
+            Counter({spec["constant"]: 2 for spec in specs}),
+            actual_constant_reads,
+        )
+
+        for spec in specs:
+            self.assert_read("Fonts", spec)
+            dialog = "showFontDialog" if spec["writer"] == "font" else "showSizeDialog"
+            self.assert_occurs_once(
+                "Fonts", f"view -> {dialog}({spec['constant']},"
+            )
+
+        self.assert_contains(
+            "Fonts", "preferences.edit().putString(key, value).apply()"
+        )
+        self.assert_contains(
+            "Fonts", "applyFontPreference(preferences, key, value)"
+        )
+        self.assert_contains("Fonts", "markNativeFontCacheDirty(key)")
+        self.assert_contains(
+            "Fonts",
+            "if (KEY_TITLE_SIZE.equals(key) || KEY_COMMENTS_SIZE.equals(key))",
+        )
+        self.assert_contains("Fonts", 'fieldName = "d"')
+        self.assert_contains(
+            "Fonts", "else if (KEY_TITLE_FONT.equals(key))"
+        )
+        self.assert_contains("Fonts", 'fieldName = "h"')
+        self.assert_contains(
+            "Fonts", 'Class.forName("id.b").getDeclaredField(fieldName)'
+        )
+        for spec in specs:
+            self.assert_contains("Fonts", f".remove({spec['constant']})")
+
+    def test_app_icon_options_are_complete_and_component_states_are_exclusive(self):
+        actual = []
+        for title, resource, alias in re.findall(
+            r'new IconOption\("([^\"]+)", "([^\"]+)", (null|"[^\"]+")\)',
+            self.sources["AppIcon"],
+        ):
+            actual.append(
+                {
+                    "title": title,
+                    "resource": resource,
+                    "alias": None if alias == "null" else alias.strip('"'),
+                }
+            )
+        self.assertEqual(self.manifest["app_icons"], actual)
+        self.assert_contains(
+            "AppIcon",
+            "candidate.alias.equals(selectedAlias) ? PackageManager.COMPONENT_ENABLED_STATE_ENABLED : PackageManager.COMPONENT_ENABLED_STATE_DISABLED",
+        )
+        self.assert_contains(
+            "AppIcon", "applyIconSelection(context, option.alias)"
+        )
+        self.assert_contains(
+            "AppIcon", "packageManager.setComponentEnabledSetting( component, state, PackageManager.DONT_KILL_APP )"
+        )
+        self.assert_contains(
+            "AppIcon", "packageManager.getComponentEnabledSetting( aliasComponent(context, option.alias) )"
+        )
+
+    def test_saved_views_use_the_native_store_domain_and_crud_operations(self):
+        spec = self.manifest["saved_views"]
+        source = self.sources["SavedViews"]
+        self.assertIn(f'"{spec["preferences"]}"', source)
+        self.assertEqual(spec["domain"], int_array(source, "VIEW_VALUES"))
+        for key in spec["special_keys"]:
+            self.assertIn(f'"{key}"', source)
+        self.assertIn(f'"{spec["custom_feed_suffix"]}"', source)
+        for operation in (
+            "savedViews.getAll()",
+            "applySavedView( savedViews, entry.key, VIEW_VALUES[choice] )",
+            "removeSavedView(savedViews, entry.key)",
+            "clearSavedViews(savedViews)",
+            "savedViews.edit().putInt(key, viewType).apply()",
+            "savedViews.edit().remove(key).apply()",
+            "savedViews.edit().clear().apply()",
+            "normalizeSavedViewKey(",
+        ):
+            self.assertIn(compact(operation), compact(source))
+
+
+if __name__ == "__main__":
+    suite = unittest.defaultTestLoader.loadTestsFromTestCase(
+        MorpheSettingsBindingsSourceContract
+    )
+    result = unittest.TextTestRunner(verbosity=2).run(suite)
+    if result.wasSuccessful():
+        print(f"SOURCE_CONTRACT=PASS path={TEST_PATH.relative_to(REPO_ROOT) if TEST_PATH.is_relative_to(REPO_ROOT) else TEST_PATH}")
+        print("RESULT=MORPHE_ISSUE106_SETTINGS_BINDINGS_SOURCE_OK")
+    raise SystemExit(0 if result.wasSuccessful() else 1)

--- a/tests/tools/test_boost_mpp_workflow.py
+++ b/tests/tools/test_boost_mpp_workflow.py
@@ -85,6 +85,65 @@ class BoostMppWorkflowContractTests(unittest.TestCase):
         build = text.index("===== build patched normal candidate =====")
         self.assertLess(check, build)
 
+    def test_debuggable_dev_is_opt_in_and_forwarded_only_to_clone(self) -> None:
+        text = (ROOT / "tools" / "boost-dev-from-mpp.sh").read_text(
+            encoding="utf-8"
+        )
+        self.assertIn("--debuggable-dev", text)
+        self.assertIn("DEBUGGABLE_DEV=0", text)
+        self.assertIn("DEVCLONE_ARGS+=(--debuggable)", text)
+        self.assertIn("normal candidate must remain non-debuggable", text)
+
+    def test_devclone_sets_and_verifies_debuggable_manifest_on_request(self) -> None:
+        text = (ROOT / "tools" / "build-boost-devclone-candidate.sh").read_text(
+            encoding="utf-8"
+        )
+        self.assertIn("DEBUGGABLE=0", text)
+        self.assertIn('node.set(android_debuggable, "true")', text)
+        self.assertIn("signed DEV debuggable state matches request", text)
+
+    def test_debuggable_dev_gateway_is_exact_dump_protected_and_opt_in(self) -> None:
+        text = (ROOT / "tools" / "build-boost-devclone-candidate.sh").read_text(
+            encoding="utf-8"
+        )
+        self.assertIn(
+            'AUDIT_SETTINGS_ACTIVITY="com.rubenmayayo.reddit.ui.preferences.v2.SettingsActivityCompat"',
+            text,
+        )
+        self.assertIn('AUDIT_GATEWAY_PERMISSION="android.permission.DUMP"', text)
+        self.assertIn('node.set(android_exported, "true")', text)
+        self.assertIn(
+            "node.set(android_permission, audit_gateway_permission)", text
+        )
+        self.assertIn("if debuggable and audit_gateway_rewrites != 1", text)
+        self.assertIn(
+            "signed DEV settings audit gateway is exported and DUMP-protected",
+            text,
+        )
+        self.assertIn("check_boost_settings_audit_gateway.py", text)
+        self.assertIn(
+            "decoded DEV settings audit gateway state matches request", text
+        )
+
+    def test_normal_candidate_builder_does_not_enable_android_debugging(self) -> None:
+        text = (ROOT / "tools" / "build-boost-candidate.sh").read_text(
+            encoding="utf-8"
+        )
+        self.assertNotIn('key == "Enable Android debugging"', text)
+
+    def test_outer_workflow_rejects_audit_gateway_in_normal_candidate(self) -> None:
+        text = (ROOT / "tools" / "boost-dev-from-mpp.sh").read_text(
+            encoding="utf-8"
+        )
+        self.assertIn(
+            "normal candidate must not expose the settings audit gateway", text
+        )
+        self.assertIn("check_boost_settings_audit_gateway.py", text)
+        self.assertNotIn(
+            "grep -Fq 'android.permission.DUMP' \"$NORMAL_MANIFEST_XMLTREE\"",
+            text,
+        )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/tools/test_check_boost_settings_audit_gateway.py
+++ b/tests/tools/test_check_boost_settings_audit_gateway.py
@@ -1,0 +1,90 @@
+import subprocess
+import tempfile
+import textwrap
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+CHECKER = ROOT / "tools" / "check_boost_settings_audit_gateway.py"
+ACTIVITY = "com.rubenmayayo.reddit.ui.preferences.v2.SettingsActivityCompat"
+
+
+class BoostSettingsAuditGatewayTests(unittest.TestCase):
+    def run_checker(self, manifest: str, expected: str) -> subprocess.CompletedProcess[str]:
+        with tempfile.TemporaryDirectory(prefix="settings-audit-gateway-") as temp:
+            path = Path(temp) / "manifest.txt"
+            path.write_text(textwrap.dedent(manifest), encoding="utf-8")
+            return subprocess.run(
+                [
+                    "python3",
+                    str(CHECKER),
+                    "--manifest",
+                    str(path),
+                    "--expect",
+                    expected,
+                ],
+                text=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                check=False,
+            )
+
+    @staticmethod
+    def xmltree(settings_attributes: str) -> str:
+        return f"""
+        N: android=http://schemas.android.com/apk/res/android
+          E: manifest
+            E: application
+              E: activity
+                A: android:name(0x01010003)=\"{ACTIVITY}\" (Raw: \"{ACTIVITY}\")
+                {settings_attributes}
+              E: receiver
+                A: android:name(0x01010003)=\"androidx.work.impl.diagnostics.DiagnosticsReceiver\"
+                A: android:permission(0x01010006)=\"android.permission.DUMP\" (Raw: \"android.permission.DUMP\")
+                A: android:exported(0x01010010)=(type 0x12)0xffffffff
+        """
+
+    def test_existing_dump_receiver_does_not_create_settings_gateway(self) -> None:
+        completed = self.run_checker(self.xmltree(""), "absent")
+        self.assertEqual(completed.returncode, 0, completed.stderr)
+        self.assertIn("SETTINGS_AUDIT_GATEWAY=ABSENT", completed.stdout)
+
+    def test_exact_exported_dump_protected_activity_is_present(self) -> None:
+        completed = self.run_checker(
+            self.xmltree(
+                """A: android:permission(0x01010006)=\"android.permission.DUMP\" (Raw: \"android.permission.DUMP\")
+                A: android:exported(0x01010010)=(type 0x12)0xffffffff"""
+            ),
+            "present",
+        )
+        self.assertEqual(completed.returncode, 0, completed.stderr)
+        self.assertIn("SETTINGS_AUDIT_GATEWAY=PRESENT", completed.stdout)
+
+    def test_partial_gateway_fails_closed(self) -> None:
+        completed = self.run_checker(
+            self.xmltree(
+                'A: android:permission(0x01010006)="android.permission.DUMP"'
+            ),
+            "absent",
+        )
+        self.assertEqual(completed.returncode, 1)
+
+    def test_decoded_xml_uses_same_exact_component_check(self) -> None:
+        completed = self.run_checker(
+            f"""<?xml version=\"1.0\" encoding=\"utf-8\"?>
+            <manifest xmlns:android=\"http://schemas.android.com/apk/res/android\">
+              <application>
+                <activity android:name=\"{ACTIVITY}\" />
+                <receiver android:name=\"DiagnosticsReceiver\"
+                  android:permission=\"android.permission.DUMP\"
+                  android:exported=\"true\" />
+              </application>
+            </manifest>""",
+            "absent",
+        )
+        self.assertEqual(completed.returncode, 0, completed.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/tools/test_write_boost_morphe_settings_audit_report.py
+++ b/tests/tools/test_write_boost_morphe_settings_audit_report.py
@@ -1,0 +1,159 @@
+#!/usr/bin/env python3
+"""Contract tests for the structured Boost settings audit report."""
+
+import json
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+
+TEST_PATH = Path(__file__).resolve()
+REPO_ROOT = TEST_PATH.parents[2]
+MANIFEST = TEST_PATH.parent / "fixtures" / "boost_morphe_settings_bindings.json"
+WRITER = REPO_ROOT / "tools/write-boost-morphe-settings-audit-report.py"
+
+
+def domain_count(spec, manifest):
+    if spec["type"] == "boolean":
+        return 2
+    if spec["type"] == "integer":
+        domain = spec["domain"]
+        return domain["maximum"] - domain["minimum"] + 1
+    if spec["key"] == "pref_view":
+        return len(spec["domain"])
+    if spec["writer"] == "font":
+        return len(manifest["font_domain"])
+    return len(manifest["font_size_domain"])
+
+
+def complete_log():
+    manifest = json.loads(MANIFEST.read_text(encoding="utf-8"))
+    lines = []
+    for spec in (
+        manifest["appearance"]
+        + manifest["post_views"]
+        + manifest["fonts"]
+    ):
+        lines.append(
+            "MORPHE_AUDIT_ITEM_OK "
+            f"key={spec['key']} "
+            f"domain_count={domain_count(spec, manifest)} "
+            f"consumer=id.b.{spec['consumer']} "
+            "effect=direct_consumer render=not_rendered"
+        )
+    lines.append(
+        "MORPHE_AUDIT_ITEM_OK key=saved_views domain_count=8 "
+        "consumer=VIEW_PER_SUBSCRIPTION "
+        "effect=canonical_named_preferences render=native_consumer"
+    )
+    lines.append(
+        "MORPHE_AUDIT_ITEM_OK key=app_icon domain_count=5 "
+        "consumer=PackageManager effect=launcher_alias "
+        "render=launcher_components"
+    )
+    for probe, keys in (
+        ("title_typography", "pref_title_font,pref_font_size_title"),
+        ("comment_typography", "pref_comments_font,pref_font_size"),
+        ("saved_views_enabled", "pref_view_per_subscription"),
+        ("preview_lines_enabled", "pref_cards_preview_self"),
+        ("default_view_summary", "pref_view"),
+        ("settings_shell_system_bars", "-"),
+    ):
+        lines.append(
+            "MORPHE_RENDER_AUDIT_ITEM_OK "
+            f"probe={probe} keys={keys}"
+        )
+    lines.extend(
+        (
+            "MORPHE_BINDING_AUDIT_WRITE_OK",
+            "MORPHE_DOMAIN_AUDIT_OK items=26 actions=196",
+            "MORPHE_RENDER_AUDIT_OK count=6",
+            "MORPHE_BINDING_AUDIT_RELOAD_OK",
+            "MORPHE_DOMAIN_AUDIT_RELOAD_OK count=26",
+            "MORPHE_BINDING_AUDIT_RESTORE_OK",
+            "RESULT=MORPHE_BOOST_SETTINGS_"
+            "APPEARANCE_LAYOUT_AUDIT_V56_APP_PASS",
+        )
+    )
+    return "\n".join(lines) + "\n"
+
+
+class AuditReportWriterContract(unittest.TestCase):
+    def run_writer(self, log_text, requested_status="PASS"):
+        temporary = tempfile.TemporaryDirectory()
+        root = Path(temporary.name)
+        log = root / "audit.log"
+        output = root / "audit.json"
+        log.write_text(log_text, encoding="utf-8")
+        command = [
+            "python3",
+            str(WRITER),
+            "--log",
+            str(log),
+            "--manifest",
+            str(MANIFEST),
+            "--output",
+            str(output),
+            "--status",
+            requested_status,
+            "--package",
+            "com.rubenmayayo.reddit.dev",
+            "--version-name",
+            "1.12.12",
+            "--version-code",
+            "1234",
+            "--apk-sha256",
+            "a" * 64,
+            "--android-release",
+            "17",
+            "--android-sdk",
+            "37",
+            "--device",
+            "oriole",
+            "--model",
+            "Pixel_6",
+            "--normal-boost-untouched",
+            "true",
+        ]
+        result = subprocess.run(command, capture_output=True, text=True)
+        report = json.loads(output.read_text(encoding="utf-8"))
+        return temporary, result, report
+
+    def test_complete_pass_report_is_machine_readable_and_exact(self):
+        temporary, result, report = self.run_writer(complete_log())
+        self.addCleanup(temporary.cleanup)
+        self.assertEqual(0, result.returncode, result.stderr)
+        self.assertEqual("PASS", report["result"]["status"])
+        self.assertEqual(26, report["summary"]["audit_items"])
+        self.assertEqual(196, report["summary"]["domain_actions"])
+        self.assertEqual(6, report["summary"]["render_probes"])
+        self.assertEqual(56, report["harness"]["version"])
+        self.assertEqual(64, len(report["harness"]["manifest_sha256"]))
+        self.assertEqual(
+            "reversible_dev_only",
+            report["safety"]["classification"],
+        )
+
+    def test_requested_pass_fails_closed_when_a_phase_is_missing(self):
+        log = complete_log().replace("MORPHE_BINDING_AUDIT_RESTORE_OK\n", "")
+        temporary, result, report = self.run_writer(log)
+        self.addCleanup(temporary.cleanup)
+        self.assertNotEqual(0, result.returncode)
+        self.assertEqual("FAIL", report["result"]["status"])
+        self.assertFalse(report["phases"]["restore"])
+        self.assertIn("missing phases", report["result"]["failure_reason"])
+
+    def test_explicit_failure_report_can_be_written_from_partial_log(self):
+        temporary, result, report = self.run_writer(
+            "MORPHE_BINDING_AUDIT_FAIL phase=write\n",
+            requested_status="FAIL",
+        )
+        self.addCleanup(temporary.cleanup)
+        self.assertEqual(0, result.returncode)
+        self.assertEqual("FAIL", report["result"]["status"])
+        self.assertEqual([], report["items"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/boost-dev-from-mpp.sh
+++ b/tools/boost-dev-from-mpp.sh
@@ -15,6 +15,10 @@ SERIAL=""
 MARKERS=()
 INSTALL=0
 NO_VERIFY_WITH_SDK=1
+DEBUGGABLE_DEV=0
+AUDIT_SETTINGS_ACTIVITY="com.rubenmayayo.reddit.ui.preferences.v2.SettingsActivityCompat"
+AUDIT_GATEWAY_PERMISSION="android.permission.DUMP"
+AUDIT_GATEWAY_CHECKER="tools/check_boost_settings_audit_gateway.py"
 
 usage() {
   cat <<'EOF'
@@ -30,6 +34,10 @@ Options:
   --serial SERIAL            adb serial. Required when --install is used.
   --marker TEXT              Marker string required in normal and DEV APK. Repeatable.
   --install                  Install DEV APK to the selected device.
+  --debuggable-dev           Make only the DEV clone debuggable and enable its
+                             DUMP-protected settings audit gateway.
+                             The patched normal candidate remains non-debuggable
+                             and does not expose the audit gateway.
   --verify-with-sdk          Pass SDK verifier to Morphe CLI. Default is --no-verify-with-sdk.
   --no-verify-with-sdk       Do not pass SDK verifier to Morphe CLI. Default.
   --dev-package PACKAGE      DEV package. Default: com.rubenmayayo.reddit.dev.
@@ -81,6 +89,10 @@ while [ "$#" -gt 0 ]; do
       INSTALL=1
       shift
       ;;
+    --debuggable-dev)
+      DEBUGGABLE_DEV=1
+      shift
+      ;;
     --verify-with-sdk)
       NO_VERIFY_WITH_SDK=0
       shift
@@ -129,6 +141,11 @@ if [ -z "$NAME" ]; then
   exit 2
 fi
 
+if [ ! -f "$AUDIT_GATEWAY_CHECKER" ]; then
+  echo "Audit gateway checker missing: $AUDIT_GATEWAY_CHECKER" >&2
+  exit 2
+fi
+
 if [ "$INSTALL" -eq 1 ] && [ -z "$SERIAL" ]; then
   echo "Missing --serial when --install is used" >&2
   usage >&2
@@ -154,6 +171,7 @@ echo "EXPECTED_TARGET_SDK=$EXPECTED_TARGET_SDK"
 echo "INSTALL=$INSTALL"
 echo "SERIAL=$SERIAL"
 echo "NO_VERIFY_WITH_SDK=$NO_VERIFY_WITH_SDK"
+echo "DEBUGGABLE_DEV=$DEBUGGABLE_DEV"
 printf 'MARKERS=%s\n' "${MARKERS[*]:-}"
 
 echo
@@ -238,6 +256,21 @@ if [ "$FAIL" -eq 0 ]; then
   [ "$NORMAL_CANDIDATE_PACKAGE" = "$NORMAL_PACKAGE" ] || mark_fail "normal candidate package mismatch"
   [ "$NORMAL_TARGET_SDK" = "$EXPECTED_TARGET_SDK" ] || mark_fail "normal candidate targetSdk mismatch"
 
+  NORMAL_MANIFEST_XMLTREE="$OUT_DIR/normal-manifest-xmltree.txt"
+  if ! aapt dump xmltree "$NORMAL_APK" AndroidManifest.xml > "$NORMAL_MANIFEST_XMLTREE"; then
+    mark_fail "could not inspect normal candidate debuggable state"
+  elif grep -Eq 'android:debuggable.*0xffffffff' "$NORMAL_MANIFEST_XMLTREE"; then
+    mark_fail "normal candidate must remain non-debuggable"
+  elif ! python3 "$AUDIT_GATEWAY_CHECKER" \
+      --manifest "$NORMAL_MANIFEST_XMLTREE" \
+      --expect absent \
+      --activity "$AUDIT_SETTINGS_ACTIVITY" \
+      --permission "$AUDIT_GATEWAY_PERMISSION"; then
+    mark_fail "normal candidate must not expose the settings audit gateway"
+  else
+    echo "OK: normal candidate is non-debuggable and has no settings audit gateway"
+  fi
+
   for marker in "${MARKERS[@]}"; do
     if unzip -p "$NORMAL_APK" '*.dex' 2>/dev/null | strings | grep -F "$marker" >/dev/null; then
       echo "OK: normal marker present: $marker"
@@ -253,15 +286,20 @@ DEV_APK=""
 DEV_DIR=""
 if [ "$FAIL" -eq 0 ]; then
   DEV_NAME="${NAME}-devclone"
-  tools/build-boost-devclone-candidate.sh \
-    --source-apk "$NORMAL_APK" \
-    --base-apk "$BASE_APK" \
-    --patch-result "$NORMAL_DIR/patch-result.json" \
-    --name "$DEV_NAME" \
-    --dev-package "$DEV_PACKAGE" \
-    --normal-package "$NORMAL_PACKAGE" \
-    --label "$LABEL" \
-    2>&1 | tee "$OUT_DIR/build-devclone.log"
+  DEVCLONE_ARGS=(
+    tools/build-boost-devclone-candidate.sh
+    --source-apk "$NORMAL_APK"
+    --base-apk "$BASE_APK"
+    --patch-result "$NORMAL_DIR/patch-result.json"
+    --name "$DEV_NAME"
+    --dev-package "$DEV_PACKAGE"
+    --normal-package "$NORMAL_PACKAGE"
+    --label "$LABEL"
+  )
+  if [ "$DEBUGGABLE_DEV" -eq 1 ]; then
+    DEVCLONE_ARGS+=(--debuggable)
+  fi
+  "${DEVCLONE_ARGS[@]}" 2>&1 | tee "$OUT_DIR/build-devclone.log"
 
   RC=${PIPESTATUS[0]}
   [ "$RC" -eq 0 ] || mark_fail "DEV clone build failed rc=$RC"
@@ -288,6 +326,32 @@ if [ "$FAIL" -eq 0 ]; then
 
   [ "$DEV_CANDIDATE_PACKAGE" = "$DEV_PACKAGE" ] || mark_fail "DEV package mismatch: expected $DEV_PACKAGE got $DEV_CANDIDATE_PACKAGE"
   [ "$DEV_TARGET_SDK" = "$EXPECTED_TARGET_SDK" ] || mark_fail "DEV targetSdk mismatch"
+
+  DEV_MANIFEST_XMLTREE="$OUT_DIR/dev-manifest-xmltree.txt"
+  if ! aapt dump xmltree "$DEV_APK" AndroidManifest.xml > "$DEV_MANIFEST_XMLTREE"; then
+    mark_fail "could not inspect DEV debuggable state"
+    DEV_IS_DEBUGGABLE=-1
+  elif grep -Eq 'android:debuggable.*0xffffffff' "$DEV_MANIFEST_XMLTREE"; then
+    DEV_IS_DEBUGGABLE=1
+  else
+    DEV_IS_DEBUGGABLE=0
+  fi
+  if [ "$DEV_IS_DEBUGGABLE" -eq "$DEBUGGABLE_DEV" ]; then
+    echo "OK: DEV debuggable state matches request: $DEBUGGABLE_DEV"
+  else
+    mark_fail "DEV debuggable state mismatch: requested $DEBUGGABLE_DEV got $DEV_IS_DEBUGGABLE"
+  fi
+  if [ "$DEBUGGABLE_DEV" -eq 1 ]; then
+    EXPECTED_AUDIT_GATEWAY=present
+  else
+    EXPECTED_AUDIT_GATEWAY=absent
+  fi
+  python3 "$AUDIT_GATEWAY_CHECKER" \
+    --manifest "$DEV_MANIFEST_XMLTREE" \
+    --expect "$EXPECTED_AUDIT_GATEWAY" \
+    --activity "$AUDIT_SETTINGS_ACTIVITY" \
+    --permission "$AUDIT_GATEWAY_PERMISSION" \
+    || mark_fail "DEV settings audit gateway state mismatch: expected $EXPECTED_AUDIT_GATEWAY"
 
   apksigner verify --print-certs "$DEV_APK" > "$OUT_DIR/dev-apksigner.txt" 2>&1 \
     || mark_fail "DEV APK signature verification failed"

--- a/tools/boost-morphe-settings-binding-runtime.sh
+++ b/tools/boost-morphe-settings-binding-runtime.sh
@@ -1,0 +1,348 @@
+#!/usr/bin/env bash
+set -u
+
+DEV_PACKAGE='com.rubenmayayo.reddit.dev'
+NORMAL_PACKAGE='com.rubenmayayo.reddit'
+SETTINGS_ACTIVITY='com.rubenmayayo.reddit.ui.preferences.v2.SettingsActivityCompat'
+AUDIT_FRAGMENT='app.morphe.extension.boostforreddit.settings.MorpheSettingsV4BindingRuntimeAuditFragment'
+EXTRA_FRAGMENT='extra_show_fragment'
+EXTRA_PHASE='morphe_settings_binding_audit_phase'
+EXTRA_NONCE='morphe_settings_binding_audit_nonce'
+EXTRA_SCOPE='morphe_settings_binding_audit_scope'
+SCOPE='appearance-layout'
+SERIAL=''
+AUDIT_ACTIVE=0
+HOST_LOCK=''
+LOCK_HELD=0
+RECOVER_ORPHANED=0
+REPORT_READY=0
+REPORT_WRITTEN=0
+FAIL_REASON=''
+NORMAL_UPDATE_BEFORE=''
+NORMAL_UNTOUCHED='unknown'
+AUDIT_LOG_FILE=''
+APK_COPY=''
+REPORT_PATH=''
+DEV_UID=''
+APK_SHA256=''
+VERSION_NAME='unknown'
+VERSION_CODE='unknown'
+ANDROID_RELEASE='unknown'
+ANDROID_SDK='unknown'
+DEVICE='unknown'
+MODEL='unknown'
+ADB=()
+
+usage() {
+  printf '%s\n' \
+    'Usage: MORPHE_RUNTIME_AUDIT_MUTATE_DEV=1 tools/boost-morphe-settings-binding-runtime.sh [--scope appearance-layout] [--serial SERIAL]' \
+    'Recovery: MORPHE_RUNTIME_AUDIT_RECOVER_ORPHANED_DEV=1 tools/boost-morphe-settings-binding-runtime.sh --recover-orphaned [--serial SERIAL]' \
+    '' \
+    'Runs the reversible Morphe settings audit against Boost DEV only.' \
+    'Every registered domain is exercised through the real UI action method.' \
+    'Native consumers, stable rendered properties, cold reload, and recovery are verified.' \
+    'Boost DEV must be built with --debuggable-dev so the audit gateway is present.' \
+    'A machine-readable JSON report is written under local-artifacts/boost-settings-audits.' \
+    'Normal Boost is read-only and is never stopped, launched, or modified.'
+}
+
+fail() {
+  FAIL_REASON="$*"
+  echo "FAIL: $*" >&2
+  exit 1
+}
+
+start_phase() {
+  local phase="$1"
+  "${ADB[@]}" shell am start -W \
+    -n "${DEV_PACKAGE}/${SETTINGS_ACTIVITY}" \
+    --es "$EXTRA_FRAGMENT" "$AUDIT_FRAGMENT" \
+    --es "$EXTRA_PHASE" "$phase" \
+    --es "$EXTRA_NONCE" "$NONCE" \
+    --es "$EXTRA_SCOPE" "$SCOPE"
+}
+
+audit_log() {
+  "${ADB[@]}" logcat -d -v brief -s 'MorpheSettingsAudit:I' '*:S'
+}
+
+capture_audit_log() {
+  [ -n "$AUDIT_LOG_FILE" ] || return 0
+  audit_log >"$AUDIT_LOG_FILE" 2>/dev/null || true
+}
+
+normal_last_update() {
+  "${ADB[@]}" shell dumpsys package "$NORMAL_PACKAGE" \
+    | sed -n 's/^[[:space:]]*lastUpdateTime=//p' \
+    | head -1 \
+    | tr -d '\r'
+}
+
+write_report() {
+  local status="$1"
+  local reason="$2"
+  [ "$REPORT_READY" -eq 1 ] || return 0
+  python3 tools/write-boost-morphe-settings-audit-report.py \
+    --log "$AUDIT_LOG_FILE" \
+    --manifest tests/tools/fixtures/boost_morphe_settings_bindings.json \
+    --output "$REPORT_PATH" \
+    --status "$status" \
+    --failure-reason "$reason" \
+    --package "$DEV_PACKAGE" \
+    --version-name "$VERSION_NAME" \
+    --version-code "$VERSION_CODE" \
+    --apk-sha256 "$APK_SHA256" \
+    --android-release "$ANDROID_RELEASE" \
+    --android-sdk "$ANDROID_SDK" \
+    --device "$DEVICE" \
+    --model "$MODEL" \
+    --normal-boost-untouched "$NORMAL_UNTOUCHED"
+}
+
+recover_on_exit() {
+  local rc=$?
+  local normal_after=''
+  trap - EXIT INT TERM
+  if [ "$AUDIT_ACTIVE" -eq 1 ]; then
+    echo 'RECOVERY=ATTEMPTING_DEV_SETTINGS_AND_ICON_RESTORE' >&2
+    "${ADB[@]}" shell am force-stop "$DEV_PACKAGE" >/dev/null 2>&1 || true
+    start_phase recover >/dev/null 2>&1 || true
+    capture_audit_log
+    audit_log | tail -40 >&2 || true
+    "${ADB[@]}" shell am force-stop "$DEV_PACKAGE" >/dev/null 2>&1 || true
+  fi
+  if [ -n "$NORMAL_UPDATE_BEFORE" ]; then
+    normal_after="$(normal_last_update 2>/dev/null || true)"
+    if [ -n "$normal_after" ] && [ "$normal_after" = "$NORMAL_UPDATE_BEFORE" ]; then
+      NORMAL_UNTOUCHED='true'
+    else
+      NORMAL_UNTOUCHED='false'
+    fi
+  fi
+  if [ "$REPORT_READY" -eq 1 ] && [ "$REPORT_WRITTEN" -eq 0 ]; then
+    capture_audit_log
+    write_report FAIL "${FAIL_REASON:-audit interrupted}" >&2 || true
+  fi
+  if [ "$LOCK_HELD" -eq 1 ]; then
+    flock -u 9 2>/dev/null || true
+    exec 9>&-
+  fi
+  if [ -n "$APK_COPY" ]; then
+    rm -f -- "$APK_COPY"
+  fi
+  exit "$rc"
+}
+
+trap recover_on_exit EXIT
+trap 'FAIL_REASON=interrupted; exit 130' INT
+trap 'FAIL_REASON=terminated; exit 143' TERM
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --serial) SERIAL="${2:-}"; shift 2 ;;
+    --scope) SCOPE="${2:-}"; shift 2 ;;
+    --recover-orphaned) RECOVER_ORPHANED=1; shift ;;
+    -h|--help) usage; exit 0 ;;
+    *) fail "unknown argument: $1" ;;
+  esac
+done
+
+[ "$SCOPE" = 'appearance-layout' ] \
+  || fail "unsupported audit scope: $SCOPE"
+if [ "$RECOVER_ORPHANED" -eq 1 ]; then
+  [ "${MORPHE_RUNTIME_AUDIT_RECOVER_ORPHANED_DEV:-}" = '1' ] || {
+    usage
+    fail 'set MORPHE_RUNTIME_AUDIT_RECOVER_ORPHANED_DEV=1 to authorize forced DEV recovery'
+  }
+else
+  [ "${MORPHE_RUNTIME_AUDIT_MUTATE_DEV:-}" = '1' ] || {
+    usage
+    fail 'set MORPHE_RUNTIME_AUDIT_MUTATE_DEV=1 to authorize temporary DEV-only settings writes'
+  }
+fi
+
+ROOT="$(git rev-parse --show-toplevel 2>/dev/null)" \
+  || fail 'not inside repository'
+cd "$ROOT" || fail 'cannot enter repository root'
+
+if [ -n "$SERIAL" ]; then
+  export MORPHE_ADB_SERIAL="$SERIAL"
+fi
+SERIAL="$(env -u ANDROID_SERIAL tools/boost-adb-serial.sh)" \
+  || fail 'could not resolve adb target'
+ADB=(env -u ANDROID_SERIAL adb -s "$SERIAL")
+NONCE="settings-audit-v56-$(date +%s)-$$"
+
+LOCK_KEY="$(printf '%s' "$SERIAL" | tr -c 'A-Za-z0-9._-' '_')"
+HOST_LOCK="/tmp/morphe-boost-settings-audit-${LOCK_KEY}.lock"
+command -v flock >/dev/null 2>&1 \
+  || fail 'flock is required for crash-safe host locking'
+exec 9>"$HOST_LOCK" || fail "could not open ${HOST_LOCK}"
+flock -n 9 \
+  || fail "another settings audit owns ${HOST_LOCK}"
+LOCK_HELD=1
+
+"${ADB[@]}" get-state >/dev/null \
+  || fail "adb target unavailable: $SERIAL"
+"${ADB[@]}" shell pm path "$DEV_PACKAGE" | rg -q '^package:' \
+  || fail "Boost DEV is not installed: $DEV_PACKAGE"
+DEV_UID="$("${ADB[@]}" shell dumpsys package "$DEV_PACKAGE" \
+  | sed -n 's/^[[:space:]]*\(userId\|appId\)=\([0-9][0-9]*\).*$/\2/p' \
+  | head -1 \
+  | tr -d '\r')"
+if [ -z "$DEV_UID" ]; then
+  DEV_UID="$("${ADB[@]}" shell pm list packages -U "$DEV_PACKAGE" \
+    | tr -d '\r' \
+    | sed -n "s/^package:${DEV_PACKAGE}[[:space:]]uid:\([0-9][0-9]*\)$/\1/p" \
+    | head -1)"
+fi
+case "$DEV_UID" in
+  ''|*[!0-9]*) fail 'could not resolve Boost DEV uid from userId, appId, or pm -U' ;;
+esac
+"${ADB[@]}" shell dumpsys package "$DEV_PACKAGE" \
+  | rg -q 'pkgFlags=.*DEBUGGABLE' \
+  || fail 'Boost DEV is not debuggable; rebuild it with the Morphe "Enable Android debugging" patch'
+RUN_AS_ID="$("${ADB[@]}" shell run-as "$DEV_PACKAGE" id 2>/dev/null | tr -d '\r')"
+printf '%s\n' "$RUN_AS_ID" | rg -q "^uid=${DEV_UID}\\(" \
+  || fail "run-as did not resolve to Boost DEV uid ${DEV_UID}"
+
+if [ "$RECOVER_ORPHANED" -eq 1 ]; then
+  NORMAL_UPDATE_BEFORE="$(normal_last_update)"
+  [ -n "$NORMAL_UPDATE_BEFORE" ] \
+    || fail 'could not capture Normal Boost package timestamp'
+  "${ADB[@]}" logcat -c
+  "${ADB[@]}" shell am force-stop "$DEV_PACKAGE"
+  start_phase recover_force >/dev/null
+  RECOVERY_LOG="$(audit_log)"
+  printf '%s\n' "$RECOVERY_LOG" \
+    | rg -q 'MORPHE_BINDING_AUDIT_RECOVERY_(OK|NOT_NEEDED)' \
+    || fail 'forced DEV recovery did not complete'
+  "${ADB[@]}" shell am force-stop "$DEV_PACKAGE"
+  NORMAL_UPDATE_AFTER="$(normal_last_update)"
+  [ "$NORMAL_UPDATE_BEFORE" = "$NORMAL_UPDATE_AFTER" ] \
+    || fail 'Normal Boost package changed during DEV recovery'
+  NORMAL_UNTOUCHED='true'
+  echo 'DEV_ORPHANED_SETTINGS_AND_ICON_RECOVERY=PASS'
+  echo 'NORMAL_BOOST_UNTOUCHED=PASS'
+  echo 'RESULT=MORPHE_BOOST_SETTINGS_AUDIT_V56_ORPHAN_RECOVERY_PASS'
+  exit 0
+fi
+
+PACKAGE_DUMP="$("${ADB[@]}" shell dumpsys package "$DEV_PACKAGE")"
+VERSION_NAME="$(printf '%s\n' "$PACKAGE_DUMP" \
+  | sed -n 's/^[[:space:]]*versionName=//p' | head -1 | tr -d '\r')"
+VERSION_CODE="$(printf '%s\n' "$PACKAGE_DUMP" \
+  | sed -n 's/^[[:space:]]*versionCode=\([0-9][0-9]*\).*$/\1/p' \
+  | head -1 | tr -d '\r')"
+INSTALLED_APK_PATH="$("${ADB[@]}" shell pm path "$DEV_PACKAGE" \
+  | sed -n 's/^package://p' | head -1 | tr -d '\r')"
+[ -n "$INSTALLED_APK_PATH" ] || fail 'could not resolve installed DEV APK'
+APK_COPY="$(mktemp /tmp/morphe-settings-audit-v56-apk-XXXXXX.apk)" \
+  || fail 'could not allocate APK verification file'
+"${ADB[@]}" pull "$INSTALLED_APK_PATH" "$APK_COPY" >/dev/null \
+  || fail 'could not pull installed DEV APK for hashing'
+APK_SHA256="$(sha256sum "$APK_COPY" | cut -d' ' -f1)"
+ANDROID_RELEASE="$("${ADB[@]}" shell getprop ro.build.version.release | tr -d '\r')"
+ANDROID_SDK="$("${ADB[@]}" shell getprop ro.build.version.sdk | tr -d '\r')"
+DEVICE="$("${ADB[@]}" shell getprop ro.product.device | tr -d '\r')"
+MODEL="$("${ADB[@]}" shell getprop ro.product.model | tr -d '\r')"
+
+REPORT_DIR='local-artifacts/boost-settings-audits'
+mkdir -p "$REPORT_DIR" || fail 'could not create audit report directory'
+REPORT_PATH="${REPORT_DIR}/morphe-boost-settings-${SCOPE}-v56-$(date -u +%Y%m%dT%H%M%SZ).json"
+AUDIT_LOG_FILE="$(mktemp /tmp/morphe-settings-audit-v56-log-XXXXXX.txt)" \
+  || fail 'could not allocate audit log file'
+REPORT_READY=1
+
+echo 'DEV_DEBUGGABLE=PASS'
+echo 'DEV_RUN_AS_UID=PASS'
+echo 'DEV_AUDIT_GATEWAY_LAUNCH=ARMED'
+echo 'DEV_AUDIT_HOST_LOCK=PASS'
+echo "AUDIT_SCOPE=$SCOPE"
+
+NORMAL_UPDATE_BEFORE="$(normal_last_update)"
+[ -n "$NORMAL_UPDATE_BEFORE" ] \
+  || fail 'could not capture Normal Boost package timestamp'
+"${ADB[@]}" logcat -c
+"${ADB[@]}" shell am force-stop "$DEV_PACKAGE"
+
+AUDIT_ACTIVE=1
+start_phase write >/dev/null
+WRITE_LOG="$(audit_log)"
+printf '%s\n' "$WRITE_LOG" | rg -F 'MORPHE_BINDING_AUDIT_WRITE_OK' >/dev/null \
+  || fail 'DEV write phase did not complete'
+printf '%s\n' "$WRITE_LOG" \
+  | rg -F 'MORPHE_DOMAIN_AUDIT_OK items=26 actions=196' >/dev/null \
+  || fail 'DEV full-domain UI-action audit did not complete'
+ITEM_COUNT="$(printf '%s\n' "$WRITE_LOG" \
+  | rg -c -F 'MORPHE_AUDIT_ITEM_OK')"
+[ "$ITEM_COUNT" = '26' ] \
+  || fail "expected 26 audit items, got ${ITEM_COUNT}"
+printf '%s\n' "$WRITE_LOG" \
+  | rg -F 'MORPHE_RENDER_AUDIT_OK count=6' >/dev/null \
+  || fail 'DEV rendered-effect probes did not complete'
+RENDER_ITEM_COUNT="$(printf '%s\n' "$WRITE_LOG" \
+  | rg -c -F 'MORPHE_RENDER_AUDIT_ITEM_OK')"
+[ "$RENDER_ITEM_COUNT" = '6' ] \
+  || fail "expected 6 render probes, got ${RENDER_ITEM_COUNT}"
+printf '%s\n' "$WRITE_LOG" \
+  | rg -F 'MORPHE_BINDING_AUDIT_APP_ICONS_OK' >/dev/null \
+  || fail 'DEV app-icon component audit did not complete'
+echo 'DEV_ALL_REGISTERED_DOMAINS_VIA_UI_ACTIONS=PASS'
+echo 'DEV_APPEARANCE_LAYOUT_NATIVE_CONSUMERS=PASS'
+echo 'DEV_RENDERED_EFFECT_PROBES=PASS'
+echo 'DEV_APP_ICON_FULL_DOMAIN=PASS'
+echo 'DEV_APP_ICON_DURABLE_SNAPSHOT=PASS'
+
+"${ADB[@]}" shell am force-stop "$DEV_PACKAGE"
+start_phase verify_restore >/dev/null
+VERIFY_LOG="$(audit_log)"
+printf '%s\n' "$VERIFY_LOG" \
+  | rg -F 'MORPHE_BINDING_AUDIT_RELOAD_OK' >/dev/null \
+  || fail 'DEV cold-reload verification did not complete'
+printf '%s\n' "$VERIFY_LOG" \
+  | rg -F 'MORPHE_DOMAIN_AUDIT_RELOAD_OK count=26' >/dev/null \
+  || fail 'DEV consumers and app icon did not reload expected values'
+printf '%s\n' "$VERIFY_LOG" \
+  | rg -F 'MORPHE_BINDING_AUDIT_RESTORE_OK' >/dev/null \
+  || fail 'DEV settings and app-icon restoration did not complete'
+printf '%s\n' "$VERIFY_LOG" \
+  | rg -F 'RESULT=MORPHE_BOOST_SETTINGS_APPEARANCE_LAYOUT_AUDIT_V56_APP_PASS' >/dev/null \
+  || fail 'DEV in-app audit did not emit V56 PASS'
+AUDIT_ACTIVE=0
+
+echo 'DEV_COLD_RELOAD=PASS'
+echo 'DEV_NATIVE_CONSUMERS_AND_ICON_AFTER_COLD_RELOAD=PASS'
+echo 'DEV_ORIGINAL_SETTINGS_AND_ICON_RESTORED=PASS'
+
+ERROR_LOG="$("${ADB[@]}" logcat --uid="$DEV_UID" -d -v threadtime \
+  | rg 'FATAL EXCEPTION|AndroidRuntime|NoSuchMethodError|NoClassDefFoundError|Resources\$NotFoundException|InflateException' \
+  || true)"
+[ -z "$ERROR_LOG" ] || {
+  printf '%s\n' "$ERROR_LOG" >&2
+  fail 'DEV runtime errors observed'
+}
+echo 'DEV_RUNTIME_ERRORS=ABSENT'
+
+NORMAL_UPDATE_AFTER="$(normal_last_update)"
+[ "$NORMAL_UPDATE_BEFORE" = "$NORMAL_UPDATE_AFTER" ] \
+  || fail 'Normal Boost package changed during DEV audit'
+NORMAL_UNTOUCHED='true'
+echo 'NORMAL_BOOST_UNTOUCHED=PASS'
+
+capture_audit_log
+write_report PASS '' || fail 'structured audit report failed closed'
+REPORT_WRITTEN=1
+echo 'STRUCTURED_AUDIT_REPORT=PASS'
+
+"${ADB[@]}" shell am force-stop "$DEV_PACKAGE"
+"${ADB[@]}" shell monkey \
+  -p "$DEV_PACKAGE" \
+  -c android.intent.category.LAUNCHER \
+  1 >/dev/null
+
+echo "SERIAL=$SERIAL"
+echo "DEV_UID=$DEV_UID"
+echo "DEV_APK_SHA256=$APK_SHA256"
+echo "AUDIT_REPORT_JSON=$REPORT_PATH"
+echo 'RESULT=MORPHE_BOOST_SETTINGS_APPEARANCE_LAYOUT_AUDIT_V56_RUNTIME_PASS'

--- a/tools/build-boost-devclone-candidate.sh
+++ b/tools/build-boost-devclone-candidate.sh
@@ -16,6 +16,8 @@ Options:
   --dev-package PACKAGE   Dev clone package. Default: com.rubenmayayo.reddit.dev.
   --normal-package PKG    Original package. Default: com.rubenmayayo.reddit.
   --label LABEL           App label. Default: Boost Dev.
+  --debuggable            Set android:debuggable=true and enable the
+                          DUMP-protected settings audit gateway on DEV only.
   --out-root DIR          Output root. Default: local-artifacts/boost-dev-overwrite-candidates.
   --help                  Show this help.
 
@@ -43,6 +45,10 @@ DEV_PACKAGE="com.rubenmayayo.reddit.dev"
 NORMAL_PACKAGE="com.rubenmayayo.reddit"
 LABEL="Boost Dev"
 OUT_ROOT="local-artifacts/boost-dev-overwrite-candidates"
+DEBUGGABLE=0
+AUDIT_SETTINGS_ACTIVITY="com.rubenmayayo.reddit.ui.preferences.v2.SettingsActivityCompat"
+AUDIT_GATEWAY_PERMISSION="android.permission.DUMP"
+AUDIT_GATEWAY_CHECKER="tools/check_boost_settings_audit_gateway.py"
 
 while [ "$#" -gt 0 ]; do
   case "$1" in
@@ -74,6 +80,10 @@ while [ "$#" -gt 0 ]; do
       LABEL="${2:-}"
       shift 2
       ;;
+    --debuggable)
+      DEBUGGABLE=1
+      shift
+      ;;
     --out-root)
       OUT_ROOT="${2:-}"
       shift 2
@@ -96,6 +106,7 @@ if [ -z "$PATCH_RESULT" ]; then
 fi
 [ -f "$PATCH_RESULT" ] || fail "Patch result missing: $PATCH_RESULT"
 [ -x tools/boost-bytecode-safety-gate.sh ] || fail "bytecode safety gate missing or not executable"
+[ -f "$AUDIT_GATEWAY_CHECKER" ] || fail "audit gateway checker missing: $AUDIT_GATEWAY_CHECKER"
 
 AAPT="$(command -v aapt || true)"
 [ -n "$AAPT" ] || fail "aapt missing"
@@ -148,6 +159,9 @@ mkdir -p "$DEV_DIR"
   echo "DEV_PACKAGE=$DEV_PACKAGE"
   echo "NORMAL_PACKAGE=$NORMAL_PACKAGE"
   echo "LABEL=$LABEL"
+  echo "DEBUGGABLE=$DEBUGGABLE"
+  echo "AUDIT_SETTINGS_ACTIVITY=$AUDIT_SETTINGS_ACTIVITY"
+  echo "AUDIT_GATEWAY_PERMISSION=$AUDIT_GATEWAY_PERMISSION"
   echo "OUT_DIR=$OUT_DIR"
   echo "AAPT=$AAPT"
   echo "APKTOOL_MODE=$APKTOOL_MODE"
@@ -184,7 +198,14 @@ mkdir -p "$DEV_DIR"
 
   echo
   echo "===== rewrite manifest/resources ====="
-  DECODED="$DECODED" NORMAL_PACKAGE="$NORMAL_PACKAGE" DEV_PACKAGE="$DEV_PACKAGE" LABEL="$LABEL" python3 <<'PY'
+  DECODED="$DECODED" \
+    NORMAL_PACKAGE="$NORMAL_PACKAGE" \
+    DEV_PACKAGE="$DEV_PACKAGE" \
+    LABEL="$LABEL" \
+    DEBUGGABLE="$DEBUGGABLE" \
+    AUDIT_SETTINGS_ACTIVITY="$AUDIT_SETTINGS_ACTIVITY" \
+    AUDIT_GATEWAY_PERMISSION="$AUDIT_GATEWAY_PERMISSION" \
+    python3 <<'PY'
 from pathlib import Path
 import os
 import xml.etree.ElementTree as ET
@@ -193,6 +214,9 @@ decoded = Path(os.environ["DECODED"])
 normal_pkg = os.environ["NORMAL_PACKAGE"]
 dev_pkg = os.environ["DEV_PACKAGE"]
 label = os.environ["LABEL"]
+debuggable = os.environ["DEBUGGABLE"] == "1"
+audit_settings_activity = os.environ["AUDIT_SETTINGS_ACTIVITY"]
+audit_gateway_permission = os.environ["AUDIT_GATEWAY_PERMISSION"]
 
 android_ns = "http://schemas.android.com/apk/res/android"
 ET.register_namespace("android", android_ns)
@@ -205,16 +229,38 @@ root.set("package", dev_pkg)
 android_label = f"{{{android_ns}}}label"
 android_authorities = f"{{{android_ns}}}authorities"
 android_target_package = f"{{{android_ns}}}targetPackage"
+android_debuggable = f"{{{android_ns}}}debuggable"
+android_name = f"{{{android_ns}}}name"
+android_exported = f"{{{android_ns}}}exported"
+android_permission = f"{{{android_ns}}}permission"
 
 manifest_attr_rewrites = 0
+audit_gateway_rewrites = 0
 for node in root.iter():
     if node.tag == "application":
         node.set(android_label, label)
+        if debuggable:
+            node.set(android_debuggable, "true")
+
+    if (
+        debuggable
+        and node.tag == "activity"
+        and node.attrib.get(android_name) == audit_settings_activity
+    ):
+        node.set(android_exported, "true")
+        node.set(android_permission, audit_gateway_permission)
+        audit_gateway_rewrites += 1
 
     for attr in (android_authorities, android_target_package):
         if attr in node.attrib and normal_pkg in node.attrib[attr]:
             node.set(attr, node.attrib[attr].replace(normal_pkg, dev_pkg))
             manifest_attr_rewrites += 1
+
+if debuggable and audit_gateway_rewrites != 1:
+    raise RuntimeError(
+        "expected exactly one DEV settings audit gateway rewrite, "
+        f"found {audit_gateway_rewrites}"
+    )
 
 tree.write(manifest_path, encoding="utf-8", xml_declaration=True)
 
@@ -245,6 +291,8 @@ for strings in (decoded / "res").glob("values*/strings.xml"):
 print(f"MANIFEST_ATTR_REWRITES={manifest_attr_rewrites}")
 print(f"RESOURCE_XML_REWRITE_FILES={resource_xml_rewrites}")
 print(f"LABEL_REWRITE_FILES={label_rewrites}")
+print(f"DEV_DEBUGGABLE={int(debuggable)}")
+print(f"DEV_AUDIT_GATEWAY_REWRITES={audit_gateway_rewrites}")
 PY
 
   echo
@@ -259,6 +307,22 @@ PY
   else
     echo "[WARN] no dev targetPackage values found"
   fi
+
+  if [ "$DEBUGGABLE" -eq 1 ]; then
+    grep -Eq 'android:debuggable="true"' "$DECODED/AndroidManifest.xml" \
+      || fail "decoded DEV manifest is not debuggable"
+    pass "decoded DEV manifest is debuggable"
+    EXPECTED_AUDIT_GATEWAY=present
+  else
+    EXPECTED_AUDIT_GATEWAY=absent
+  fi
+  python3 "$AUDIT_GATEWAY_CHECKER" \
+    --manifest "$DECODED/AndroidManifest.xml" \
+    --expect "$EXPECTED_AUDIT_GATEWAY" \
+    --activity "$AUDIT_SETTINGS_ACTIVITY" \
+    --permission "$AUDIT_GATEWAY_PERMISSION" \
+    || fail "decoded DEV settings audit gateway state is invalid"
+  pass "decoded DEV settings audit gateway state matches request: $EXPECTED_AUDIT_GATEWAY"
 
   echo
   echo "===== build ====="
@@ -284,6 +348,35 @@ PY
   echo "DEV_APK_SHA256=$(sha256sum "$SIGNED_APK" | awk '{print $1}')"
 
   "$AAPT" dump badging "$SIGNED_APK" | grep -E "package:|targetSdkVersion|application-label|launchable-activity" | sed -n '1,160p'
+
+  SIGNED_MANIFEST_XMLTREE="$DEV_DIR/manifest-xmltree.txt"
+  "$AAPT" dump xmltree "$SIGNED_APK" AndroidManifest.xml > "$SIGNED_MANIFEST_XMLTREE" \
+    || fail "could not inspect signed DEV manifest"
+  if grep -Eq 'android:debuggable.*0xffffffff' "$SIGNED_MANIFEST_XMLTREE"; then
+    APK_DEBUGGABLE=1
+  else
+    APK_DEBUGGABLE=0
+  fi
+  [ "$APK_DEBUGGABLE" -eq "$DEBUGGABLE" ] \
+    || fail "signed DEV debuggable state mismatch: requested $DEBUGGABLE got $APK_DEBUGGABLE"
+  pass "signed DEV debuggable state matches request: $DEBUGGABLE"
+
+  if [ "$DEBUGGABLE" -eq 1 ]; then
+    EXPECTED_AUDIT_GATEWAY=present
+  else
+    EXPECTED_AUDIT_GATEWAY=absent
+  fi
+  python3 "$AUDIT_GATEWAY_CHECKER" \
+    --manifest "$SIGNED_MANIFEST_XMLTREE" \
+    --expect "$EXPECTED_AUDIT_GATEWAY" \
+    --activity "$AUDIT_SETTINGS_ACTIVITY" \
+    --permission "$AUDIT_GATEWAY_PERMISSION" \
+    || fail "signed DEV settings audit gateway state is invalid"
+  if [ "$DEBUGGABLE" -eq 1 ]; then
+    pass "signed DEV settings audit gateway is exported and DUMP-protected"
+  else
+    pass "signed non-debuggable DEV has no settings audit gateway"
+  fi
 
   "$APKSIGNER" verify --print-certs "$SIGNED_APK" | grep -E 'Signer #1 certificate DN|Signer #1 certificate SHA-256 digest' | sed -n '1,40p'
 

--- a/tools/check-boost-inline-media-size-contract.sh
+++ b/tools/check-boost-inline-media-size-contract.sh
@@ -89,17 +89,29 @@ if rg -q -F 'no Glide override method found' "$SOURCE"; then
   exit 1
 fi
 
-test "$(
+INLINE_MEDIA_PREVIEW_SIZE_KEY_COUNT="$(
   rg -c -F \
     'android:key="morphe_boost_inline_media_preview_size"' \
-    "$SETTINGS"
-)" -eq 2
+    "$SETTINGS" ||
+    true
+)"
 
-test "$(
+if test "$INLINE_MEDIA_PREVIEW_SIZE_KEY_COUNT" -ne 1; then
+  echo "FAIL: expected one canonical inline media preview size preference, found $INLINE_MEDIA_PREVIEW_SIZE_KEY_COUNT" >&2
+  exit 1
+fi
+
+INLINE_MEDIA_BALANCED_DEFAULT_COUNT="$(
   rg -c -F \
     'android:defaultValue="balanced"' \
-    "$SETTINGS"
-)" -eq 2
+    "$SETTINGS" ||
+    true
+)"
+
+if test "$INLINE_MEDIA_BALANCED_DEFAULT_COUNT" -ne 1; then
+  echo "FAIL: expected one canonical balanced inline media default, found $INLINE_MEDIA_BALANCED_DEFAULT_COUNT" >&2
+  exit 1
+fi
 
 rg -q -F '"Compact"' "$PREFERENCE"
 rg -q -F '"Balanced"' "$PREFERENCE"

--- a/tools/check-boost-morphe-settings-contract.sh
+++ b/tools/check-boost-morphe-settings-contract.sh
@@ -8,6 +8,7 @@ HUB="$ROOT/extensions/boostforreddit/src/main/java/app/morphe/extension/boostfor
 LAYOUT="$ROOT/extensions/boostforreddit/src/main/java/app/morphe/extension/boostforreddit/settings/MorpheSettingsLayout.java"
 V4="$ROOT/extensions/boostforreddit/src/main/java/app/morphe/extension/boostforreddit/settings/MorpheSettingsV4.java"
 V4_FRAGMENT="$ROOT/extensions/boostforreddit/src/main/java/app/morphe/extension/boostforreddit/settings/MorpheSettingsV4Fragment.java"
+V4_APPEARANCE="$ROOT/extensions/boostforreddit/src/main/java/app/morphe/extension/boostforreddit/settings/MorpheSettingsV4AppearanceFragment.java"
 V4_CATALOG="$ROOT/extensions/boostforreddit/src/main/java/app/morphe/extension/boostforreddit/settings/MorpheSettingsV4Catalog.java"
 V4_THEME="$ROOT/extensions/boostforreddit/src/main/java/app/morphe/extension/boostforreddit/settings/MorpheSettingsV4Theme.java"
 SYSTEM_BARS="$ROOT/extensions/boostforreddit/src/main/java/app/morphe/extension/boostforreddit/utils/BoostSystemBarInsetsFix.java"
@@ -18,6 +19,7 @@ test -f "$HUB"
 test -f "$LAYOUT"
 test -f "$V4"
 test -f "$V4_FRAGMENT"
+test -f "$V4_APPEARANCE"
 test -f "$V4_CATALOG"
 test -f "$V4_THEME"
 test -f "$SYSTEM_BARS"
@@ -30,6 +32,8 @@ rg -q -F 'MORPHE_BOOST_SETTINGS_LAYOUT_ISSUE106_V2_1' "$LAYOUT"
 rg -q -F 'MORPHE_BOOST_SETTINGS_HUBS_ISSUE106_V2_1' "$HUB"
 rg -q -F 'MORPHE_BOOST_SETTINGS_V4_ISSUE106_V1' "$V4"
 rg -q -F 'MORPHE_BOOST_SETTINGS_V4_UI_ISSUE106_V1' "$V4_FRAGMENT"
+rg -q -F 'MORPHE_BOOST_SETTINGS_V4_APPEARANCE_ISSUE106_V1' "$V4_APPEARANCE"
+rg -q -F 'MORPHE_BOOST_SETTINGS_V4_COMPACT_GROUPS_ISSUE106_V1' "$V4_APPEARANCE"
 rg -q -F 'setPreferencesFromResource(resourceId, rootKey);' "$FRAGMENT" "$HUB"
 
 if rg -q -F 'get("res/xml/pref_advanced_v2.xml")' "$SETTINGS"; then
@@ -44,6 +48,7 @@ python3 - \
     "$HUB" \
     "$V4" \
     "$V4_FRAGMENT" \
+    "$V4_APPEARANCE" \
     "$V4_CATALOG" \
     "$V4_THEME" \
     "$SYSTEM_BARS" <<'PY_CHECK'
@@ -57,9 +62,10 @@ layout = Path(sys.argv[3]).read_text()
 hub = Path(sys.argv[4]).read_text()
 v4 = Path(sys.argv[5]).read_text()
 v4_fragment = Path(sys.argv[6]).read_text()
-v4_catalog = Path(sys.argv[7]).read_text()
-v4_theme = Path(sys.argv[8]).read_text()
-system_bars = Path(sys.argv[9]).read_text()
+v4_appearance = Path(sys.argv[7]).read_text()
+v4_catalog = Path(sys.argv[8]).read_text()
+v4_theme = Path(sys.argv[9]).read_text()
+system_bars = Path(sys.argv[10]).read_text()
 
 preference_keys = [
     "morphe_boost_inline_media_previews_enabled",
@@ -218,10 +224,14 @@ assert 'LEGACY_V2_ENABLED_KEY =\n            "morphe_boost_settings_layout_v2_en
 assert 'public static void prepareIntent(Activity activity)' in v4
 assert 'preferences.contains(ENABLED_KEY)' in v4
 assert 'preferences.getBoolean(\n                LEGACY_V2_ENABLED_KEY,' in v4
-assert 'preferences.edit().putBoolean(ENABLED_KEY, true).apply();' in v4
+assert '.putBoolean(ENABLED_KEY, true)' in v4
 assert 'intent.getStringExtra(EXTRA_SHOW_FRAGMENT)' in v4
 assert 'intent.putExtra(EXTRA_SHOW_FRAGMENT, FRAGMENT_NAME);' in v4
 assert 'MorpheSettingsV4Fragment' in v4
+assert 'THEME_MODE_KEY = "pref_theme_mode_type"' in v4
+assert 'SYSTEM_THEME_MODE = "system"' in v4
+assert 'forceSystemThemeMode(preferences);' in v4
+assert '.putString(THEME_MODE_KEY, SYSTEM_THEME_MODE)' in v4
 
 assert 'extends Fragment' in v4_fragment
 assert 'new ScrollView(context)' in v4_fragment
@@ -245,6 +255,47 @@ for forbidden_call in [
     assert forbidden_call not in v4_fragment, forbidden_call
 assert 'androidx.compose' not in v4_fragment
 assert 'ComposeView' not in v4_fragment
+
+assert 'extends Fragment' in v4_appearance
+assert 'MORPHE_BOOST_SETTINGS_V4_APPEARANCE_ISSUE106_V1' in v4_appearance
+assert 'MORPHE_BOOST_SETTINGS_V4_COMPACT_GROUPS_ISSUE106_V1' in v4_appearance
+assert 'MORPHE_BOOST_SETTINGS_V4_SYSTEM_THEME_ISSUE106_V1' in v4_appearance
+assert 'PreferenceManager.getDefaultSharedPreferences(context)' in v4_appearance
+assert 'KEY_DYNAMIC_COLORS = "pref_dynamic_colors"' in v4_appearance
+assert 'KEY_COLORED_STATUS_BAR' in v4_appearance
+assert 'KEY_COLORED_NAV_BAR' in v4_appearance
+assert 'Class.forName("id.b")' in v4_appearance
+assert 'BoostSystemBarInsetsFix.applyMorpheSettingsV4SystemBars(' in v4_appearance
+assert 'BoostSystemBarInsetsFix.clearMorpheSettingsV4SystemBars(activity);' in v4_appearance
+assert 'private LinearLayout addGroup(LinearLayout parent)' in v4_appearance
+assert 'private void addGroupedRow(LinearLayout group, LinearLayout row)' in v4_appearance
+assert 'private void addGroupDivider(LinearLayout group)' in v4_appearance
+assert 'row.setMinimumHeight(dp(68));' in v4_appearance
+assert 'addHeader(content);' not in v4_appearance
+assert 'createIconContainer(' not in v4_appearance
+assert 'addSectionLabel(content, "Appearance");' in v4_appearance
+assert 'addSectionLabel(content, "Personalization");' in v4_appearance
+assert 'addSectionLabel(content, "System bars");' in v4_appearance
+for removed_theme_ui in [
+    '"Theme mode"',
+    '"Customize colors"',
+    '"Dark starts"',
+    '"Light starts"',
+    'new AlertDialog.Builder',
+    'new TimePickerDialog',
+    'openClassicAppearance()',
+    'Open classic appearance settings',
+]:
+    assert removed_theme_ui not in v4_appearance, removed_theme_ui
+for forbidden_call in [
+    'getActivity()',
+    'getFragmentManager()',
+    'getParentFragmentManager()',
+    'setTargetFragment(',
+]:
+    assert forbidden_call not in v4_appearance, forbidden_call
+assert 'androidx.compose' not in v4_appearance
+assert 'ComposeView' not in v4_appearance
 
 category_ids = [
     "appearance_layout",
@@ -271,6 +322,15 @@ assert 'attributeText(resources, parser, "title")' in v4_catalog
 assert 'attributeText(resources, parser, "summary")' in v4_catalog
 assert 'attributeText(resources, parser, "key")' in v4_catalog
 assert 'BACKUP_ACTIVITY' in v4_catalog
+assert 'V4_APPEARANCE_FRAGMENT' in v4_catalog
+assert 'CLASSIC_APPEARANCE_FRAGMENT' in v4_catalog
+assert 'addV4AppearanceSearchItems(result, seen);' in v4_catalog
+assert 'Leaf.fragment("Appearance", "Dynamic color, app icon, and system bars"' in v4_catalog
+assert 'Leaf.fragment("Classic theme editor", "Legacy Boost palettes and per-color customization"' in v4_catalog
+assert '{"Theme mode",' not in v4_catalog
+assert '{"Customize colors",' not in v4_catalog
+assert 'pref_colored_status_bar' in v4_catalog
+assert 'pref_colored_nav_bar' in v4_catalog
 
 assert 'system_accent1_200' in v4_theme
 assert 'system_accent1_600' in v4_theme
@@ -280,6 +340,9 @@ assert 'system_accent3_200' in v4_theme
 assert 'system_accent3_600' in v4_theme
 assert 'system_neutral1_900' in v4_theme
 assert 'system_neutral2_700' in v4_theme
+assert 'KEY_DYNAMIC_COLORS = "pref_dynamic_colors"' in v4_theme
+assert '.getBoolean(KEY_DYNAMIC_COLORS, false)' in v4_theme
+assert 'TypedArray' not in v4_theme
 assert 'Accent navigationAccent()' in v4_theme
 assert 'hashCode()' not in v4_theme
 assert 'tokens.navigationAccent()' in v4_fragment
@@ -333,6 +396,9 @@ echo 'SETTINGS_V4_SUBTLE_DYNAMIC_COLOR=PASS'
 echo 'SETTINGS_V4_SYSTEM_BARS_MATCH=PASS'
 echo 'SETTINGS_V4_SYSTEM_BAR_OWNER=PASS'
 echo 'SETTINGS_V4_NAVIGATION_SURFACE=PASS'
+echo 'SETTINGS_V4_APPEARANCE_CONTROLS=PASS'
+echo 'SETTINGS_V4_COMPACT_GROUPS=PASS'
+echo 'SETTINGS_V4_SYSTEM_THEME=PASS'
 echo 'SETTINGS_V4_TASK_HUBS=PASS'
 echo 'SETTINGS_V4_SEARCH_INDEX=PASS'
 echo 'SETTINGS_V4_CLASSIC_FALLBACK=PASS'

--- a/tools/check-boost-morphe-settings-contract.sh
+++ b/tools/check-boost-morphe-settings-contract.sh
@@ -285,6 +285,8 @@ assert 'KEY_DYNAMIC_COLORS = "pref_dynamic_colors"' in v4_appearance
 assert 'KEY_COLORED_STATUS_BAR' in v4_appearance
 assert 'KEY_COLORED_NAV_BAR' in v4_appearance
 assert 'Class.forName("id.b")' in v4_appearance
+assert 'applyDynamicColors(preferences, enabled);' in v4_appearance
+assert 'applySystemBarPreference(preferences, key, enabled);' in v4_appearance
 assert 'BoostSystemBarInsetsFix.applyMorpheSettingsV4SystemBars(' in v4_appearance
 assert 'BoostSystemBarInsetsFix.clearMorpheSettingsV4SystemBars(activity);' in v4_appearance
 assert 'private LinearLayout addGroup(LinearLayout parent)' in v4_appearance
@@ -325,6 +327,7 @@ assert 'PackageManager.COMPONENT_ENABLED_STATE_ENABLED' in v4_app_icon
 assert 'PackageManager.COMPONENT_ENABLED_STATE_DISABLED' in v4_app_icon
 assert 'PackageManager.DONT_KILL_APP' in v4_app_icon
 assert 'packageManager.setComponentEnabledSetting(' in v4_app_icon
+assert 'applyIconSelection(context, option.alias);' in v4_app_icon
 for alias in ['"grey"', '"vivid"', '"metal"', '"yellow"']:
     assert alias in v4_app_icon, alias
 for resource_name in [
@@ -376,6 +379,9 @@ assert 'openBoostHelper("h1")' not in v4_post_views
 assert 'setBoostStaticBoolean("g")' in v4_post_views
 assert 'setBoostStaticBoolean("i")' in v4_post_views
 assert 'setBoostStaticString("c", enabled ? "r/" : "")' in v4_post_views
+assert 'applyBooleanPreference(preferences, key, value, refreshFlag);' in v4_post_views
+assert 'applyDefaultViewPreference(' in v4_post_views
+assert 'applyPreviewLinesPreference(preferences, current);' in v4_post_views
 assert 'private void showDefaultViewDialog()' in v4_post_views
 assert 'previewLinesSeekBar.setMax(100);' in v4_post_views
 assert 'BoostSystemBarInsetsFix.applyMorpheSettingsV4SystemBars(' in v4_post_views
@@ -393,9 +399,12 @@ assert 'ComposeView' not in v4_post_views
 assert 'MORPHE_BOOST_SETTINGS_V4_SAVED_VIEWS_ISSUE106_V1' in v4_saved_views
 assert 'com.rubenmayayo.reddit.VIEW_PER_SUBSCRIPTION' in v4_saved_views
 assert 'savedViews.getAll()' in v4_saved_views
-assert 'savedViews.edit().remove(entry.key).apply();' in v4_saved_views
+assert 'applySavedView(' in v4_saved_views
+assert 'removeSavedView(savedViews, entry.key);' in v4_saved_views
+assert 'clearSavedViews(savedViews);' in v4_saved_views
+assert 'savedViews.edit().putInt(key, viewType).apply();' in v4_saved_views
+assert 'savedViews.edit().remove(key).apply();' in v4_saved_views
 assert 'savedViews.edit().clear().apply();' in v4_saved_views
-assert '.putInt(entry.key, VIEW_VALUES[choice])' in v4_saved_views
 assert 'No saved views yet' in v4_saved_views
 assert 'showViewTypeDialog(entry)' in v4_saved_views
 assert 'addAddSavedViewCard(entriesHost);' in v4_saved_views
@@ -449,12 +458,17 @@ assert '"POST PREVIEW"' not in v4_fonts
 assert '"COMMENT PREVIEW"' not in v4_fonts
 assert 'previewExampleCard' not in v4_fonts
 assert 'previewDrawable' not in v4_fonts
-assert 'previewComment.setTypeface(typefaceFor(commentsFontValue));' in v4_fonts
-assert 'private void markNativeFontCacheDirty(String key)' in v4_fonts
+assert 'applyPreviewTypography(' in v4_fonts
+assert 'preview.setTypeface(typefaceFor(fontValue));' in v4_fonts
+assert 'preview.setTextSize(previewSizeSp(sizeValue, title));' in v4_fonts
+assert 'applyFontPreference(preferences, key, value);' in v4_fonts
+assert 'private static void markNativeFontCacheDirty(String key)' in v4_fonts
 assert 'Class.forName("id.b")' in v4_fonts
 assert '.remove(KEY_TITLE_FONT)' in v4_fonts
 assert 'BoostSystemBarInsetsFix.applyMorpheSettingsV4SystemBars(' in v4_fonts
 assert 'BoostSystemBarInsetsFix.clearMorpheSettingsV4SystemBars(activity);' in v4_fonts
+assert 'applyDependentRowState(' in v4_post_views
+assert 'row.setAlpha(enabled ? 1.0f : 0.44f);' in v4_post_views
 for forbidden_call in [
     'getActivity()',
     'getFragmentManager()',

--- a/tools/check-boost-morphe-settings-contract.sh
+++ b/tools/check-boost-morphe-settings-contract.sh
@@ -9,6 +9,10 @@ LAYOUT="$ROOT/extensions/boostforreddit/src/main/java/app/morphe/extension/boost
 V4="$ROOT/extensions/boostforreddit/src/main/java/app/morphe/extension/boostforreddit/settings/MorpheSettingsV4.java"
 V4_FRAGMENT="$ROOT/extensions/boostforreddit/src/main/java/app/morphe/extension/boostforreddit/settings/MorpheSettingsV4Fragment.java"
 V4_APPEARANCE="$ROOT/extensions/boostforreddit/src/main/java/app/morphe/extension/boostforreddit/settings/MorpheSettingsV4AppearanceFragment.java"
+V4_APP_ICON="$ROOT/extensions/boostforreddit/src/main/java/app/morphe/extension/boostforreddit/settings/MorpheSettingsV4AppIconFragment.java"
+V4_POST_VIEWS="$ROOT/extensions/boostforreddit/src/main/java/app/morphe/extension/boostforreddit/settings/MorpheSettingsV4PostViewsFragment.java"
+V4_SAVED_VIEWS="$ROOT/extensions/boostforreddit/src/main/java/app/morphe/extension/boostforreddit/settings/MorpheSettingsV4SavedViewsFragment.java"
+V4_FONTS="$ROOT/extensions/boostforreddit/src/main/java/app/morphe/extension/boostforreddit/settings/MorpheSettingsV4FontsFragment.java"
 V4_CATALOG="$ROOT/extensions/boostforreddit/src/main/java/app/morphe/extension/boostforreddit/settings/MorpheSettingsV4Catalog.java"
 V4_THEME="$ROOT/extensions/boostforreddit/src/main/java/app/morphe/extension/boostforreddit/settings/MorpheSettingsV4Theme.java"
 SYSTEM_BARS="$ROOT/extensions/boostforreddit/src/main/java/app/morphe/extension/boostforreddit/utils/BoostSystemBarInsetsFix.java"
@@ -20,6 +24,10 @@ test -f "$LAYOUT"
 test -f "$V4"
 test -f "$V4_FRAGMENT"
 test -f "$V4_APPEARANCE"
+test -f "$V4_APP_ICON"
+test -f "$V4_POST_VIEWS"
+test -f "$V4_SAVED_VIEWS"
+test -f "$V4_FONTS"
 test -f "$V4_CATALOG"
 test -f "$V4_THEME"
 test -f "$SYSTEM_BARS"
@@ -33,7 +41,11 @@ rg -q -F 'MORPHE_BOOST_SETTINGS_HUBS_ISSUE106_V2_1' "$HUB"
 rg -q -F 'MORPHE_BOOST_SETTINGS_V4_ISSUE106_V1' "$V4"
 rg -q -F 'MORPHE_BOOST_SETTINGS_V4_UI_ISSUE106_V1' "$V4_FRAGMENT"
 rg -q -F 'MORPHE_BOOST_SETTINGS_V4_APPEARANCE_ISSUE106_V1' "$V4_APPEARANCE"
+rg -q -F 'MORPHE_BOOST_SETTINGS_V4_APP_ICON_ISSUE106_V1' "$V4_APP_ICON"
 rg -q -F 'MORPHE_BOOST_SETTINGS_V4_COMPACT_GROUPS_ISSUE106_V1' "$V4_APPEARANCE"
+rg -q -F 'MORPHE_BOOST_SETTINGS_V4_POST_VIEWS_ISSUE106_V1' "$V4_POST_VIEWS"
+rg -q -F 'MORPHE_BOOST_SETTINGS_V4_SAVED_VIEWS_ISSUE106_V1' "$V4_SAVED_VIEWS"
+rg -q -F 'MORPHE_BOOST_SETTINGS_V4_FONTS_ISSUE106_V1' "$V4_FONTS"
 rg -q -F 'setPreferencesFromResource(resourceId, rootKey);' "$FRAGMENT" "$HUB"
 
 if rg -q -F 'get("res/xml/pref_advanced_v2.xml")' "$SETTINGS"; then
@@ -49,6 +61,10 @@ python3 - \
     "$V4" \
     "$V4_FRAGMENT" \
     "$V4_APPEARANCE" \
+    "$V4_APP_ICON" \
+    "$V4_POST_VIEWS" \
+    "$V4_SAVED_VIEWS" \
+    "$V4_FONTS" \
     "$V4_CATALOG" \
     "$V4_THEME" \
     "$SYSTEM_BARS" <<'PY_CHECK'
@@ -63,9 +79,13 @@ hub = Path(sys.argv[4]).read_text()
 v4 = Path(sys.argv[5]).read_text()
 v4_fragment = Path(sys.argv[6]).read_text()
 v4_appearance = Path(sys.argv[7]).read_text()
-v4_catalog = Path(sys.argv[8]).read_text()
-v4_theme = Path(sys.argv[9]).read_text()
-system_bars = Path(sys.argv[10]).read_text()
+v4_app_icon = Path(sys.argv[8]).read_text()
+v4_post_views = Path(sys.argv[9]).read_text()
+v4_saved_views = Path(sys.argv[10]).read_text()
+v4_fonts = Path(sys.argv[11]).read_text()
+v4_catalog = Path(sys.argv[12]).read_text()
+v4_theme = Path(sys.argv[13]).read_text()
+system_bars = Path(sys.argv[14]).read_text()
 
 preference_keys = [
     "morphe_boost_inline_media_previews_enabled",
@@ -296,6 +316,154 @@ for forbidden_call in [
     assert forbidden_call not in v4_appearance, forbidden_call
 assert 'androidx.compose' not in v4_appearance
 assert 'ComposeView' not in v4_appearance
+assert 'openBoostHelper("w")' not in v4_appearance
+assert 'V4_APP_ICON_FRAGMENT' in v4_appearance
+
+assert 'extends Fragment' in v4_app_icon
+assert 'MORPHE_BOOST_SETTINGS_V4_APP_ICON_ISSUE106_V1' in v4_app_icon
+assert 'PackageManager.COMPONENT_ENABLED_STATE_ENABLED' in v4_app_icon
+assert 'PackageManager.COMPONENT_ENABLED_STATE_DISABLED' in v4_app_icon
+assert 'PackageManager.DONT_KILL_APP' in v4_app_icon
+assert 'packageManager.setComponentEnabledSetting(' in v4_app_icon
+for alias in ['"grey"', '"vivid"', '"metal"', '"yellow"']:
+    assert alias in v4_app_icon, alias
+for resource_name in [
+    '"ic_launcher"',
+    '"ic_launcher_grey"',
+    '"ic_launcher_vivid"',
+    '"ic_launcher_metal"',
+    '"ic_launcher_yellow"',
+]:
+    assert resource_name in v4_app_icon, resource_name
+for forbidden_call in [
+    'getActivity()',
+    'getFragmentManager()',
+    'getParentFragmentManager()',
+    'setTargetFragment(',
+]:
+    assert forbidden_call not in v4_app_icon, forbidden_call
+assert 'androidx.compose' not in v4_app_icon
+assert 'ComposeView' not in v4_app_icon
+
+assert 'extends Fragment' in v4_post_views
+assert 'MORPHE_BOOST_SETTINGS_V4_POST_VIEWS_ISSUE106_V1' in v4_post_views
+assert 'PreferenceManager.getDefaultSharedPreferences(context)' in v4_post_views
+for key in [
+    'pref_view',
+    'pref_view_per_subscription',
+    'pref_left_handed',
+    'pref_show_subreddit_prefix',
+    'pref_cards_rounded_corners',
+    'pref_cards_full_preview',
+    'pref_cards_subreddit_icon',
+    'pref_cards_gallery_carousel',
+    'pref_cards_links_as_thumbnails',
+    'pref_cards_preview_self',
+    'pref_cards_preview_self_lines',
+    'pref_mini_cards_rounded_corners',
+    'pref_mini_cards_truncate_title',
+    'pref_mini_cards_buttons_visible',
+    'pref_dense_buttons_visible',
+    'pref_load_readability',
+    'pref_lock_sidebar',
+]:
+    assert key in v4_post_views, key
+for view_value in ['"0"', '"7"', '"1"', '"4"', '"5"', '"2"', '"6"', '"3"']:
+    assert view_value in v4_post_views, view_value
+assert 'MorpheSettingsV4Catalog.V4_SAVED_VIEWS_FRAGMENT' in v4_post_views
+assert 'openMorpheFragment(' in v4_post_views
+assert 'openBoostHelper("h1")' not in v4_post_views
+assert 'setBoostStaticBoolean("g")' in v4_post_views
+assert 'setBoostStaticBoolean("i")' in v4_post_views
+assert 'setBoostStaticString("c", enabled ? "r/" : "")' in v4_post_views
+assert 'private void showDefaultViewDialog()' in v4_post_views
+assert 'previewLinesSeekBar.setMax(100);' in v4_post_views
+assert 'BoostSystemBarInsetsFix.applyMorpheSettingsV4SystemBars(' in v4_post_views
+assert 'BoostSystemBarInsetsFix.clearMorpheSettingsV4SystemBars(activity);' in v4_post_views
+for forbidden_call in [
+    'getActivity()',
+    'getFragmentManager()',
+    'getParentFragmentManager()',
+    'setTargetFragment(',
+]:
+    assert forbidden_call not in v4_post_views, forbidden_call
+assert 'androidx.compose' not in v4_post_views
+assert 'ComposeView' not in v4_post_views
+
+assert 'MORPHE_BOOST_SETTINGS_V4_SAVED_VIEWS_ISSUE106_V1' in v4_saved_views
+assert 'com.rubenmayayo.reddit.VIEW_PER_SUBSCRIPTION' in v4_saved_views
+assert 'savedViews.getAll()' in v4_saved_views
+assert 'savedViews.edit().remove(entry.key).apply();' in v4_saved_views
+assert 'savedViews.edit().clear().apply();' in v4_saved_views
+assert '.putInt(entry.key, VIEW_VALUES[choice])' in v4_saved_views
+assert 'No saved views yet' in v4_saved_views
+assert 'showViewTypeDialog(entry)' in v4_saved_views
+assert 'addAddSavedViewCard(entriesHost);' in v4_saved_views
+assert 'private void showAddSavedViewDialog()' in v4_saved_views
+assert 'private String normalizeSavedViewKey(' in v4_saved_views
+assert '"Add saved view"' in v4_saved_views
+assert '"Custom feed"' in v4_saved_views
+assert 'SavedViewsActivity' not in v4_saved_views
+for forbidden_call in [
+    'getActivity()',
+    'getFragmentManager()',
+    'getParentFragmentManager()',
+    'setTargetFragment(',
+]:
+    assert forbidden_call not in v4_saved_views, forbidden_call
+assert 'androidx.compose' not in v4_saved_views
+assert 'ComposeView' not in v4_saved_views
+
+assert 'extends Fragment' in v4_fonts
+assert 'MORPHE_BOOST_SETTINGS_V4_FONTS_ISSUE106_V1' in v4_fonts
+assert 'MORPHE_BOOST_SETTINGS_V4_FONT_PREVIEWS_ISSUE106_V2' in v4_fonts
+assert 'MORPHE_BOOST_SETTINGS_V4_FONT_SPECIMEN_ISSUE106_V3' in v4_fonts
+assert 'PreferenceManager.getDefaultSharedPreferences(context)' in v4_fonts
+for key in [
+    'pref_title_font',
+    'pref_font_size_title',
+    'pref_comments_font',
+    'pref_font_size',
+]:
+    assert key in v4_fonts, key
+for font_value in [
+    'sans-serif-thin',
+    'sans-serif-condensed-light',
+    'sans-serif-condensed',
+    'serif-monospace',
+    'sans-serif-smallcaps',
+    'RobotoSlab-Regular.ttf',
+]:
+    assert font_value in v4_fonts, font_value
+for size_value in ['XSmall', 'Small', 'Medium', 'Large', 'XLarge', 'XXLarge']:
+    assert f'"{size_value}"' in v4_fonts, size_value
+assert 'private void showFontDialog(' in v4_fonts
+assert 'private void showSizeDialog(' in v4_fonts
+assert 'private void updatePreviewAndSummaries()' in v4_fonts
+assert 'addSectionLabel(content, "Live preview")' in v4_fonts
+assert 'private void addPreviewDivider(LinearLayout parent)' in v4_fonts
+assert 'previewCanvas.setBackground(MorpheSettingsV4Theme.rounded(' in v4_fonts
+assert '"Updates as you choose"' not in v4_fonts
+assert '"LIVE PREVIEW"' not in v4_fonts
+assert '"POST PREVIEW"' not in v4_fonts
+assert '"COMMENT PREVIEW"' not in v4_fonts
+assert 'previewExampleCard' not in v4_fonts
+assert 'previewDrawable' not in v4_fonts
+assert 'previewComment.setTypeface(typefaceFor(commentsFontValue));' in v4_fonts
+assert 'private void markNativeFontCacheDirty(String key)' in v4_fonts
+assert 'Class.forName("id.b")' in v4_fonts
+assert '.remove(KEY_TITLE_FONT)' in v4_fonts
+assert 'BoostSystemBarInsetsFix.applyMorpheSettingsV4SystemBars(' in v4_fonts
+assert 'BoostSystemBarInsetsFix.clearMorpheSettingsV4SystemBars(activity);' in v4_fonts
+for forbidden_call in [
+    'getActivity()',
+    'getFragmentManager()',
+    'getParentFragmentManager()',
+    'setTargetFragment(',
+]:
+    assert forbidden_call not in v4_fonts, forbidden_call
+assert 'androidx.compose' not in v4_fonts
+assert 'ComposeView' not in v4_fonts
 
 category_ids = [
     "appearance_layout",
@@ -313,6 +481,11 @@ for category_id in category_ids:
     assert f'"{category_id}"' in v4_catalog, category_id
 
 for name in v2_leaf_fragments:
+    if name in {
+        "PreferenceFragmentViewsCompat",
+        "PreferenceFragmentFontsCompat",
+    }:
+        continue
     assert name in v4_catalog, name
 
 assert 'morphe_boost_settings_skeleton' in v4_catalog
@@ -323,9 +496,20 @@ assert 'attributeText(resources, parser, "summary")' in v4_catalog
 assert 'attributeText(resources, parser, "key")' in v4_catalog
 assert 'BACKUP_ACTIVITY' in v4_catalog
 assert 'V4_APPEARANCE_FRAGMENT' in v4_catalog
+assert 'V4_APP_ICON_FRAGMENT' in v4_catalog
+assert 'V4_POST_VIEWS_FRAGMENT' in v4_catalog
+assert 'V4_SAVED_VIEWS_FRAGMENT' in v4_catalog
+assert 'V4_FONTS_FRAGMENT' in v4_catalog
 assert 'CLASSIC_APPEARANCE_FRAGMENT' in v4_catalog
 assert 'addV4AppearanceSearchItems(result, seen);' in v4_catalog
+assert 'addV4PostViewsSearchItems(result, seen);' in v4_catalog
+assert 'addV4FontsSearchItems(result, seen);' in v4_catalog
 assert 'Leaf.fragment("Appearance", "Dynamic color, app icon, and system bars"' in v4_catalog
+assert 'Leaf.fragment("Post views", "Cards, lists, thumbnails, and density"' in v4_catalog
+assert 'Leaf.fragment("Fonts", "Font family, size, and style"' in v4_catalog
+assert '"Appearance & layout · Fonts"' in v4_catalog
+assert 'PreferenceFragmentFontsCompat' not in v4_catalog
+assert 'PreferenceFragmentViewsCompat' not in v4_catalog
 assert 'Leaf.fragment("Classic theme editor", "Legacy Boost palettes and per-color customization"' in v4_catalog
 assert '{"Theme mode",' not in v4_catalog
 assert '{"Customize colors",' not in v4_catalog
@@ -399,6 +583,13 @@ echo 'SETTINGS_V4_NAVIGATION_SURFACE=PASS'
 echo 'SETTINGS_V4_APPEARANCE_CONTROLS=PASS'
 echo 'SETTINGS_V4_COMPACT_GROUPS=PASS'
 echo 'SETTINGS_V4_SYSTEM_THEME=PASS'
+echo 'SETTINGS_V4_APP_ICON_M3=PASS'
+echo 'SETTINGS_V4_POST_VIEWS_CONTROLS=PASS'
+echo 'SETTINGS_V4_SAVED_VIEWS_M3=PASS'
+echo 'SETTINGS_V4_SAVED_VIEWS_ADD=PASS'
+echo 'SETTINGS_V4_FONTS_M3=PASS'
+echo 'SETTINGS_V4_FONT_PREVIEWS=PASS'
+echo 'SETTINGS_V4_FONT_SPECIMEN=PASS'
 echo 'SETTINGS_V4_TASK_HUBS=PASS'
 echo 'SETTINGS_V4_SEARCH_INDEX=PASS'
 echo 'SETTINGS_V4_CLASSIC_FALLBACK=PASS'

--- a/tools/check-boost-morphe-settings-contract.sh
+++ b/tools/check-boost-morphe-settings-contract.sh
@@ -15,6 +15,8 @@ V4_SAVED_VIEWS="$ROOT/extensions/boostforreddit/src/main/java/app/morphe/extensi
 V4_FONTS="$ROOT/extensions/boostforreddit/src/main/java/app/morphe/extension/boostforreddit/settings/MorpheSettingsV4FontsFragment.java"
 V4_CATALOG="$ROOT/extensions/boostforreddit/src/main/java/app/morphe/extension/boostforreddit/settings/MorpheSettingsV4Catalog.java"
 V4_THEME="$ROOT/extensions/boostforreddit/src/main/java/app/morphe/extension/boostforreddit/settings/MorpheSettingsV4Theme.java"
+V4_NATIVE_PAGES="$ROOT/extensions/boostforreddit/src/main/java/app/morphe/extension/boostforreddit/settings/MorpheSettingsV4NativePages.java"
+V14_UI="$ROOT/extensions/boostforreddit/src/main/java/app/morphe/extension/boostforreddit/settings/MorpheSettingsV14Ui.java"
 SYSTEM_BARS="$ROOT/extensions/boostforreddit/src/main/java/app/morphe/extension/boostforreddit/utils/BoostSystemBarInsetsFix.java"
 
 test -f "$SETTINGS"
@@ -30,6 +32,8 @@ test -f "$V4_SAVED_VIEWS"
 test -f "$V4_FONTS"
 test -f "$V4_CATALOG"
 test -f "$V4_THEME"
+test -f "$V4_NATIVE_PAGES"
+test -f "$V14_UI"
 test -f "$SYSTEM_BARS"
 
 rg -q -F 'get("res/xml/pref_headers_v2.xml")' "$SETTINGS"
@@ -46,6 +50,8 @@ rg -q -F 'MORPHE_BOOST_SETTINGS_V4_COMPACT_GROUPS_ISSUE106_V1' "$V4_APPEARANCE"
 rg -q -F 'MORPHE_BOOST_SETTINGS_V4_POST_VIEWS_ISSUE106_V1' "$V4_POST_VIEWS"
 rg -q -F 'MORPHE_BOOST_SETTINGS_V4_SAVED_VIEWS_ISSUE106_V1' "$V4_SAVED_VIEWS"
 rg -q -F 'MORPHE_BOOST_SETTINGS_V4_FONTS_ISSUE106_V1' "$V4_FONTS"
+rg -q -F 'MORPHE_BOOST_SETTINGS_V4_NATIVE_REST_ISSUE106_V1' "$V4_NATIVE_PAGES"
+rg -q -F 'MORPHE_BOOST_SETTINGS_V14_COHERENT_UI_ISSUE106_V1' "$V14_UI"
 rg -q -F 'setPreferencesFromResource(resourceId, rootKey);' "$FRAGMENT" "$HUB"
 
 if rg -q -F 'get("res/xml/pref_advanced_v2.xml")' "$SETTINGS"; then
@@ -67,6 +73,8 @@ python3 - \
     "$V4_FONTS" \
     "$V4_CATALOG" \
     "$V4_THEME" \
+    "$V4_NATIVE_PAGES" \
+    "$V14_UI" \
     "$SYSTEM_BARS" <<'PY_CHECK'
 import re
 import sys
@@ -85,7 +93,9 @@ v4_saved_views = Path(sys.argv[10]).read_text()
 v4_fonts = Path(sys.argv[11]).read_text()
 v4_catalog = Path(sys.argv[12]).read_text()
 v4_theme = Path(sys.argv[13]).read_text()
-system_bars = Path(sys.argv[14]).read_text()
+v4_native_pages = Path(sys.argv[14]).read_text()
+v14_ui = Path(sys.argv[15]).read_text()
+system_bars = Path(sys.argv[16]).read_text()
 
 preference_keys = [
     "morphe_boost_inline_media_previews_enabled",
@@ -115,21 +125,21 @@ toggle = re.search(
     re.S,
 )
 assert toggle is not None
-assert 'android:title="Settings v4 (preview)"' in toggle.group(0)
-assert 'android:defaultValue="false"' in toggle.group(0)
-assert 'Close and reopen Settings to apply.' in toggle.group(0)
+assert 'android:title="Material settings"' in toggle.group(0)
+assert 'android:defaultValue="true"' in toggle.group(0)
+assert "Use Morphe's modern task-based settings. Reopen Settings to apply." in toggle.group(0)
 
 categories = re.findall(
     r'<PreferenceCategory android:title="([^"]+)">',
     settings,
 )
 assert categories == [
-    "Settings",
     "Media previews",
     "Open behavior",
     "Search",
     "Display &amp; performance",
     "Recovery &amp; archives",
+    "Settings",
 ]
 
 legacy_start = settings.index('get("res/xml/pref_headers_v2.xml")')
@@ -243,7 +253,8 @@ assert f'ENABLED_KEY =\n            "{toggle_key}"' in v4
 assert 'LEGACY_V2_ENABLED_KEY =\n            "morphe_boost_settings_layout_v2_enabled"' in v4
 assert 'public static void prepareIntent(Activity activity)' in v4
 assert 'preferences.contains(ENABLED_KEY)' in v4
-assert 'preferences.getBoolean(\n                LEGACY_V2_ENABLED_KEY,' in v4
+assert 'boolean legacyEnabled = preferences.getBoolean(' in v4
+assert 'LEGACY_V2_ENABLED_KEY,' in v4
 assert '.putBoolean(ENABLED_KEY, true)' in v4
 assert 'intent.getStringExtra(EXTRA_SHOW_FRAGMENT)' in v4
 assert 'intent.putExtra(EXTRA_SHOW_FRAGMENT, FRAGMENT_NAME);' in v4
@@ -259,8 +270,8 @@ assert 'new EditText(context)' in v4_fragment
 assert 'renderSearchResults' in v4_fragment
 assert 'hideMenuItem(menu, "action_generic_search")' in v4_fragment
 assert 'openClassicSettings' in v4_fragment
-assert 'MorpheSettingsV4Fragment.class.getName()' in v4_fragment
-assert 'intent.putExtra(ARGUMENT_PAGE, category.id);' in v4_fragment
+assert 'view -> openLeaf(leaf, null)' in v4_fragment
+assert 'MorpheSettingsV14Ui.addSegmentedRow(' in v4_fragment
 assert 'intent.putExtra(EXTRA_SHOW_FRAGMENT, fragmentName);' in v4_fragment
 assert 'activity.startActivity(intent);' in v4_fragment
 assert 'private Activity hostActivity()' in v4_fragment
@@ -292,7 +303,11 @@ assert 'BoostSystemBarInsetsFix.clearMorpheSettingsV4SystemBars(activity);' in v
 assert 'private LinearLayout addGroup(LinearLayout parent)' in v4_appearance
 assert 'private void addGroupedRow(LinearLayout group, LinearLayout row)' in v4_appearance
 assert 'private void addGroupDivider(LinearLayout group)' in v4_appearance
-assert 'row.setMinimumHeight(dp(68));' in v4_appearance
+assert 'return MorpheSettingsV14Ui.baseRow(context, tokens);' in v4_appearance
+assert 'MorpheSettingsV14Ui.addSegmentedRow(group, row, tokens);' in v4_appearance
+assert 'ROW_SINGLE_DP = 56' in v14_ui
+assert 'ROW_TWO_LINE_DP = 72' in v14_ui
+assert 'row.setMinimumHeight(dp(context, ROW_SINGLE_DP));' in v14_ui
 assert 'addHeader(content);' not in v4_appearance
 assert 'createIconContainer(' not in v4_appearance
 assert 'addSectionLabel(content, "Appearance");' in v4_appearance
@@ -494,13 +509,59 @@ category_ids = [
 for category_id in category_ids:
     assert f'"{category_id}"' in v4_catalog, category_id
 
-for name in v2_leaf_fragments:
-    if name in {
-        "PreferenceFragmentViewsCompat",
-        "PreferenceFragmentFontsCompat",
-    }:
-        continue
+for name in [
+    "PreferenceFragmentAppearanceCompat",
+    "PreferenceFragmentAccountCompat",
+]:
     assert name in v4_catalog, name
+
+native_leaf_mappings = {
+    "PreferenceFragmentPostsCompat": "Posts",
+    "PreferenceFragmentCommentsCompat": "Comments",
+    "PreferenceFragmentBottomNavigationCompat": "BottomNavigation",
+    "PreferenceFragmentDrawerCompat": "Drawer",
+    "PreferenceFragmentMediaCompat": "Media",
+    "PreferenceFragmentLinksCompat": "Links",
+    "PreferenceFragmentSearchCompat": "Search",
+    "PreferenceFragmentFiltersCompat": "Filters",
+    "PreferenceFragmentMessagesCompat": "Messages",
+    "PreferenceFragmentPrivacyCompat": "Privacy",
+    "PreferenceFragmentGeneralCompat": "General",
+    "PreferenceFragmentMiscCompat": "Misc",
+    "PreferenceFragmentAboutCompat": "About",
+}
+for legacy_fragment, native_page in native_leaf_mappings.items():
+    assert (
+        f'legacyDestination.endsWith("{legacy_fragment}")'
+        in v4_native_pages
+    ), legacy_fragment
+    assert f'return PREFIX + "{native_page}";' in v4_native_pages, native_page
+
+native_redirects = {
+    "PreferenceFragmentViewsCompat": "V4_POST_VIEWS_FRAGMENT",
+    "PreferenceFragmentToolbarCompat": "V4_TOOLBAR_FRAGMENT",
+}
+for legacy_fragment, destination in native_redirects.items():
+    assert (
+        f'legacyDestination.endsWith("{legacy_fragment}")'
+        in v4_native_pages
+    ), legacy_fragment
+    assert (
+        f'return MorpheSettingsV4Catalog.{destination};'
+        in v4_native_pages
+    ), destination
+
+for retired_catalog_fragment in [
+    "PreferenceFragmentFontsCompat",
+    "PreferenceFragmentDataSavingCompat",
+]:
+    assert retired_catalog_fragment not in v4_catalog, retired_catalog_fragment
+
+for native_destination in [
+    "V4_FONTS_FRAGMENT",
+    "V4_DATA_STORAGE_FRAGMENT",
+]:
+    assert native_destination in v4_catalog, native_destination
 
 assert 'morphe_boost_settings_skeleton' in v4_catalog
 assert 'buildSearchIndex(Context context)' in v4_catalog
@@ -524,7 +585,12 @@ assert 'Leaf.fragment("Fonts", "Font family, size, and style"' in v4_catalog
 assert '"Appearance & layout · Fonts"' in v4_catalog
 assert 'PreferenceFragmentFontsCompat' not in v4_catalog
 assert 'PreferenceFragmentViewsCompat' not in v4_catalog
-assert 'Leaf.fragment("Classic theme editor", "Legacy Boost palettes and per-color customization"' in v4_catalog
+assert 'Leaf.fragment("Classic theme editor", "Legacy Boost palettes and per-color customization"' not in v4_catalog
+assert 'MORPHE_BOOST_SETTINGS_V14_EDITOR_SYSTEM_ISSUE106_V1' in v4_native_pages
+assert 'MORPHE_BOOST_SETTINGS_V14_NO_COMPILE_ONLY_UI_ABI_ISSUE106_V1' in v4_native_pages
+assert 'MORPHE_BOOST_SETTINGS_V14_3_MATERIAL_TOGGLE_LAST_ISSUE106_V1' in v4_native_pages
+assert 'preview toggle here is self-referential clutter' not in v4_native_pages
+assert 'showColorPatternEditor();' in v4_native_pages
 assert '{"Theme mode",' not in v4_catalog
 assert '{"Customize colors",' not in v4_catalog
 assert 'pref_colored_status_bar' in v4_catalog
@@ -548,7 +614,7 @@ assert 'tokens.accentFor(' not in v4_fragment
 assert 'MORPHE_BOOST_SETTINGS_V4_SUBTLE_COLOR_ISSUE106_V1' in v4_fragment
 assert 'MORPHE_BOOST_SETTINGS_V4_SYSTEM_BARS_ISSUE106_V1' in v4_fragment
 assert 'MORPHE_BOOST_SETTINGS_V4_SYSTEM_BAR_OWNER_ISSUE106_V2' in v4_fragment
-assert 'tokens.dark ? 0.06f : 0.05f' in v4_fragment
+assert 'MORPHE_BOOST_SETTINGS_V14_COHERENT_UI_ISSUE106_V1' in v14_ui
 assert 'tokens.dark ? 0.06f : 0.08f' in v4_fragment
 assert 'styleSystemBars(activity);' in v4_fragment
 assert 'BoostSystemBarInsetsFix.applyMorpheSettingsV4SystemBars(' in v4_fragment
@@ -584,8 +650,8 @@ assert "dependsOn(sharedExtensionPatch, boostMorpheSettingsResourcesPatch)" in s
 PY_CHECK
 
 echo 'TOP_LEVEL_MORPHE_ENTRY=PASS'
-echo 'ORIGINAL_LAYOUT_DEFAULT=PASS'
-echo 'SETTINGS_V4_TOGGLE_DEFAULT_OFF=PASS'
+echo 'LEGACY_V2_LAYOUT_DEFAULT_OFF=PASS'
+echo 'SETTINGS_V4_TOGGLE_DEFAULT_ON=PASS'
 echo 'SETTINGS_V4_V2_MIGRATION=PASS'
 echo 'SETTINGS_V4_ACTIVITY_ROUTE=PASS'
 echo 'SETTINGS_V4_MATERIAL3_VIEW_SHELL=PASS'
@@ -607,6 +673,9 @@ echo 'SETTINGS_V4_FONT_SPECIMEN=PASS'
 echo 'SETTINGS_V4_TASK_HUBS=PASS'
 echo 'SETTINGS_V4_SEARCH_INDEX=PASS'
 echo 'SETTINGS_V4_CLASSIC_FALLBACK=PASS'
+echo 'SETTINGS_V14_NATIVE_PAGES=PASS'
+echo 'SETTINGS_V14_COHERENT_UI=PASS'
+echo 'SETTINGS_V14_3_MATERIAL_TOGGLE_LAST=PASS'
 echo 'SETTINGS_V4_MINIFIED_ANDROIDX_COMPAT=PASS'
 echo 'SETTINGS_V4_NO_COMPOSE=PASS'
 echo 'SETTINGS_V2_RESOURCE_FALLBACK=PASS'

--- a/tools/check-boost-morphe-settings-contract.sh
+++ b/tools/check-boost-morphe-settings-contract.sh
@@ -1,0 +1,113 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SETTINGS="$ROOT/patches/src/main/kotlin/app/morphe/patches/reddit/customclients/boostforreddit/misc/settings/BoostMorpheSettingsSkeletonPatch.kt"
+FRAGMENT="$ROOT/extensions/boostforreddit/src/main/java/app/morphe/extension/boostforreddit/settings/MorpheSettingsFragment.java"
+
+test -f "$SETTINGS"
+test -f "$FRAGMENT"
+
+rg -q -F 'get("res/xml/pref_headers_v2.xml")' "$SETTINGS"
+rg -q -F 'morphe_boost_settings_entry' "$SETTINGS"
+rg -q -F 'app.morphe.extension.boostforreddit.settings.MorpheSettingsFragment' "$SETTINGS"
+rg -q -F 'MORPHE_BOOST_TOP_LEVEL_SETTINGS_ISSUE106_V1' "$FRAGMENT"
+rg -q -F 'setPreferencesFromResource(resourceId, rootKey);' "$FRAGMENT"
+
+if rg -q -F 'get("res/xml/pref_advanced_v2.xml")' "$SETTINGS"; then
+    echo 'FAIL: Morphe settings are still written into Advanced' >&2
+    exit 1
+fi
+
+python3 - "$SETTINGS" "$FRAGMENT" <<'PY_CHECK'
+import re
+import sys
+from pathlib import Path
+
+settings = Path(sys.argv[1]).read_text()
+fragment = Path(sys.argv[2]).read_text()
+
+preference_keys = [
+    "morphe_boost_inline_media_previews_enabled",
+    "morphe_boost_inline_media_preview_size",
+    "morphe_boost_inline_media_preview_alignment",
+    "morphe_boost_inline_media_preview_show_source_text",
+    "morphe_boost_direct_reddit_gif_tap_action",
+    "morphe_boost_giphy_preview_tap_action",
+    "morphe_boost_static_preview_tap_action",
+    "morphe_boost_search_open_keyboard_on_entry",
+    "morphe_boost_prefer_high_refresh_rate",
+    "morphe_boost_reddit_undelete_enabled",
+    "morphe_boost_imgur_undelete_enabled",
+]
+
+for key in preference_keys:
+    assert settings.count(f'android:key="{key}"') == 1, key
+
+assert settings.count('android:key="morphe_boost_settings_entry"') == 1
+assert settings.count('android:title="Morphe"') == 1
+assert settings.count(
+    'android:summary="Features added by Morphe patches"'
+) == 1
+assert settings.index(
+    'android:key="morphe_boost_settings_entry"'
+) < settings.index("PreferenceFragmentGeneralCompat")
+
+morphe_entry = re.search(
+    r'<Preference\s+[^>]*android:key="morphe_boost_settings_entry"[^>]*/>',
+    settings,
+    re.S,
+)
+assert morphe_entry is not None
+assert 'app:allowDividerBelow="true"' in morphe_entry.group(0)
+
+general_entry = re.search(
+    r'<Preference\s+[^>]*PreferenceFragmentGeneralCompat[^>]*/>',
+    settings,
+    re.S,
+)
+assert general_entry is not None
+assert 'app:allowDividerAbove="true"' in general_entry.group(0)
+
+categories = re.findall(
+    r'<PreferenceCategory android:title="([^"]+)">',
+    settings,
+)
+
+assert categories == [
+    "Media previews",
+    "Open behavior",
+    "Search",
+    "Display &amp; performance",
+    "Recovery &amp; archives",
+]
+
+root_fragments = [
+    "PreferenceFragmentGeneralCompat",
+    "PreferenceFragmentAppearanceCompat",
+    "PreferenceFragmentMessagesCompat",
+    "PreferenceFragmentFiltersCompat",
+    "PreferenceFragmentDataSavingCompat",
+    "PreferenceFragmentPrivacyCompat",
+    "MorpheSettingsFragment",
+    "PreferenceFragmentAdvancedCompat",
+    "PreferenceFragmentAboutCompat",
+]
+
+for name in root_fragments:
+    assert settings.count(name) == 1, name
+
+assert 'RESOURCE_NAME = "morphe_boost_settings_skeleton"' in fragment
+assert 'context.getPackageName()' in fragment
+assert 'BOOST_PACKAGE = "com.rubenmayayo.reddit"' in fragment
+assert fragment.count("resources.getIdentifier(") == 2
+assert "if (resourceId == 0)" in fragment
+assert "throw new IllegalStateException(" in fragment
+PY_CHECK
+
+echo 'TOP_LEVEL_MORPHE_ENTRY=PASS'
+echo 'MORPHE_ENTRY_FIRST_WITH_DIVIDER=PASS'
+echo 'CANONICAL_MORPHE_KEYS=PASS'
+echo 'ADVANCED_DUPLICATE_REMOVED=PASS'
+echo 'MORPHE_FRAGMENT_RESOURCE_FALLBACK=PASS'
+echo 'RESULT=MORPHE_ISSUE106_SETTINGS_CONTRACT_OK'

--- a/tools/check-boost-morphe-settings-contract.sh
+++ b/tools/check-boost-morphe-settings-contract.sh
@@ -4,28 +4,62 @@ set -euo pipefail
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 SETTINGS="$ROOT/patches/src/main/kotlin/app/morphe/patches/reddit/customclients/boostforreddit/misc/settings/BoostMorpheSettingsSkeletonPatch.kt"
 FRAGMENT="$ROOT/extensions/boostforreddit/src/main/java/app/morphe/extension/boostforreddit/settings/MorpheSettingsFragment.java"
+HUB="$ROOT/extensions/boostforreddit/src/main/java/app/morphe/extension/boostforreddit/settings/MorpheSettingsHubFragment.java"
+LAYOUT="$ROOT/extensions/boostforreddit/src/main/java/app/morphe/extension/boostforreddit/settings/MorpheSettingsLayout.java"
+V4="$ROOT/extensions/boostforreddit/src/main/java/app/morphe/extension/boostforreddit/settings/MorpheSettingsV4.java"
+V4_FRAGMENT="$ROOT/extensions/boostforreddit/src/main/java/app/morphe/extension/boostforreddit/settings/MorpheSettingsV4Fragment.java"
+V4_CATALOG="$ROOT/extensions/boostforreddit/src/main/java/app/morphe/extension/boostforreddit/settings/MorpheSettingsV4Catalog.java"
+V4_THEME="$ROOT/extensions/boostforreddit/src/main/java/app/morphe/extension/boostforreddit/settings/MorpheSettingsV4Theme.java"
+SYSTEM_BARS="$ROOT/extensions/boostforreddit/src/main/java/app/morphe/extension/boostforreddit/utils/BoostSystemBarInsetsFix.java"
 
 test -f "$SETTINGS"
 test -f "$FRAGMENT"
+test -f "$HUB"
+test -f "$LAYOUT"
+test -f "$V4"
+test -f "$V4_FRAGMENT"
+test -f "$V4_CATALOG"
+test -f "$V4_THEME"
+test -f "$SYSTEM_BARS"
 
 rg -q -F 'get("res/xml/pref_headers_v2.xml")' "$SETTINGS"
 rg -q -F 'morphe_boost_settings_entry' "$SETTINGS"
 rg -q -F 'app.morphe.extension.boostforreddit.settings.MorpheSettingsFragment' "$SETTINGS"
 rg -q -F 'MORPHE_BOOST_TOP_LEVEL_SETTINGS_ISSUE106_V1' "$FRAGMENT"
-rg -q -F 'setPreferencesFromResource(resourceId, rootKey);' "$FRAGMENT"
+rg -q -F 'MORPHE_BOOST_SETTINGS_LAYOUT_ISSUE106_V2_1' "$LAYOUT"
+rg -q -F 'MORPHE_BOOST_SETTINGS_HUBS_ISSUE106_V2_1' "$HUB"
+rg -q -F 'MORPHE_BOOST_SETTINGS_V4_ISSUE106_V1' "$V4"
+rg -q -F 'MORPHE_BOOST_SETTINGS_V4_UI_ISSUE106_V1' "$V4_FRAGMENT"
+rg -q -F 'setPreferencesFromResource(resourceId, rootKey);' "$FRAGMENT" "$HUB"
 
 if rg -q -F 'get("res/xml/pref_advanced_v2.xml")' "$SETTINGS"; then
     echo 'FAIL: Morphe settings are still written into Advanced' >&2
     exit 1
 fi
 
-python3 - "$SETTINGS" "$FRAGMENT" <<'PY_CHECK'
+python3 - \
+    "$SETTINGS" \
+    "$FRAGMENT" \
+    "$LAYOUT" \
+    "$HUB" \
+    "$V4" \
+    "$V4_FRAGMENT" \
+    "$V4_CATALOG" \
+    "$V4_THEME" \
+    "$SYSTEM_BARS" <<'PY_CHECK'
 import re
 import sys
 from pathlib import Path
 
 settings = Path(sys.argv[1]).read_text()
 fragment = Path(sys.argv[2]).read_text()
+layout = Path(sys.argv[3]).read_text()
+hub = Path(sys.argv[4]).read_text()
+v4 = Path(sys.argv[5]).read_text()
+v4_fragment = Path(sys.argv[6]).read_text()
+v4_catalog = Path(sys.argv[7]).read_text()
+v4_theme = Path(sys.argv[8]).read_text()
+system_bars = Path(sys.argv[9]).read_text()
 
 preference_keys = [
     "morphe_boost_inline_media_previews_enabled",
@@ -44,37 +78,27 @@ preference_keys = [
 for key in preference_keys:
     assert settings.count(f'android:key="{key}"') == 1, key
 
-assert settings.count('android:key="morphe_boost_settings_entry"') == 1
-assert settings.count('android:title="Morphe"') == 1
+toggle_key = "morphe_boost_settings_v4_enabled"
+assert settings.count(f'android:key="{toggle_key}"') == 1
 assert settings.count(
-    'android:summary="Features added by Morphe patches"'
-) == 1
-assert settings.index(
-    'android:key="morphe_boost_settings_entry"'
-) < settings.index("PreferenceFragmentGeneralCompat")
-
-morphe_entry = re.search(
-    r'<Preference\s+[^>]*android:key="morphe_boost_settings_entry"[^>]*/>',
+    'android:key="morphe_boost_settings_layout_v2_enabled"'
+) == 0
+toggle = re.search(
+    rf'<CheckBoxPreference\s+[^>]*android:key="{toggle_key}"[^>]*/>',
     settings,
     re.S,
 )
-assert morphe_entry is not None
-assert 'app:allowDividerBelow="true"' in morphe_entry.group(0)
-
-general_entry = re.search(
-    r'<Preference\s+[^>]*PreferenceFragmentGeneralCompat[^>]*/>',
-    settings,
-    re.S,
-)
-assert general_entry is not None
-assert 'app:allowDividerAbove="true"' in general_entry.group(0)
+assert toggle is not None
+assert 'android:title="Settings v4 (preview)"' in toggle.group(0)
+assert 'android:defaultValue="false"' in toggle.group(0)
+assert 'Close and reopen Settings to apply.' in toggle.group(0)
 
 categories = re.findall(
     r'<PreferenceCategory android:title="([^"]+)">',
     settings,
 )
-
 assert categories == [
+    "Settings",
     "Media previews",
     "Open behavior",
     "Search",
@@ -82,32 +106,239 @@ assert categories == [
     "Recovery &amp; archives",
 ]
 
-root_fragments = [
-    "PreferenceFragmentGeneralCompat",
+legacy_start = settings.index('get("res/xml/pref_headers_v2.xml")')
+v2_start = settings.index('"morphe_boost_settings_layout_v2" to')
+first_hub_start = settings.index(
+    '"morphe_boost_settings_hub_appearance_layout" to'
+)
+legacy_root = settings[legacy_start:v2_start]
+v2_root = settings[v2_start:first_hub_start]
+v2_resources = settings[v2_start:]
+
+for root in (legacy_root, v2_root):
+    assert root.count('android:key="morphe_boost_settings_entry"') == 1
+    assert root.count('android:title="Morphe"') == 1
+    assert root.count(
+        'android:summary="Features added by Morphe patches"'
+    ) == 1
+
+    morphe_entry = re.search(
+        r'<Preference\s+[^>]*android:key="morphe_boost_settings_entry"[^>]*/>',
+        root,
+        re.S,
+    )
+    assert morphe_entry is not None
+    assert 'app:allowDividerBelow="true"' in morphe_entry.group(0)
+
+assert legacy_root.index(
+    'android:key="morphe_boost_settings_entry"'
+) < legacy_root.index("PreferenceFragmentGeneralCompat")
+assert v2_root.index(
+    'android:key="morphe_boost_settings_entry"'
+) < v2_root.index("morphe_boost_settings_v2_appearance_layout")
+assert 'app:allowDividerAbove="true"' in v2_root.split(
+    'morphe_boost_settings_v2_appearance_layout', 1
+)[1].split('</Preference>', 1)[0]
+
+hub_names = [
+    "appearance_layout",
+    "posts_comments",
+    "navigation",
+    "media_links",
+    "search_filters",
+    "data_storage",
+    "account_privacy",
+    "app_legacy",
+]
+
+for name in hub_names:
+    resource_name = f"morphe_boost_settings_hub_{name}"
+    assert settings.count(f'"{resource_name}" to') == 1, resource_name
+    assert v2_root.count(f'android:value="{resource_name}"') == 1, name
+
+assert v2_root.count("MorpheSettingsHubFragment") == len(hub_names)
+assert "PreferenceFragmentAdvancedCompat" not in v2_resources
+assert 'android:key="remove_ads"' not in v2_resources
+assert 'android:key="buy_pro"' not in v2_resources
+assert 'android:key="support_launch"' not in v2_resources
+assert 'android:key="privacy_policy"' not in v2_resources
+
+v2_leaf_fragments = [
     "PreferenceFragmentAppearanceCompat",
-    "PreferenceFragmentMessagesCompat",
+    "PreferenceFragmentViewsCompat",
+    "PreferenceFragmentFontsCompat",
+    "PreferenceFragmentPostsCompat",
+    "PreferenceFragmentCommentsCompat",
+    "PreferenceFragmentToolbarCompat",
+    "PreferenceFragmentBottomNavigationCompat",
+    "PreferenceFragmentDrawerCompat",
+    "PreferenceFragmentMediaCompat",
+    "PreferenceFragmentLinksCompat",
+    "PreferenceFragmentSearchCompat",
     "PreferenceFragmentFiltersCompat",
+    "PreferenceFragmentMessagesCompat",
     "PreferenceFragmentDataSavingCompat",
+    "PreferenceFragmentAccountCompat",
     "PreferenceFragmentPrivacyCompat",
-    "MorpheSettingsFragment",
-    "PreferenceFragmentAdvancedCompat",
+    "PreferenceFragmentGeneralCompat",
+    "PreferenceFragmentMiscCompat",
     "PreferenceFragmentAboutCompat",
 ]
 
-for name in root_fragments:
-    assert settings.count(name) == 1, name
+for name in v2_leaf_fragments:
+    assert v2_resources.count(name) == 1, name
 
+assert 'get("res/xml/$resourceName.xml")' in settings
+assert 'get("res/xml/\\$resourceName.xml")' not in settings
 assert 'RESOURCE_NAME = "morphe_boost_settings_skeleton"' in fragment
 assert 'context.getPackageName()' in fragment
 assert 'BOOST_PACKAGE = "com.rubenmayayo.reddit"' in fragment
 assert fragment.count("resources.getIdentifier(") == 2
-assert "if (resourceId == 0)" in fragment
 assert "throw new IllegalStateException(" in fragment
+
+assert 'ENABLED_KEY =\n            "morphe_boost_settings_layout_v2_enabled"' in layout
+assert f'V4_ENABLED_KEY =\n            "{toggle_key}"' in layout
+assert 'RESOURCE_NAME =\n            "morphe_boost_settings_layout_v2"' in layout
+assert "import android.preference.PreferenceManager;" in layout
+assert "import androidx.preference.PreferenceManager;" not in layout
+assert 'preferences.contains(V4_ENABLED_KEY)' in layout
+assert 'preferences.getBoolean(ENABLED_KEY, false)' in layout
+assert 'return originalResourceId;' in layout
+assert 'return resourceId == 0 ? originalResourceId : resourceId;' in layout
+assert layout.count("resources.getIdentifier(") == 2
+
+assert 'RESOURCE_ARGUMENT =\n            "morphe_boost_settings_hub_resource"' in hub
+assert 'resourceName.startsWith(RESOURCE_PREFIX)' in hub
+assert 'Preference backup = findPreference(BACKUP_KEY);' in hub
+assert 'intent.setClassName(context.getPackageName(), BACKUP_ACTIVITY);' in hub
+assert 'startActivity(intent);' in hub
+
+assert f'ENABLED_KEY =\n            "{toggle_key}"' in v4
+assert 'LEGACY_V2_ENABLED_KEY =\n            "morphe_boost_settings_layout_v2_enabled"' in v4
+assert 'public static void prepareIntent(Activity activity)' in v4
+assert 'preferences.contains(ENABLED_KEY)' in v4
+assert 'preferences.getBoolean(\n                LEGACY_V2_ENABLED_KEY,' in v4
+assert 'preferences.edit().putBoolean(ENABLED_KEY, true).apply();' in v4
+assert 'intent.getStringExtra(EXTRA_SHOW_FRAGMENT)' in v4
+assert 'intent.putExtra(EXTRA_SHOW_FRAGMENT, FRAGMENT_NAME);' in v4
+assert 'MorpheSettingsV4Fragment' in v4
+
+assert 'extends Fragment' in v4_fragment
+assert 'new ScrollView(context)' in v4_fragment
+assert 'new EditText(context)' in v4_fragment
+assert 'renderSearchResults' in v4_fragment
+assert 'hideMenuItem(menu, "action_generic_search")' in v4_fragment
+assert 'openClassicSettings' in v4_fragment
+assert 'MorpheSettingsV4Fragment.class.getName()' in v4_fragment
+assert 'intent.putExtra(ARGUMENT_PAGE, category.id);' in v4_fragment
+assert 'intent.putExtra(EXTRA_SHOW_FRAGMENT, fragmentName);' in v4_fragment
+assert 'activity.startActivity(intent);' in v4_fragment
+assert 'private Activity hostActivity()' in v4_fragment
+for forbidden_call in [
+    'getActivity()',
+    'getFragmentManager()',
+    'fragment.setTargetFragment',
+    'fragmentManager.beginTransaction()',
+    'navigateFragment(',
+    'fragment_container',
+]:
+    assert forbidden_call not in v4_fragment, forbidden_call
+assert 'androidx.compose' not in v4_fragment
+assert 'ComposeView' not in v4_fragment
+
+category_ids = [
+    "appearance_layout",
+    "posts_comments",
+    "navigation",
+    "media_links",
+    "search_filters",
+    "notifications",
+    "data_storage",
+    "account_privacy",
+    "app_legacy",
+    "about",
+]
+for category_id in category_ids:
+    assert f'"{category_id}"' in v4_catalog, category_id
+
+for name in v2_leaf_fragments:
+    assert name in v4_catalog, name
+
+assert 'morphe_boost_settings_skeleton' in v4_catalog
+assert 'buildSearchIndex(Context context)' in v4_catalog
+assert 'resources.getXml(resourceId)' in v4_catalog
+assert 'attributeText(resources, parser, "title")' in v4_catalog
+assert 'attributeText(resources, parser, "summary")' in v4_catalog
+assert 'attributeText(resources, parser, "key")' in v4_catalog
+assert 'BACKUP_ACTIVITY' in v4_catalog
+
+assert 'system_accent1_200' in v4_theme
+assert 'system_accent1_600' in v4_theme
+assert 'system_accent2_200' in v4_theme
+assert 'system_accent2_600' in v4_theme
+assert 'system_accent3_200' in v4_theme
+assert 'system_accent3_600' in v4_theme
+assert 'system_neutral1_900' in v4_theme
+assert 'system_neutral2_700' in v4_theme
+assert 'Accent navigationAccent()' in v4_theme
+assert 'hashCode()' not in v4_theme
+assert 'tokens.navigationAccent()' in v4_fragment
+assert 'tokens.accentFor(' not in v4_fragment
+assert 'MORPHE_BOOST_SETTINGS_V4_SUBTLE_COLOR_ISSUE106_V1' in v4_fragment
+assert 'MORPHE_BOOST_SETTINGS_V4_SYSTEM_BARS_ISSUE106_V1' in v4_fragment
+assert 'MORPHE_BOOST_SETTINGS_V4_SYSTEM_BAR_OWNER_ISSUE106_V2' in v4_fragment
+assert 'tokens.dark ? 0.06f : 0.05f' in v4_fragment
+assert 'tokens.dark ? 0.06f : 0.08f' in v4_fragment
+assert 'styleSystemBars(activity);' in v4_fragment
+assert 'BoostSystemBarInsetsFix.applyMorpheSettingsV4SystemBars(' in v4_fragment
+assert 'BoostSystemBarInsetsFix.clearMorpheSettingsV4SystemBars(activity);' in v4_fragment
+assert 'window.setStatusBarColor(tokens.background);' not in v4_fragment
+assert 'MORPHE_BOOST_SETTINGS_V4_SYSTEM_BAR_OWNER_ISSUE106_V2' in system_bars
+assert 'MORPHE_BOOST_SETTINGS_V4_NAVIGATION_SURFACE_ISSUE106_V3' in system_bars
+assert 'MORPHE_SETTINGS_V4_SYSTEM_BARS.get(activity)' in system_bars
+assert 'applyMorpheSettingsV4SystemBarsNow(activity, v4State);' in system_bars
+assert 'installStatusBarSurface(decor, statusHeight, state.color);' in system_bars
+assert 'installMorpheSettingsV4NavigationBarSurface(' in system_bars
+assert 'surface.setTag(MORPHE_SETTINGS_V4_NAVIGATION_SURFACE_MARKER);' in system_bars
+assert 'window.setNavigationBarColor(state.color);' in system_bars
+assert 'removeMorpheSettingsV4NavigationBarSurface(decor);' in system_bars
+assert 'window.setNavigationBarColor(Color.TRANSPARENT);' in system_bars
+assert 'window.setNavigationBarContrastEnforced(false);' in system_bars
+assert 'RippleDrawable' in v4_theme
+assert 'primaryContainer' in v4_theme
+
+assert "settingsHeaderOnCreatePreferencesFingerprint" in settings
+assert "settingsActivityOnCreateFingerprint" in settings
+assert "SettingsActivityCompat\\$HeaderFragment" in settings
+assert 'SettingsActivityCompat;"' in settings
+assert "SET_PREFERENCES_FROM_RESOURCE_REFERENCE" in settings
+assert "GET_INTENT_REFERENCE" in settings
+assert "val loadPreferencesIndex = indexOfFirstInstructionOrThrow" in settings
+assert "val getIntentIndex = indexOfFirstInstructionOrThrow" in settings
+assert "addInstructions(\n                loadPreferencesIndex," in settings
+assert "addInstructions(\n                getIntentIndex," in settings
+assert "$SETTINGS_LAYOUT_EXTENSION_DESCRIPTOR->resolveRootResource" in settings
+assert "$SETTINGS_V4_EXTENSION_DESCRIPTOR->prepareIntent" in settings
+assert "dependsOn(sharedExtensionPatch, boostMorpheSettingsResourcesPatch)" in settings
 PY_CHECK
 
 echo 'TOP_LEVEL_MORPHE_ENTRY=PASS'
-echo 'MORPHE_ENTRY_FIRST_WITH_DIVIDER=PASS'
+echo 'ORIGINAL_LAYOUT_DEFAULT=PASS'
+echo 'SETTINGS_V4_TOGGLE_DEFAULT_OFF=PASS'
+echo 'SETTINGS_V4_V2_MIGRATION=PASS'
+echo 'SETTINGS_V4_ACTIVITY_ROUTE=PASS'
+echo 'SETTINGS_V4_MATERIAL3_VIEW_SHELL=PASS'
+echo 'SETTINGS_V4_FULL_DYNAMIC_COLOR=PASS'
+echo 'SETTINGS_V4_SUBTLE_DYNAMIC_COLOR=PASS'
+echo 'SETTINGS_V4_SYSTEM_BARS_MATCH=PASS'
+echo 'SETTINGS_V4_SYSTEM_BAR_OWNER=PASS'
+echo 'SETTINGS_V4_NAVIGATION_SURFACE=PASS'
+echo 'SETTINGS_V4_TASK_HUBS=PASS'
+echo 'SETTINGS_V4_SEARCH_INDEX=PASS'
+echo 'SETTINGS_V4_CLASSIC_FALLBACK=PASS'
+echo 'SETTINGS_V4_MINIFIED_ANDROIDX_COMPAT=PASS'
+echo 'SETTINGS_V4_NO_COMPOSE=PASS'
+echo 'SETTINGS_V2_RESOURCE_FALLBACK=PASS'
 echo 'CANONICAL_MORPHE_KEYS=PASS'
 echo 'ADVANCED_DUPLICATE_REMOVED=PASS'
-echo 'MORPHE_FRAGMENT_RESOURCE_FALLBACK=PASS'
 echo 'RESULT=MORPHE_ISSUE106_SETTINGS_CONTRACT_OK'

--- a/tools/check-boost-search-route-contract.sh
+++ b/tools/check-boost-search-route-contract.sh
@@ -91,7 +91,7 @@ matching = [
     if f'android:key="{key}"' in block
 ]
 
-assert len(matching) == 2
+assert len(matching) == 1
 
 assert all(
     'android:defaultValue="false"' in block
@@ -102,14 +102,14 @@ assert (
     settings.count(
         'android:title="Open keyboard when entering Search"'
     )
-    == 2
+    == 1
 )
 
 assert (
     settings.count(
         "When disabled, tap Search again to start typing."
     )
-    == 2
+    == 1
 )
 PY_CHECK
 

--- a/tools/check_boost_settings_audit_gateway.py
+++ b/tools/check_boost_settings_audit_gateway.py
@@ -1,0 +1,135 @@
+#!/usr/bin/env python3
+"""Validate the exact Boost settings audit gateway manifest component."""
+
+from __future__ import annotations
+
+import argparse
+import re
+import xml.etree.ElementTree as ET
+from pathlib import Path
+
+
+DEFAULT_ACTIVITY = (
+    "com.rubenmayayo.reddit.ui.preferences.v2.SettingsActivityCompat"
+)
+DEFAULT_PERMISSION = "android.permission.DUMP"
+ANDROID_NAMESPACE = "http://schemas.android.com/apk/res/android"
+
+
+def _state_from_xml(
+    path: Path, activity_name: str, permission: str
+) -> tuple[int, bool, bool]:
+    root = ET.parse(path).getroot()
+    android_name = f"{{{ANDROID_NAMESPACE}}}name"
+    android_exported = f"{{{ANDROID_NAMESPACE}}}exported"
+    android_permission = f"{{{ANDROID_NAMESPACE}}}permission"
+    matches = [
+        node
+        for node in root.iter("activity")
+        if node.attrib.get(android_name) == activity_name
+    ]
+    if len(matches) != 1:
+        return len(matches), False, False
+    activity = matches[0]
+    return (
+        1,
+        activity.attrib.get(android_exported) == "true",
+        activity.attrib.get(android_permission) == permission,
+    )
+
+
+def _activity_attribute_blocks(lines: list[str]) -> list[list[str]]:
+    blocks: list[list[str]] = []
+    for index, line in enumerate(lines):
+        stripped = line.lstrip()
+        if not (stripped == "E: activity" or stripped.startswith("E: activity ")):
+            continue
+        indent = len(line) - len(stripped)
+        attributes: list[str] = []
+        for candidate in lines[index + 1 :]:
+            candidate_stripped = candidate.lstrip()
+            candidate_indent = len(candidate) - len(candidate_stripped)
+            if candidate_stripped.startswith("E:"):
+                break
+            if candidate_indent <= indent:
+                break
+            if candidate_stripped.startswith("A:"):
+                attributes.append(candidate_stripped)
+        blocks.append(attributes)
+    return blocks
+
+
+def _state_from_xmltree(
+    path: Path, activity_name: str, permission: str
+) -> tuple[int, bool, bool]:
+    lines = path.read_text(encoding="utf-8", errors="replace").splitlines()
+    name_marker = f'"{activity_name}"'
+    matches = [
+        attributes
+        for attributes in _activity_attribute_blocks(lines)
+        if any(
+            line.startswith("A: android:name") and name_marker in line
+            for line in attributes
+        )
+    ]
+    if len(matches) != 1:
+        return len(matches), False, False
+
+    attributes = matches[0]
+    exported_true = any(
+        line.startswith("A: android:exported")
+        and re.search(r"\(type 0x12\)0xffffffff(?:\s|$)", line)
+        for line in attributes
+    )
+    permission_marker = f'"{permission}"'
+    dump_protected = any(
+        line.startswith("A: android:permission") and permission_marker in line
+        for line in attributes
+    )
+    return 1, exported_true, dump_protected
+
+
+def inspect_gateway(
+    path: Path, activity_name: str, permission: str
+) -> tuple[int, bool, bool]:
+    first_non_space = path.read_text(
+        encoding="utf-8", errors="replace"
+    ).lstrip()[:1]
+    if first_non_space == "<":
+        return _state_from_xml(path, activity_name, permission)
+    return _state_from_xmltree(path, activity_name, permission)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--manifest", required=True, type=Path)
+    parser.add_argument("--expect", required=True, choices=("present", "absent"))
+    parser.add_argument("--activity", default=DEFAULT_ACTIVITY)
+    parser.add_argument("--permission", default=DEFAULT_PERMISSION)
+    args = parser.parse_args()
+
+    if not args.manifest.is_file():
+        parser.error(f"manifest does not exist: {args.manifest}")
+
+    count, exported_true, dump_protected = inspect_gateway(
+        args.manifest, args.activity, args.permission
+    )
+    print(f"SETTINGS_ACTIVITY_BLOCK_COUNT={count}")
+    if count != 1:
+        print("SETTINGS_AUDIT_GATEWAY=INVALID_ACTIVITY_COUNT")
+        return 1
+
+    present = exported_true and dump_protected
+    partial = exported_true != dump_protected
+    print(f"SETTINGS_ACTIVITY_EXPORTED_TRUE={int(exported_true)}")
+    print(f"SETTINGS_ACTIVITY_DUMP_PROTECTED={int(dump_protected)}")
+    print(f"SETTINGS_AUDIT_GATEWAY={'PRESENT' if present else 'ABSENT'}")
+
+    expected_present = args.expect == "present"
+    if partial or present != expected_present:
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/write-boost-morphe-settings-audit-report.py
+++ b/tools/write-boost-morphe-settings-audit-report.py
@@ -1,0 +1,223 @@
+#!/usr/bin/env python3
+"""Write a deterministic JSON report for the Boost DEV settings audit."""
+
+import argparse
+import hashlib
+import json
+import re
+from datetime import datetime, timezone
+from pathlib import Path
+
+
+ITEM_PATTERN = re.compile(
+    r"MORPHE_AUDIT_ITEM_OK "
+    r"key=(?P<key>\S+) "
+    r"domain_count=(?P<domain_count>\d+) "
+    r"consumer=(?P<consumer>\S+) "
+    r"effect=(?P<effect>\S+) "
+    r"render=(?P<render>\S+)"
+)
+RENDER_PATTERN = re.compile(
+    r"MORPHE_RENDER_AUDIT_ITEM_OK "
+    r"probe=(?P<probe>\S+) keys=(?P<keys>\S+)"
+)
+PASS_MARKERS = {
+    "write": "MORPHE_BINDING_AUDIT_WRITE_OK",
+    "domain_actions": "MORPHE_DOMAIN_AUDIT_OK items=26 actions=196",
+    "rendered_effects": "MORPHE_RENDER_AUDIT_OK count=6",
+    "cold_reload": "MORPHE_BINDING_AUDIT_RELOAD_OK",
+    "native_consumers_after_reload": "MORPHE_DOMAIN_AUDIT_RELOAD_OK count=26",
+    "restore": "MORPHE_BINDING_AUDIT_RESTORE_OK",
+    "app_result": (
+        "RESULT=MORPHE_BOOST_SETTINGS_"
+        "APPEARANCE_LAYOUT_AUDIT_V56_APP_PASS"
+    ),
+}
+
+
+def parse_args():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--log", required=True, type=Path)
+    parser.add_argument("--manifest", required=True, type=Path)
+    parser.add_argument("--output", required=True, type=Path)
+    parser.add_argument("--status", required=True, choices=("PASS", "FAIL"))
+    parser.add_argument("--failure-reason", default="")
+    parser.add_argument("--package", required=True)
+    parser.add_argument("--version-name", required=True)
+    parser.add_argument("--version-code", required=True)
+    parser.add_argument("--apk-sha256", required=True)
+    parser.add_argument("--android-release", required=True)
+    parser.add_argument("--android-sdk", required=True)
+    parser.add_argument("--device", required=True)
+    parser.add_argument("--model", required=True)
+    parser.add_argument("--normal-boost-untouched", required=True)
+    return parser.parse_args()
+
+
+def sha256(path):
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def parse_items(log_text):
+    items = []
+    seen = set()
+    for match in ITEM_PATTERN.finditer(log_text):
+        key = match.group("key")
+        if key in seen:
+            raise ValueError(f"duplicate audit item: {key}")
+        seen.add(key)
+        items.append(
+            {
+                "key": key,
+                "status": "PASS",
+                "domain_count": int(match.group("domain_count")),
+                "consumer": match.group("consumer"),
+                "side_effect": match.group("effect"),
+                "render_probe": match.group("render"),
+            }
+        )
+    return items
+
+
+def parse_render_probes(log_text):
+    probes = []
+    seen = set()
+    for match in RENDER_PATTERN.finditer(log_text):
+        name = match.group("probe")
+        if name in seen:
+            raise ValueError(f"duplicate render probe: {name}")
+        seen.add(name)
+        probes.append(
+            {
+                "probe": name,
+                "status": "PASS",
+                "keys": (
+                    []
+                    if match.group("keys") == "-"
+                    else match.group("keys").split(",")
+                ),
+            }
+        )
+    return probes
+
+
+def manifest_domain_count(spec, manifest):
+    if spec["type"] == "boolean":
+        return 2
+    if spec["type"] == "integer":
+        domain = spec["domain"]
+        return domain["maximum"] - domain["minimum"] + 1
+    if "domain" in spec:
+        return len(spec["domain"])
+    if spec["writer"] == "font":
+        return len(manifest["font_domain"])
+    return len(manifest["font_size_domain"])
+
+
+def manifest_expectations(manifest):
+    specs = manifest["appearance"] + manifest["post_views"] + manifest["fonts"]
+    item_domains = {
+        spec["key"]: manifest_domain_count(spec, manifest) for spec in specs
+    }
+    item_domains["saved_views"] = len(manifest["saved_views"]["domain"])
+    item_domains["app_icon"] = len(manifest["app_icons"])
+    render_probes = {
+        probe["name"]: probe["keys"] for probe in manifest["render_probes"]
+    }
+    return item_domains, render_probes
+
+
+def main():
+    args = parse_args()
+    log_text = args.log.read_text(encoding="utf-8", errors="replace")
+    manifest = json.loads(args.manifest.read_text(encoding="utf-8"))
+    errors = []
+    try:
+        items = parse_items(log_text)
+        render_probes = parse_render_probes(log_text)
+    except ValueError as error:
+        errors.append(str(error))
+        items = []
+        render_probes = []
+
+    phases = {
+        name: marker in log_text for name, marker in PASS_MARKERS.items()
+    }
+    domain_actions = sum(item["domain_count"] for item in items)
+    expected_items, expected_render_probes = manifest_expectations(manifest)
+    if args.status == "PASS":
+        if manifest.get("schema") != 2:
+            errors.append("manifest schema is not 2")
+        if manifest.get("scope") != "appearance-layout":
+            errors.append("manifest scope mismatch")
+        if manifest.get("harness_version") != 56:
+            errors.append("manifest harness version mismatch")
+        actual_items = {item["key"]: item["domain_count"] for item in items}
+        if actual_items != expected_items:
+            errors.append("audit item/domain manifest mismatch")
+        expected_actions = sum(expected_items.values())
+        if domain_actions != expected_actions:
+            errors.append(
+                f"expected {expected_actions} domain actions, got {domain_actions}"
+            )
+        actual_render_probes = {
+            probe["probe"]: probe["keys"] for probe in render_probes
+        }
+        if actual_render_probes != expected_render_probes:
+            errors.append("render-probe manifest mismatch")
+        missing_phases = [name for name, passed in phases.items() if not passed]
+        if missing_phases:
+            errors.append("missing phases: " + ",".join(missing_phases))
+        if args.normal_boost_untouched != "true":
+            errors.append("Normal Boost untouched proof missing")
+
+    status = "FAIL" if errors or args.status == "FAIL" else "PASS"
+    reasons = [reason for reason in (args.failure_reason, *errors) if reason]
+    report = {
+        "schema": 1,
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+        "scope": manifest.get("scope"),
+        "harness": {
+            "version": manifest.get("harness_version"),
+            "manifest_schema": manifest.get("schema"),
+            "manifest_sha256": sha256(args.manifest),
+        },
+        "safety": manifest.get("safety"),
+        "target": {
+            "package": args.package,
+            "version_name": args.version_name,
+            "version_code": args.version_code,
+            "apk_sha256": args.apk_sha256,
+            "android_release": args.android_release,
+            "android_sdk": args.android_sdk,
+            "device": args.device,
+            "model": args.model,
+        },
+        "result": {
+            "status": status,
+            "failure_reason": "; ".join(reasons) or None,
+            "normal_boost_untouched": (
+                args.normal_boost_untouched == "true"
+            ),
+        },
+        "summary": {
+            "audit_items": len(items),
+            "domain_actions": domain_actions,
+            "render_probes": len(render_probes),
+        },
+        "phases": phases,
+        "items": items,
+        "render_probes": render_probes,
+    }
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(
+        json.dumps(report, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    print(f"AUDIT_REPORT_STATUS={status}")
+    print(f"AUDIT_REPORT_JSON={args.output}")
+    return 0 if status == args.status else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

- Add a dedicated top-level **Settings → Morphe** destination.
- Replace the outdated settings presentation with a Material-style, task-based interface.
- Preserve existing preference keys and values, search, and the classic fallback.
- Complete the appearance, post views, saved views, toolbar, fonts, downloads, and data/storage pages.
- Make Material settings the default while retaining the classic layout.

## Validation

- Static settings contract passed.
- Settings binding and runtime source audits passed.
- Release-candidate build and packaging preflight passed.
- Runtime-tested in `com.rubenmayayo.reddit.dev`.
- Normal Boost was not overwritten.

Addresses #106