### PR TITLE
fix(boost): preserve source tab selection across activities

### DIFF
--- a/extensions/boostforreddit/src/main/java/app/morphe/extension/boostforreddit/utils/BoostSearchBottomNavigation.java
+++ b/extensions/boostforreddit/src/main/java/app/morphe/extension/boostforreddit/utils/BoostSearchBottomNavigation.java
@@ -126,6 +126,8 @@ public final class BoostSearchBottomNavigation {
     private static volatile Integer SHARED_INBOX_BADGE_COUNT;
     private static final String ALL_ACTIVITY_SELECTION_GUARD_MARKER =
             "MORPHE_BOOST_BOTTOM_NAV_ALL_ACTIVITY_SELECTION_GUARD_V6";
+    private static final String SOURCE_SELECTION_RETAINED_MARKER =
+            "MORPHE_BOOST_BOTTOM_NAV_SOURCE_SELECTION_RETAINED_ISSUE117_V2";
     private static final String SHOW_PREFERENCE_STABILITY_GUARD_MARKER =
             "MORPHE_BOOST_BOTTOM_NAV_SHOW_PREFERENCE_STABILITY_GUARD_ISSUE97_V1";
     private static final String PERSISTED_INBOX_BADGE_MARKER =
@@ -1955,7 +1957,6 @@ public final class BoostSearchBottomNavigation {
                         )
         );
     }
-
 
     private static String nativeCoordinatorBehaviorName(
             View navigation
@@ -4172,9 +4173,18 @@ public final class BoostSearchBottomNavigation {
                                         && args.length == 1
                                         && args[0] instanceof MenuItem
                         ) {
-                            return handleItem(
+                            MenuItem item =
+                                    (MenuItem) args[0];
+                            boolean handled =
+                                    handleItem(
+                                            activity,
+                                            item
+                                    );
+
+                            return preserveSourceSelectionAfterRoute(
                                     activity,
-                                    (MenuItem) args[0]
+                                    item,
+                                    handled
                             );
                         }
 
@@ -4193,6 +4203,55 @@ public final class BoostSearchBottomNavigation {
         setter.setAccessible(true);
         setter.invoke(navigation, listener);
         return api;
+    }
+
+    private static boolean preserveSourceSelectionAfterRoute(
+            Activity activity,
+            MenuItem routedItem,
+            boolean handled
+    ) {
+        if (
+                !handled
+                        || activity == null
+                        || routedItem == null
+        ) {
+            return handled;
+        }
+
+        int sourceItemId =
+                selectedItemIdForActivity(
+                        activity,
+                        0
+                );
+        int routedItemId =
+                routedItem.getItemId();
+
+        if (
+                sourceItemId == 0
+                        || sourceItemId == routedItemId
+        ) {
+            return true;
+        }
+
+        /*
+         * BottomNavigationView interprets true as permission to persist the
+         * tapped destination as selected in the current Activity. Morphe has
+         * already opened a different Activity, so the source Activity must
+         * reject that visual state change and retain its own destination.
+         */
+        Log.i(
+                TAG,
+                "Source selection retained after routed tab marker="
+                        + SOURCE_SELECTION_RETAINED_MARKER
+                        + " activity="
+                        + activity.getClass().getName()
+                        + " sourceItemId="
+                        + sourceItemId
+                        + " routedItemId="
+                        + routedItemId
+        );
+
+        return false;
     }
 
     private static String attachSubredditNavigationListeners(

--- a/tools/check-boost-back-resume-selection-contract.sh
+++ b/tools/check-boost-back-resume-selection-contract.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT"
+
+SOURCE='extensions/boostforreddit/src/main/java/app/morphe/extension/boostforreddit/utils/BoostSearchBottomNavigation.java'
+
+python3 - "$SOURCE" <<'PY_CONTRACT'
+from pathlib import Path
+import sys
+
+source = Path(sys.argv[1]).read_text(encoding="utf-8")
+
+def method_body(text: str, signature: str) -> str:
+    start = text.index(signature)
+    brace = text.index("{", start)
+    depth = 0
+    for index in range(brace, len(text)):
+        char = text[index]
+        if char == "{":
+            depth += 1
+        elif char == "}":
+            depth -= 1
+            if depth == 0:
+                return text[start:index + 1]
+    raise AssertionError(f"unterminated method: {signature}")
+
+assert "MORPHE_BOOST_BOTTOM_NAV_SOURCE_SELECTION_RETAINED_ISSUE117_V2" in source
+assert "MORPHE_BOOST_BOTTOM_NAV_BACK_RESUME_SELECTION_ISSUE117_V1" not in source
+assert "refreshMaterialNavigationSelection(" not in source
+
+listener = method_body(
+    source,
+    "private static String attachSelectedListener("
+)
+selection_contract = method_body(
+    source,
+    "private static boolean preserveSourceSelectionAfterRoute("
+)
+
+for needle in (
+    "boolean handled =",
+    "handleItem(",
+    "preserveSourceSelectionAfterRoute(",
+):
+    assert needle in listener, needle
+
+for needle in (
+    "selectedItemIdForActivity(",
+    "routedItem.getItemId()",
+    "sourceItemId == routedItemId",
+    "Source selection retained after routed tab marker=",
+    "return false;",
+):
+    assert needle in selection_contract, needle
+
+assert selection_contract.index(
+    "sourceItemId == routedItemId"
+) < selection_contract.index("return false;")
+
+print("FAILED_ON_RESUME_APPROACH_REMOVED=PASS")
+print("ROUTE_EXECUTES_BEFORE_SELECTION_DECISION=PASS")
+print("CROSS_ACTIVITY_SOURCE_SELECTION_REJECTED=PASS")
+print("SAME_ACTIVITY_SELECTION_PRESERVED=PASS")
+PY_CONTRACT
+
+echo 'RESULT=MORPHE_ISSUE117_SOURCE_SELECTION_V2_CONTRACT_OK'


### PR DESCRIPTION
## Summary

- preserve each Boost Activity's own selected bottom-navigation destination while routing to another Activity
- prevent Android Back from returning to Home with Search, Subscriptions, Inbox, or Profile still selected
- add an Issue #117 source contract covering the listener return-value behavior

## Root cause

The `BottomNavigationView` listener launched the requested destination Activity and then returned `true`. Material interpreted that return value as permission to persist the tapped destination as selected in the source Activity. When Android Back revealed that preserved Activity again, its navigation state was stale.

The fix keeps the route, but returns `false` for cross-Activity navigation so the source Activity retains its own selected destination.

## Validation

- Issue #117 source-selection contract: PASS
- all project contracts: PASS
- Android MPP build and required-entry gate: PASS
- normal candidate static and bytecode safety gates: PASS
- DEV runtime on Pixel 6 / Android 17:
  - Search → Back → Home: PASS
  - Subscriptions → Back → Home: PASS
  - Inbox → Back → Home: PASS
  - Profile → Back → Home: PASS
- 16 source-selection runtime markers
- zero fatal exceptions
- zero AndroidRuntime lines
- normal Boost package unchanged

## Scope

- no release metadata changes
- no normal Boost installation
- issue remains open until merge, release, and post-release confirmation
- existing non-fatal Profile long-press attach log noise on Search/GoTo is outside this PR

Addresses #117.
