### PR TITLE
fix(release): report incomplete observer diagnostics

### DIFF
--- a/scripts/releasectl.py
+++ b/scripts/releasectl.py
@@ -4962,6 +4962,94 @@ def _idempotent_draft_creation_guard(
 
     return guard()
 
+def _incomplete_observation_diagnostics(
+    inspection: ReleaseInspectionResult,
+) -> str:
+    # Describe exactly which authoritative observer was incomplete.
+
+    sources: tuple[tuple[str, Any, bool], ...] = (
+        (
+            "local_git",
+            inspection.local_git,
+            inspection.local_git.safety.observations_complete,
+        ),
+        (
+            "remote_git",
+            inspection.remote_git,
+            inspection.remote_git.observations_complete,
+        ),
+        (
+            "github_release",
+            inspection.github_release,
+            inspection.github_release.observations_complete,
+        ),
+        (
+            "local_artifacts",
+            inspection.local_artifacts,
+            inspection.local_artifacts.observations_complete,
+        ),
+        (
+            "local_metadata",
+            inspection.local_metadata,
+            inspection.local_metadata.observations_complete,
+        ),
+        (
+            "remote_assets",
+            inspection.remote_assets,
+            inspection.remote_assets.observations_complete,
+        ),
+    )
+
+    details: list[str] = []
+    for label, result, complete in sources:
+        if complete:
+            continue
+
+        components = [f"{label}=INCOMPLETE"]
+        errors = tuple(getattr(result, "errors", ()))
+        warnings = tuple(getattr(result, "warnings", ()))
+        mismatches = tuple(getattr(result, "mismatches", ()))
+
+        if label == "local_git":
+            safety = result.safety
+            components.extend(
+                (
+                    f"current_branch_is_main={safety.current_branch_is_main}",
+                    f"worktree_clean={safety.worktree_clean}",
+                    f"index_clean={safety.index_clean}",
+                    (
+                        "required_tools_available="
+                        f"{safety.required_tools_available}"
+                    ),
+                )
+            )
+
+        if errors:
+            components.append("errors=" + " | ".join(errors))
+        if mismatches:
+            components.append(
+                "mismatches=" + " | ".join(mismatches)
+            )
+        if warnings:
+            components.append("warnings=" + " | ".join(warnings))
+
+        details.append(", ".join(components))
+
+    if details:
+        return "; ".join(details)
+
+    aggregate_errors = tuple(inspection.errors)
+    aggregate_warnings = tuple(inspection.warnings)
+    fallback = ["aggregate observations are incomplete"]
+    if aggregate_errors:
+        fallback.append("errors=" + " | ".join(aggregate_errors))
+    if aggregate_warnings:
+        fallback.append(
+            "warnings=" + " | ".join(aggregate_warnings)
+        )
+    return ", ".join(fallback)
+
+
 def publish_release_workflow(
     repo_path: str | Path,
     repository: str,
@@ -5033,7 +5121,10 @@ def publish_release_workflow(
                 + "; ".join(initial.state_result.reasons)
             )
         if not initial.state_result.observations_complete:
-            raise RuntimeError("one or more required release observations are incomplete")
+            raise RuntimeError(
+                "one or more required release observations are incomplete: "
+                + _incomplete_observation_diagnostics(initial)
+            )
         if initial.state_result.state is ReleaseState.PUBLISHED_AND_VERIFIED:
             token = "MORPHE_RELEASE_ALREADY_PUBLISHED_VERIFIED_OK"
             append_transaction_entry(
@@ -5075,7 +5166,10 @@ def publish_release_workflow(
             if state is ReleaseState.INCONSISTENT_ABORT:
                 raise RuntimeError("release state is inconsistent: " + "; ".join(inspection.state_result.reasons))
             if not inspection.state_result.observations_complete:
-                raise RuntimeError("one or more required release observations are incomplete")
+                raise RuntimeError(
+                    "one or more required release observations are incomplete: "
+                    + _incomplete_observation_diagnostics(inspection)
+                )
             if state is ReleaseState.PUBLISHED_AND_VERIFIED:
                 append_transaction_entry(
                     log_path, command=command_name, phase="COMPLETE", status="COMPLETED",

--- a/tests/tools/test_releasectl_incomplete_observer_diagnostics.py
+++ b/tests/tools/test_releasectl_incomplete_observer_diagnostics.py
@@ -1,0 +1,118 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+import sys
+from types import SimpleNamespace
+import unittest
+
+
+ROOT = Path(__file__).resolve().parents[2]
+SOURCE = ROOT / "scripts" / "releasectl.py"
+
+SPEC = importlib.util.spec_from_file_location(
+    "morphe_releasectl",
+    SOURCE,
+)
+assert SPEC is not None
+assert SPEC.loader is not None
+MODULE = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = MODULE
+SPEC.loader.exec_module(MODULE)
+
+
+def complete_result() -> SimpleNamespace:
+    return SimpleNamespace(
+        observations_complete=True,
+        errors=(),
+        warnings=(),
+    )
+
+
+class IncompleteObserverDiagnosticsTest(unittest.TestCase):
+    def test_reports_incomplete_github_release_error(self) -> None:
+        local_git = SimpleNamespace(
+            safety=SimpleNamespace(
+                observations_complete=True,
+                current_branch_is_main=True,
+                worktree_clean=True,
+                index_clean=True,
+                required_tools_available=True,
+            ),
+            errors=(),
+            warnings=(),
+        )
+        github_release = SimpleNamespace(
+            observations_complete=False,
+            errors=(
+                "GitHub repository metadata is missing "
+                "the authenticated permissions object",
+            ),
+            warnings=(),
+        )
+        inspection = SimpleNamespace(
+            local_git=local_git,
+            remote_git=complete_result(),
+            github_release=github_release,
+            local_artifacts=complete_result(),
+            local_metadata=SimpleNamespace(
+                observations_complete=True,
+                errors=(),
+                warnings=(),
+                mismatches=(),
+            ),
+            remote_assets=complete_result(),
+            errors=github_release.errors,
+            warnings=(),
+        )
+
+        result = MODULE._incomplete_observation_diagnostics(
+            inspection
+        )
+
+        self.assertIn("github_release=INCOMPLETE", result)
+        self.assertIn(
+            "missing the authenticated permissions object",
+            result,
+        )
+
+    def test_reports_dirty_local_git_safety_state(self) -> None:
+        local_git = SimpleNamespace(
+            safety=SimpleNamespace(
+                observations_complete=False,
+                current_branch_is_main=True,
+                worktree_clean=False,
+                index_clean=True,
+                required_tools_available=True,
+            ),
+            errors=(),
+            warnings=(),
+        )
+        inspection = SimpleNamespace(
+            local_git=local_git,
+            remote_git=complete_result(),
+            github_release=complete_result(),
+            local_artifacts=complete_result(),
+            local_metadata=SimpleNamespace(
+                observations_complete=True,
+                errors=(),
+                warnings=(),
+                mismatches=(),
+            ),
+            remote_assets=complete_result(),
+            errors=(),
+            warnings=(),
+        )
+
+        result = MODULE._incomplete_observation_diagnostics(
+            inspection
+        )
+
+        self.assertIn("local_git=INCOMPLETE", result)
+        self.assertIn("worktree_clean=False", result)
+        self.assertIn("index_clean=True", result)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Report the exact authoritative observer that causes a protected-main release inspection to be incomplete.

## Context

Morphe patch bundle 1.4.95 is merged and locally classifies as `PARTIALLY_PUBLISHED / RESUME`, but the protected-main Actions environment aborts before its first release mutation with only:

`one or more required release observations are incomplete`

No tag, GitHub release, asset, or `dev` update was created.

## Changes

- Add per-observer incomplete-state diagnostics.
- Include observer errors, warnings, metadata mismatches, and local Git safety flags.
- Use the detailed message in both initial publish inspection and the iterative resume loop.
- Add focused Python 3.14-compatible unit coverage.

## Validation

- Python compilation: PASS
- focused diagnostics unit tests: PASS
- complete project contracts: PASS
- release dispatches or mutations: NONE

This PR changes fail-closed diagnostics only. Release 1.4.95 remains pending.
