### PR TITLE
chore(release): prepare Morphe patch bundle 1.4.95

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Changelog
 
 <!-- MORPHE_MANAGER_CHANGELOG_START -->
+## [1.4.95](https://github.com/brealorg/breal-morphe-patches/compare/morphe-patches-94...morphe-patches-95) (2026-07-25)
+
+* **Boost for Reddit:** Bug Fixes
+
+- Preserve each Activity's selected bottom-navigation destination when returning with Android Back.
+
 ## [1.4.94](https://github.com/brealorg/breal-morphe-patches/compare/morphe-patches-93...morphe-patches-94) (2026-07-23)
 
 * **Boost for Reddit:** Features

--- a/README.md
+++ b/README.md
@@ -72,14 +72,14 @@ The repository shorthand shown at the top is the preferred Manager setup. Raw
 
 | Field | Value |
 |---|---|
-| Version | `1.4.94` |
-| Release tag | `morphe-patches-94` |
-| Asset | `patches-1.4.94.mpp` |
-| SHA256 | `ca77f23a75ce908a5ccc47f9f23fffc79a2e0c7382faa4f932666f1ffe003b57` |
+| Version | `1.4.95` |
+| Release tag | `morphe-patches-95` |
+| Asset | `patches-1.4.95.mpp` |
+| SHA256 | `5c998b8bc159c4ab8fbb077a72bf1b758285b9512ffab76eead0a63c077eb7bd` |
 | Manager JSON | `https://raw.githubusercontent.com/brealorg/breal-morphe-patches/main/patches-bundle.json` |
-| Download URL | `https://github.com/brealorg/breal-morphe-patches/releases/download/morphe-patches-94/patches-1.4.94.mpp` |
+| Download URL | `https://github.com/brealorg/breal-morphe-patches/releases/download/morphe-patches-95/patches-1.4.95.mpp` |
 
-SHA256: `ca77f23a75ce908a5ccc47f9f23fffc79a2e0c7382faa4f932666f1ffe003b57`
+SHA256: `5c998b8bc159c4ab8fbb077a72bf1b758285b9512ffab76eead0a63c077eb7bd`
 ## What this bundle does
 
 The current bundle is focused on practical hotfixes for tested app versions, especially Boost for Reddit behavior on newer Android versions.
@@ -126,7 +126,7 @@ Included Imgur patches:
 ### Patches list
 
 <!-- PATCHES_START -->
-> **Patch source version:** `1.4.94` • `main` • 52 unique patches • 104 package entries
+> **Patch source version:** `1.4.95` • `main` • 52 unique patches • 104 package entries
 
 <details>
 <summary><strong>Boost for Reddit</strong> • 43 patches</summary>
@@ -539,16 +539,16 @@ Compatibility with other app versions is not guaranteed.
 
 ## Verification
 
-Release `1.4.94` is prepared and locally verified with:
+Release `1.4.95` is prepared and locally verified with:
 
-- Release tag `morphe-patches-94`.
+- Release tag `morphe-patches-95`.
 - Local built MPP SHA256 matching README.
-`ca77f23a75ce908a5ccc47f9f23fffc79a2e0c7382faa4f932666f1ffe003b57`
-- `patches-bundle.json` returning version `1.4.94`.
-- `patches-bundle.json` pointing to the `morphe-patches-94` asset.
+`5c998b8bc159c4ab8fbb077a72bf1b758285b9512ffab76eead0a63c077eb7bd`
+- `patches-bundle.json` returning version `1.4.95`.
+- `patches-bundle.json` pointing to the `morphe-patches-95` asset.
 - Expected release asset:
-`patches-1.4.94.mpp`
-- `ca77f23a75ce908a5ccc47f9f23fffc79a2e0c7382faa4f932666f1ffe003b57  patches-1.4.94.mpp`
+`patches-1.4.95.mpp`
+- `5c998b8bc159c4ab8fbb077a72bf1b758285b9512ffab76eead0a63c077eb7bd  patches-1.4.95.mpp`
 
 ## Development notes
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,4 +3,4 @@ org.gradle.jvmargs = -Xms512M -Xmx2048M
 org.gradle.parallel = true
 android.useAndroidX = true
 kotlin.code.style = official
-version = 1.4.94
+version = 1.4.95

--- a/patches-bundle.json
+++ b/patches-bundle.json
@@ -1,7 +1,7 @@
 {
-  "created_at": "2026-07-23T19:45:01",
-  "description": "Features\n\n- Modernize Boost Morphe settings with a Material-style, task-based interface and retain the classic fallback.\n",
-  "download_url": "https://github.com/brealorg/breal-morphe-patches/releases/download/morphe-patches-94/patches-1.4.94.mpp",
-  "signature_download_url": "https://github.com/brealorg/breal-morphe-patches/releases/download/morphe-patches-94/patches-1.4.94.mpp.asc",
-  "version": "1.4.94"
+  "created_at": "2026-07-25T16:51:02",
+  "description": "Bug Fixes\n\n- Keep the correct Boost bottom-navigation destination selected after returning with Android Back.\n",
+  "download_url": "https://github.com/brealorg/breal-morphe-patches/releases/download/morphe-patches-95/patches-1.4.95.mpp",
+  "signature_download_url": "https://github.com/brealorg/breal-morphe-patches/releases/download/morphe-patches-95/patches-1.4.95.mpp.asc",
+  "version": "1.4.95"
 }

--- a/patches-list.json
+++ b/patches-list.json
@@ -1,6 +1,6 @@
 {
   "NOTE": "Do NOT manually edit this file. This file is automatically updated when semantic release (release.yml) runs. Manually editing this file can break your releases and break third party tools that use this file.",
-  "version": "1.4.94",
+  "version": "1.4.95",
   "patches": [
     {
       "name": "Add Boost Search bottom navigation",


### PR DESCRIPTION
## Summary

Prepares protected-main metadata and the reproducible release artifact for Morphe patch bundle 1.4.95.

## User-visible Boost change

- Keep the correct bottom-navigation destination selected after returning with Android Back from Search, Subscriptions, Inbox, or Profile.

Addresses #117.

## Release identity

- Version: `1.4.95`
- Tag: `morphe-patches-95`
- Asset: `patches-1.4.95.mpp`
- Expected SHA-256: `5c998b8bc159c4ab8fbb077a72bf1b758285b9512ffab76eead0a63c077eb7bd`

## Validation

- Issue #117 source-selection contract: PASS
- DEV runtime on Pixel 6 / Android 17: PASS
- all project contracts: PASS
- reproducible Android MPP build: PASS
- MPP required-entry structure: PASS
- Issue #117 runtime marker in Boost extension: PASS
- generated patch catalog drift rejected
- canonical `patches-list.json` compatibility metadata preserved
- release metadata limited to five expected files

This PR prepares release metadata only. Publication and Issue #117 closeout occur after merge.
