### PR TITLE
chore(project): add lifecycle audit and push readiness

### DIFF
--- a/docs/morphe-flow.md
+++ b/docs/morphe-flow.md
@@ -66,10 +66,32 @@ Use `--strict` when a caller should receive exit code `2` for incomplete
 observations or lifecycle blockers. Normal audit mode prints the complete report
 and exits successfully so inspection remains usable during diagnosis.
 
+## v22.2 operation-specific push readiness
+
+A repository-wide blocker no longer automatically blocks every unrelated
+operation. The command below evaluates only the exact work branch, while still
+requiring canonical `main`, current `origin/main`, complete remote/GitHub
+observation, a clean target worktree, and a forward-only remote relation:
+
+```bash
+python3 tools/morphe-flow.py \
+  --repo ~/dev/breal-morphe-patches \
+  branch ready-push work/example
+```
+
+The command disables local Git hooks and executes an exact SHA-bound
+`git push --dry-run --porcelain`. It snapshots local refs, the worktree
+registry, target status, and target index bytes/metadata before and after, then
+re-observes remote `main` and the target remote branch. A successful result
+contains `OPERATION_READY=YES`, `MUTATIONS=NONE`, `REMOTE_WRITES=NONE`, an
+`OPERATION_FINGERPRINT`, and `NEXT=REQUEST_EXPLICIT_PUSH_AUTHORIZATION`. It
+never performs the actual push. Dirty unrelated worktrees are counted and
+reported, but do not invalidate a correctly isolated target operation.
+
 ## Mutation boundary
 
-Later v22 phases may consume this report, but they must not bypass it. A future
-mutation command must:
+Later v22 phases may consume the audit and readiness reports, but they must
+not bypass them. A future mutation command must:
 
 1. collect a fresh complete audit;
 2. bind the intended operation to exact branch, worktree, local HEAD, remote HEAD,

--- a/docs/morphe-flow.md
+++ b/docs/morphe-flow.md
@@ -1,0 +1,80 @@
+# Morphe flow lifecycle controller
+
+`tools/morphe-flow.py` is the canonical lifecycle observer introduced by
+Hardening v22.1.
+
+## v22.1 scope
+
+The first version is read-only. It does not run `fetch`, `checkout`, `stash`,
+`commit`, `branch`, `worktree add/remove`, `push`, pull-request mutations,
+workflow dispatches, tags, releases, or asset uploads.
+
+It observes:
+
+- every registered Git worktree;
+- dirty tracked and untracked files;
+- local branch, HEAD, upstream, ahead/behind, and merge-base state;
+- patch-equivalent commits using `git cherry`;
+- repository-wide stashes;
+- remote branch heads using `git ls-remote`;
+- GitHub pull requests using read-only `gh pr list`;
+- remote-only work/release branches and open PRs without a local branch.
+
+Merged pull-request cleanup is proven from GitHub identity rather than patch-id
+heuristics: the local branch HEAD must equal the recorded PR head, and the PR
+merge commit must be reachable from current `main`. This correctly handles
+squash merges where `git cherry` reports the original branch commits as unique.
+
+Every report declares `MUTATIONS=NONE`, includes a canonical
+`REPORT_FINGERPRINT=sha256:...`, and provides normalized lifecycle states,
+blockers, warnings, and exactly one next action. A stale local `origin/main`
+tracking ref is a blocker, not a warning. `SAFE_TO_MUTATE=YES` means only
+that the complete observed state is internally consistent enough for a future
+operation-specific planner; it is not mutation authorization.
+
+## Commands
+
+Full audit with remote and PR observation:
+
+```bash
+python3 tools/morphe-flow.py \
+  --repo ~/dev/breal-morphe-patches \
+  --json-output /tmp/morphe-flow-audit.json \
+  audit
+```
+
+Local-only audit without network or GitHub CLI. This mode is diagnostic and
+never authorizes mutation because remote and PR observations are intentionally
+skipped:
+
+```bash
+python3 tools/morphe-flow.py \
+  --repo ~/dev/breal-morphe-patches \
+  --local-only \
+  audit
+```
+
+Issue-scoped status:
+
+```bash
+python3 tools/morphe-flow.py \
+  --repo ~/dev/breal-morphe-patches \
+  issue status 106
+```
+
+Use `--strict` when a caller should receive exit code `2` for incomplete
+observations or lifecycle blockers. Normal audit mode prints the complete report
+and exits successfully so inspection remains usable during diagnosis.
+
+## Mutation boundary
+
+Later v22 phases may consume this report, but they must not bypass it. A future
+mutation command must:
+
+1. collect a fresh complete audit;
+2. bind the intended operation to exact branch, worktree, local HEAD, remote HEAD,
+   PR head, base SHA, and report fingerprint;
+3. print a dry-run plan;
+4. require explicit approval for the exact mutation;
+5. re-observe all preconditions immediately before mutation;
+6. verify postconditions and record one transaction result.

--- a/tests/tools/test_morphe_flow.py
+++ b/tests/tools/test_morphe_flow.py
@@ -1,0 +1,378 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import hashlib
+import importlib.util
+import json
+import os
+from pathlib import Path
+import subprocess
+import sys
+import tempfile
+import unittest
+
+
+ROOT = Path(__file__).resolve().parents[2]
+SOURCE = ROOT / "tools" / "morphe-flow.py"
+SPEC = importlib.util.spec_from_file_location("morphe_flow", SOURCE)
+assert SPEC is not None
+assert SPEC.loader is not None
+MODULE = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = MODULE
+SPEC.loader.exec_module(MODULE)
+
+
+def run(*argv: str, cwd: Path | None = None) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        list(argv),
+        cwd=str(cwd) if cwd else None,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+
+def git(cwd: Path, *args: str) -> str:
+    result = run("git", *args, cwd=cwd)
+    if result.returncode != 0:
+        raise AssertionError(result.stderr or result.stdout)
+    return result.stdout.strip()
+
+
+def git_ro(cwd: Path, *args: str) -> str:
+    environment = os.environ.copy()
+    environment["GIT_OPTIONAL_LOCKS"] = "0"
+    environment["GIT_TERMINAL_PROMPT"] = "0"
+    result = subprocess.run(
+        ["git", *args],
+        cwd=str(cwd),
+        text=True,
+        capture_output=True,
+        check=False,
+        env=environment,
+    )
+    if result.returncode != 0:
+        raise AssertionError(result.stderr or result.stdout)
+    return result.stdout.strip()
+
+
+class ReadOnlyAllowlistTest(unittest.TestCase):
+    def test_rejects_mutating_git_operations(self) -> None:
+        for args in (
+            ("push", "origin", "main"),
+            ("fetch", "origin"),
+            ("commit", "-m", "x"),
+            ("checkout", "main"),
+            ("branch", "-D", "work/x"),
+            ("worktree", "remove", "/tmp/x"),
+            ("stash", "push"),
+            ("config", "user.name", "Mutating"),
+            ("symbolic-ref", "HEAD", "refs/heads/main"),
+        ):
+            with self.subTest(args=args):
+                with self.assertRaises(ValueError):
+                    MODULE.GitReader._validate(args)
+
+    def test_accepts_required_read_only_git_operations(self) -> None:
+        for args in (
+            ("status", "--porcelain=v1"),
+            ("rev-parse", "HEAD"),
+            ("worktree", "list", "--porcelain"),
+            ("stash", "list"),
+            ("remote", "get-url", "origin"),
+            ("config", "--get", "remote.origin.url"),
+            ("ls-remote", "--heads", "origin"),
+        ):
+            with self.subTest(args=args):
+                MODULE.GitReader._validate(args)
+
+
+class ParsingTest(unittest.TestCase):
+    def test_origin_slug_variants(self) -> None:
+        self.assertEqual(
+            "brealorg/breal-morphe-patches",
+            MODULE._parse_origin_slug("git@github.com:brealorg/breal-morphe-patches.git"),
+        )
+        self.assertEqual(
+            "brealorg/breal-morphe-patches",
+            MODULE._parse_origin_slug("https://github.com/brealorg/breal-morphe-patches.git"),
+        )
+
+    def test_issue_number_variants(self) -> None:
+        self.assertEqual(106, MODULE._issue_number("work/issue106-settings-v2"))
+        self.assertEqual(117, MODULE._issue_number("work/issue-117-back-selection"))
+        self.assertIsNone(MODULE._issue_number("work/release-1.4.95"))
+
+    def test_worktree_porcelain(self) -> None:
+        parsed = MODULE._parse_worktree_porcelain(
+            "worktree /repo\nHEAD abc\nbranch refs/heads/main\n\n"
+            "worktree /repo-2\nHEAD def\ndetached\nprunable gitdir file points to non-existent location\n\n"
+        )
+        self.assertEqual(2, len(parsed))
+        self.assertEqual("refs/heads/main", parsed[0]["branch"])
+        self.assertTrue(parsed[1]["detached"])
+
+
+
+
+class MergedPullRequestClassificationTest(unittest.TestCase):
+    def _classify(
+        self,
+        *,
+        head_matches: bool | None,
+        merge_in_main: bool | None,
+    ) -> tuple[str, bool, tuple[str, ...], tuple[str, ...], str]:
+        pull_request = MODULE.PullRequestObservation(
+            number=118,
+            state="MERGED",
+            draft=False,
+            head_branch="work/issue106-test",
+            head_sha="branch-head",
+            base_branch="main",
+            url="https://example.invalid/pr/118",
+            merge_commit_sha="merge-commit",
+        )
+        return MODULE._classify_worktree(
+            branch="work/issue106-test",
+            exists=True,
+            detached=False,
+            prunable=None,
+            dirty=False,
+            head_sha="branch-head",
+            upstream="origin/work/issue106-test",
+            upstream_ahead=0,
+            upstream_behind=0,
+            main_ahead=7,
+            main_behind=5,
+            cherry_unique=7,
+            cherry_equivalent=0,
+            remote_relation="EQUAL",
+            pull_request=pull_request,
+            pull_request_head_matches=head_matches,
+            pull_request_merge_in_main=merge_in_main,
+        )
+
+    def test_merged_squash_branch_is_cleanup_ready_despite_unique_patch_ids(self) -> None:
+        state, safe, blockers, _, next_action = self._classify(
+            head_matches=True,
+            merge_in_main=True,
+        )
+        self.assertEqual("MERGED_CLEANUP_READY", state)
+        self.assertTrue(safe)
+        self.assertEqual((), blockers)
+        self.assertEqual("REMOVE_STALE_BRANCH_AND_WORKTREE", next_action)
+
+    def test_merged_branch_moved_after_pr_is_blocked(self) -> None:
+        state, safe, blockers, _, next_action = self._classify(
+            head_matches=False,
+            merge_in_main=True,
+        )
+        self.assertEqual("MERGED_PR_BRANCH_MOVED", state)
+        self.assertFalse(safe)
+        self.assertIn("post-merge work", blockers[0])
+        self.assertEqual("MANUAL_DIAGNOSIS", next_action)
+
+
+class IntegrationAuditTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temp = tempfile.TemporaryDirectory()
+        self.base = Path(self.temp.name)
+        self.remote = self.base / "remote.git"
+        self.repo = self.base / "repo"
+        self.issue_worktree = self.base / "repo-issue106"
+
+        git(self.base, "init", "--bare", str(self.remote))
+        git(self.base, "clone", str(self.remote), str(self.repo))
+        git(self.repo, "config", "user.name", "Test")
+        git(self.repo, "config", "user.email", "test@example.invalid")
+        git(self.repo, "checkout", "-b", "main")
+        (self.repo / "README.md").write_text("base\n", encoding="utf-8")
+        git(self.repo, "add", "README.md")
+        git(self.repo, "commit", "-m", "base")
+        git(self.repo, "push", "-u", "origin", "main")
+        git(self.remote, "symbolic-ref", "HEAD", "refs/heads/main")
+
+        git(self.repo, "branch", "work/issue106-test")
+        git(self.repo, "worktree", "add", str(self.issue_worktree), "work/issue106-test")
+
+    def tearDown(self) -> None:
+        self.temp.cleanup()
+
+    def _index_state(self, worktree: Path) -> str:
+        index = Path(git_ro(worktree, "rev-parse", "--git-path", "index"))
+        if not index.is_absolute():
+            index = worktree / index
+        payload = index.read_bytes()
+        stat = index.stat()
+        return f"{hashlib.sha256(payload).hexdigest()}:{stat.st_mtime_ns}:{stat.st_size}"
+
+    def _snapshot(self) -> dict[str, str]:
+        return {
+            "refs": git_ro(self.repo, "show-ref"),
+            "status_main": git_ro(self.repo, "status", "--porcelain=v1"),
+            "status_issue": git_ro(self.issue_worktree, "status", "--porcelain=v1"),
+            "worktrees": git_ro(self.repo, "worktree", "list", "--porcelain"),
+            "index_main": self._index_state(self.repo),
+            "index_issue": self._index_state(self.issue_worktree),
+        }
+
+    def test_audit_detects_dirty_issue_worktree_without_mutation(self) -> None:
+        (self.issue_worktree / "dirty.txt").write_text("dirty\n", encoding="utf-8")
+        before = self._snapshot()
+
+        report = MODULE.collect_audit(self.repo, local_only=True)
+
+        after = self._snapshot()
+        self.assertEqual(before, after)
+        issue = next(item for item in report.worktrees if item.branch == "work/issue106-test")
+        self.assertEqual(106, issue.issue_number)
+        self.assertTrue(issue.dirty)
+        self.assertEqual("WORKTREE_DIRTY", issue.lifecycle_state)
+        self.assertEqual("NONE", report.mutations)
+        self.assertRegex(report.report_fingerprint, r"^sha256:[0-9a-f]{64}$")
+        self.assertFalse(report.safe_to_mutate)
+
+
+    def test_clean_local_only_audit_never_authorizes_mutation(self) -> None:
+        report = MODULE.collect_audit(self.repo, local_only=True)
+        self.assertFalse(report.safe_to_mutate)
+        main = next(item for item in report.worktrees if item.branch == "main")
+        self.assertFalse(main.safe_to_mutate)
+        self.assertIn("remote Git and GitHub observations were skipped", main.warnings)
+        issue = next(item for item in report.worktrees if item.branch == "work/issue106-test")
+        self.assertEqual("LOCAL_OBSERVATION_REDUNDANT_BRANCH", issue.lifecycle_state)
+        self.assertFalse(issue.safe_to_mutate)
+
+    def test_cli_json_is_machine_readable(self) -> None:
+        result = run(
+            sys.executable,
+            str(SOURCE),
+            "--repo",
+            str(self.repo),
+            "--local-only",
+            "--format",
+            "json",
+            "audit",
+            cwd=ROOT,
+        )
+        self.assertEqual(0, result.returncode, result.stderr)
+        payload = json.loads(result.stdout)
+        self.assertEqual(1, payload["schema_version"])
+        self.assertEqual("NONE", payload["mutations"])
+        self.assertEqual(2, len(payload["worktrees"]))
+
+    def test_full_audit_observes_matching_remote_and_open_pr(self) -> None:
+        (self.issue_worktree / "feature.txt").write_text("feature\n", encoding="utf-8")
+        git(self.issue_worktree, "add", "feature.txt")
+        git(self.issue_worktree, "commit", "-m", "feature")
+        git(self.issue_worktree, "push", "-u", "origin", "work/issue106-test")
+        head = git(self.issue_worktree, "rev-parse", "HEAD")
+        github_url = "https://github.com/brealorg/breal-morphe-patches.git"
+        git(self.repo, "config", "remote.origin.url", github_url)
+        git(
+            self.repo,
+            "config",
+            f"url.file://{self.remote}.insteadOf",
+            github_url,
+        )
+
+        fake_bin = self.base / "bin"
+        fake_bin.mkdir()
+        fake_gh = fake_bin / "gh"
+        fake_gh.write_text(
+            "#!/usr/bin/env python3\n"
+            "import json\n"
+            f"print(json.dumps([{{'number': 500, 'state': 'OPEN', 'isDraft': False, "
+            f"'headRefName': 'work/issue106-test', 'headRefOid': '{head}', "
+            "'baseRefName': 'main', 'url': 'https://example.invalid/pr/500', "
+            "'mergeCommit': None}]))\n",
+            encoding="utf-8",
+        )
+        fake_gh.chmod(0o755)
+
+        old_path = MODULE.os.environ.get("PATH", "")
+        MODULE.os.environ["PATH"] = f"{fake_bin}:{old_path}"
+        try:
+            report = MODULE.collect_audit(self.repo, local_only=False)
+        finally:
+            MODULE.os.environ["PATH"] = old_path
+
+        issue = next(item for item in report.worktrees if item.branch == "work/issue106-test")
+        self.assertEqual("PR_OPEN", issue.lifecycle_state)
+        self.assertEqual(500, issue.pull_request.number if issue.pull_request else None)
+        self.assertEqual("EQUAL", issue.remote_relation)
+        self.assertTrue(report.origin_main_tracking_current)
+        self.assertTrue(report.safe_to_mutate)
+
+    def test_full_audit_proves_squash_merged_pr_cleanup(self) -> None:
+        (self.issue_worktree / "part-one.txt").write_text("one\n", encoding="utf-8")
+        git(self.issue_worktree, "add", "part-one.txt")
+        git(self.issue_worktree, "commit", "-m", "part one")
+        (self.issue_worktree / "part-two.txt").write_text("two\n", encoding="utf-8")
+        git(self.issue_worktree, "add", "part-two.txt")
+        git(self.issue_worktree, "commit", "-m", "part two")
+        git(self.issue_worktree, "push", "-u", "origin", "work/issue106-test")
+        branch_head = git(self.issue_worktree, "rev-parse", "HEAD")
+
+        git(self.repo, "merge", "--squash", "work/issue106-test")
+        git(self.repo, "commit", "-m", "squash merged feature")
+        merge_commit = git(self.repo, "rev-parse", "HEAD")
+        git(self.repo, "push", "origin", "main")
+
+        github_url = "https://github.com/brealorg/breal-morphe-patches.git"
+        git(self.repo, "config", "remote.origin.url", github_url)
+        git(
+            self.repo,
+            "config",
+            f"url.file://{self.remote}.insteadOf",
+            github_url,
+        )
+
+        fake_bin = self.base / "bin-merged"
+        fake_bin.mkdir()
+        fake_gh = fake_bin / "gh"
+        fake_gh.write_text(
+            "#!/usr/bin/env python3\n"
+            "import json\n"
+            f"print(json.dumps([{{'number': 118, 'state': 'MERGED', 'isDraft': False, "
+            f"'headRefName': 'work/issue106-test', 'headRefOid': '{branch_head}', "
+            "'baseRefName': 'main', 'url': 'https://example.invalid/pr/118', "
+            f"'mergeCommit': {{'oid': '{merge_commit}'}}}}]))\n",
+            encoding="utf-8",
+        )
+        fake_gh.chmod(0o755)
+
+        old_path = MODULE.os.environ.get("PATH", "")
+        MODULE.os.environ["PATH"] = f"{fake_bin}:{old_path}"
+        try:
+            report = MODULE.collect_audit(self.repo, local_only=False)
+        finally:
+            MODULE.os.environ["PATH"] = old_path
+
+        issue = next(item for item in report.worktrees if item.branch == "work/issue106-test")
+        self.assertGreater(issue.cherry_unique or 0, 0)
+        self.assertTrue(issue.pull_request_head_matches)
+        self.assertTrue(issue.pull_request_merge_in_main)
+        self.assertEqual("MERGED_CLEANUP_READY", issue.lifecycle_state)
+        self.assertTrue(issue.safe_to_mutate)
+        self.assertTrue(report.safe_to_mutate)
+
+    def test_strict_mode_returns_two_for_blockers(self) -> None:
+        (self.issue_worktree / "dirty.txt").write_text("dirty\n", encoding="utf-8")
+        result = run(
+            sys.executable,
+            str(SOURCE),
+            "--repo",
+            str(self.repo),
+            "--local-only",
+            "--strict",
+            "audit",
+            cwd=ROOT,
+        )
+        self.assertEqual(2, result.returncode)
+        self.assertIn("SAFE_TO_MUTATE=NO", result.stdout)
+        self.assertIn("MUTATIONS=NONE", result.stdout)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/tools/test_morphe_flow.py
+++ b/tests/tools/test_morphe_flow.py
@@ -374,5 +374,120 @@ class IntegrationAuditTest(unittest.TestCase):
         self.assertIn("MUTATIONS=NONE", result.stdout)
 
 
+class PushReadinessTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temp = tempfile.TemporaryDirectory()
+        self.base = Path(self.temp.name)
+        self.remote = self.base / "remote.git"
+        self.repo = self.base / "repo"
+        self.unrelated = self.base / "repo-issue121"
+        self.target = self.base / "repo-hardening"
+
+        git(self.base, "init", "--bare", str(self.remote))
+        git(self.base, "clone", str(self.remote), str(self.repo))
+        git(self.repo, "config", "user.name", "Test")
+        git(self.repo, "config", "user.email", "test@example.invalid")
+        git(self.repo, "checkout", "-b", "main")
+        (self.repo / "README.md").write_text("base\n", encoding="utf-8")
+        git(self.repo, "add", "README.md")
+        git(self.repo, "commit", "-m", "base")
+        git(self.repo, "push", "-u", "origin", "main")
+        git(self.remote, "symbolic-ref", "HEAD", "refs/heads/main")
+
+        git(self.repo, "branch", "work/issue121-dirty")
+        git(self.repo, "worktree", "add", str(self.unrelated), "work/issue121-dirty")
+        (self.unrelated / "dirty.txt").write_text("dirty\n", encoding="utf-8")
+
+        git(self.repo, "branch", "work/hardening-v22-test")
+        git(self.repo, "worktree", "add", str(self.target), "work/hardening-v22-test")
+        (self.target / "feature.txt").write_text("feature\n", encoding="utf-8")
+        git(self.target, "add", "feature.txt")
+        git(self.target, "commit", "-m", "feature")
+
+        github_url = "https://github.com/brealorg/breal-morphe-patches.git"
+        git(self.repo, "config", "remote.origin.url", github_url)
+        git(
+            self.repo,
+            "config",
+            f"url.file://{self.remote}.insteadOf",
+            github_url,
+        )
+        self.fake_bin = self.base / "bin"
+        self.fake_bin.mkdir()
+        fake_gh = self.fake_bin / "gh"
+        fake_gh.write_text("#!/bin/sh\nprintf '[]\\n'\n", encoding="utf-8")
+        fake_gh.chmod(0o755)
+        self.old_path = MODULE.os.environ.get("PATH", "")
+        MODULE.os.environ["PATH"] = f"{self.fake_bin}:{self.old_path}"
+
+    def tearDown(self) -> None:
+        MODULE.os.environ["PATH"] = self.old_path
+        self.temp.cleanup()
+
+    def test_push_dry_runner_rejects_non_work_branch_and_non_exact_sha(self) -> None:
+        with self.assertRaises(ValueError):
+            MODULE.PushDryRunner._validate("main", "0" * 40)
+        with self.assertRaises(ValueError):
+            MODULE.PushDryRunner._validate("work/test", "abc")
+        MODULE.PushDryRunner._validate("work/test-safe", "a" * 40)
+
+    def test_ready_push_ignores_unrelated_dirty_worktree_and_mutates_nothing(self) -> None:
+        refs_before = git_ro(self.repo, "show-ref")
+        worktrees_before = git_ro(self.repo, "worktree", "list", "--porcelain")
+        status_target_before = git_ro(self.target, "status", "--porcelain=v1")
+        remote_before = git_ro(self.repo, "ls-remote", "--heads", "origin")
+
+        report = MODULE.collect_push_readiness(
+            self.repo,
+            "work/hardening-v22-test",
+        )
+
+        self.assertTrue(report.ready, report.blockers)
+        self.assertEqual("PASS", report.dry_run_status)
+        self.assertEqual(1, report.unrelated_blocker_count)
+        self.assertTrue(report.local_repository_unchanged)
+        self.assertTrue(report.remote_branch_unchanged)
+        self.assertTrue(report.remote_main_unchanged)
+        self.assertEqual("REQUEST_EXPLICIT_PUSH_AUTHORIZATION", report.next_action)
+        self.assertEqual("NONE", report.mutations)
+        self.assertEqual("NONE", report.remote_writes)
+        self.assertIsNone(report.remote_branch_before_sha)
+        self.assertIsNone(report.remote_branch_after_sha)
+
+        self.assertEqual(refs_before, git_ro(self.repo, "show-ref"))
+        self.assertEqual(worktrees_before, git_ro(self.repo, "worktree", "list", "--porcelain"))
+        self.assertEqual(status_target_before, git_ro(self.target, "status", "--porcelain=v1"))
+        self.assertEqual(remote_before, git_ro(self.repo, "ls-remote", "--heads", "origin"))
+
+    def test_dirty_target_blocks_before_push_dry_run(self) -> None:
+        (self.target / "uncommitted.txt").write_text("no\n", encoding="utf-8")
+        report = MODULE.collect_push_readiness(
+            self.repo,
+            "work/hardening-v22-test",
+        )
+        self.assertFalse(report.ready)
+        self.assertEqual("SKIPPED", report.dry_run_status)
+        self.assertIn("target worktree is not clean", report.blockers)
+        self.assertIsNone(report.local_repository_unchanged)
+
+    def test_ready_push_cli_emits_bound_plan(self) -> None:
+        result = run(
+            sys.executable,
+            str(SOURCE),
+            "--repo",
+            str(self.repo),
+            "branch",
+            "ready-push",
+            "work/hardening-v22-test",
+            cwd=ROOT,
+        )
+        self.assertEqual(0, result.returncode, result.stderr + result.stdout)
+        self.assertIn("OPERATION_READY=YES", result.stdout)
+        self.assertIn("DRY_RUN_STATUS=PASS", result.stdout)
+        self.assertIn("UNRELATED_BLOCKER_COUNT=1", result.stdout)
+        self.assertIn("REMOTE_WRITES=NONE", result.stdout)
+        self.assertIn("NEXT=REQUEST_EXPLICIT_PUSH_AUTHORIZATION", result.stdout)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/tools/test_morphe_flow_source_contract.py
+++ b/tests/tools/test_morphe_flow_source_contract.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+import unittest
+
+
+ROOT = Path(__file__).resolve().parents[2]
+SOURCE = ROOT / "tools" / "morphe-flow.py"
+
+
+class MorpheFlowSourceContractTest(unittest.TestCase):
+    def test_read_only_contract_markers_exist_once(self) -> None:
+        text = SOURCE.read_text(encoding="utf-8")
+        self.assertEqual(1, text.count("Hardening v22.1 deliberately performs no Git or GitHub mutation"))
+        self.assertIn('mutations: str = "NONE"', text)
+        self.assertIn("report_fingerprint: str", text)
+        self.assertIn("refusing non-read-only Git operation", text)
+
+    def test_all_subprocess_calls_are_centralized(self) -> None:
+        tree = ast.parse(SOURCE.read_text(encoding="utf-8"))
+        calls: list[tuple[str, int]] = []
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Call):
+                continue
+            function = node.func
+            if (
+                isinstance(function, ast.Attribute)
+                and isinstance(function.value, ast.Name)
+                and function.value.id == "subprocess"
+            ):
+                calls.append((function.attr, node.lineno))
+        self.assertEqual(1, len(calls))
+        self.assertEqual("run", calls[0][0])
+
+    def test_no_shell_execution(self) -> None:
+        text = SOURCE.read_text(encoding="utf-8")
+        self.assertNotIn("shell=True", text)
+        self.assertNotIn("os.system", text)
+        self.assertNotIn("subprocess.Popen", text)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/tools/test_morphe_flow_source_contract.py
+++ b/tests/tools/test_morphe_flow_source_contract.py
@@ -17,6 +17,12 @@ class MorpheFlowSourceContractTest(unittest.TestCase):
         self.assertIn('mutations: str = "NONE"', text)
         self.assertIn("report_fingerprint: str", text)
         self.assertIn("refusing non-read-only Git operation", text)
+        self.assertIn('remote_writes: str = "NONE"', text)
+        self.assertIn("class PushDryRunner", text)
+        self.assertIn('"--dry-run"', text)
+        self.assertIn('"core.hooksPath=/dev/null"', text)
+        self.assertIn("REQUEST_EXPLICIT_PUSH_AUTHORIZATION", text)
+        self.assertEqual(1, text.count('"push",'))
 
     def test_all_subprocess_calls_are_centralized(self) -> None:
         tree = ast.parse(SOURCE.read_text(encoding="utf-8"))

--- a/tools/check-morphe-flow-contract.sh
+++ b/tools/check-morphe-flow-contract.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT"
+
+python3 -m py_compile tools/morphe-flow.py
+python3 -m unittest -q \
+  tests/tools/test_morphe_flow.py \
+  tests/tools/test_morphe_flow_source_contract.py
+
+echo 'MORPHE_FLOW_READ_ONLY_CONTRACT=PASS'
+echo 'MORPHE_FLOW_INTEGRATION_TESTS=PASS'
+echo 'RESULT=MORPHE_FLOW_CONTRACT_OK'

--- a/tools/morphe-flow.py
+++ b/tools/morphe-flow.py
@@ -1,0 +1,1200 @@
+#!/usr/bin/env python3
+"""Read-only lifecycle audit for Morphe repository worktrees and branches.
+
+Hardening v22.1 deliberately performs no Git or GitHub mutation. It observes
+local worktrees, branches, stashes, remote heads, and pull requests, then emits
+one normalized lifecycle report that later mutation commands can consume.
+"""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+from datetime import datetime, timezone
+import argparse
+import hashlib
+import json
+import os
+from pathlib import Path
+import re
+import shutil
+import subprocess
+import sys
+from typing import Any, Iterable, Sequence
+
+
+SCHEMA_VERSION = 1
+ISSUE_BRANCH_RE = re.compile(r"(?:^|[\/_-])issue[-_]?([0-9]+)(?:$|[\/_-])", re.IGNORECASE)
+
+
+class ObservationError(RuntimeError):
+    """Raised when a required local observation cannot be completed."""
+
+
+@dataclass(frozen=True, slots=True)
+class CommandResult:
+    argv: tuple[str, ...]
+    returncode: int
+    stdout: str
+    stderr: str
+
+
+class CommandRunner:
+    """Execute commands without invoking a shell."""
+
+    def run(
+        self,
+        argv: Sequence[str],
+        *,
+        cwd: Path | None = None,
+        timeout: int = 30,
+        env_overrides: dict[str, str] | None = None,
+    ) -> CommandResult:
+        environment = os.environ.copy()
+        if env_overrides:
+            environment.update(env_overrides)
+        completed = subprocess.run(
+            list(argv),
+            cwd=str(cwd) if cwd is not None else None,
+            text=True,
+            capture_output=True,
+            timeout=timeout,
+            check=False,
+            env=environment,
+        )
+        return CommandResult(
+            argv=tuple(argv),
+            returncode=completed.returncode,
+            stdout=completed.stdout,
+            stderr=completed.stderr,
+        )
+
+
+class GitReader:
+    """Fail-closed allowlist for read-only Git operations."""
+
+    _SIMPLE_READ_ONLY = {
+        "cat-file",
+        "cherry",
+        "for-each-ref",
+        "ls-remote",
+        "merge-base",
+        "rev-list",
+        "rev-parse",
+        "status",
+    }
+
+    def __init__(self, runner: CommandRunner) -> None:
+        self._runner = runner
+
+    @staticmethod
+    def _validate(args: Sequence[str]) -> None:
+        if not args:
+            raise ValueError("missing Git subcommand")
+        command = args[0]
+        if command in GitReader._SIMPLE_READ_ONLY:
+            return
+        if command == "config" and tuple(args[1:]) == (
+            "--get",
+            "remote.origin.url",
+        ):
+            return
+        if command == "worktree" and len(args) >= 2 and args[1] == "list":
+            return
+        if command == "stash" and len(args) >= 2 and args[1] == "list":
+            return
+        if command == "remote" and len(args) >= 2 and args[1] == "get-url":
+            return
+        raise ValueError(f"refusing non-read-only Git operation: {' '.join(args)}")
+
+    def run(
+        self,
+        cwd: Path,
+        *args: str,
+        timeout: int = 30,
+        allow_failure: bool = False,
+    ) -> CommandResult:
+        self._validate(args)
+        result = self._runner.run(
+            ("git", *args),
+            cwd=cwd,
+            timeout=timeout,
+            env_overrides={
+                "GIT_OPTIONAL_LOCKS": "0",
+                "GIT_TERMINAL_PROMPT": "0",
+                "LC_ALL": "C",
+            },
+        )
+        if result.returncode != 0 and not allow_failure:
+            detail = result.stderr.strip() or result.stdout.strip() or "unknown Git error"
+            raise ObservationError(f"git {' '.join(args)} failed in {cwd}: {detail}")
+        return result
+
+
+@dataclass(frozen=True, slots=True)
+class PullRequestObservation:
+    number: int
+    state: str
+    draft: bool
+    head_branch: str
+    head_sha: str | None
+    base_branch: str
+    url: str
+    merge_commit_sha: str | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class WorktreeObservation:
+    path: str
+    exists: bool
+    head_sha: str | None
+    branch: str | None
+    detached: bool
+    locked: str | None
+    prunable: str | None
+    issue_number: int | None
+    dirty: bool | None
+    dirty_entries: tuple[str, ...]
+    upstream: str | None
+    upstream_ahead: int | None
+    upstream_behind: int | None
+    main_ahead: int | None
+    main_behind: int | None
+    merge_base_with_main: str | None
+    cherry_unique: int | None
+    cherry_equivalent: int | None
+    remote_head_sha: str | None
+    remote_relation: str
+    pull_request: PullRequestObservation | None
+    pull_request_head_matches: bool | None
+    pull_request_merge_in_main: bool | None
+    lifecycle_state: str
+    safe_to_mutate: bool
+    blockers: tuple[str, ...]
+    warnings: tuple[str, ...]
+    next_action: str
+
+
+@dataclass(frozen=True, slots=True)
+class BranchObservation:
+    branch: str
+    head_sha: str
+    worktree_path: str | None
+    issue_number: int | None
+    upstream: str | None
+    upstream_track: str | None
+    main_ahead: int | None
+    main_behind: int | None
+    cherry_unique: int | None
+    cherry_equivalent: int | None
+    remote_head_sha: str | None
+    pull_request: PullRequestObservation | None
+    pull_request_head_matches: bool | None
+    pull_request_merge_in_main: bool | None
+    lifecycle_state: str
+    next_action: str
+
+
+@dataclass(frozen=True, slots=True)
+class StashObservation:
+    ref: str
+    commit_sha: str
+    message: str
+
+
+@dataclass(frozen=True, slots=True)
+class ObserverStatus:
+    status: str
+    errors: tuple[str, ...] = ()
+    warnings: tuple[str, ...] = ()
+
+
+@dataclass(frozen=True, slots=True)
+class AuditReport:
+    schema_version: int
+    generated_at: str
+    repository_root: str
+    repository_slug: str | None
+    origin_url: str | None
+    local_main_sha: str | None
+    origin_main_tracking_sha: str | None
+    remote_main_sha: str | None
+    origin_main_tracking_current: bool | None
+    worktrees: tuple[WorktreeObservation, ...]
+    branches: tuple[BranchObservation, ...]
+    stashes: tuple[StashObservation, ...]
+    remote_only_branches: tuple[str, ...]
+    open_pull_requests_without_local_branch: tuple[PullRequestObservation, ...]
+    local_observer: ObserverStatus
+    remote_git_observer: ObserverStatus
+    github_observer: ObserverStatus
+    global_blockers: tuple[str, ...]
+    global_warnings: tuple[str, ...]
+    blocker_count: int
+    warning_count: int
+    safe_to_mutate: bool
+    report_fingerprint: str
+    mutations: str = "NONE"
+
+    def as_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+def _git_stdout(result: CommandResult) -> str:
+    return result.stdout.strip()
+
+
+def _resolve_repository_root(git: GitReader, candidate: Path) -> Path:
+    result = git.run(candidate, "rev-parse", "--show-toplevel")
+    return Path(_git_stdout(result)).resolve()
+
+
+def _parse_origin_slug(url: str | None) -> str | None:
+    if not url:
+        return None
+    value = url.strip()
+    patterns = (
+        r"^https?://github\.com/([^/]+/[^/]+?)(?:\.git)?$",
+        r"^git@github\.com:([^/]+/[^/]+?)(?:\.git)?$",
+        r"^ssh://git@github\.com/([^/]+/[^/]+?)(?:\.git)?$",
+    )
+    for pattern in patterns:
+        match = re.match(pattern, value)
+        if match:
+            return match.group(1)
+    return None
+
+
+def _issue_number(branch: str | None) -> int | None:
+    if not branch:
+        return None
+    match = ISSUE_BRANCH_RE.search(branch)
+    return int(match.group(1)) if match else None
+
+
+def _parse_worktree_porcelain(text: str) -> list[dict[str, str | bool]]:
+    records: list[dict[str, str | bool]] = []
+    current: dict[str, str | bool] = {}
+    for raw_line in text.splitlines() + [""]:
+        line = raw_line.rstrip("\n")
+        if not line:
+            if current:
+                records.append(current)
+                current = {}
+            continue
+        key, separator, value = line.partition(" ")
+        current[key] = value if separator else True
+    return records
+
+
+def _parse_count_pair(text: str) -> tuple[int, int]:
+    fields = text.strip().split()
+    if len(fields) != 2:
+        raise ObservationError(f"expected two revision counts, got: {text!r}")
+    return int(fields[0]), int(fields[1])
+
+
+def _rev_counts(
+    git: GitReader,
+    cwd: Path,
+    left: str,
+    right: str,
+) -> tuple[int | None, int | None]:
+    result = git.run(
+        cwd,
+        "rev-list",
+        "--left-right",
+        "--count",
+        f"{left}...{right}",
+        allow_failure=True,
+    )
+    if result.returncode != 0:
+        return None, None
+    left_only, right_only = _parse_count_pair(result.stdout)
+    return right_only, left_only
+
+
+def _merge_base(git: GitReader, cwd: Path, left: str, right: str) -> str | None:
+    result = git.run(cwd, "merge-base", left, right, allow_failure=True)
+    return _git_stdout(result) if result.returncode == 0 else None
+
+
+def _cherry_counts(git: GitReader, cwd: Path, upstream: str, head: str) -> tuple[int | None, int | None]:
+    result = git.run(cwd, "cherry", upstream, head, allow_failure=True)
+    if result.returncode != 0:
+        return None, None
+    unique = 0
+    equivalent = 0
+    for line in result.stdout.splitlines():
+        if line.startswith("+"):
+            unique += 1
+        elif line.startswith("-"):
+            equivalent += 1
+    return unique, equivalent
+
+
+def _object_exists(git: GitReader, cwd: Path, sha: str) -> bool:
+    result = git.run(cwd, "cat-file", "-e", f"{sha}^{{commit}}", allow_failure=True)
+    return result.returncode == 0
+
+
+def _is_ancestor(git: GitReader, cwd: Path, ancestor: str, descendant: str) -> bool | None:
+    result = git.run(
+        cwd,
+        "merge-base",
+        "--is-ancestor",
+        ancestor,
+        descendant,
+        allow_failure=True,
+    )
+    if result.returncode == 0:
+        return True
+    if result.returncode == 1:
+        return False
+    return None
+
+
+def _remote_relation(git: GitReader, cwd: Path, local_sha: str | None, remote_sha: str | None) -> str:
+    if not remote_sha:
+        return "ABSENT"
+    if not local_sha:
+        return "UNKNOWN"
+    if local_sha == remote_sha:
+        return "EQUAL"
+    if not _object_exists(git, cwd, remote_sha):
+        return "UNKNOWN_REMOTE_OBJECT"
+    local_contains_remote = _is_ancestor(git, cwd, remote_sha, local_sha)
+    remote_contains_local = _is_ancestor(git, cwd, local_sha, remote_sha)
+    if local_contains_remote is True:
+        return "LOCAL_AHEAD"
+    if remote_contains_local is True:
+        return "REMOTE_AHEAD"
+    if local_contains_remote is False and remote_contains_local is False:
+        return "DIVERGENT"
+    return "UNKNOWN"
+
+
+def _status_entries(git: GitReader, cwd: Path) -> tuple[str, ...]:
+    result = git.run(
+        cwd,
+        "status",
+        "--porcelain=v1",
+        "-z",
+        "--untracked-files=all",
+    )
+    return tuple(entry for entry in result.stdout.split("\x00") if entry)
+
+
+def _upstream(git: GitReader, cwd: Path) -> str | None:
+    result = git.run(
+        cwd,
+        "rev-parse",
+        "--abbrev-ref",
+        "--symbolic-full-name",
+        "@{upstream}",
+        allow_failure=True,
+    )
+    return _git_stdout(result) if result.returncode == 0 else None
+
+
+def _read_worktrees(git: GitReader, root: Path) -> list[dict[str, str | bool]]:
+    result = git.run(root, "worktree", "list", "--porcelain")
+    return _parse_worktree_porcelain(result.stdout)
+
+
+def _read_local_branches(git: GitReader, root: Path) -> list[dict[str, str | None]]:
+    fmt = "%00".join(
+        (
+            "%(refname:short)",
+            "%(objectname)",
+            "%(upstream:short)",
+            "%(upstream:track)",
+            "%(worktreepath)",
+        )
+    )
+    result = git.run(root, "for-each-ref", f"--format={fmt}", "refs/heads")
+    branches: list[dict[str, str | None]] = []
+    for raw_line in result.stdout.splitlines():
+        fields = raw_line.split("\x00")
+        if len(fields) != 5:
+            raise ObservationError(f"unexpected for-each-ref output: {raw_line!r}")
+        branches.append(
+            {
+                "branch": fields[0],
+                "sha": fields[1],
+                "upstream": fields[2] or None,
+                "upstream_track": fields[3] or None,
+                "worktree_path": fields[4] or None,
+            }
+        )
+    return branches
+
+
+def _read_stashes(git: GitReader, root: Path) -> tuple[StashObservation, ...]:
+    fmt = "%gd%x00%H%x00%gs"
+    result = git.run(root, "stash", "list", f"--format={fmt}")
+    observations: list[StashObservation] = []
+    for raw_line in result.stdout.splitlines():
+        fields = raw_line.split("\x00", 2)
+        if len(fields) == 3:
+            observations.append(StashObservation(fields[0], fields[1], fields[2]))
+    return tuple(observations)
+
+
+def _read_remote_heads(git: GitReader, root: Path) -> tuple[dict[str, str], tuple[str, ...]]:
+    result = git.run(root, "ls-remote", "--heads", "origin", allow_failure=True, timeout=45)
+    if result.returncode != 0:
+        detail = result.stderr.strip() or result.stdout.strip() or "git ls-remote failed"
+        return {}, (detail,)
+    heads: dict[str, str] = {}
+    for line in result.stdout.splitlines():
+        sha, separator, ref = line.partition("\t")
+        if separator and ref.startswith("refs/heads/"):
+            heads[ref.removeprefix("refs/heads/")] = sha
+    return heads, ()
+
+
+def _read_pull_requests(
+    runner: CommandRunner,
+    root: Path,
+    repository_slug: str | None,
+) -> tuple[tuple[PullRequestObservation, ...], tuple[str, ...]]:
+    if not repository_slug:
+        return (), ("could not derive GitHub owner/repository from origin URL",)
+    if shutil.which("gh") is None:
+        return (), ("GitHub CLI (gh) is unavailable",)
+    fields = "number,state,isDraft,headRefName,headRefOid,baseRefName,url,mergeCommit"
+    result = runner.run(
+        (
+            "gh",
+            "pr",
+            "list",
+            "--repo",
+            repository_slug,
+            "--state",
+            "all",
+            "--limit",
+            "200",
+            "--json",
+            fields,
+        ),
+        cwd=root,
+        timeout=45,
+    )
+    if result.returncode != 0:
+        detail = result.stderr.strip() or result.stdout.strip() or "gh pr list failed"
+        return (), (detail,)
+    try:
+        payload = json.loads(result.stdout)
+    except json.JSONDecodeError as exc:
+        return (), (f"gh pr list returned invalid JSON: {exc}",)
+    observations: list[PullRequestObservation] = []
+    for item in payload:
+        merge_commit = item.get("mergeCommit") or {}
+        observations.append(
+            PullRequestObservation(
+                number=int(item["number"]),
+                state=str(item.get("state") or "UNKNOWN"),
+                draft=bool(item.get("isDraft")),
+                head_branch=str(item.get("headRefName") or ""),
+                head_sha=item.get("headRefOid"),
+                base_branch=str(item.get("baseRefName") or ""),
+                url=str(item.get("url") or ""),
+                merge_commit_sha=merge_commit.get("oid") if isinstance(merge_commit, dict) else None,
+            )
+        )
+    return tuple(observations), ()
+
+
+def _pr_by_branch(pull_requests: Iterable[PullRequestObservation]) -> dict[str, PullRequestObservation]:
+    grouped: dict[str, list[PullRequestObservation]] = {}
+    for pull_request in pull_requests:
+        grouped.setdefault(pull_request.head_branch, []).append(pull_request)
+    selected: dict[str, PullRequestObservation] = {}
+    for branch, items in grouped.items():
+        items.sort(
+            key=lambda item: (
+                item.state.upper() == "OPEN",
+                item.number,
+            ),
+            reverse=True,
+        )
+        selected[branch] = items[0]
+    return selected
+
+
+def _classify_worktree(
+    *,
+    branch: str | None,
+    exists: bool,
+    detached: bool,
+    prunable: str | None,
+    dirty: bool | None,
+    head_sha: str | None,
+    upstream: str | None,
+    upstream_ahead: int | None,
+    upstream_behind: int | None,
+    main_ahead: int | None,
+    main_behind: int | None,
+    cherry_unique: int | None,
+    cherry_equivalent: int | None,
+    remote_relation: str,
+    pull_request: PullRequestObservation | None,
+    pull_request_head_matches: bool | None,
+    pull_request_merge_in_main: bool | None,
+) -> tuple[str, bool, tuple[str, ...], tuple[str, ...], str]:
+    blockers: list[str] = []
+    warnings: list[str] = []
+
+    if not exists or prunable:
+        blockers.append("worktree path is missing or marked prunable")
+        return "PRUNABLE_WORKTREE", False, tuple(blockers), tuple(warnings), "PRUNE_WORKTREE_METADATA"
+    if detached or not branch:
+        blockers.append("worktree is detached from a local branch")
+        return "DETACHED_WORKTREE", False, tuple(blockers), tuple(warnings), "ATTACH_OR_ARCHIVE_WORKTREE"
+    if dirty:
+        blockers.append("worktree contains tracked or untracked changes")
+        state = "MAIN_DIRTY" if branch == "main" else "WORKTREE_DIRTY"
+        return state, False, tuple(blockers), tuple(warnings), "CREATE_VERIFIED_CHECKPOINT"
+
+    if branch == "main":
+        if upstream_behind not in (None, 0) or upstream_ahead not in (None, 0):
+            blockers.append("local main is not equal to its upstream")
+            return "MAIN_NOT_ALIGNED", False, tuple(blockers), tuple(warnings), "ALIGN_MAIN_WITH_ORIGIN"
+        return "MAIN_CLEAN", True, (), (), "NONE"
+
+    if remote_relation in {"DIVERGENT", "REMOTE_AHEAD", "UNKNOWN_REMOTE_OBJECT", "UNKNOWN"}:
+        blockers.append(f"local branch and remote branch relation is {remote_relation}")
+
+    if pull_request and pull_request.state.upper() == "OPEN":
+        if pull_request.base_branch != "main":
+            blockers.append(f"pull request targets {pull_request.base_branch}, not main")
+        if pull_request.head_sha and head_sha and pull_request.head_sha != head_sha:
+            blockers.append("local HEAD does not equal the pull request head SHA")
+        if main_behind not in (None, 0):
+            warnings.append(f"branch is behind origin/main by {main_behind} commits")
+        if blockers:
+            return "PR_OPEN_BLOCKED", False, tuple(blockers), tuple(warnings), "RECONCILE_BRANCH_PR_STATE"
+        return "PR_OPEN", True, (), tuple(warnings), "WAIT_FOR_OR_MERGE_PR"
+
+    if pull_request and pull_request.state.upper() == "MERGED":
+        if pull_request_head_matches is False:
+            blockers.append(
+                "local HEAD does not equal the merged pull request head SHA; "
+                "the branch may contain post-merge work"
+            )
+            return "MERGED_PR_BRANCH_MOVED", False, tuple(blockers), tuple(warnings), "MANUAL_DIAGNOSIS"
+        if pull_request_merge_in_main is False:
+            blockers.append("merged pull request commit is not reachable from current main")
+            return "MERGED_PR_NOT_IN_MAIN", False, tuple(blockers), tuple(warnings), "MANUAL_DIAGNOSIS"
+        if pull_request_head_matches is True and pull_request_merge_in_main is True:
+            return "MERGED_CLEANUP_READY", True, (), (), "REMOVE_STALE_BRANCH_AND_WORKTREE"
+        blockers.append("merged pull request integration could not be proven from local main")
+        return "MERGED_PR_INTEGRATION_UNKNOWN", False, tuple(blockers), tuple(warnings), "REFRESH_AND_RERUN_AUDIT"
+
+    if pull_request and pull_request.state.upper() == "CLOSED":
+        if cherry_unique == 0:
+            return "CLOSED_PR_CLEANUP_READY", True, (), (), "REMOVE_STALE_BRANCH_AND_WORKTREE"
+        blockers.append("closed unmerged pull request branch still has unique patches not present on main")
+        return "CLOSED_PR_WITH_UNIQUE_WORK", False, tuple(blockers), tuple(warnings), "MANUAL_DIAGNOSIS"
+
+    if cherry_unique == 0 and (cherry_equivalent or 0) > 0:
+        return "PATCH_EQUIVALENT_TO_MAIN", True, (), (), "REMOVE_REDUNDANT_BRANCH_AND_WORKTREE"
+    if main_ahead == 0 and main_behind not in (None, 0):
+        return "BRANCH_ANCESTOR_OF_MAIN", True, (), (), "REMOVE_REDUNDANT_BRANCH_AND_WORKTREE"
+
+    if remote_relation == "SKIPPED":
+        if main_behind not in (None, 0):
+            warnings.append(f"branch is behind origin/main by {main_behind} commits")
+            return "LOCAL_OBSERVATION_NEEDS_REBASE", False, (), tuple(warnings), "RUN_FULL_AUDIT"
+        if (cherry_unique or 0) > 0:
+            return "LOCAL_OBSERVATION_UNPUBLISHED_WORK", False, (), tuple(warnings), "RUN_FULL_AUDIT"
+        return "LOCAL_OBSERVATION_REDUNDANT_BRANCH", False, (), tuple(warnings), "RUN_FULL_AUDIT"
+
+    if remote_relation == "ABSENT":
+        if main_behind not in (None, 0):
+            warnings.append(f"branch is behind origin/main by {main_behind} commits")
+            return "LOCAL_ONLY_NEEDS_REBASE", False, ("branch must be rebased before publication",), tuple(warnings), "REBASE_ON_MAIN"
+        return "LOCAL_ONLY_READY", True, (), (), "PREFLIGHT_PUSH"
+
+    if remote_relation == "EQUAL":
+        if main_behind not in (None, 0):
+            warnings.append(f"branch is behind origin/main by {main_behind} commits")
+            return "REMOTE_BRANCH_NEEDS_REBASE", False, ("published branch is behind main",), tuple(warnings), "REBASE_WITH_FORCE_WITH_LEASE_PREFLIGHT"
+        return "REMOTE_BRANCH_NO_PR", True, (), (), "CREATE_OR_RECOVER_PR"
+
+    if remote_relation == "LOCAL_AHEAD":
+        if main_behind not in (None, 0):
+            warnings.append(f"branch is behind origin/main by {main_behind} commits")
+            return "LOCAL_AHEAD_REMOTE_NEEDS_REBASE", False, ("branch must be rebased before publication",), tuple(warnings), "REBASE_ON_MAIN"
+        return "LOCAL_AHEAD_OF_REMOTE", True, (), tuple(warnings), "PREFLIGHT_PUSH"
+
+    if remote_relation == "REMOTE_AHEAD":
+        return "REMOTE_AHEAD_OF_LOCAL", False, tuple(blockers), tuple(warnings), "FETCH_AND_RECONCILE"
+    if remote_relation == "UNKNOWN_REMOTE_OBJECT":
+        return "REMOTE_OBJECT_NOT_FETCHED", False, tuple(blockers), tuple(warnings), "FETCH_ORIGIN_AND_RERUN_AUDIT"
+    if remote_relation == "DIVERGENT":
+        return "LOCAL_REMOTE_DIVERGED", False, tuple(blockers), tuple(warnings), "MANUAL_DIAGNOSIS"
+
+    if blockers:
+        return "BRANCH_REMOTE_MISMATCH", False, tuple(blockers), tuple(warnings), "MANUAL_DIAGNOSIS"
+    return "UNCLASSIFIED", False, ("lifecycle state could not be classified",), tuple(warnings), "MANUAL_DIAGNOSIS"
+
+
+def _classify_branch(
+    *,
+    branch: str,
+    main_ahead: int | None,
+    main_behind: int | None,
+    cherry_unique: int | None,
+    cherry_equivalent: int | None,
+    remote_head_sha: str | None,
+    pull_request: PullRequestObservation | None,
+    pull_request_head_matches: bool | None,
+    pull_request_merge_in_main: bool | None,
+    worktree_path: str | None,
+) -> tuple[str, str]:
+    if branch == "main":
+        return "CANONICAL_MAIN", "NONE"
+    if branch == "dev":
+        return "RELEASE_MIRROR", "NONE"
+    if worktree_path:
+        return "ATTACHED_TO_WORKTREE", "SEE_WORKTREE_STATE"
+    if pull_request and pull_request.state.upper() == "OPEN":
+        return "OPEN_PR_WITHOUT_WORKTREE", "REVIEW_OR_REATTACH_WORKTREE"
+    if pull_request and pull_request.state.upper() == "MERGED":
+        if pull_request_head_matches is True and pull_request_merge_in_main is True:
+            return "STALE_MERGED_PR_BRANCH", "DELETE_LOCAL_BRANCH"
+        return "MERGED_PR_BRANCH_REQUIRES_DIAGNOSIS", "MANUAL_DIAGNOSIS"
+    if pull_request and pull_request.state.upper() == "CLOSED" and cherry_unique == 0:
+        return "STALE_CLOSED_PR_BRANCH", "DELETE_LOCAL_BRANCH"
+    if cherry_unique == 0 and (cherry_equivalent or 0) > 0:
+        return "PATCH_EQUIVALENT_LOCAL_BRANCH", "DELETE_LOCAL_BRANCH"
+    if main_ahead == 0 and main_behind not in (None, 0):
+        return "MERGED_LOCAL_BRANCH", "DELETE_LOCAL_BRANCH"
+    if remote_head_sha is None and (cherry_unique or 0) > 0:
+        return "UNPUBLISHED_LOCAL_BRANCH", "REATTACH_OR_ARCHIVE"
+    if remote_head_sha is None and main_ahead == 0 and main_behind == 0:
+        return "REDUNDANT_LOCAL_BRANCH", "DELETE_LOCAL_BRANCH"
+    if remote_head_sha is not None and pull_request is None:
+        return "REMOTE_BRANCH_WITHOUT_PR", "CREATE_OR_CLOSE_REMOTE_BRANCH"
+    return "UNCLASSIFIED_LOCAL_BRANCH", "MANUAL_DIAGNOSIS"
+
+
+def _canonical_fingerprint(value: Any) -> str:
+    encoded = json.dumps(
+        value,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=True,
+    ).encode("utf-8")
+    return f"sha256:{hashlib.sha256(encoded).hexdigest()}"
+
+
+def collect_audit(
+    candidate: Path,
+    *,
+    local_only: bool,
+    runner: CommandRunner | None = None,
+) -> AuditReport:
+    command_runner = runner or CommandRunner()
+    git = GitReader(command_runner)
+    local_errors: list[str] = []
+    local_warnings: list[str] = []
+    remote_errors: list[str] = []
+    github_errors: list[str] = []
+    global_blockers: list[str] = []
+    global_warnings: list[str] = []
+
+    root = _resolve_repository_root(git, candidate.resolve())
+
+    origin_result = git.run(
+        root,
+        "config",
+        "--get",
+        "remote.origin.url",
+        allow_failure=True,
+    )
+    if origin_result.returncode != 0:
+        origin_result = git.run(root, "remote", "get-url", "origin", allow_failure=True)
+    origin_url = _git_stdout(origin_result) if origin_result.returncode == 0 else None
+    repository_slug = _parse_origin_slug(origin_url)
+
+    worktree_records = _read_worktrees(git, root)
+    branch_records = _read_local_branches(git, root)
+    stashes = _read_stashes(git, root)
+
+    local_main_result = git.run(root, "rev-parse", "refs/heads/main", allow_failure=True)
+    local_main_sha = _git_stdout(local_main_result) if local_main_result.returncode == 0 else None
+    tracking_result = git.run(root, "rev-parse", "refs/remotes/origin/main", allow_failure=True)
+    origin_main_tracking_sha = _git_stdout(tracking_result) if tracking_result.returncode == 0 else None
+    if local_main_sha is None:
+        global_blockers.append("local main branch is unavailable")
+    if origin_main_tracking_sha is None:
+        global_blockers.append("refs/remotes/origin/main is unavailable")
+
+    remote_heads: dict[str, str] = {}
+    pull_requests: tuple[PullRequestObservation, ...] = ()
+    if local_only:
+        remote_status = ObserverStatus("SKIPPED", warnings=("local-only audit requested",))
+        github_status = ObserverStatus("SKIPPED", warnings=("local-only audit requested",))
+    else:
+        remote_heads, remote_failures = _read_remote_heads(git, root)
+        remote_errors.extend(remote_failures)
+        pull_requests, pr_failures = _read_pull_requests(command_runner, root, repository_slug)
+        github_errors.extend(pr_failures)
+        remote_status = ObserverStatus("PASS" if not remote_errors else "INCOMPLETE", tuple(remote_errors))
+        github_status = ObserverStatus("PASS" if not github_errors else "INCOMPLETE", tuple(github_errors))
+
+    remote_main_sha = remote_heads.get("main") if remote_heads else None
+    origin_main_tracking_current = (
+        origin_main_tracking_sha == remote_main_sha
+        if origin_main_tracking_sha and remote_main_sha
+        else None
+    )
+    if not local_only and remote_main_sha is None:
+        global_blockers.append("remote main ref is unavailable")
+    if not local_only and remote_main_sha and local_main_sha != remote_main_sha:
+        global_blockers.append("local main branch does not equal remote main")
+    if origin_main_tracking_current is False:
+        global_blockers.append(
+            "local origin/main tracking ref is stale relative to remote main"
+        )
+
+    pr_map = _pr_by_branch(pull_requests)
+    worktrees: list[WorktreeObservation] = []
+
+    for record in worktree_records:
+        path_value = str(record.get("worktree") or "")
+        path = Path(path_value)
+        exists = path.exists()
+        branch_ref = record.get("branch")
+        branch = (
+            str(branch_ref).removeprefix("refs/heads/")
+            if isinstance(branch_ref, str)
+            else None
+        )
+        detached = bool(record.get("detached")) or branch is None
+        head_sha = str(record.get("HEAD")) if record.get("HEAD") else None
+        prunable = str(record.get("prunable")) if record.get("prunable") else None
+        locked = str(record.get("locked")) if record.get("locked") else None
+
+        dirty_entries: tuple[str, ...] = ()
+        dirty: bool | None = None
+        upstream = None
+        upstream_ahead = None
+        upstream_behind = None
+        main_ahead = None
+        main_behind = None
+        merge_base = None
+        cherry_unique = None
+        cherry_equivalent = None
+
+        if exists:
+            try:
+                dirty_entries = _status_entries(git, path)
+                dirty = bool(dirty_entries)
+                upstream = _upstream(git, path)
+                if upstream:
+                    upstream_ahead, upstream_behind = _rev_counts(git, path, upstream, "HEAD")
+                if origin_main_tracking_sha:
+                    main_ahead, main_behind = _rev_counts(git, path, "origin/main", "HEAD")
+                    merge_base = _merge_base(git, path, "origin/main", "HEAD")
+                    cherry_unique, cherry_equivalent = _cherry_counts(git, path, "origin/main", "HEAD")
+            except ObservationError as exc:
+                local_errors.append(str(exc))
+
+        remote_head_sha = remote_heads.get(branch) if branch else None
+        relation = _remote_relation(git, root, head_sha, remote_head_sha) if not local_only else "SKIPPED"
+        pull_request = pr_map.get(branch or "")
+        pull_request_head_matches = None
+        pull_request_merge_in_main = None
+        if pull_request and pull_request.head_sha and head_sha:
+            pull_request_head_matches = pull_request.head_sha == head_sha
+        if (
+            pull_request
+            and pull_request.state.upper() == "MERGED"
+            and pull_request.merge_commit_sha
+            and local_main_sha
+            and _object_exists(git, root, pull_request.merge_commit_sha)
+        ):
+            pull_request_merge_in_main = _is_ancestor(
+                git,
+                root,
+                pull_request.merge_commit_sha,
+                local_main_sha,
+            )
+        state, safe, blockers, warnings, next_action = _classify_worktree(
+            branch=branch,
+            exists=exists,
+            detached=detached,
+            prunable=prunable,
+            dirty=dirty,
+            head_sha=head_sha,
+            upstream=upstream,
+            upstream_ahead=upstream_ahead,
+            upstream_behind=upstream_behind,
+            main_ahead=main_ahead,
+            main_behind=main_behind,
+            cherry_unique=cherry_unique,
+            cherry_equivalent=cherry_equivalent,
+            remote_relation=relation,
+            pull_request=pull_request,
+            pull_request_head_matches=pull_request_head_matches,
+            pull_request_merge_in_main=pull_request_merge_in_main,
+        )
+        if local_only:
+            safe = False
+            warnings = (*warnings, "remote Git and GitHub observations were skipped")
+            if next_action == "NONE":
+                next_action = "RUN_FULL_AUDIT"
+        worktrees.append(
+            WorktreeObservation(
+                path=str(path),
+                exists=exists,
+                head_sha=head_sha,
+                branch=branch,
+                detached=detached,
+                locked=locked,
+                prunable=prunable,
+                issue_number=_issue_number(branch),
+                dirty=dirty,
+                dirty_entries=dirty_entries,
+                upstream=upstream,
+                upstream_ahead=upstream_ahead,
+                upstream_behind=upstream_behind,
+                main_ahead=main_ahead,
+                main_behind=main_behind,
+                merge_base_with_main=merge_base,
+                cherry_unique=cherry_unique,
+                cherry_equivalent=cherry_equivalent,
+                remote_head_sha=remote_head_sha,
+                remote_relation=relation,
+                pull_request=pull_request,
+                pull_request_head_matches=pull_request_head_matches,
+                pull_request_merge_in_main=pull_request_merge_in_main,
+                lifecycle_state=state,
+                safe_to_mutate=safe,
+                blockers=blockers,
+                warnings=warnings,
+                next_action=next_action,
+            )
+        )
+
+    branches: list[BranchObservation] = []
+    local_branch_names = {str(item["branch"]) for item in branch_records}
+    for record in branch_records:
+        branch = str(record["branch"])
+        head_sha = str(record["sha"])
+        main_ahead = None
+        main_behind = None
+        cherry_unique = None
+        cherry_equivalent = None
+        if origin_main_tracking_sha:
+            main_ahead, main_behind = _rev_counts(git, root, "origin/main", branch)
+            cherry_unique, cherry_equivalent = _cherry_counts(git, root, "origin/main", branch)
+        remote_head_sha = remote_heads.get(branch)
+        pull_request = pr_map.get(branch)
+        pull_request_head_matches = None
+        pull_request_merge_in_main = None
+        if pull_request and pull_request.head_sha:
+            pull_request_head_matches = pull_request.head_sha == head_sha
+        if (
+            pull_request
+            and pull_request.state.upper() == "MERGED"
+            and pull_request.merge_commit_sha
+            and local_main_sha
+            and _object_exists(git, root, pull_request.merge_commit_sha)
+        ):
+            pull_request_merge_in_main = _is_ancestor(
+                git,
+                root,
+                pull_request.merge_commit_sha,
+                local_main_sha,
+            )
+        lifecycle_state, next_action = _classify_branch(
+            branch=branch,
+            main_ahead=main_ahead,
+            main_behind=main_behind,
+            cherry_unique=cherry_unique,
+            cherry_equivalent=cherry_equivalent,
+            remote_head_sha=remote_head_sha,
+            pull_request=pull_request,
+            pull_request_head_matches=pull_request_head_matches,
+            pull_request_merge_in_main=pull_request_merge_in_main,
+            worktree_path=record["worktree_path"],
+        )
+        branches.append(
+            BranchObservation(
+                branch=branch,
+                head_sha=head_sha,
+                worktree_path=record["worktree_path"],
+                issue_number=_issue_number(branch),
+                upstream=record["upstream"],
+                upstream_track=record["upstream_track"],
+                main_ahead=main_ahead,
+                main_behind=main_behind,
+                cherry_unique=cherry_unique,
+                cherry_equivalent=cherry_equivalent,
+                remote_head_sha=remote_head_sha,
+                pull_request=pull_request,
+                pull_request_head_matches=pull_request_head_matches,
+                pull_request_merge_in_main=pull_request_merge_in_main,
+                lifecycle_state=lifecycle_state,
+                next_action=next_action,
+            )
+        )
+
+    remote_only_branches = tuple(
+        sorted(
+            branch
+            for branch in remote_heads
+            if branch not in local_branch_names
+            and (branch.startswith("work/") or branch.startswith("release/") or branch.startswith("work-") or branch.startswith("release-"))
+        )
+    )
+    open_prs_without_local = tuple(
+        sorted(
+            (
+                pull_request
+                for pull_request in pull_requests
+                if pull_request.state.upper() == "OPEN"
+                and pull_request.head_branch not in local_branch_names
+            ),
+            key=lambda item: item.number,
+        )
+    )
+
+    if local_errors:
+        global_blockers.append("local Git observations are incomplete")
+    if remote_errors:
+        global_blockers.append("remote Git observations are incomplete")
+    if github_errors:
+        global_blockers.append("GitHub pull-request observations are incomplete")
+    if stashes:
+        global_warnings.append(f"repository contains {len(stashes)} stash entries")
+    if remote_only_branches:
+        global_warnings.append(f"repository contains {len(remote_only_branches)} remote-only work/release branches")
+    if open_prs_without_local:
+        global_warnings.append(f"repository contains {len(open_prs_without_local)} open pull requests without local branches")
+
+    blocker_count = len(global_blockers) + sum(len(item.blockers) for item in worktrees)
+    warning_count = (
+        len(global_warnings)
+        + sum(len(item.warnings) for item in worktrees)
+        + len(local_warnings)
+    )
+    observers_complete = not local_errors and not local_only and not remote_errors and not github_errors
+    safe_to_mutate = observers_complete and blocker_count == 0
+
+    local_status = ObserverStatus(
+        "PASS" if not local_errors else "INCOMPLETE",
+        tuple(local_errors),
+        tuple(local_warnings),
+    )
+
+    sorted_worktrees = tuple(sorted(worktrees, key=lambda item: item.path))
+    sorted_branches = tuple(sorted(branches, key=lambda item: item.branch))
+    fingerprint_payload = {
+        "schema_version": SCHEMA_VERSION,
+        "repository_root": str(root),
+        "repository_slug": repository_slug,
+        "origin_url": origin_url,
+        "local_main_sha": local_main_sha,
+        "origin_main_tracking_sha": origin_main_tracking_sha,
+        "remote_main_sha": remote_main_sha,
+        "origin_main_tracking_current": origin_main_tracking_current,
+        "worktrees": [asdict(item) for item in sorted_worktrees],
+        "branches": [asdict(item) for item in sorted_branches],
+        "stashes": [asdict(item) for item in stashes],
+        "remote_only_branches": list(remote_only_branches),
+        "open_pull_requests_without_local_branch": [asdict(item) for item in open_prs_without_local],
+        "local_observer": asdict(local_status),
+        "remote_git_observer": asdict(remote_status),
+        "github_observer": asdict(github_status),
+        "global_blockers": global_blockers,
+        "global_warnings": global_warnings,
+    }
+    report_fingerprint = _canonical_fingerprint(fingerprint_payload)
+
+    return AuditReport(
+        schema_version=SCHEMA_VERSION,
+        generated_at=datetime.now(timezone.utc).isoformat(),
+        repository_root=str(root),
+        repository_slug=repository_slug,
+        origin_url=origin_url,
+        local_main_sha=local_main_sha,
+        origin_main_tracking_sha=origin_main_tracking_sha,
+        remote_main_sha=remote_main_sha,
+        origin_main_tracking_current=origin_main_tracking_current,
+        worktrees=sorted_worktrees,
+        branches=sorted_branches,
+        stashes=stashes,
+        remote_only_branches=remote_only_branches,
+        open_pull_requests_without_local_branch=open_prs_without_local,
+        local_observer=local_status,
+        remote_git_observer=remote_status,
+        github_observer=github_status,
+        global_blockers=tuple(global_blockers),
+        global_warnings=tuple(global_warnings),
+        blocker_count=blocker_count,
+        warning_count=warning_count,
+        safe_to_mutate=safe_to_mutate,
+        report_fingerprint=report_fingerprint,
+    )
+
+
+def _short_sha(value: str | None) -> str:
+    return value[:12] if value else "-"
+
+
+def _tri_state(value: bool | None) -> str:
+    return "UNKNOWN" if value is None else str(value).upper()
+
+
+def _print_human(report: AuditReport, *, issue: int | None = None) -> None:
+    print("===== MORPHE FLOW AUDIT =====")
+    print(f"SCHEMA_VERSION={report.schema_version}")
+    print(f"REPOSITORY_ROOT={report.repository_root}")
+    print(f"REPOSITORY_SLUG={report.repository_slug or '-'}")
+    print(f"LOCAL_MAIN={_short_sha(report.local_main_sha)}")
+    print(f"ORIGIN_MAIN_TRACKING={_short_sha(report.origin_main_tracking_sha)}")
+    print(f"REMOTE_MAIN={_short_sha(report.remote_main_sha)}")
+    tracking = report.origin_main_tracking_current
+    print(f"ORIGIN_MAIN_TRACKING_CURRENT={'UNKNOWN' if tracking is None else str(tracking).upper()}")
+    print(f"LOCAL_OBSERVER={report.local_observer.status}")
+    print(f"REMOTE_GIT_OBSERVER={report.remote_git_observer.status}")
+    print(f"GITHUB_OBSERVER={report.github_observer.status}")
+    print(f"REPORT_FINGERPRINT={report.report_fingerprint}")
+    print(f"MUTATIONS={report.mutations}")
+    for blocker in report.global_blockers:
+        print(f"GLOBAL_BLOCKER={blocker}")
+    for warning in report.global_warnings:
+        print(f"GLOBAL_WARNING={warning}")
+
+    worktrees = [item for item in report.worktrees if issue is None or item.issue_number == issue]
+    branches = [item for item in report.branches if issue is None or item.issue_number == issue]
+
+    print()
+    print(f"===== WORKTREES ({len(worktrees)}) =====")
+    for item in worktrees:
+        print(
+            " ".join(
+                (
+                    f"STATE={item.lifecycle_state}",
+                    f"SAFE={'YES' if item.safe_to_mutate else 'NO'}",
+                    f"BRANCH={item.branch or 'DETACHED'}",
+                    f"HEAD={_short_sha(item.head_sha)}",
+                    f"DIRTY={'UNKNOWN' if item.dirty is None else str(item.dirty).upper()}",
+                    f"MAIN_AHEAD={item.main_ahead if item.main_ahead is not None else '-'}",
+                    f"MAIN_BEHIND={item.main_behind if item.main_behind is not None else '-'}",
+                    f"REMOTE={item.remote_relation}",
+                    f"PR={item.pull_request.number if item.pull_request else '-'}",
+                    f"PR_HEAD_MATCH={_tri_state(item.pull_request_head_matches)}",
+                    f"PR_MERGE_MAIN={_tri_state(item.pull_request_merge_in_main)}",
+                    f"NEXT={item.next_action}",
+                    f"PATH={item.path}",
+                )
+            )
+        )
+        for blocker in item.blockers:
+            print(f"  BLOCKER={blocker}")
+        for warning in item.warnings:
+            print(f"  WARNING={warning}")
+        for dirty_entry in item.dirty_entries[:20]:
+            print(f"  DIRTY_ENTRY={dirty_entry}")
+        if len(item.dirty_entries) > 20:
+            print(f"  DIRTY_ENTRY_TRUNCATED={len(item.dirty_entries) - 20}")
+
+    print()
+    print(f"===== LOCAL BRANCHES ({len(branches)}) =====")
+    for item in branches:
+        print(
+            " ".join(
+                (
+                    f"STATE={item.lifecycle_state}",
+                    f"BRANCH={item.branch}",
+                    f"HEAD={_short_sha(item.head_sha)}",
+                    f"MAIN_AHEAD={item.main_ahead if item.main_ahead is not None else '-'}",
+                    f"MAIN_BEHIND={item.main_behind if item.main_behind is not None else '-'}",
+                    f"REMOTE={'YES' if item.remote_head_sha else 'NO'}",
+                    f"PR={item.pull_request.number if item.pull_request else '-'}",
+                    f"PR_HEAD_MATCH={_tri_state(item.pull_request_head_matches)}",
+                    f"PR_MERGE_MAIN={_tri_state(item.pull_request_merge_in_main)}",
+                    f"WORKTREE={item.worktree_path or '-'}",
+                    f"NEXT={item.next_action}",
+                )
+            )
+        )
+
+    print()
+    print(f"STASH_COUNT={len(report.stashes)}")
+    print(f"REMOTE_ONLY_BRANCH_COUNT={len(report.remote_only_branches)}")
+    print(f"OPEN_PR_WITHOUT_LOCAL_BRANCH_COUNT={len(report.open_pull_requests_without_local_branch)}")
+    print(f"BLOCKER_COUNT={report.blocker_count}")
+    print(f"WARNING_COUNT={report.warning_count}")
+    print(f"SAFE_TO_MUTATE={'YES' if report.safe_to_mutate else 'NO'}")
+    print("RESULT=MORPHE_FLOW_AUDIT_COMPLETE")
+
+
+def _write_json(report: AuditReport, path: Path) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(report.as_dict(), indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(prog="morphe-flow", description=__doc__)
+    parser.add_argument("--repo", type=Path, default=Path.cwd(), help="path inside the target Git repository")
+    parser.add_argument("--local-only", action="store_true", help="skip git ls-remote and GitHub pull-request observation")
+    parser.add_argument("--json-output", type=Path, help="write the complete report as JSON")
+    parser.add_argument("--format", choices=("human", "json"), default="human")
+    parser.add_argument("--strict", action="store_true", help="return non-zero when observations are incomplete or blockers exist")
+
+    subparsers = parser.add_subparsers(dest="command", required=True)
+    subparsers.add_parser("audit", help="audit every local worktree and branch")
+    issue_parser = subparsers.add_parser("issue", help="issue-scoped lifecycle commands")
+    issue_subparsers = issue_parser.add_subparsers(dest="issue_command", required=True)
+    issue_status = issue_subparsers.add_parser("status", help="show worktrees and branches associated with one issue")
+    issue_status.add_argument("issue_number", type=int)
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+    try:
+        report = collect_audit(args.repo, local_only=args.local_only)
+    except (ObservationError, OSError, subprocess.SubprocessError, ValueError) as exc:
+        print("===== MORPHE FLOW AUDIT =====")
+        print(f"ERROR={exc}")
+        print("MUTATIONS=NONE")
+        print("RESULT=MORPHE_FLOW_AUDIT_FAILED")
+        return 1
+
+    issue = args.issue_number if args.command == "issue" else None
+    if args.json_output:
+        _write_json(report, args.json_output)
+        print(f"JSON_OUTPUT={args.json_output}", file=sys.stderr if args.format == "json" else sys.stdout)
+
+    if args.format == "json":
+        if issue is None:
+            payload = report.as_dict()
+        else:
+            payload = {
+                "schema_version": report.schema_version,
+                "generated_at": report.generated_at,
+                "issue_number": issue,
+                "worktrees": [asdict(item) for item in report.worktrees if item.issue_number == issue],
+                "branches": [asdict(item) for item in report.branches if item.issue_number == issue],
+                "mutations": "NONE",
+            }
+        print(json.dumps(payload, indent=2, sort_keys=True))
+    else:
+        _print_human(report, issue=issue)
+
+    if args.strict and (not report.safe_to_mutate):
+        return 2
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/morphe-flow.py
+++ b/tools/morphe-flow.py
@@ -1,9 +1,10 @@
 #!/usr/bin/env python3
-"""Read-only lifecycle audit for Morphe repository worktrees and branches.
+"""Read-only lifecycle audit and operation-specific readiness for Morphe.
 
-Hardening v22.1 deliberately performs no Git or GitHub mutation. It observes
-local worktrees, branches, stashes, remote heads, and pull requests, then emits
-one normalized lifecycle report that later mutation commands can consume.
+Hardening v22.1 deliberately performs no Git or GitHub mutation. Hardening
+v22.2 adds an exact push dry-run and a fingerprinted push plan, but still
+performs no local-ref mutation, remote write, pull-request mutation, workflow
+dispatch, tag, release, or asset upload.
 """
 
 from __future__ import annotations
@@ -80,6 +81,7 @@ class GitReader:
         "merge-base",
         "rev-list",
         "rev-parse",
+        "show-ref",
         "status",
     }
 
@@ -128,6 +130,55 @@ class GitReader:
             detail = result.stderr.strip() or result.stdout.strip() or "unknown Git error"
             raise ObservationError(f"git {' '.join(args)} failed in {cwd}: {detail}")
         return result
+
+
+class PushDryRunner:
+    """Run one exact hook-disabled Git push dry-run without updating refs."""
+
+    _WORK_BRANCH = re.compile(r"^work/[A-Za-z0-9][A-Za-z0-9._/-]*$")
+    _FULL_SHA = re.compile(r"^[0-9a-f]{40}$")
+
+    def __init__(self, runner: CommandRunner) -> None:
+        self._runner = runner
+
+    @classmethod
+    def validate_branch(cls, branch: str) -> None:
+        if not cls._WORK_BRANCH.fullmatch(branch):
+            raise ValueError(f"refusing push readiness for non-work branch: {branch}")
+        if ".." in branch or "//" in branch or branch.endswith(("/", ".")):
+            raise ValueError(f"refusing malformed work branch: {branch}")
+
+    @classmethod
+    def _validate(cls, branch: str, local_sha: str) -> None:
+        cls.validate_branch(branch)
+        if not cls._FULL_SHA.fullmatch(local_sha):
+            raise ValueError("push readiness requires an exact lowercase 40-character commit SHA")
+
+    @classmethod
+    def command(cls, branch: str, local_sha: str) -> tuple[str, ...]:
+        cls._validate(branch, local_sha)
+        return (
+            "git",
+            "-c",
+            "core.hooksPath=/dev/null",
+            "push",
+            "--dry-run",
+            "--porcelain",
+            "origin",
+            f"{local_sha}:refs/heads/{branch}",
+        )
+
+    def run(self, cwd: Path, *, branch: str, local_sha: str) -> CommandResult:
+        return self._runner.run(
+            self.command(branch, local_sha),
+            cwd=cwd,
+            timeout=60,
+            env_overrides={
+                "GIT_OPTIONAL_LOCKS": "0",
+                "GIT_TERMINAL_PROMPT": "0",
+                "LC_ALL": "C",
+            },
+        )
 
 
 @dataclass(frozen=True, slots=True)
@@ -234,6 +285,59 @@ class AuditReport:
     safe_to_mutate: bool
     report_fingerprint: str
     mutations: str = "NONE"
+
+    def as_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(frozen=True, slots=True)
+class RepositoryIntegritySnapshot:
+    refs_sha256: str
+    worktree_registry_sha256: str
+    target_status_sha256: str
+    target_index_sha256: str
+    target_index_size: int
+    target_index_mtime_ns: int
+
+
+@dataclass(frozen=True, slots=True)
+class PushReadinessReport:
+    schema_version: int
+    generated_at: str
+    repository_root: str
+    repository_slug: str | None
+    operation: str
+    branch: str
+    worktree_path: str | None
+    local_head_sha: str | None
+    local_main_sha: str | None
+    origin_main_tracking_sha: str | None
+    remote_main_before_sha: str | None
+    remote_main_after_sha: str | None
+    remote_branch_before_sha: str | None
+    remote_branch_after_sha: str | None
+    target_lifecycle_state: str | None
+    target_main_ahead: int | None
+    target_main_behind: int | None
+    target_dirty: bool | None
+    audit_fingerprint: str
+    operation_fingerprint: str
+    dry_run_command: tuple[str, ...]
+    dry_run_status: str
+    dry_run_exit_code: int | None
+    dry_run_stdout: str
+    dry_run_stderr: str
+    local_repository_unchanged: bool | None
+    remote_branch_unchanged: bool | None
+    remote_main_unchanged: bool | None
+    unrelated_blocker_count: int
+    unrelated_warning_count: int
+    blockers: tuple[str, ...]
+    warnings: tuple[str, ...]
+    ready: bool
+    next_action: str
+    mutations: str = "NONE"
+    remote_writes: str = "NONE"
 
     def as_dict(self) -> dict[str, Any]:
         return asdict(self)
@@ -1043,6 +1147,239 @@ def collect_audit(
     )
 
 
+def _sha256_text(value: str) -> str:
+    return hashlib.sha256(value.encode("utf-8")).hexdigest()
+
+
+def _repository_integrity_snapshot(
+    git: GitReader,
+    root: Path,
+    target: WorktreeObservation,
+) -> RepositoryIntegritySnapshot:
+    target_path = Path(target.path)
+    refs = git.run(root, "show-ref", allow_failure=True)
+    if refs.returncode not in (0, 1):
+        detail = refs.stderr.strip() or refs.stdout.strip() or "git show-ref failed"
+        raise ObservationError(detail)
+    worktrees = git.run(root, "worktree", "list", "--porcelain")
+    status = git.run(
+        target_path,
+        "status",
+        "--porcelain=v1",
+        "-z",
+        "--untracked-files=all",
+    )
+    index_result = git.run(target_path, "rev-parse", "--git-path", "index")
+    index_path = Path(_git_stdout(index_result))
+    if not index_path.is_absolute():
+        index_path = target_path / index_path
+    payload = index_path.read_bytes()
+    stat = index_path.stat()
+    return RepositoryIntegritySnapshot(
+        refs_sha256=_sha256_text(refs.stdout),
+        worktree_registry_sha256=_sha256_text(worktrees.stdout),
+        target_status_sha256=_sha256_text(status.stdout),
+        target_index_sha256=hashlib.sha256(payload).hexdigest(),
+        target_index_size=stat.st_size,
+        target_index_mtime_ns=stat.st_mtime_ns,
+    )
+
+
+
+def collect_push_readiness(
+    candidate: Path,
+    branch: str,
+    *,
+    runner: CommandRunner | None = None,
+) -> PushReadinessReport:
+    command_runner = runner or CommandRunner()
+    PushDryRunner.validate_branch(branch)
+    audit = collect_audit(candidate, local_only=False, runner=command_runner)
+    root = Path(audit.repository_root)
+    git = GitReader(command_runner)
+    blockers: list[str] = []
+    warnings: list[str] = []
+
+    targets = [item for item in audit.worktrees if item.branch == branch]
+    target = targets[0] if len(targets) == 1 else None
+    if not targets:
+        blockers.append("target branch is not attached to a registered worktree")
+    elif len(targets) > 1:
+        blockers.append("target branch is attached to multiple registered worktrees")
+
+    if audit.local_observer.status != "PASS":
+        blockers.append("local Git observer is incomplete")
+    if audit.remote_git_observer.status != "PASS":
+        blockers.append("remote Git observer is incomplete")
+    if audit.github_observer.status != "PASS":
+        blockers.append("GitHub observer is incomplete")
+    if audit.local_main_sha is None or audit.remote_main_sha is None:
+        blockers.append("canonical main identity is incomplete")
+    elif audit.local_main_sha != audit.remote_main_sha:
+        blockers.append("local main does not equal remote main")
+    if audit.origin_main_tracking_current is not True:
+        blockers.append("origin/main tracking ref is not current")
+
+    local_head = target.head_sha if target else None
+    remote_branch_before = target.remote_head_sha if target else None
+    target_state = target.lifecycle_state if target else None
+    target_next = target.next_action if target else "ATTACH_TARGET_WORKTREE"
+    if target:
+        if target.dirty is not False:
+            blockers.append("target worktree is not clean")
+        if target.main_behind != 0:
+            blockers.append("target branch is not based on current origin/main")
+        if target.main_ahead is None or target.main_ahead < 1:
+            blockers.append("target branch contains no commit ahead of origin/main")
+        if target.remote_relation not in {"ABSENT", "LOCAL_AHEAD"}:
+            blockers.append(
+                f"target remote relation {target.remote_relation} does not require a safe forward push"
+            )
+        if target.lifecycle_state not in {"LOCAL_ONLY_READY", "LOCAL_AHEAD_OF_REMOTE"}:
+            blockers.append(
+                f"target lifecycle state {target.lifecycle_state} is not push-ready"
+            )
+        if target.pull_request is not None:
+            blockers.append("target branch is already associated with a pull request")
+        blockers.extend(
+            blocker for blocker in target.blockers if blocker not in blockers
+        )
+        warnings.extend(target.warnings)
+
+    unrelated_blocker_count = sum(
+        len(item.blockers)
+        for item in audit.worktrees
+        if item.branch != branch
+    )
+    unrelated_warning_count = (
+        len(audit.global_warnings)
+        + sum(len(item.warnings) for item in audit.worktrees if item.branch != branch)
+    )
+    if unrelated_blocker_count:
+        warnings.append(
+            f"repository has {unrelated_blocker_count} blocker(s) outside target branch; "
+            "they do not affect this exact push plan"
+        )
+    warnings.extend(audit.global_warnings)
+
+    dry_run_status = "SKIPPED"
+    dry_run_exit_code: int | None = None
+    dry_run_stdout = ""
+    dry_run_stderr = ""
+    local_unchanged: bool | None = None
+    remote_branch_after = remote_branch_before
+    remote_main_after = audit.remote_main_sha
+    remote_branch_unchanged: bool | None = None
+    remote_main_unchanged: bool | None = None
+    dry_run_command: tuple[str, ...] = ()
+
+    if not blockers and target and local_head:
+        dry_run_command = PushDryRunner.command(branch, local_head)
+        before_integrity = _repository_integrity_snapshot(git, root, target)
+        dry_run = PushDryRunner(command_runner).run(
+            root,
+            branch=branch,
+            local_sha=local_head,
+        )
+        dry_run_exit_code = dry_run.returncode
+        dry_run_stdout = dry_run.stdout.strip()
+        dry_run_stderr = dry_run.stderr.strip()
+        dry_run_status = "PASS" if dry_run.returncode == 0 else "FAIL"
+        if dry_run.returncode != 0:
+            detail = dry_run_stderr or dry_run_stdout or "git push --dry-run failed"
+            blockers.append(f"push dry-run failed: {detail}")
+
+        after_integrity = _repository_integrity_snapshot(git, root, target)
+        local_unchanged = before_integrity == after_integrity
+        if not local_unchanged:
+            blockers.append("local repository state changed during push dry-run")
+
+        remote_heads_after, remote_errors = _read_remote_heads(git, root)
+        if remote_errors:
+            blockers.append(f"post-dry-run remote observation failed: {remote_errors[0]}")
+            remote_branch_unchanged = None
+            remote_main_unchanged = None
+        else:
+            remote_branch_after = remote_heads_after.get(branch)
+            remote_main_after = remote_heads_after.get("main")
+            remote_branch_unchanged = remote_branch_after == remote_branch_before
+            remote_main_unchanged = remote_main_after == audit.remote_main_sha
+            if not remote_branch_unchanged:
+                blockers.append("remote target branch changed during push dry-run")
+            if not remote_main_unchanged:
+                blockers.append("remote main changed during push dry-run")
+
+    operation_payload = {
+        "schema_version": SCHEMA_VERSION,
+        "operation": "PUSH_BRANCH",
+        "repository_root": str(root),
+        "repository_slug": audit.repository_slug,
+        "branch": branch,
+        "worktree_path": target.path if target else None,
+        "local_head_sha": local_head,
+        "local_main_sha": audit.local_main_sha,
+        "origin_main_tracking_sha": audit.origin_main_tracking_sha,
+        "remote_main_before_sha": audit.remote_main_sha,
+        "remote_main_after_sha": remote_main_after,
+        "remote_branch_before_sha": remote_branch_before,
+        "remote_branch_after_sha": remote_branch_after,
+        "target_lifecycle_state": target_state,
+        "target_main_ahead": target.main_ahead if target else None,
+        "target_main_behind": target.main_behind if target else None,
+        "audit_fingerprint": audit.report_fingerprint,
+        "dry_run_status": dry_run_status,
+        "dry_run_exit_code": dry_run_exit_code,
+        "local_repository_unchanged": local_unchanged,
+        "remote_branch_unchanged": remote_branch_unchanged,
+        "remote_main_unchanged": remote_main_unchanged,
+    }
+    operation_fingerprint = _canonical_fingerprint(operation_payload)
+    ready = not blockers and dry_run_status == "PASS"
+    next_action = (
+        "REQUEST_EXPLICIT_PUSH_AUTHORIZATION"
+        if ready
+        else target_next if target_next not in {"PREFLIGHT_PUSH", "NONE"}
+        else "RESOLVE_PUSH_READINESS_BLOCKERS"
+    )
+
+    return PushReadinessReport(
+        schema_version=SCHEMA_VERSION,
+        generated_at=datetime.now(timezone.utc).isoformat(),
+        repository_root=str(root),
+        repository_slug=audit.repository_slug,
+        operation="PUSH_BRANCH",
+        branch=branch,
+        worktree_path=target.path if target else None,
+        local_head_sha=local_head,
+        local_main_sha=audit.local_main_sha,
+        origin_main_tracking_sha=audit.origin_main_tracking_sha,
+        remote_main_before_sha=audit.remote_main_sha,
+        remote_main_after_sha=remote_main_after,
+        remote_branch_before_sha=remote_branch_before,
+        remote_branch_after_sha=remote_branch_after,
+        target_lifecycle_state=target_state,
+        target_main_ahead=target.main_ahead if target else None,
+        target_main_behind=target.main_behind if target else None,
+        target_dirty=target.dirty if target else None,
+        audit_fingerprint=audit.report_fingerprint,
+        operation_fingerprint=operation_fingerprint,
+        dry_run_command=dry_run_command,
+        dry_run_status=dry_run_status,
+        dry_run_exit_code=dry_run_exit_code,
+        dry_run_stdout=dry_run_stdout,
+        dry_run_stderr=dry_run_stderr,
+        local_repository_unchanged=local_unchanged,
+        remote_branch_unchanged=remote_branch_unchanged,
+        remote_main_unchanged=remote_main_unchanged,
+        unrelated_blocker_count=unrelated_blocker_count,
+        unrelated_warning_count=unrelated_warning_count,
+        blockers=tuple(blockers),
+        warnings=tuple(dict.fromkeys(warnings)),
+        ready=ready,
+        next_action=next_action,
+    )
+
+
 def _short_sha(value: str | None) -> str:
     return value[:12] if value else "-"
 
@@ -1136,9 +1473,58 @@ def _print_human(report: AuditReport, *, issue: int | None = None) -> None:
     print("RESULT=MORPHE_FLOW_AUDIT_COMPLETE")
 
 
-def _write_json(report: AuditReport, path: Path) -> None:
+def _print_push_readiness(report: PushReadinessReport) -> None:
+    print("===== MORPHE FLOW PUSH READINESS =====")
+    print(f"SCHEMA_VERSION={report.schema_version}")
+    print(f"OPERATION={report.operation}")
+    print(f"REPOSITORY_ROOT={report.repository_root}")
+    print(f"REPOSITORY_SLUG={report.repository_slug or '-'}")
+    print(f"BRANCH={report.branch}")
+    print(f"WORKTREE={report.worktree_path or '-'}")
+    print(f"LOCAL_HEAD={report.local_head_sha or '-'}")
+    print(f"LOCAL_MAIN={report.local_main_sha or '-'}")
+    print(f"ORIGIN_MAIN_TRACKING={report.origin_main_tracking_sha or '-'}")
+    print(f"REMOTE_MAIN_BEFORE={report.remote_main_before_sha or 'ABSENT'}")
+    print(f"REMOTE_MAIN_AFTER={report.remote_main_after_sha or 'ABSENT'}")
+    print(f"REMOTE_BRANCH_BEFORE={report.remote_branch_before_sha or 'ABSENT'}")
+    print(f"REMOTE_BRANCH_AFTER={report.remote_branch_after_sha or 'ABSENT'}")
+    print(f"TARGET_STATE={report.target_lifecycle_state or 'MISSING'}")
+    print(f"TARGET_DIRTY={_tri_state(report.target_dirty)}")
+    print(f"TARGET_MAIN_AHEAD={report.target_main_ahead if report.target_main_ahead is not None else '-'}")
+    print(f"TARGET_MAIN_BEHIND={report.target_main_behind if report.target_main_behind is not None else '-'}")
+    print(f"AUDIT_FINGERPRINT={report.audit_fingerprint}")
+    print(f"OPERATION_FINGERPRINT={report.operation_fingerprint}")
+    print(f"DRY_RUN_STATUS={report.dry_run_status}")
+    print(f"DRY_RUN_EXIT_CODE={report.dry_run_exit_code if report.dry_run_exit_code is not None else '-'}")
+    if report.dry_run_command:
+        print(f"DRY_RUN_COMMAND={' '.join(report.dry_run_command)}")
+    for line in report.dry_run_stdout.splitlines():
+        print(f"DRY_RUN_STDOUT={line}")
+    for line in report.dry_run_stderr.splitlines():
+        print(f"DRY_RUN_STDERR={line}")
+    print(f"LOCAL_REPOSITORY_UNCHANGED={_tri_state(report.local_repository_unchanged)}")
+    print(f"REMOTE_BRANCH_UNCHANGED={_tri_state(report.remote_branch_unchanged)}")
+    print(f"REMOTE_MAIN_UNCHANGED={_tri_state(report.remote_main_unchanged)}")
+    print(f"UNRELATED_BLOCKER_COUNT={report.unrelated_blocker_count}")
+    print(f"UNRELATED_WARNING_COUNT={report.unrelated_warning_count}")
+    for blocker in report.blockers:
+        print(f"BLOCKER={blocker}")
+    for warning in report.warnings:
+        print(f"WARNING={warning}")
+    print(f"OPERATION_READY={'YES' if report.ready else 'NO'}")
+    print(f"NEXT={report.next_action}")
+    print(f"MUTATIONS={report.mutations}")
+    print(f"REMOTE_WRITES={report.remote_writes}")
+    print("RESULT=MORPHE_FLOW_PUSH_READINESS_COMPLETE")
+
+
+def _write_payload(payload: dict[str, Any], path: Path) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text(json.dumps(report.as_dict(), indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def _write_json(report: AuditReport, path: Path) -> None:
+    _write_payload(report.as_dict(), path)
 
 
 def _build_parser() -> argparse.ArgumentParser:
@@ -1155,12 +1541,45 @@ def _build_parser() -> argparse.ArgumentParser:
     issue_subparsers = issue_parser.add_subparsers(dest="issue_command", required=True)
     issue_status = issue_subparsers.add_parser("status", help="show worktrees and branches associated with one issue")
     issue_status.add_argument("issue_number", type=int)
+
+    branch_parser = subparsers.add_parser("branch", help="branch-scoped lifecycle commands")
+    branch_subparsers = branch_parser.add_subparsers(dest="branch_command", required=True)
+    ready_push = branch_subparsers.add_parser(
+        "ready-push",
+        help="prove one exact work branch is ready for explicit push authorization",
+    )
+    ready_push.add_argument("branch")
     return parser
 
 
 def main(argv: Sequence[str] | None = None) -> int:
     parser = _build_parser()
     args = parser.parse_args(argv)
+
+    if args.command == "branch" and args.branch_command == "ready-push":
+        if args.local_only:
+            parser.error("branch ready-push requires complete remote and GitHub observations")
+        try:
+            readiness = collect_push_readiness(args.repo, args.branch)
+        except (ObservationError, OSError, subprocess.SubprocessError, ValueError) as exc:
+            print("===== MORPHE FLOW PUSH READINESS =====")
+            print(f"ERROR={exc}")
+            print("MUTATIONS=NONE")
+            print("REMOTE_WRITES=NONE")
+            print("RESULT=MORPHE_FLOW_PUSH_READINESS_FAILED")
+            return 1
+        if args.json_output:
+            _write_payload(readiness.as_dict(), args.json_output)
+            print(
+                f"JSON_OUTPUT={args.json_output}",
+                file=sys.stderr if args.format == "json" else sys.stdout,
+            )
+        if args.format == "json":
+            print(json.dumps(readiness.as_dict(), indent=2, sort_keys=True))
+        else:
+            _print_push_readiness(readiness)
+        return 0 if readiness.ready else 2
+
     try:
         report = collect_audit(args.repo, local_only=args.local_only)
     except (ObservationError, OSError, subprocess.SubprocessError, ValueError) as exc:


### PR DESCRIPTION
## Summary

- Add `tools/morphe-flow.py` as the canonical repository lifecycle observer for worktrees, branches, remotes, pull requests, stashes, and cleanup state.
- Emit normalized human-readable and JSON reports with stable audit fingerprints and explicit next actions.
- Correctly recognize squash-merged PR branches as cleanup-ready by proving both PR-head identity and merge-commit ancestry on `main`.
- Add operation-specific branch push readiness bound to exact branch, worktree, HEAD, `main`, remote state, and operation fingerprint.
- Run an exact hook-disabled `git push --dry-run --porcelain` and prove local and remote state remain unchanged.
- Report unrelated dirty worktrees without blocking an otherwise isolated target operation.

## Validation

- `20` Morphe flow unit and integration tests passed.
- Full `tools/check-project-contracts.sh` passed: `15` shell contracts and `7` Python source contracts.
- Live repository audit completed with complete local, remote Git, and GitHub observation.
- Exact push readiness passed for commit `8258d8eefa1f306afd3e5aa165e6b3ce2907c219`.
- Authorized branch push created only `work/hardening-v22-lifecycle-audit-v1-20260725` at that exact commit.
- Remote `main` remained unchanged at `d1af237bf40ee7442f5eea410b72c7c13c076f8a`.

## Scope

This PR adds tooling and documentation only. It does not publish a patch bundle, alter app runtime behavior, close a user-visible issue, merge itself, dispatch a workflow, create a tag, or publish a release.
