### PR TITLE
feat(tools): add operation-scoped main sync receipts

### DIFF
--- a/docs/morphe-flow.md
+++ b/docs/morphe-flow.md
@@ -88,6 +88,37 @@ contains `OPERATION_READY=YES`, `MUTATIONS=NONE`, `REMOTE_WRITES=NONE`, an
 never performs the actual push. Dirty unrelated worktrees are counted and
 reported, but do not invalidate a correctly isolated target operation.
 
+## v22.3 operation-scoped receipts
+
+Repository-wide snapshots remain useful diagnostics, but they are not universal
+postconditions. A transaction verifier now checks only the fields that the
+specific operation is authorized to change or must preserve by contract.
+
+The first v22.3 verifier covers a completed local `main` synchronization:
+
+```bash
+python3 tools/morphe-flow.py \
+  --repo ~/dev/breal-morphe-patches \
+  main verify-sync \
+  --old-main <previous-main-sha> \
+  --new-main <merged-main-sha> \
+  --pr-head <authorized-pr-head-sha> \
+  --work-branch work/example
+```
+
+`SYNC_LOCAL_MAIN` verifies local `main`, `origin/main`, remote `main`, the
+preserved work branch, the clean main worktree, the squash parent, the squash
+tree, and the optional symbolic `origin/HEAD` alias. Other worktrees are observed
+only for diagnostic context. Dirty state, index metadata, or concurrent work in
+an unrelated issue worktree is reported under
+`UNRELATED_ACTIVITY_POLICY=REPORT_ONLY_NEVER_GATE_SYNC_LOCAL_MAIN` and cannot
+make the main-sync receipt fail.
+
+Every required mismatch is emitted as a field-level `CHECK=... STATUS=FAIL`
+entry with expected and actual values. The verifier is read-only, requires no
+historic whole-repository snapshot, and emits an operation fingerprint derived
+only from the authorized operation and its relevant observations.
+
 ## Mutation boundary
 
 Later v22 phases may consume the audit and readiness reports, but they must

--- a/tests/tools/test_morphe_flow_main_sync.py
+++ b/tests/tools/test_morphe_flow_main_sync.py
@@ -1,0 +1,161 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import importlib.util
+import os
+from pathlib import Path
+import subprocess
+import sys
+import tempfile
+import unittest
+
+
+ROOT = Path(__file__).resolve().parents[2]
+SOURCE = ROOT / "tools" / "morphe_flow_operations.py"
+SPEC = importlib.util.spec_from_file_location("morphe_flow_operations", SOURCE)
+assert SPEC is not None
+assert SPEC.loader is not None
+MODULE = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = MODULE
+SPEC.loader.exec_module(MODULE)
+
+
+def run(*argv: str, cwd: Path, allow: tuple[int, ...] = (0,)) -> str:
+    result = subprocess.run(
+        list(argv),
+        cwd=str(cwd),
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    if result.returncode not in allow:
+        raise AssertionError(result.stderr or result.stdout)
+    return result.stdout.strip()
+
+
+def git(cwd: Path, *args: str) -> str:
+    return run("git", *args, cwd=cwd)
+
+
+class MainSyncVerificationTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temp = tempfile.TemporaryDirectory()
+        self.base = Path(self.temp.name)
+        self.remote = self.base / "remote.git"
+        self.repo = self.base / "repo"
+        self.feature = self.base / "repo-feature"
+        self.unrelated = self.base / "repo-issue121"
+
+        git(self.base, "init", "--bare", str(self.remote))
+        git(self.base, "clone", str(self.remote), str(self.repo))
+        git(self.repo, "config", "user.name", "Test")
+        git(self.repo, "config", "user.email", "test@example.invalid")
+        git(self.repo, "checkout", "-b", "main")
+        (self.repo / "base.txt").write_text("base\n", encoding="utf-8")
+        git(self.repo, "add", "base.txt")
+        git(self.repo, "commit", "-m", "base")
+        self.old_main = git(self.repo, "rev-parse", "HEAD")
+        git(self.repo, "push", "-u", "origin", "main")
+        git(self.remote, "symbolic-ref", "HEAD", "refs/heads/main")
+        git(self.repo, "remote", "set-head", "origin", "main")
+
+        self.work_branch = "work/hardening-v22-test"
+        git(self.repo, "branch", self.work_branch)
+        git(self.repo, "worktree", "add", str(self.feature), self.work_branch)
+        git(self.feature, "config", "user.name", "Test")
+        git(self.feature, "config", "user.email", "test@example.invalid")
+        (self.feature / "feature.txt").write_text("feature\n", encoding="utf-8")
+        git(self.feature, "add", "feature.txt")
+        git(self.feature, "commit", "-m", "feature")
+        self.pr_head = git(self.feature, "rev-parse", "HEAD")
+        git(self.feature, "push", "-u", "origin", self.work_branch)
+
+        git(self.repo, "merge", "--squash", self.work_branch)
+        git(self.repo, "commit", "-m", "squash feature")
+        self.new_main = git(self.repo, "rev-parse", "HEAD")
+        git(self.repo, "push", "origin", "main")
+
+        git(self.repo, "branch", "work/issue121-dirty")
+        git(self.repo, "worktree", "add", str(self.unrelated), "work/issue121-dirty")
+        (self.unrelated / "dirty.txt").write_text("dirty\n", encoding="utf-8")
+
+    def tearDown(self) -> None:
+        self.temp.cleanup()
+
+    def _collect(self):
+        return MODULE.collect_main_sync_verification(
+            self.repo,
+            old_main_sha=self.old_main,
+            new_main_sha=self.new_main,
+            pr_head_sha=self.pr_head,
+            work_branch=self.work_branch,
+        )
+
+    def test_verification_ignores_dirty_unrelated_worktree(self) -> None:
+        report = self._collect()
+        self.assertTrue(report.verified, report.blockers)
+        self.assertEqual(1, report.unrelated_dirty_worktree_count)
+        self.assertEqual("REPORT_ONLY_NEVER_GATE_SYNC_LOCAL_MAIN", report.unrelated_activity_policy)
+        self.assertEqual((), report.blockers)
+        self.assertEqual("NONE", report.mutations)
+        checks = {item.field: item for item in report.checks}
+        self.assertEqual("PASS", checks["local_main"].status)
+        self.assertEqual("PASS", checks["origin_main"].status)
+        self.assertEqual("PASS", checks["remote_main"].status)
+        self.assertEqual("PASS", checks["squash_parent_line"].status)
+        self.assertEqual("PASS", checks["squash_tree"].status)
+
+    def test_verifier_is_read_only(self) -> None:
+        refs_before = git(self.repo, "show-ref")
+        worktrees_before = git(self.repo, "worktree", "list", "--porcelain")
+        main_status_before = git(self.repo, "status", "--porcelain=v1")
+        unrelated_status_before = git(self.unrelated, "status", "--porcelain=v1")
+
+        report = self._collect()
+
+        self.assertTrue(report.verified)
+        self.assertEqual(refs_before, git(self.repo, "show-ref"))
+        self.assertEqual(worktrees_before, git(self.repo, "worktree", "list", "--porcelain"))
+        self.assertEqual(main_status_before, git(self.repo, "status", "--porcelain=v1"))
+        self.assertEqual(unrelated_status_before, git(self.unrelated, "status", "--porcelain=v1"))
+
+    def test_remote_main_mismatch_reports_exact_field(self) -> None:
+        other = self.base / "other"
+        git(self.base, "clone", str(self.remote), str(other))
+        git(other, "config", "user.name", "Other")
+        git(other, "config", "user.email", "other@example.invalid")
+        (other / "remote-only.txt").write_text("remote\n", encoding="utf-8")
+        git(other, "add", "remote-only.txt")
+        git(other, "commit", "-m", "advance remote")
+        git(other, "push", "origin", "main")
+
+        report = self._collect()
+
+        self.assertFalse(report.verified)
+        self.assertTrue(any(item.startswith("remote_main:") for item in report.blockers))
+        checks = {item.field: item for item in report.checks}
+        self.assertEqual("FAIL", checks["remote_main"].status)
+        self.assertEqual(self.new_main, checks["remote_main"].expected)
+        self.assertNotEqual(self.new_main, checks["remote_main"].actual)
+
+    def test_validation_rejects_non_exact_identifiers(self) -> None:
+        with self.assertRaises(ValueError):
+            MODULE.collect_main_sync_verification(
+                self.repo,
+                old_main_sha="abc",
+                new_main_sha=self.new_main,
+                pr_head_sha=self.pr_head,
+                work_branch=self.work_branch,
+            )
+        with self.assertRaises(ValueError):
+            MODULE.collect_main_sync_verification(
+                self.repo,
+                old_main_sha=self.old_main,
+                new_main_sha=self.new_main,
+                pr_head_sha=self.pr_head,
+                work_branch="main",
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/tools/test_morphe_flow_operations_source_contract.py
+++ b/tests/tools/test_morphe_flow_operations_source_contract.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+import unittest
+
+
+ROOT = Path(__file__).resolve().parents[2]
+SOURCE = ROOT / "tools" / "morphe_flow_operations.py"
+LAUNCHER = ROOT / "tools" / "morphe-flow.py"
+
+
+class OperationSourceContractTest(unittest.TestCase):
+    def test_operation_scoped_markers_exist(self) -> None:
+        text = SOURCE.read_text(encoding="utf-8")
+        self.assertIn("REPORT_ONLY_NEVER_GATE_SYNC_LOCAL_MAIN", text)
+        self.assertIn("Verify only the postconditions causally relevant", text)
+        self.assertIn('mutations: str = "NONE"', text)
+        self.assertIn("CHECK={check.field}", text)
+        self.assertNotIn("worktree_registry_sha256", text)
+        self.assertNotIn("target_index_mtime_ns", text)
+
+    def test_launcher_bootstraps_sibling_module_before_import(self) -> None:
+        text = LAUNCHER.read_text(encoding="utf-8")
+        tools_dir = '_TOOLS_DIR = str(Path(__file__).resolve().parent)'
+        path_insert = 'sys.path.insert(0, _TOOLS_DIR)'
+        sibling_import = 'from morphe_flow_operations import ('
+        self.assertIn(tools_dir, text)
+        self.assertIn(path_insert, text)
+        self.assertIn(sibling_import, text)
+        self.assertLess(text.index(path_insert), text.index(sibling_import))
+
+    def test_subprocess_execution_is_centralized(self) -> None:
+        tree = ast.parse(SOURCE.read_text(encoding="utf-8"))
+        calls = []
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Call):
+                continue
+            func = node.func
+            if isinstance(func, ast.Attribute) and func.attr == "run":
+                if isinstance(func.value, ast.Name) and func.value.id == "subprocess":
+                    calls.append(node.lineno)
+        self.assertEqual(1, len(calls), calls)
+
+    def test_mutating_git_commands_are_rejected(self) -> None:
+        text = SOURCE.read_text(encoding="utf-8")
+        tree = ast.parse(text)
+        functions = {
+            node.name: node
+            for node in ast.walk(tree)
+            if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+        }
+        self.assertIn("_validate", functions)
+        validator = ast.get_source_segment(text, functions["_validate"])
+        assert validator is not None
+        for command in ("fetch", "merge", "push", "checkout", "commit", "branch"):
+            self.assertNotIn(f'command == "{command}"', validator)
+        self.assertIn("refusing non-read-only operation Git command", validator)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/check-morphe-flow-contract.sh
+++ b/tools/check-morphe-flow-contract.sh
@@ -4,11 +4,16 @@ set -euo pipefail
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$ROOT"
 
-python3 -m py_compile tools/morphe-flow.py
+python3 -m py_compile \
+  tools/morphe-flow.py \
+  tools/morphe_flow_operations.py
 python3 -m unittest -q \
   tests/tools/test_morphe_flow.py \
+  tests/tools/test_morphe_flow_main_sync.py \
+  tests/tools/test_morphe_flow_operations_source_contract.py \
   tests/tools/test_morphe_flow_source_contract.py
 
 echo 'MORPHE_FLOW_READ_ONLY_CONTRACT=PASS'
 echo 'MORPHE_FLOW_INTEGRATION_TESTS=PASS'
+echo 'MORPHE_FLOW_OPERATION_RECEIPTS=PASS'
 echo 'RESULT=MORPHE_FLOW_CONTRACT_OK'

--- a/tools/morphe-flow.py
+++ b/tools/morphe-flow.py
@@ -5,6 +5,11 @@ Hardening v22.1 deliberately performs no Git or GitHub mutation. Hardening
 v22.2 adds an exact push dry-run and a fingerprinted push plan, but still
 performs no local-ref mutation, remote write, pull-request mutation, workflow
 dispatch, tag, release, or asset upload.
+
+Hardening v22.3 adds operation-scoped postcondition receipts. They verify only
+the fields causally relevant to an authorized operation and report unrelated
+activity without turning it into a transaction failure. These receipts remain
+read-only.
 """
 
 from __future__ import annotations
@@ -21,6 +26,16 @@ import shutil
 import subprocess
 import sys
 from typing import Any, Iterable, Sequence
+
+_TOOLS_DIR = str(Path(__file__).resolve().parent)
+if _TOOLS_DIR not in sys.path:
+    sys.path.insert(0, _TOOLS_DIR)
+
+from morphe_flow_operations import (
+    OperationObservationError,
+    collect_main_sync_verification,
+    print_main_sync_verification,
+)
 
 
 SCHEMA_VERSION = 1
@@ -1549,12 +1564,57 @@ def _build_parser() -> argparse.ArgumentParser:
         help="prove one exact work branch is ready for explicit push authorization",
     )
     ready_push.add_argument("branch")
+
+    main_parser = subparsers.add_parser("main", help="main-branch lifecycle commands")
+    main_subparsers = main_parser.add_subparsers(dest="main_command", required=True)
+    verify_sync = main_subparsers.add_parser(
+        "verify-sync",
+        help="verify operation-scoped postconditions for a completed local main sync",
+    )
+    verify_sync.add_argument("--old-main", required=True)
+    verify_sync.add_argument("--new-main", required=True)
+    verify_sync.add_argument("--pr-head", required=True)
+    verify_sync.add_argument("--work-branch", required=True)
     return parser
 
 
 def main(argv: Sequence[str] | None = None) -> int:
     parser = _build_parser()
     args = parser.parse_args(argv)
+
+    if args.command == "main" and args.main_command == "verify-sync":
+        if args.local_only:
+            parser.error("main verify-sync requires remote Git observation")
+        try:
+            verification = collect_main_sync_verification(
+                args.repo,
+                old_main_sha=args.old_main,
+                new_main_sha=args.new_main,
+                pr_head_sha=args.pr_head,
+                work_branch=args.work_branch,
+            )
+        except (
+            OperationObservationError,
+            OSError,
+            subprocess.SubprocessError,
+            ValueError,
+        ) as exc:
+            print("===== MORPHE FLOW MAIN SYNC VERIFICATION =====")
+            print(f"ERROR={exc}")
+            print("MUTATIONS=NONE")
+            print("RESULT=MORPHE_FLOW_MAIN_SYNC_VERIFICATION_FAILED")
+            return 1
+        if args.json_output:
+            _write_payload(verification.as_dict(), args.json_output)
+            print(
+                f"JSON_OUTPUT={args.json_output}",
+                file=sys.stderr if args.format == "json" else sys.stdout,
+            )
+        if args.format == "json":
+            print(json.dumps(verification.as_dict(), indent=2, sort_keys=True))
+        else:
+            print_main_sync_verification(verification)
+        return 0 if verification.verified else 2
 
     if args.command == "branch" and args.branch_command == "ready-push":
         if args.local_only:

--- a/tools/morphe_flow_operations.py
+++ b/tools/morphe_flow_operations.py
@@ -1,0 +1,565 @@
+#!/usr/bin/env python3
+"""Operation-scoped, read-only verification for Morphe lifecycle transactions."""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+from datetime import datetime, timezone
+import hashlib
+import json
+import os
+from pathlib import Path
+import re
+import subprocess
+from typing import Any, Sequence
+
+
+OPERATION_SCHEMA_VERSION = 1
+_FULL_SHA = re.compile(r"^[0-9a-f]{40}$")
+_WORK_BRANCH = re.compile(r"^work/[A-Za-z0-9][A-Za-z0-9._/-]*$")
+
+
+class OperationObservationError(RuntimeError):
+    """Raised when an operation-scoped observation cannot be completed."""
+
+
+@dataclass(frozen=True, slots=True)
+class CommandResult:
+    argv: tuple[str, ...]
+    returncode: int
+    stdout: str
+    stderr: str
+
+
+class CommandRunner:
+    """Execute one command without a shell."""
+
+    def run(
+        self,
+        argv: Sequence[str],
+        *,
+        cwd: Path,
+        timeout: int = 45,
+        allow_failure: bool = False,
+    ) -> CommandResult:
+        completed = subprocess.run(
+            list(argv),
+            cwd=str(cwd),
+            text=True,
+            capture_output=True,
+            timeout=timeout,
+            check=False,
+            env={
+                **os.environ,
+                "GIT_OPTIONAL_LOCKS": "0",
+                "GIT_TERMINAL_PROMPT": "0",
+                "LC_ALL": "C",
+            },
+        )
+        result = CommandResult(
+            argv=tuple(argv),
+            returncode=completed.returncode,
+            stdout=completed.stdout,
+            stderr=completed.stderr,
+        )
+        if result.returncode != 0 and not allow_failure:
+            detail = result.stderr.strip() or result.stdout.strip() or "unknown command error"
+            raise OperationObservationError(f"{' '.join(argv)} failed in {cwd}: {detail}")
+        return result
+
+
+class GitOperationReader:
+    """Fail-closed read-only Git observer for operation receipts."""
+
+    def __init__(self, runner: CommandRunner) -> None:
+        self._runner = runner
+
+    @staticmethod
+    def _validate(args: Sequence[str]) -> None:
+        if not args:
+            raise ValueError("missing Git subcommand")
+        command = args[0]
+        if command == "rev-parse":
+            return
+        if command == "rev-list" and tuple(args[1:4]) == ("--parents", "-n", "1"):
+            return
+        if command == "status" and tuple(args[1:]) == (
+            "--porcelain=v1",
+            "-z",
+            "--untracked-files=all",
+        ):
+            return
+        if command == "worktree" and tuple(args[1:]) == ("list", "--porcelain"):
+            return
+        if command == "ls-remote" and len(args) >= 4 and tuple(args[1:3]) == (
+            "--heads",
+            "origin",
+        ):
+            return
+        if command == "symbolic-ref" and tuple(args[1:]) == (
+            "-q",
+            "refs/remotes/origin/HEAD",
+        ):
+            return
+        raise ValueError(f"refusing non-read-only operation Git command: {' '.join(args)}")
+
+    def run(
+        self,
+        cwd: Path,
+        *args: str,
+        allow_failure: bool = False,
+    ) -> CommandResult:
+        self._validate(args)
+        return self._runner.run(
+            ("git", *args),
+            cwd=cwd,
+            allow_failure=allow_failure,
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class FieldCheck:
+    field: str
+    expected: str
+    actual: str
+    status: str
+    required: bool
+    detail: str
+
+
+@dataclass(frozen=True, slots=True)
+class UnrelatedWorktreeActivity:
+    path: str
+    branch: str
+    head_sha: str
+    dirty: bool | None
+    status: str
+
+
+@dataclass(frozen=True, slots=True)
+class MainSyncVerificationReport:
+    schema_version: int
+    generated_at: str
+    operation: str
+    phase: str
+    repository_root: str
+    expected_old_main_sha: str
+    expected_new_main_sha: str
+    expected_pr_head_sha: str
+    work_branch: str
+    main_worktree_path: str | None
+    local_main_sha: str | None
+    origin_main_sha: str | None
+    remote_main_sha: str | None
+    remote_work_branch_sha: str | None
+    main_worktree_head_sha: str | None
+    main_worktree_dirty: bool | None
+    origin_head_symbolic_target: str | None
+    origin_head_resolved_sha: str | None
+    merge_parent_line: str | None
+    merge_tree_sha: str | None
+    pr_head_tree_sha: str | None
+    checks: tuple[FieldCheck, ...]
+    unrelated_worktrees: tuple[UnrelatedWorktreeActivity, ...]
+    unrelated_dirty_worktree_count: int
+    unrelated_activity_policy: str
+    blockers: tuple[str, ...]
+    warnings: tuple[str, ...]
+    operation_fingerprint: str
+    verified: bool
+    next_action: str
+    mutations: str = "NONE"
+
+    def as_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+def _require_sha(name: str, value: str) -> None:
+    if not _FULL_SHA.fullmatch(value):
+        raise ValueError(f"{name} requires an exact lowercase 40-character commit SHA")
+
+
+def _require_work_branch(branch: str) -> None:
+    if not _WORK_BRANCH.fullmatch(branch):
+        raise ValueError("work branch must start with work/ and contain only safe ref characters")
+    if ".." in branch or "//" in branch or branch.endswith(("/", ".")):
+        raise ValueError(f"malformed work branch: {branch}")
+
+
+def _parse_worktrees(text: str) -> list[dict[str, str | bool]]:
+    records: list[dict[str, str | bool]] = []
+    current: dict[str, str | bool] = {}
+    for raw_line in text.splitlines() + [""]:
+        if not raw_line:
+            if current:
+                records.append(current)
+                current = {}
+            continue
+        key, separator, value = raw_line.partition(" ")
+        current[key] = value if separator else True
+    return records
+
+
+def _remote_heads(git: GitOperationReader, root: Path, work_branch: str) -> dict[str, str]:
+    result = git.run(
+        root,
+        "ls-remote",
+        "--heads",
+        "origin",
+        "refs/heads/main",
+        f"refs/heads/{work_branch}",
+    )
+    heads: dict[str, str] = {}
+    for line in result.stdout.splitlines():
+        sha, separator, ref = line.partition("\t")
+        if separator and ref.startswith("refs/heads/"):
+            heads[ref.removeprefix("refs/heads/")] = sha
+    return heads
+
+
+def _rev_parse(
+    git: GitOperationReader,
+    root: Path,
+    expression: str,
+    *,
+    allow_missing: bool = False,
+) -> str | None:
+    result = git.run(root, "rev-parse", expression, allow_failure=allow_missing)
+    if result.returncode != 0:
+        return None
+    return result.stdout.strip()
+
+
+def _status_dirty(git: GitOperationReader, path: Path) -> bool:
+    result = git.run(
+        path,
+        "status",
+        "--porcelain=v1",
+        "-z",
+        "--untracked-files=all",
+    )
+    return bool(result.stdout)
+
+
+def _check(
+    field: str,
+    expected: str | None,
+    actual: str | None,
+    *,
+    detail: str,
+    required: bool = True,
+) -> FieldCheck:
+    expected_text = expected if expected is not None else "ABSENT"
+    actual_text = actual if actual is not None else "ABSENT"
+    status = "PASS" if expected_text == actual_text else ("FAIL" if required else "WARN")
+    return FieldCheck(
+        field=field,
+        expected=expected_text,
+        actual=actual_text,
+        status=status,
+        required=required,
+        detail=detail,
+    )
+
+
+def _fingerprint(payload: dict[str, Any]) -> str:
+    canonical = json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=True)
+    return "sha256:" + hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+
+
+def collect_main_sync_verification(
+    candidate: Path,
+    *,
+    old_main_sha: str,
+    new_main_sha: str,
+    pr_head_sha: str,
+    work_branch: str,
+    runner: CommandRunner | None = None,
+) -> MainSyncVerificationReport:
+    """Verify only the postconditions causally relevant to SYNC_LOCAL_MAIN."""
+
+    _require_sha("old main", old_main_sha)
+    _require_sha("new main", new_main_sha)
+    _require_sha("PR head", pr_head_sha)
+    _require_work_branch(work_branch)
+    if old_main_sha == new_main_sha:
+        raise ValueError("old and new main SHAs must differ")
+
+    command_runner = runner or CommandRunner()
+    git = GitOperationReader(command_runner)
+    root_result = git.run(candidate.resolve(), "rev-parse", "--show-toplevel")
+    root = Path(root_result.stdout.strip()).resolve()
+
+    local_main = _rev_parse(git, root, "refs/heads/main", allow_missing=True)
+    origin_main = _rev_parse(git, root, "refs/remotes/origin/main", allow_missing=True)
+    heads = _remote_heads(git, root, work_branch)
+    remote_main = heads.get("main")
+    remote_work_branch = heads.get(work_branch)
+
+    worktree_result = git.run(root, "worktree", "list", "--porcelain")
+    worktree_records = _parse_worktrees(worktree_result.stdout)
+    main_records = [
+        item
+        for item in worktree_records
+        if item.get("branch") == "refs/heads/main"
+    ]
+    main_record = main_records[0] if len(main_records) == 1 else None
+    main_path = Path(str(main_record["worktree"])) if main_record else None
+    main_head = str(main_record.get("HEAD")) if main_record and main_record.get("HEAD") else None
+    main_dirty = _status_dirty(git, main_path) if main_path and main_path.exists() else None
+
+    origin_head_result = git.run(
+        root,
+        "symbolic-ref",
+        "-q",
+        "refs/remotes/origin/HEAD",
+        allow_failure=True,
+    )
+    origin_head_target = (
+        origin_head_result.stdout.strip()
+        if origin_head_result.returncode == 0
+        else None
+    )
+    origin_head_sha = (
+        _rev_parse(git, root, "refs/remotes/origin/HEAD", allow_missing=True)
+        if origin_head_target
+        else None
+    )
+
+    parent_result = git.run(root, "rev-list", "--parents", "-n", "1", new_main_sha)
+    parent_line = parent_result.stdout.strip()
+    merge_tree = _rev_parse(git, root, f"{new_main_sha}^{{tree}}", allow_missing=True)
+    pr_tree = _rev_parse(git, root, f"{pr_head_sha}^{{tree}}", allow_missing=True)
+
+    checks: list[FieldCheck] = [
+        _check(
+            "local_main",
+            new_main_sha,
+            local_main,
+            detail="local refs/heads/main must equal the authorized squash commit",
+        ),
+        _check(
+            "origin_main",
+            new_main_sha,
+            origin_main,
+            detail="local refs/remotes/origin/main must equal the authorized squash commit",
+        ),
+        _check(
+            "remote_main",
+            new_main_sha,
+            remote_main,
+            detail="remote refs/heads/main must equal the authorized squash commit",
+        ),
+        _check(
+            "remote_work_branch",
+            pr_head_sha,
+            remote_work_branch,
+            detail="the merged work branch must remain at the authorized PR head until cleanup",
+        ),
+        _check(
+            "main_worktree_count",
+            "1",
+            str(len(main_records)),
+            detail="exactly one registered worktree must own refs/heads/main",
+        ),
+        _check(
+            "main_worktree_head",
+            new_main_sha,
+            main_head,
+            detail="the main worktree HEAD must equal local main",
+        ),
+        _check(
+            "main_worktree_clean",
+            "FALSE",
+            None if main_dirty is None else str(main_dirty).upper(),
+            detail="the main worktree must be clean after fast-forward",
+        ),
+        _check(
+            "squash_parent_line",
+            f"{new_main_sha} {old_main_sha}",
+            parent_line,
+            detail="the squash commit must have exactly the authorized old main as parent",
+        ),
+        _check(
+            "squash_tree",
+            pr_tree,
+            merge_tree,
+            detail="the squash commit tree must equal the authorized PR-head tree",
+        ),
+    ]
+
+    warnings: list[str] = []
+    if origin_head_target is None:
+        warnings.append("refs/remotes/origin/HEAD is absent; this optional alias is not required")
+    else:
+        checks.extend(
+            (
+                _check(
+                    "origin_head_symbolic_target",
+                    "refs/remotes/origin/main",
+                    origin_head_target,
+                    detail="origin/HEAD must remain a symbolic alias of origin/main",
+                ),
+                _check(
+                    "origin_head_resolved_sha",
+                    new_main_sha,
+                    origin_head_sha,
+                    detail="origin/HEAD must resolve to the synchronized origin/main SHA",
+                ),
+            )
+        )
+
+    unrelated: list[UnrelatedWorktreeActivity] = []
+    for item in worktree_records:
+        path_text = str(item.get("worktree") or "")
+        if not path_text or (main_path and Path(path_text) == main_path):
+            continue
+        branch_ref = item.get("branch")
+        branch = (
+            str(branch_ref).removeprefix("refs/heads/")
+            if branch_ref
+            else "DETACHED"
+        )
+        head = str(item.get("HEAD") or "UNKNOWN")
+        path = Path(path_text)
+        dirty: bool | None
+        status: str
+        if not path.exists():
+            dirty = None
+            status = "MISSING_PATH_REPORTED_ONLY"
+        else:
+            try:
+                dirty = _status_dirty(git, path)
+                status = "DIRTY_REPORTED_ONLY" if dirty else "CLEAN_REPORTED_ONLY"
+            except (OSError, OperationObservationError):
+                dirty = None
+                status = "UNOBSERVED_REPORTED_ONLY"
+        unrelated.append(
+            UnrelatedWorktreeActivity(
+                path=path_text,
+                branch=branch,
+                head_sha=head,
+                dirty=dirty,
+                status=status,
+            )
+        )
+
+    blockers = tuple(
+        f"{item.field}: expected {item.expected}, observed {item.actual}"
+        for item in checks
+        if item.required and item.status == "FAIL"
+    )
+    unrelated_dirty_count = sum(item.dirty is True for item in unrelated)
+    if unrelated_dirty_count:
+        warnings.append(
+            f"observed {unrelated_dirty_count} dirty unrelated worktree(s); "
+            "operation-scoped policy reports but does not gate on them"
+        )
+
+    payload = {
+        "schema_version": OPERATION_SCHEMA_VERSION,
+        "operation": "SYNC_LOCAL_MAIN",
+        "phase": "POSTCONDITION",
+        "repository_root": str(root),
+        "expected_old_main_sha": old_main_sha,
+        "expected_new_main_sha": new_main_sha,
+        "expected_pr_head_sha": pr_head_sha,
+        "work_branch": work_branch,
+        "actual": {
+            "local_main_sha": local_main,
+            "origin_main_sha": origin_main,
+            "remote_main_sha": remote_main,
+            "remote_work_branch_sha": remote_work_branch,
+            "main_worktree_path": str(main_path) if main_path else None,
+            "main_worktree_head_sha": main_head,
+            "main_worktree_dirty": main_dirty,
+            "origin_head_symbolic_target": origin_head_target,
+            "origin_head_resolved_sha": origin_head_sha,
+            "merge_parent_line": parent_line,
+            "merge_tree_sha": merge_tree,
+            "pr_head_tree_sha": pr_tree,
+        },
+        "checks": [asdict(item) for item in checks],
+        "unrelated_activity_policy": "REPORT_ONLY_NEVER_GATE_SYNC_LOCAL_MAIN",
+    }
+    operation_fingerprint = _fingerprint(payload)
+    verified = not blockers
+
+    return MainSyncVerificationReport(
+        schema_version=OPERATION_SCHEMA_VERSION,
+        generated_at=datetime.now(timezone.utc).isoformat(),
+        operation="SYNC_LOCAL_MAIN",
+        phase="POSTCONDITION",
+        repository_root=str(root),
+        expected_old_main_sha=old_main_sha,
+        expected_new_main_sha=new_main_sha,
+        expected_pr_head_sha=pr_head_sha,
+        work_branch=work_branch,
+        main_worktree_path=str(main_path) if main_path else None,
+        local_main_sha=local_main,
+        origin_main_sha=origin_main,
+        remote_main_sha=remote_main,
+        remote_work_branch_sha=remote_work_branch,
+        main_worktree_head_sha=main_head,
+        main_worktree_dirty=main_dirty,
+        origin_head_symbolic_target=origin_head_target,
+        origin_head_resolved_sha=origin_head_sha,
+        merge_parent_line=parent_line,
+        merge_tree_sha=merge_tree,
+        pr_head_tree_sha=pr_tree,
+        checks=tuple(checks),
+        unrelated_worktrees=tuple(unrelated),
+        unrelated_dirty_worktree_count=unrelated_dirty_count,
+        unrelated_activity_policy="REPORT_ONLY_NEVER_GATE_SYNC_LOCAL_MAIN",
+        blockers=blockers,
+        warnings=tuple(warnings),
+        operation_fingerprint=operation_fingerprint,
+        verified=verified,
+        next_action="START_NEXT_OPERATION" if verified else "RESOLVE_MAIN_SYNC_POSTCONDITION_FAILURES",
+    )
+
+
+def print_main_sync_verification(report: MainSyncVerificationReport) -> None:
+    print("===== MORPHE FLOW MAIN SYNC VERIFICATION =====")
+    print(f"SCHEMA_VERSION={report.schema_version}")
+    print(f"OPERATION={report.operation}")
+    print(f"PHASE={report.phase}")
+    print(f"REPOSITORY_ROOT={report.repository_root}")
+    print(f"EXPECTED_OLD_MAIN={report.expected_old_main_sha}")
+    print(f"EXPECTED_NEW_MAIN={report.expected_new_main_sha}")
+    print(f"EXPECTED_PR_HEAD={report.expected_pr_head_sha}")
+    print(f"WORK_BRANCH={report.work_branch}")
+    print(f"MAIN_WORKTREE={report.main_worktree_path or 'ABSENT'}")
+    print(f"LOCAL_MAIN={report.local_main_sha or 'ABSENT'}")
+    print(f"ORIGIN_MAIN={report.origin_main_sha or 'ABSENT'}")
+    print(f"REMOTE_MAIN={report.remote_main_sha or 'ABSENT'}")
+    print(f"REMOTE_WORK_BRANCH={report.remote_work_branch_sha or 'ABSENT'}")
+    print(f"MAIN_WORKTREE_HEAD={report.main_worktree_head_sha or 'ABSENT'}")
+    print(
+        "MAIN_WORKTREE_DIRTY="
+        + ("UNKNOWN" if report.main_worktree_dirty is None else str(report.main_worktree_dirty).upper())
+    )
+    print(f"ORIGIN_HEAD_TARGET={report.origin_head_symbolic_target or 'ABSENT'}")
+    print(f"ORIGIN_HEAD_SHA={report.origin_head_resolved_sha or 'ABSENT'}")
+    for check in report.checks:
+        print(
+            f"CHECK={check.field} STATUS={check.status} REQUIRED={str(check.required).upper()} "
+            f"EXPECTED={check.expected} ACTUAL={check.actual} DETAIL={check.detail}"
+        )
+    print(f"UNRELATED_ACTIVITY_POLICY={report.unrelated_activity_policy}")
+    print(f"UNRELATED_WORKTREE_COUNT={len(report.unrelated_worktrees)}")
+    print(f"UNRELATED_DIRTY_WORKTREE_COUNT={report.unrelated_dirty_worktree_count}")
+    for item in report.unrelated_worktrees:
+        print(
+            f"UNRELATED_ACTIVITY={item.status} BRANCH={item.branch} "
+            f"HEAD={item.head_sha} PATH={item.path}"
+        )
+    for blocker in report.blockers:
+        print(f"BLOCKER={blocker}")
+    for warning in report.warnings:
+        print(f"WARNING={warning}")
+    print(f"OPERATION_FINGERPRINT={report.operation_fingerprint}")
+    print(f"VERIFIED={'YES' if report.verified else 'NO'}")
+    print(f"NEXT={report.next_action}")
+    print(f"MUTATIONS={report.mutations}")
+    print("RESULT=MORPHE_FLOW_MAIN_SYNC_VERIFICATION_COMPLETE")


### PR DESCRIPTION
## Summary

- Add operation-scoped receipt verification for `SYNC_LOCAL_MAIN`.
- Verify only fields the operation can affect: local `main`, `origin/main`, remote `main`, the preserved merged work branch, main-worktree state, squash parent/tree, and optional `origin/HEAD` aliasing.
- Report unrelated dirty worktrees without allowing them to invalidate the main-sync transaction.
- Emit field-level `CHECK=... STATUS=... EXPECTED=... ACTUAL=...` diagnostics instead of generic repository-drift failures.
- Add a sibling module for operation contracts and a robust import bootstrap for CLI and `importlib` execution.

## Validation

- `28` Morphe-flow tests passed.
- Full `tools/check-project-contracts.sh` passed: `15` shell contracts and `8` Python source contracts.
- Live verification of the completed v22.2 main synchronization passed.
- The dirty Issue #121 worktree was reported as `DIRTY_REPORTED_ONLY` and did not gate `SYNC_LOCAL_MAIN`.
- Exact branch push created only `work/hardening-v22-3-operation-receipts-v1-20260725` at `b4d81a6ca1b7c05b334c2b5a096793c764a4734b`.
- Remote `main` remained unchanged at `2cf0b2956a16fb06b2abf6336bf1e066fdd70119`.

## Scope

Tooling, tests, and documentation only. This PR does not alter app runtime behavior, publish a patch bundle, dispatch a release workflow, create a tag or release, merge itself, or clean up unrelated branches, worktrees, or stashes.
