### PR TITLE
chore(release): prepare Morphe patch bundle 1.4.94

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Changelog
 
 <!-- MORPHE_MANAGER_CHANGELOG_START -->
+## [1.4.94](https://github.com/brealorg/breal-morphe-patches/compare/morphe-patches-93...morphe-patches-94) (2026-07-23)
+
+* **Boost for Reddit:** Features
+
+- Modernize Boost Morphe settings with a Material-style, task-based interface and retain the classic fallback.
+
 ## [1.4.93](https://github.com/brealorg/breal-morphe-patches/compare/morphe-patches-92...morphe-patches-93) (2026-07-22)
 
 * **Boost for Reddit:** Features

--- a/README.md
+++ b/README.md
@@ -72,14 +72,14 @@ The repository shorthand shown at the top is the preferred Manager setup. Raw
 
 | Field | Value |
 |---|---|
-| Version | `1.4.93` |
-| Release tag | `morphe-patches-93` |
-| Asset | `patches-1.4.93.mpp` |
-| SHA256 | `70f41972c86078032b0cfadfb01cd4ccfe5cbd0e579e9f778908098d6a276ea2` |
+| Version | `1.4.94` |
+| Release tag | `morphe-patches-94` |
+| Asset | `patches-1.4.94.mpp` |
+| SHA256 | `ca77f23a75ce908a5ccc47f9f23fffc79a2e0c7382faa4f932666f1ffe003b57` |
 | Manager JSON | `https://raw.githubusercontent.com/brealorg/breal-morphe-patches/main/patches-bundle.json` |
-| Download URL | `https://github.com/brealorg/breal-morphe-patches/releases/download/morphe-patches-93/patches-1.4.93.mpp` |
+| Download URL | `https://github.com/brealorg/breal-morphe-patches/releases/download/morphe-patches-94/patches-1.4.94.mpp` |
 
-SHA256: `70f41972c86078032b0cfadfb01cd4ccfe5cbd0e579e9f778908098d6a276ea2`
+SHA256: `ca77f23a75ce908a5ccc47f9f23fffc79a2e0c7382faa4f932666f1ffe003b57`
 ## What this bundle does
 
 The current bundle is focused on practical hotfixes for tested app versions, especially Boost for Reddit behavior on newer Android versions.
@@ -126,7 +126,7 @@ Included Imgur patches:
 ### Patches list
 
 <!-- PATCHES_START -->
-> **Patch source version:** `1.4.93` • `main` • 52 unique patches • 104 package entries
+> **Patch source version:** `1.4.94` • `main` • 52 unique patches • 104 package entries
 
 <details>
 <summary><strong>Boost for Reddit</strong> • 43 patches</summary>
@@ -145,7 +145,7 @@ Included Imgur patches:
 | [Animate media in Boost gallery previews](#animate-media-in-boost-gallery-previews) | Autoplays selected Reddit gallery GIF and video media while preserving Boost's poster, data preferences, and full-screen media route. |  |
 | [Automatically undelete Imgur images](#automatically-undelete-imgur-images) |  |  |
 | [Automatically undelete Reddit content](#automatically-undelete-reddit-content) |  |  |
-| [Boost Morphe settings](#boost-morphe-settings) | Adds Boost Morphe settings for Search keyboard behavior, inline media previews, undelete toggles, adaptive refresh rate, source text visibility, and preview alignment. |  |
+| [Boost Morphe settings](#boost-morphe-settings) | Adds dedicated Morphe settings and Morphe-owned Material-style Settings v4 pages with a classic fallback. |  |
 | [Boost search default discovery](#boost-search-default-discovery) | Starts Boost search on an instant cached active-subreddit landing with Reddit-native labels. |  |
 | [Custom Synccit URL](#custom-synccit-url) | Allows Boost to use a custom self-hosted Synccit API endpoint. | • Synccit API URL |
 | [Disable ads](#disable-ads) |  |  |
@@ -539,16 +539,16 @@ Compatibility with other app versions is not guaranteed.
 
 ## Verification
 
-Release `1.4.93` is prepared and locally verified with:
+Release `1.4.94` is prepared and locally verified with:
 
-- Release tag `morphe-patches-93`.
+- Release tag `morphe-patches-94`.
 - Local built MPP SHA256 matching README.
-`70f41972c86078032b0cfadfb01cd4ccfe5cbd0e579e9f778908098d6a276ea2`
-- `patches-bundle.json` returning version `1.4.93`.
-- `patches-bundle.json` pointing to the `morphe-patches-93` asset.
+`ca77f23a75ce908a5ccc47f9f23fffc79a2e0c7382faa4f932666f1ffe003b57`
+- `patches-bundle.json` returning version `1.4.94`.
+- `patches-bundle.json` pointing to the `morphe-patches-94` asset.
 - Expected release asset:
-`patches-1.4.93.mpp`
-- `70f41972c86078032b0cfadfb01cd4ccfe5cbd0e579e9f778908098d6a276ea2  patches-1.4.93.mpp`
+`patches-1.4.94.mpp`
+- `ca77f23a75ce908a5ccc47f9f23fffc79a2e0c7382faa4f932666f1ffe003b57  patches-1.4.94.mpp`
 
 ## Development notes
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,4 +3,4 @@ org.gradle.jvmargs = -Xms512M -Xmx2048M
 org.gradle.parallel = true
 android.useAndroidX = true
 kotlin.code.style = official
-version = 1.4.93
+version = 1.4.94

--- a/patches-bundle.json
+++ b/patches-bundle.json
@@ -1,7 +1,7 @@
 {
-  "created_at": "2026-07-22T20:30:27",
-  "description": "Features\n\n- Add optional keyboard opening when entering Search.\n- Add Compact, Balanced, and Large inline media preview sizes.\n",
-  "download_url": "https://github.com/brealorg/breal-morphe-patches/releases/download/morphe-patches-93/patches-1.4.93.mpp",
-  "signature_download_url": "https://github.com/brealorg/breal-morphe-patches/releases/download/morphe-patches-93/patches-1.4.93.mpp.asc",
-  "version": "1.4.93"
+  "created_at": "2026-07-23T19:45:01",
+  "description": "Features\n\n- Modernize Boost Morphe settings with a Material-style, task-based interface and retain the classic fallback.\n",
+  "download_url": "https://github.com/brealorg/breal-morphe-patches/releases/download/morphe-patches-94/patches-1.4.94.mpp",
+  "signature_download_url": "https://github.com/brealorg/breal-morphe-patches/releases/download/morphe-patches-94/patches-1.4.94.mpp.asc",
+  "version": "1.4.94"
 }

--- a/patches-list.json
+++ b/patches-list.json
@@ -1,6 +1,6 @@
 {
   "NOTE": "Do NOT manually edit this file. This file is automatically updated when semantic release (release.yml) runs. Manually editing this file can break your releases and break third party tools that use this file.",
-  "version": "1.4.93",
+  "version": "1.4.94",
   "patches": [
     {
       "name": "Add Boost Search bottom navigation",


### PR DESCRIPTION
## Summary

Prepares protected-main metadata and the reproducible release artifact for Morphe patch bundle 1.4.94.

## User-visible Boost changes

- Modernize Morphe settings with a Material-style, task-based interface.
- Add a dedicated top-level **Settings → Morphe** destination.
- Make Material settings the default while retaining the classic fallback.
- Preserve existing preference keys, values, search, and native settings routes.

Addresses #106.

## Release identity

- Version: `1.4.94`
- Tag: `morphe-patches-94`
- Asset: `patches-1.4.94.mpp`
- Expected SHA-256: `ca77f23a75ce908a5ccc47f9f23fffc79a2e0c7382faa4f932666f1ffe003b57`

## Validation

- Issue #106 static settings contract: PASS
- Settings binding and runtime source audits: PASS
- DEV runtime validation: PASS
- Release gate: PASS
- Reproducible MPP build: PASS
- Generated Manager feed: PASS

This PR prepares release metadata only. Publication and Issue #106 closeout occur after merge.