### PR TITLE
feat(boost): add Settings V5 navigation

### DIFF
--- a/extensions/boostforreddit/src/main/java/app/morphe/extension/boostforreddit/settings/MorpheSettingsFragment.java
+++ b/extensions/boostforreddit/src/main/java/app/morphe/extension/boostforreddit/settings/MorpheSettingsFragment.java
@@ -3,6 +3,8 @@ package app.morphe.extension.boostforreddit.settings;
 import android.content.Context;
 import android.content.res.Resources;
 import android.os.Bundle;
+import android.view.Menu;
+import android.view.MenuItem;
 
 import androidx.preference.PreferenceFragmentCompat;
 
@@ -15,6 +17,7 @@ public final class MorpheSettingsFragment extends PreferenceFragmentCompat {
 
     @Override
     public void onCreatePreferences(Bundle savedInstanceState, String rootKey) {
+        setHasOptionsMenu(true);
         Context context = requireContext();
         Resources resources = context.getResources();
 
@@ -40,4 +43,19 @@ public final class MorpheSettingsFragment extends PreferenceFragmentCompat {
 
         setPreferencesFromResource(resourceId, rootKey);
     }
+
+    @Override
+    public void onPrepareOptionsMenu(Menu menu) {
+        super.onPrepareOptionsMenu(menu);
+        MorpheSettingsV4Search.prepareMenu(this, menu, true);
+    }
+
+    @Override
+    public boolean onOptionsItemSelected(MenuItem item) {
+        if (MorpheSettingsV4Search.handleMenuItem(this, item)) {
+            return true;
+        }
+        return super.onOptionsItemSelected(item);
+    }
+
 }

--- a/extensions/boostforreddit/src/main/java/app/morphe/extension/boostforreddit/settings/MorpheSettingsHubFragment.java
+++ b/extensions/boostforreddit/src/main/java/app/morphe/extension/boostforreddit/settings/MorpheSettingsHubFragment.java
@@ -4,6 +4,8 @@ import android.content.Context;
 import android.content.Intent;
 import android.content.res.Resources;
 import android.os.Bundle;
+import android.view.Menu;
+import android.view.MenuItem;
 
 import androidx.preference.Preference;
 import androidx.preference.PreferenceFragmentCompat;
@@ -25,6 +27,7 @@ public final class MorpheSettingsHubFragment extends PreferenceFragmentCompat {
 
     @Override
     public void onCreatePreferences(Bundle savedInstanceState, String rootKey) {
+        setHasOptionsMenu(true);
         Bundle arguments = getArguments();
         String resourceName = arguments == null
                 ? null
@@ -75,4 +78,19 @@ public final class MorpheSettingsHubFragment extends PreferenceFragmentCompat {
             return true;
         });
     }
+
+    @Override
+    public void onPrepareOptionsMenu(Menu menu) {
+        super.onPrepareOptionsMenu(menu);
+        MorpheSettingsV4Search.prepareMenu(this, menu, true);
+    }
+
+    @Override
+    public boolean onOptionsItemSelected(MenuItem item) {
+        if (MorpheSettingsV4Search.handleMenuItem(this, item)) {
+            return true;
+        }
+        return super.onOptionsItemSelected(item);
+    }
+
 }

--- a/extensions/boostforreddit/src/main/java/app/morphe/extension/boostforreddit/settings/MorpheSettingsV14Ui.java
+++ b/extensions/boostforreddit/src/main/java/app/morphe/extension/boostforreddit/settings/MorpheSettingsV14Ui.java
@@ -36,12 +36,19 @@ final class MorpheSettingsV14Ui {
             "MORPHE_BOOST_SETTINGS_V14_SEGMENTED_LISTS_ISSUE106_V1";
     static final String ACCESSIBILITY_MARKER =
             "MORPHE_BOOST_SETTINGS_V14_SELECTION_A11Y_ISSUE106_V1";
+    static final String MATERIAL_DEPTH_MARKER =
+            "MORPHE_BOOST_SETTINGS_MATERIAL_DEPTH_ISSUE121_PHASE2_1_V1";
+    static final String COMPACT_SEGMENT_MARKER =
+            "MORPHE_BOOST_SETTINGS_COMPACT_SEGMENTS_ISSUE121_PHASE2_1_V1";
+    static final String ANDROID_SETTINGS_GUIDANCE_PILOT_MARKER =
+            "MORPHE_BOOST_SETTINGS_ANDROID_GUIDANCE_PILOT_"
+                    + "ISSUE121_PHASE2_2_V1";
 
-    private static final int ROW_SINGLE_DP = 56;
-    private static final int ROW_TWO_LINE_DP = 72;
-    private static final int GROUP_GAP_DP = 4;
-    private static final float OUTER_RADIUS_DP = 18.0f;
-    private static final float INNER_RADIUS_DP = 6.0f;
+    private static final int ROW_SINGLE_DP = 52;
+    private static final int ROW_TWO_LINE_DP = 64;
+    private static final int GROUP_GAP_DP = 1;
+    private static final float OUTER_RADIUS_DP = 20.0f;
+    private static final float INNER_RADIUS_DP = 0.0f;
 
     private MorpheSettingsV14Ui() {
     }
@@ -54,6 +61,103 @@ final class MorpheSettingsV14Ui {
         return group;
     }
 
+    /**
+     * Continuous list container used by the Android Settings guidance pilot.
+     * Grouping is provided by headings and dividers instead of card-per-item
+     * containment.
+     */
+    static LinearLayout standardList(Context context) {
+        LinearLayout list = new LinearLayout(context);
+        list.setOrientation(LinearLayout.VERTICAL);
+        list.setClipChildren(false);
+        list.setClipToPadding(false);
+        return list;
+    }
+
+    static LinearLayout standardListRow(
+            Context context,
+            MorpheSettingsV4Theme.Tokens tokens,
+            boolean hasSupportingText
+    ) {
+        LinearLayout row = new LinearLayout(context);
+        row.setOrientation(LinearLayout.HORIZONTAL);
+        row.setGravity(Gravity.CENTER_VERTICAL);
+        row.setMinimumHeight(dp(context, hasSupportingText ? 72 : 56));
+        row.setPadding(
+                dp(context, 16),
+                dp(context, 4),
+                dp(context, 8),
+                dp(context, 4)
+        );
+        row.setClickable(true);
+        row.setFocusable(true);
+        row.setBackground(MorpheSettingsV4Theme.interactive(
+                context,
+                0x00000000,
+                0,
+                tokens.navigationAccent().color
+        ));
+        return row;
+    }
+
+    static LinearLayout standardListLabels(
+            Context context,
+            MorpheSettingsV4Theme.Tokens tokens,
+            String titleValue,
+            String supportingValue
+    ) {
+        LinearLayout labels = new LinearLayout(context);
+        labels.setOrientation(LinearLayout.VERTICAL);
+        labels.setGravity(Gravity.CENTER_VERTICAL);
+
+        TextView title = text(context, titleValue, 16, tokens.textPrimary);
+        title.setMaxLines(2);
+        title.setEllipsize(TextUtils.TruncateAt.END);
+        labels.addView(title);
+
+        if (!TextUtils.isEmpty(supportingValue)) {
+            TextView supporting = text(
+                    context,
+                    supportingValue,
+                    14,
+                    tokens.textSecondary
+            );
+            supporting.setMaxLines(2);
+            supporting.setEllipsize(TextUtils.TruncateAt.END);
+            supporting.setLineSpacing(0, 1.04f);
+            LinearLayout.LayoutParams params = wrapParams();
+            params.topMargin = dp(context, 2);
+            labels.addView(supporting, params);
+        }
+        return labels;
+    }
+
+    static void addStandardListRow(
+            LinearLayout list,
+            View row,
+            MorpheSettingsV4Theme.Tokens tokens
+    ) {
+        if (list.getChildCount() > 0) {
+            View divider = new View(list.getContext());
+            divider.setBackgroundColor(MorpheSettingsV4Theme.withAlpha(
+                    tokens.outline,
+                    42
+            ));
+            LinearLayout.LayoutParams dividerParams =
+                    new LinearLayout.LayoutParams(
+                            ViewGroup.LayoutParams.MATCH_PARENT,
+                            Math.max(1, dp(list.getContext(), 0.5f))
+                    );
+            dividerParams.setMarginStart(dp(list.getContext(), 16));
+            dividerParams.setMarginEnd(dp(list.getContext(), 16));
+            list.addView(divider, dividerParams);
+        }
+        list.addView(row, new LinearLayout.LayoutParams(
+                ViewGroup.LayoutParams.MATCH_PARENT,
+                ViewGroup.LayoutParams.WRAP_CONTENT
+        ));
+    }
+
     static LinearLayout baseRow(
             Context context,
             MorpheSettingsV4Theme.Tokens tokens
@@ -62,7 +166,7 @@ final class MorpheSettingsV14Ui {
         row.setOrientation(LinearLayout.HORIZONTAL);
         row.setGravity(Gravity.CENTER_VERTICAL);
         row.setMinimumHeight(dp(context, ROW_SINGLE_DP));
-        row.setPadding(dp(context, 16), dp(context, 8), dp(context, 12), dp(context, 8));
+        row.setPadding(dp(context, 16), dp(context, 4), dp(context, 8), dp(context, 4));
         row.setClickable(true);
         row.setFocusable(true);
         row.setBackground(interactiveShape(
@@ -106,6 +210,38 @@ final class MorpheSettingsV14Ui {
         return labels;
     }
 
+    static LinearLayout compactLabels(
+            Context context,
+            MorpheSettingsV4Theme.Tokens tokens,
+            String titleValue,
+            String summaryValue
+    ) {
+        LinearLayout labels = new LinearLayout(context);
+        labels.setOrientation(LinearLayout.VERTICAL);
+        labels.setGravity(Gravity.CENTER_VERTICAL);
+
+        TextView title = text(context, titleValue, 16, tokens.textPrimary);
+        title.setMaxLines(2);
+        title.setEllipsize(TextUtils.TruncateAt.END);
+        labels.addView(title);
+
+        if (!TextUtils.isEmpty(summaryValue)) {
+            TextView summary = text(
+                    context,
+                    summaryValue,
+                    13,
+                    tokens.textSecondary
+            );
+            summary.setMaxLines(2);
+            summary.setEllipsize(TextUtils.TruncateAt.END);
+            summary.setLineSpacing(0, 1.04f);
+            LinearLayout.LayoutParams params = wrapParams();
+            params.topMargin = dp(context, 1);
+            labels.addView(summary, params);
+        }
+        return labels;
+    }
+
     static TextView sectionLabel(
             Context context,
             MorpheSettingsV4Theme.Tokens tokens,
@@ -129,6 +265,17 @@ final class MorpheSettingsV14Ui {
         TextView text = text(context, value, 14, tokens.textSecondary);
         text.setLineSpacing(0, 1.08f);
         text.setPadding(dp(context, 4), dp(context, 8), dp(context, 4), 0);
+        return text;
+    }
+
+    static TextView pageIntro(
+            Context context,
+            MorpheSettingsV4Theme.Tokens tokens,
+            String value
+    ) {
+        TextView text = text(context, value, 15, tokens.textSecondary);
+        text.setLineSpacing(0, 1.08f);
+        text.setPadding(dp(context, 4), 0, dp(context, 4), 0);
         return text;
     }
 
@@ -286,7 +433,7 @@ final class MorpheSettingsV14Ui {
         return MorpheSettingsV4Theme.blend(
                 tokens.surfaceContainer,
                 tokens.secondaryContainer,
-                tokens.dark ? 0.055f : 0.04f
+                tokens.dark ? 0.025f : 0.018f
         );
     }
 
@@ -422,7 +569,7 @@ final class MorpheSettingsV14Ui {
             setMinimumHeight(dp(context, TextUtils.isEmpty(summaryValue)
                     ? ROW_SINGLE_DP
                     : ROW_TWO_LINE_DP));
-            setPadding(dp(context, 16), dp(context, 8), dp(context, 12), dp(context, 8));
+            setPadding(dp(context, 16), dp(context, 4), dp(context, 8), dp(context, 4));
             setClickable(true);
             setFocusable(true);
 

--- a/extensions/boostforreddit/src/main/java/app/morphe/extension/boostforreddit/settings/MorpheSettingsV4.java
+++ b/extensions/boostforreddit/src/main/java/app/morphe/extension/boostforreddit/settings/MorpheSettingsV4.java
@@ -25,13 +25,13 @@ public final class MorpheSettingsV4 {
             "extra_show_fragment";
     private static final String FRAGMENT_NAME =
             "app.morphe.extension.boostforreddit.settings."
-                    + "MorpheSettingsV4Fragment";
+                    + "MorpheSettingsV5RootFragment";
 
     private MorpheSettingsV4() {
     }
 
     /**
-     * Selects the v4 fragment only for a normal Settings launch. Explicit Boost
+     * Selects the V5 root only for a normal Settings launch. Explicit Boost
      * deep links keep their requested destination.
      */
     public static void prepareIntent(Activity activity) {

--- a/extensions/boostforreddit/src/main/java/app/morphe/extension/boostforreddit/settings/MorpheSettingsV4AppIconFragment.java
+++ b/extensions/boostforreddit/src/main/java/app/morphe/extension/boostforreddit/settings/MorpheSettingsV4AppIconFragment.java
@@ -112,9 +112,15 @@ public final class MorpheSettingsV4AppIconFragment extends Fragment {
     @Override
     public void onPrepareOptionsMenu(Menu menu) {
         super.onPrepareOptionsMenu(menu);
-        hideMenuItem(menu, "action_generic_search");
-        hideMenuItem(menu, "action_search");
-        hideMenuItem(menu, "search");
+        MorpheSettingsV4Search.prepareMenu(this, menu, true);
+    }
+
+    @Override
+    public boolean onOptionsItemSelected(MenuItem item) {
+        if (MorpheSettingsV4Search.handleMenuItem(this, item)) {
+            return true;
+        }
+        return super.onOptionsItemSelected(item);
     }
 
     private void rebuildOptions() {

--- a/extensions/boostforreddit/src/main/java/app/morphe/extension/boostforreddit/settings/MorpheSettingsV4AppearanceFragment.java
+++ b/extensions/boostforreddit/src/main/java/app/morphe/extension/boostforreddit/settings/MorpheSettingsV4AppearanceFragment.java
@@ -152,9 +152,15 @@ public final class MorpheSettingsV4AppearanceFragment extends Fragment {
     @Override
     public void onPrepareOptionsMenu(Menu menu) {
         super.onPrepareOptionsMenu(menu);
-        hideMenuItem(menu, "action_generic_search");
-        hideMenuItem(menu, "action_search");
-        hideMenuItem(menu, "search");
+        MorpheSettingsV4Search.prepareMenu(this, menu, true);
+    }
+
+    @Override
+    public boolean onOptionsItemSelected(MenuItem item) {
+        if (MorpheSettingsV4Search.handleMenuItem(this, item)) {
+            return true;
+        }
+        return super.onOptionsItemSelected(item);
     }
 
     private LinearLayout addGroup(LinearLayout parent) {

--- a/extensions/boostforreddit/src/main/java/app/morphe/extension/boostforreddit/settings/MorpheSettingsV4Catalog.java
+++ b/extensions/boostforreddit/src/main/java/app/morphe/extension/boostforreddit/settings/MorpheSettingsV4Catalog.java
@@ -34,6 +34,39 @@ final class MorpheSettingsV4Catalog {
     static final String V4_TOOLBAR_FRAGMENT =
             "app.morphe.extension.boostforreddit.settings."
                     + "MorpheSettingsV4ToolbarFragment";
+    static final String V4_NAVIGATION_TOOLBAR_FRAGMENT =
+            "app.morphe.extension.boostforreddit.settings."
+                    + "MorpheSettingsV4NativePages$NavigationToolbar";
+    static final String V4_NAVIGATION_BOTTOM_FRAGMENT =
+            "app.morphe.extension.boostforreddit.settings."
+                    + "MorpheSettingsV4NativePages$NavigationBottom";
+    static final String V4_NAVIGATION_DRAWER_HUB_FRAGMENT =
+            "app.morphe.extension.boostforreddit.settings."
+                    + "MorpheSettingsV4NavigationDrawerHubFragment";
+    static final String V4_NAVIGATION_BACK_EXIT_FRAGMENT =
+            "app.morphe.extension.boostforreddit.settings."
+                    + "MorpheSettingsV4NativePages$NavigationBackExit";
+    static final String V4_DRAWER_FEEDS_LIBRARY_FRAGMENT =
+            "app.morphe.extension.boostforreddit.settings."
+                    + "MorpheSettingsV4NativePages$DrawerFeedsLibrary";
+    static final String V4_DRAWER_ACCOUNT_TOOLS_FRAGMENT =
+            "app.morphe.extension.boostforreddit.settings."
+                    + "MorpheSettingsV4NativePages$DrawerAccountTools";
+    static final String V4_DRAWER_GO_TO_FRAGMENT =
+            "app.morphe.extension.boostforreddit.settings."
+                    + "MorpheSettingsV4NativePages$DrawerGoToShortcuts";
+    static final String V4_DRAWER_QUICK_TOGGLES_FRAGMENT =
+            "app.morphe.extension.boostforreddit.settings."
+                    + "MorpheSettingsV4NativePages$DrawerQuickToggles";
+    static final String V4_DRAWER_SUBSCRIPTIONS_FRAGMENT =
+            "app.morphe.extension.boostforreddit.settings."
+                    + "MorpheSettingsV4NativePages$DrawerSubscriptions";
+    static final String V4_DRAWER_ACCOUNT_SWITCHER_FRAGMENT =
+            "app.morphe.extension.boostforreddit.settings."
+                    + "MorpheSettingsV4NativePages$DrawerAccountSwitcher";
+    static final String V4_DRAWER_BEHAVIOR_FRAGMENT =
+            "app.morphe.extension.boostforreddit.settings."
+                    + "MorpheSettingsV4NativePages$DrawerBehavior";
     static final String V4_DATA_STORAGE_FRAGMENT =
             "app.morphe.extension.boostforreddit.settings."
                     + "MorpheSettingsV4DataStorageFragment";
@@ -132,6 +165,31 @@ final class MorpheSettingsV4Catalog {
         }
     }
 
+    static final class RootGroup {
+        final String id;
+        final String title;
+        final String summary;
+        final String iconName;
+        final boolean includesMorphe;
+        final String[] categoryIds;
+
+        RootGroup(
+                String id,
+                String title,
+                String summary,
+                String iconName,
+                boolean includesMorphe,
+                String... categoryIds
+        ) {
+            this.id = id;
+            this.title = title;
+            this.summary = summary;
+            this.iconName = iconName;
+            this.includesMorphe = includesMorphe;
+            this.categoryIds = categoryIds;
+        }
+    }
+
     static final class SearchItem {
         final String title;
         final String summary;
@@ -140,6 +198,7 @@ final class MorpheSettingsV4Catalog {
         final String fragmentName;
         final String activityName;
         final String preferenceKey;
+        final String pageId;
 
         SearchItem(
                 String title,
@@ -150,6 +209,28 @@ final class MorpheSettingsV4Catalog {
                 String activityName,
                 String preferenceKey
         ) {
+            this(
+                    title,
+                    summary,
+                    category,
+                    iconName,
+                    fragmentName,
+                    activityName,
+                    preferenceKey,
+                    null
+            );
+        }
+
+        SearchItem(
+                String title,
+                String summary,
+                String category,
+                String iconName,
+                String fragmentName,
+                String activityName,
+                String preferenceKey,
+                String pageId
+        ) {
             this.title = title;
             this.summary = summary;
             this.category = category;
@@ -157,6 +238,7 @@ final class MorpheSettingsV4Catalog {
             this.fragmentName = fragmentName;
             this.activityName = activityName;
             this.preferenceKey = preferenceKey;
+            this.pageId = pageId;
         }
 
         boolean matches(String normalizedQuery) {
@@ -171,8 +253,8 @@ final class MorpheSettingsV4Catalog {
     }
 
     private static final Leaf MORPHE = Leaf.fragment(
-            "Morphe",
-            "Features added by Morphe patches",
+            "Patch features",
+            "Media previews, recovery, search, performance, and Settings",
             "ic_puzzle_24dp",
             V4_NATIVE_PAGES + "Morphe",
             "morphe_boost_settings_skeleton"
@@ -180,83 +262,370 @@ final class MorpheSettingsV4Catalog {
 
     private static final Category[] CATEGORIES = new Category[]{
             new Category(
-                    "appearance_layout",
-                    "Appearance & layout",
-                    "Colors, post layout, and fonts",
+                    "theme_colors",
+                    "Theme & colors",
+                    "Choose the app theme, color behavior, and system-bar appearance",
                     "ic_color_lens_24dp",
-                    Leaf.fragment("Appearance", "Dynamic color, app icon, and system bars", "ic_color_lens_24dp", V4_APPEARANCE_FRAGMENT, null),
-                    Leaf.fragment("Post views", "Cards, lists, thumbnails, and density", "ic_view_carousel_24dp", V4_POST_VIEWS_FRAGMENT, null),
-                    Leaf.fragment("Fonts", "Font family, size, and style", "ic_format_size_24dp", V4_FONTS_FRAGMENT, null)
+                    Leaf.fragment(
+                            "Theme & colors",
+                            "Theme, colors, app icon, and system bars",
+                            "ic_color_lens_24dp",
+                            V4_APPEARANCE_FRAGMENT,
+                            null
+                    )
             ),
             new Category(
-                    "posts_comments",
-                    "Posts & comments",
-                    "Post and comment behavior",
+                    "community_header",
+                    "Community header",
+                    "Control the title, description, and header shown for communities",
+                    "ic_subreddit_24dp",
+                    nativeLeaf(
+                            "Community header",
+                            "Community title, description, and header presentation",
+                            "ic_subreddit_24dp",
+                            "Headers",
+                            "pref_headers_v2"
+                    )
+            ),
+            new Category(
+                    "post_layout",
+                    "Post layout",
+                    "Control how posts and feed cards are arranged",
+                    "ic_view_carousel_24dp",
+                    Leaf.fragment(
+                            "Post layout",
+                            "Cards, compact layouts, saved views, and tablet layout",
+                            "ic_view_carousel_24dp",
+                            V4_POST_VIEWS_FRAGMENT,
+                            null
+                    )
+            ),
+            new Category(
+                    "typography",
+                    "Typography",
+                    "Adjust text size and font presentation throughout Boost",
+                    "ic_format_size_24dp",
+                    Leaf.fragment(
+                            "Typography",
+                            "Post and comment fonts with live previews",
+                            "ic_format_size_24dp",
+                            V4_FONTS_FRAGMENT,
+                            null
+                    )
+            ),
+            new Category(
+                    "display_motion",
+                    "Display & motion",
+                    "Adjust display behavior, animation, and refresh-rate preferences",
+                    "ic_toolbar_24dp"
+            ),
+            new Category(
+                    "posts",
+                    "Posts",
+                    "Choose how posts behave while browsing and reading",
                     "ic_post_24dp",
-                    nativeLeaf("Posts", "Post display and interaction behavior", "ic_post_24dp", "Posts", "pref_posts_v2"),
-                    nativeLeaf("Comments", "Comment display and interaction behavior", "ic_comment_outline_white_24dp", "Comments", "pref_comments_v2")
+                    nativeLeaf(
+                            "Posts",
+                            "Post display, actions, feeds, and reading state",
+                            "ic_post_24dp",
+                            "Posts",
+                            "pref_posts_v2"
+                    )
             ),
             new Category(
-                    "navigation",
-                    "Navigation",
-                    "Toolbar, bottom navigation, and drawer",
-                    "ic_toolbar_24dp",
-                    Leaf.fragment("Toolbar", "Toolbar buttons and behavior", "ic_toolbar_24dp", V4_TOOLBAR_FRAGMENT, "pref_toolbar_v2"),
-                    nativeLeaf("Bottom navigation", "Tabs and bottom navigation behavior", "ic_bottomnav_24dp", "BottomNavigation", "pref_bottom_navigation_v2"),
-                    nativeLeaf("Navigation drawer", "Drawer items and ordering", "ic_dock_left_24dp", "Drawer", "pref_drawer_v2")
-            ),
-            new Category(
-                    "media_links",
-                    "Media & links",
-                    "Viewers, players, and link handling",
-                    "ic_photo_outline_24dp",
-                    nativeLeaf("Media viewer", "Images, GIFs, video, and viewer behavior", "ic_photo_outline_24dp", "Media", "pref_media_v2"),
-                    nativeLeaf("Link handling", "Browser and in-app link behavior", "ic_link_24dp", "Links", "pref_links_v2")
+                    "comments",
+                    "Comments",
+                    "Control comment display, actions, and thread behavior",
+                    "ic_comment_outline_white_24dp",
+                    nativeLeaf(
+                            "Comments",
+                            "Comment display, actions, navigation, and threads",
+                            "ic_comment_outline_white_24dp",
+                            "Comments",
+                            "pref_comments_v2"
+                    )
             ),
             new Category(
                     "search_filters",
                     "Search & filters",
-                    "Search behavior and content filters",
+                    "Configure search entry, suggestions, and content filtering",
                     "ic_search_color_24dp",
-                    nativeLeaf("Search", "Search behavior and defaults", "ic_search_color_24dp", "Search", "pref_search_v2"),
-                    nativeLeaf("Content filters", "Keywords, domains, and content rules", "ic_filter_list_24dp", "Filters", "pref_filters_v2")
+                    nativeLeaf(
+                            "Search",
+                            "Search behavior, defaults, and suggestions",
+                            "ic_search_color_24dp",
+                            "Search",
+                            "pref_search_v2"
+                    ),
+                    nativeLeaf(
+                            "Content filters",
+                            "Post matching, muted content, and filter behavior",
+                            "ic_filter_list_24dp",
+                            "Filters",
+                            "pref_filters_v2"
+                    )
             ),
             new Category(
-                    "notifications",
-                    "Notifications",
-                    "Check interval, notification tone, and inbox",
-                    "ic_notifications_black_24dp",
-                    nativeLeaf("Notifications", "Messages and notification behavior", "ic_notifications_black_24dp", "Messages", "pref_messages_v2")
+                    "feeds_subscriptions",
+                    "Feeds & subscriptions",
+                    "Manage communities, custom feeds, and subscription behavior",
+                    "ic_subreddit_24dp"
             ),
             new Category(
-                    "data_storage",
-                    "Backup",
-                    "Data storage, export, and import",
+                    "composing_drafts",
+                    "Composing & drafts",
+                    "Configure editors, drafts, and uploaded composing media",
+                    "ic_post_24dp"
+            ),
+            new Category(
+                    "navigation",
+                    "Navigation & gestures",
+                    "Choose how you move around Boost and reach common destinations",
+                    "ic_toolbar_24dp",
+                    Leaf.fragment(
+                            "Toolbar",
+                            "Main action and hide-on-scroll behavior",
+                            "ic_toolbar_24dp",
+                            V4_NAVIGATION_TOOLBAR_FRAGMENT,
+                            null
+                    ),
+                    Leaf.fragment(
+                            "Bottom navigation",
+                            "Visibility and hide-on-scroll behavior",
+                            "ic_view_carousel_24dp",
+                            V4_NAVIGATION_BOTTOM_FRAGMENT,
+                            null
+                    ),
+                    Leaf.fragment(
+                            "Navigation drawer",
+                            "Destinations, shortcuts, subscriptions, and behavior",
+                            "ic_settings_24dp",
+                            V4_NAVIGATION_DRAWER_HUB_FRAGMENT,
+                            null
+                    ),
+                    Leaf.fragment(
+                            "Back & exit",
+                            "Exit confirmation and double-back behavior",
+                            "ic_restore_black_24dp",
+                            V4_NAVIGATION_BACK_EXIT_FRAGMENT,
+                            null
+                    )
+            ),
+            new Category(
+                    "playback_autoplay",
+                    "Playback & autoplay",
+                    "Control video, audio, autoplay, and player behavior",
+                    "ic_photo_outline_24dp",
+                    nativeLeaf(
+                            "Playback & autoplay",
+                            "Video, audio, autoplay, and player behavior",
+                            "ic_photo_outline_24dp",
+                            "Media",
+                            "pref_media_v2"
+                    )
+            ),
+            new Category(
+                    "images_previews",
+                    "Images, GIFs & previews",
+                    "Configure media previews, images, GIFs, and tap actions",
+                    "ic_photo_outline_24dp"
+            ),
+            new Category(
+                    "links_browser",
+                    "Links & browser",
+                    "Choose how links open and which browser behavior Boost uses",
+                    "ic_link_24dp",
+                    nativeLeaf(
+                            "Links & browser",
+                            "Browser, video links, and in-app link handling",
+                            "ic_link_24dp",
+                            "Links",
+                            "pref_links_v2"
+                    )
+            ),
+            new Category(
+                    "downloads_cache",
+                    "Downloads & cache",
+                    "Manage download locations and downloaded media behavior",
                     "ic_save_24dp",
-                    Leaf.fragment("Data storage", "Bandwidth, media quality, downloads, and cache", "outline_data_usage_24", V4_DATA_STORAGE_FRAGMENT, "pref_data_v2"),
-                    Leaf.activity("Backup", "Export or import Boost settings", "ic_save_24dp", BACKUP_ACTIVITY)
+                    Leaf.fragment(
+                            "Downloads & cache",
+                            "Download folders and folder organization",
+                            "ic_save_24dp",
+                            V4_DOWNLOADS_FRAGMENT,
+                            "pref_downloads_v2"
+                    )
             ),
             new Category(
-                    "account_privacy",
-                    "Account & privacy",
-                    "Reddit preferences, history, and privacy",
+                    "notifications_inbox",
+                    "Notifications & inbox",
+                    "Control notifications, messages, and inbox behavior",
+                    "ic_notifications_black_24dp",
+                    nativeLeaf(
+                            "Notifications & inbox",
+                            "Messages, notification checks, tone, and inbox behavior",
+                            "ic_notifications_black_24dp",
+                            "Messages",
+                            "pref_messages_v2"
+                    )
+            ),
+            new Category(
+                    "reddit_account",
+                    "Reddit account",
+                    "Open account and Reddit-specific preferences",
                     "ic_person_24dp",
-                    Leaf.fragment("Reddit preferences", "Website and account preferences", "ic_subreddit_24dp", FRAGMENT_PREFIX + "PreferenceFragmentAccountCompat", null),
-                    nativeLeaf("History & privacy", "History, recent items, and privacy controls", "ic_restore_black_24dp", "Privacy", "pref_privacy_v2")
+                    Leaf.fragment(
+                            "Reddit account",
+                            "Website and account preferences",
+                            "ic_person_24dp",
+                            FRAGMENT_PREFIX + "PreferenceFragmentAccountCompat",
+                            null
+                    )
             ),
             new Category(
-                    "app_legacy",
-                    "App behavior",
-                    "Composing, subscriptions, and exit behavior",
+                    "history_privacy_recovery",
+                    "History, privacy & recovery",
+                    "Manage history, privacy, and supported archive recovery",
+                    "ic_restore_black_24dp",
+                    nativeLeaf(
+                            "History & privacy",
+                            "History, recent items, and privacy controls",
+                            "ic_restore_black_24dp",
+                            "Privacy",
+                            "pref_privacy_v2"
+                    )
+            ),
+            new Category(
+                    "storage_bandwidth",
+                    "Storage & bandwidth",
+                    "Control data usage, caching, and bandwidth-sensitive behavior",
+                    "outline_data_usage_24",
+                    Leaf.fragment(
+                            "Storage & bandwidth",
+                            "Data saver, quality, images, cache, and storage",
+                            "outline_data_usage_24",
+                            V4_DATA_STORAGE_FRAGMENT,
+                            "pref_data_v2"
+                    )
+            ),
+            new Category(
+                    "backup_restore",
+                    "Backup & restore",
+                    "Export or restore supported Boost and Morphe preferences",
+                    "ic_save_24dp",
+                    Leaf.activity(
+                            "Backup & restore",
+                            "Export or import Boost settings",
+                            "ic_save_24dp",
+                            BACKUP_ACTIVITY
+                    )
+            ),
+            new Category(
+                    "app_behavior_compatibility",
+                    "App behavior & compatibility",
+                    "Manage app-wide compatibility options and global behavior",
                     "ic_settings_24dp",
-                    nativeLeaf("General", "Unique app behavior and composing options", "ic_settings_24dp", "General", "pref_general_v2")
+                    nativeLeaf(
+                            "App behavior & compatibility",
+                            "Compatibility, global behavior, and remaining legacy options",
+                            "ic_settings_24dp",
+                            "General",
+                            "pref_general_v2"
+                    )
             ),
             new Category(
-                    "about",
-                    "About",
-                    "Support, privacy, licenses, and app information",
+                    "settings_experience",
+                    "Settings experience",
+                    "Choose which Settings presentation Boost uses",
+                    "ic_settings_24dp"
+            ),
+            new Category(
+                    "about_support",
+                    "About & support",
+                    "View app information, legal information, and support actions",
                     "ic_help_24dp",
-                    nativeLeaf("About Boost", "Support, licenses, privacy, and version", "ic_help_24dp", "About", "pref_about_v2")
+                    nativeLeaf(
+                            "About & support",
+                            "Support, licenses, privacy, and version information",
+                            "ic_help_24dp",
+                            "About",
+                            "pref_about_v2"
+                    )
+            )
+    };
+
+    private static final RootGroup[] ROOT_GROUPS = new RootGroup[]{
+            new RootGroup(
+                    "root_morphe",
+                    "Morphe",
+                    "Features added by Morphe patches and the Settings experience",
+                    "ic_puzzle_24dp",
+                    true
+            ),
+            new RootGroup(
+                    "root_appearance",
+                    "Appearance",
+                    "Themes, layout, typography, and visual presentation",
+                    "ic_color_lens_24dp",
+                    false,
+                    "theme_colors",
+                    "community_header",
+                    "post_layout",
+                    "typography",
+                    "display_motion"
+            ),
+            new RootGroup(
+                    "root_reading_interaction",
+                    "Reading & interaction",
+                    "Posts, comments, feeds, search, and composing behavior",
+                    "ic_post_24dp",
+                    false,
+                    "posts",
+                    "comments",
+                    "search_filters",
+                    "feeds_subscriptions",
+                    "composing_drafts"
+            ),
+            new RootGroup(
+                    "root_navigation",
+                    "Navigation",
+                    "Movement, destinations, drawer behavior, and gestures",
+                    "ic_toolbar_24dp",
+                    false,
+                    "navigation"
+            ),
+            new RootGroup(
+                    "root_media",
+                    "Media",
+                    "Playback, previews, links, downloads, and bandwidth",
+                    "ic_photo_outline_24dp",
+                    false,
+                    "playback_autoplay",
+                    "images_previews",
+                    "links_browser",
+                    "downloads_cache"
+            ),
+            new RootGroup(
+                    "root_notifications_account",
+                    "Notifications & account",
+                    "Inbox behavior, account options, history, privacy, and recovery",
+                    "ic_notifications_black_24dp",
+                    false,
+                    "notifications_inbox",
+                    "reddit_account",
+                    "history_privacy_recovery"
+            ),
+            new RootGroup(
+                    "root_data_app",
+                    "Data & app",
+                    "Storage, backup, app behavior, Settings, and app information",
+                    "ic_settings_24dp",
+                    false,
+                    "storage_bandwidth",
+                    "backup_restore",
+                    "app_behavior_compatibility",
+                    "settings_experience",
+                    "about_support"
             )
     };
 
@@ -271,6 +640,19 @@ final class MorpheSettingsV4Catalog {
         return CATEGORIES.clone();
     }
 
+    static RootGroup[] rootGroups() {
+        return ROOT_GROUPS.clone();
+    }
+
+    static RootGroup findRootGroup(String id) {
+        for (RootGroup rootGroup : ROOT_GROUPS) {
+            if (rootGroup.id.equals(id)) {
+                return rootGroup;
+            }
+        }
+        return null;
+    }
+
     static Category findCategory(String id) {
         for (Category category : CATEGORIES) {
             if (category.id.equals(id)) {
@@ -280,20 +662,276 @@ final class MorpheSettingsV4Catalog {
         return null;
     }
 
+    static boolean opensDirectly(Category category) {
+        return category != null
+                && category.leaves.length == 1
+                && category.title.equals(category.leaves[0].title);
+    }
+
     static List<SearchItem> buildSearchIndex(Context context) {
         List<SearchItem> result = new ArrayList<>();
         Set<String> seen = new LinkedHashSet<>();
 
         addLeafAndXml(context, result, seen, "Morphe", MORPHE);
         for (Category category : CATEGORIES) {
+            if (!opensDirectly(category)) {
+                addTaskPageSearchItem(result, seen, category);
+            }
             for (Leaf leaf : category.leaves) {
                 addLeafAndXml(context, result, seen, category.title, leaf);
             }
         }
+        addV4NavigationSearchItems(context, result, seen);
         addV4AppearanceSearchItems(result, seen);
         addV4PostViewsSearchItems(result, seen);
         addV4FontsSearchItems(result, seen);
         return result;
+    }
+
+    private static void addTaskPageSearchItem(
+            List<SearchItem> result,
+            Set<String> seen,
+            Category category
+    ) {
+        addSearchItem(
+                result,
+                seen,
+                new SearchItem(
+                        category.title,
+                        category.summary,
+                        "Settings",
+                        category.iconName,
+                        null,
+                        null,
+                        null,
+                        category.id
+                )
+        );
+    }
+
+    private static void addV4NavigationSearchItems(
+            Context context,
+            List<SearchItem> result,
+            Set<String> seen
+    ) {
+        addV4NavigationXmlSearchItems(
+                context, result, seen, "pref_toolbar_v2"
+        );
+        addV4NavigationXmlSearchItems(
+                context, result, seen, "pref_bottom_navigation_v2"
+        );
+        addV4NavigationXmlSearchItems(
+                context, result, seen, "pref_drawer_v2"
+        );
+        addV4NavigationXmlSearchItems(
+                context, result, seen, "pref_general_v2"
+        );
+    }
+
+    private static void addV4NavigationXmlSearchItems(
+            Context context,
+            List<SearchItem> result,
+            Set<String> seen,
+            String resourceName
+    ) {
+        Resources resources = context.getResources();
+        int resourceId = resourceId(context, "xml", resourceName);
+        if (resourceId == 0) {
+            return;
+        }
+
+        XmlResourceParser parser = null;
+        try {
+            parser = resources.getXml(resourceId);
+            int event;
+            while ((event = parser.next()) != XmlPullParser.END_DOCUMENT) {
+                if (event != XmlPullParser.START_TAG) {
+                    continue;
+                }
+                String tag = parser.getName();
+                if ("PreferenceScreen".equals(tag)
+                        || "PreferenceCategory".equals(tag)) {
+                    continue;
+                }
+
+                String key = attributeText(resources, parser, "key");
+                if (!isNavigationExposedKey(key)) {
+                    continue;
+                }
+
+                String title = attributeText(resources, parser, "title");
+                String section = navigationSectionForKey(key);
+                String fragmentName = navigationFragmentForKey(key);
+                if (TextUtils.isEmpty(title)
+                        || TextUtils.isEmpty(section)
+                        || TextUtils.isEmpty(fragmentName)) {
+                    continue;
+                }
+
+                addSearchItem(
+                        result,
+                        seen,
+                        new SearchItem(
+                                title,
+                                attributeText(resources, parser, "summary"),
+                                navigationSearchCategory(
+                                        fragmentName,
+                                        section
+                                ),
+                                "ic_toolbar_24dp",
+                                fragmentName,
+                                null,
+                                key
+                        )
+                );
+            }
+        } catch (Exception ignored) {
+            // Search indexing is best-effort; navigation remains available.
+        } finally {
+            if (parser != null) {
+                parser.close();
+            }
+        }
+    }
+
+    private static String navigationFragmentForKey(String key) {
+        if (TextUtils.isEmpty(key)) {
+            return "";
+        }
+        switch (key) {
+            case "pref_toolbar_main_action":
+            case "pref_toolbar":
+                return V4_NAVIGATION_TOOLBAR_FRAGMENT;
+            case "pref_bottom_navigation":
+            case "pref_bottom_navigation_hide_on_scroll":
+                return V4_NAVIGATION_BOTTOM_FRAGMENT;
+            case "pref_drawer_show_home":
+            case "pref_drawer_show_frontpage":
+            case "pref_drawer_show_popular":
+            case "pref_drawer_show_all":
+            case "pref_drawer_show_saved":
+            case "pref_drawer_show_history":
+                return V4_DRAWER_FEEDS_LIBRARY_FRAGMENT;
+            case "pref_drawer_show_profile":
+            case "pref_drawer_show_inbox":
+            case "pref_drawer_show_drafts":
+            case "pref_drawer_show_mod":
+            case "pref_drawer_show_search_generic":
+                return V4_DRAWER_ACCOUNT_TOOLS_FRAGMENT;
+            case "pref_drawer_show_go_to":
+            case "pref_drawer_show_go_to_subreddit":
+            case "pref_drawer_show_go_to_user":
+                return V4_DRAWER_GO_TO_FRAGMENT;
+            case "pref_drawer_show_night_mode":
+            case "pref_drawer_show_nsfw_switch":
+            case "pref_drawer_show_blur_switch":
+                return V4_DRAWER_QUICK_TOGGLES_FRAGMENT;
+            case "pref_subscriptions_drawer":
+            case "pref_subscriptions_drawer_show_icon":
+            case "pref_subscriptions_only_casual":
+                return V4_DRAWER_SUBSCRIPTIONS_FRAGMENT;
+            case "pref_accounts_show_avatar":
+            case "pref_accounts_show_username":
+                return V4_DRAWER_ACCOUNT_SWITCHER_FRAGMENT;
+            case "pref_drawer_sticky_settings":
+            case "pref_drawer_end":
+                return V4_DRAWER_BEHAVIOR_FRAGMENT;
+            case "pref_ask_exit":
+            case "pref_double_exit":
+                return V4_NAVIGATION_BACK_EXIT_FRAGMENT;
+            default:
+                return "";
+        }
+    }
+
+    private static String navigationSectionForKey(String key) {
+        String fragmentName = navigationFragmentForKey(key);
+        if (V4_NAVIGATION_TOOLBAR_FRAGMENT.equals(fragmentName)) {
+            return "Toolbar";
+        }
+        if (V4_NAVIGATION_BOTTOM_FRAGMENT.equals(fragmentName)) {
+            return "Bottom navigation";
+        }
+        if (V4_DRAWER_FEEDS_LIBRARY_FRAGMENT.equals(fragmentName)) {
+            return "Feeds & library";
+        }
+        if (V4_DRAWER_ACCOUNT_TOOLS_FRAGMENT.equals(fragmentName)) {
+            return "Account & tools";
+        }
+        if (V4_DRAWER_GO_TO_FRAGMENT.equals(fragmentName)) {
+            return "Go-to shortcuts";
+        }
+        if (V4_DRAWER_QUICK_TOGGLES_FRAGMENT.equals(fragmentName)) {
+            return "Quick toggles";
+        }
+        if (V4_DRAWER_SUBSCRIPTIONS_FRAGMENT.equals(fragmentName)) {
+            return "Subscriptions";
+        }
+        if (V4_DRAWER_ACCOUNT_SWITCHER_FRAGMENT.equals(fragmentName)) {
+            return "Account switcher";
+        }
+        if (V4_DRAWER_BEHAVIOR_FRAGMENT.equals(fragmentName)) {
+            return "Drawer behavior";
+        }
+        if (V4_NAVIGATION_BACK_EXIT_FRAGMENT.equals(fragmentName)) {
+            return "Back & exit";
+        }
+        return "";
+    }
+
+    private static String navigationSearchCategory(
+            String fragmentName,
+            String section
+    ) {
+        String category = "Navigation & gestures";
+        if (fragmentName.startsWith(
+                "app.morphe.extension.boostforreddit.settings."
+                        + "MorpheSettingsV4NativePages$Drawer"
+        )) {
+            category += " · Navigation drawer";
+        }
+        return category + " · " + section;
+    }
+
+    private static boolean isNavigationExposedKey(String key) {
+        if (TextUtils.isEmpty(key)) {
+            return false;
+        }
+        switch (key) {
+            case "pref_toolbar_main_action":
+            case "pref_toolbar":
+            case "pref_bottom_navigation":
+            case "pref_bottom_navigation_hide_on_scroll":
+            case "pref_drawer_show_home":
+            case "pref_drawer_show_frontpage":
+            case "pref_drawer_show_popular":
+            case "pref_drawer_show_all":
+            case "pref_drawer_show_saved":
+            case "pref_drawer_show_history":
+            case "pref_drawer_show_profile":
+            case "pref_drawer_show_inbox":
+            case "pref_drawer_show_drafts":
+            case "pref_drawer_show_mod":
+            case "pref_drawer_show_search_generic":
+            case "pref_drawer_show_go_to":
+            case "pref_drawer_show_go_to_subreddit":
+            case "pref_drawer_show_go_to_user":
+            case "pref_drawer_show_night_mode":
+            case "pref_drawer_show_nsfw_switch":
+            case "pref_drawer_show_blur_switch":
+            case "pref_drawer_sticky_settings":
+            case "pref_subscriptions_drawer":
+            case "pref_subscriptions_drawer_show_icon":
+            case "pref_subscriptions_only_casual":
+            case "pref_accounts_show_avatar":
+            case "pref_accounts_show_username":
+            case "pref_drawer_end":
+            case "pref_ask_exit":
+            case "pref_double_exit":
+                return true;
+            default:
+                return false;
+        }
     }
 
     private static void addV4AppearanceSearchItems(
@@ -444,6 +1082,10 @@ final class MorpheSettingsV4Catalog {
 
                 String summary = attributeText(resources, parser, "summary");
                 String key = attributeText(resources, parser, "key");
+                if ("pref_general_v2".equals(leaf.resourceName)
+                        && isNavigationExposedKey(key)) {
+                    continue;
+                }
                 String nestedFragment = parser.getAttributeValue(
                         ANDROID_NAMESPACE,
                         "fragment"
@@ -485,7 +1127,8 @@ final class MorpheSettingsV4Catalog {
         String signature = normalize(item.title)
                 + "|" + normalize(item.fragmentName)
                 + "|" + normalize(item.activityName)
-                + "|" + normalize(item.preferenceKey);
+                + "|" + normalize(item.preferenceKey)
+                + "|" + normalize(item.pageId);
         if (seen.add(signature)) {
             result.add(item);
         }

--- a/extensions/boostforreddit/src/main/java/app/morphe/extension/boostforreddit/settings/MorpheSettingsV4DataStorageFragment.java
+++ b/extensions/boostforreddit/src/main/java/app/morphe/extension/boostforreddit/settings/MorpheSettingsV4DataStorageFragment.java
@@ -341,9 +341,15 @@ public final class MorpheSettingsV4DataStorageFragment extends Fragment {
     @Override
     public void onPrepareOptionsMenu(Menu menu) {
         super.onPrepareOptionsMenu(menu);
-        hideMenuItem(menu, "action_generic_search");
-        hideMenuItem(menu, "action_search");
-        hideMenuItem(menu, "search");
+        MorpheSettingsV4Search.prepareMenu(this, menu, true);
+    }
+
+    @Override
+    public boolean onOptionsItemSelected(MenuItem item) {
+        if (MorpheSettingsV4Search.handleMenuItem(this, item)) {
+            return true;
+        }
+        return super.onOptionsItemSelected(item);
     }
 
     private LinearLayout addGroup(LinearLayout parent) {

--- a/extensions/boostforreddit/src/main/java/app/morphe/extension/boostforreddit/settings/MorpheSettingsV4FontsFragment.java
+++ b/extensions/boostforreddit/src/main/java/app/morphe/extension/boostforreddit/settings/MorpheSettingsV4FontsFragment.java
@@ -196,9 +196,15 @@ public final class MorpheSettingsV4FontsFragment extends Fragment {
     @Override
     public void onPrepareOptionsMenu(Menu menu) {
         super.onPrepareOptionsMenu(menu);
-        hideMenuItem(menu, "action_generic_search");
-        hideMenuItem(menu, "action_search");
-        hideMenuItem(menu, "search");
+        MorpheSettingsV4Search.prepareMenu(this, menu, true);
+    }
+
+    @Override
+    public boolean onOptionsItemSelected(MenuItem item) {
+        if (MorpheSettingsV4Search.handleMenuItem(this, item)) {
+            return true;
+        }
+        return super.onOptionsItemSelected(item);
     }
 
     private void addPreview(LinearLayout parent) {

--- a/extensions/boostforreddit/src/main/java/app/morphe/extension/boostforreddit/settings/MorpheSettingsV4Fragment.java
+++ b/extensions/boostforreddit/src/main/java/app/morphe/extension/boostforreddit/settings/MorpheSettingsV4Fragment.java
@@ -16,6 +16,7 @@ import android.view.MenuItem;
 import android.view.View;
 import android.view.ViewGroup;
 import android.view.inputmethod.EditorInfo;
+import android.view.inputmethod.InputMethodManager;
 import android.widget.EditText;
 import android.widget.FrameLayout;
 import android.widget.ImageView;
@@ -44,10 +45,22 @@ public final class MorpheSettingsV4Fragment extends Fragment {
             "MORPHE_BOOST_SETTINGS_V4_SYSTEM_BARS_ISSUE106_V1";
     public static final String SYSTEM_BAR_OWNER_CONTRACT_MARKER =
             "MORPHE_BOOST_SETTINGS_V4_SYSTEM_BAR_OWNER_ISSUE106_V2";
+    public static final String ROOT_SHELL_PHASE1_MARKER =
+            "MORPHE_BOOST_SETTINGS_ROOT_SHELL_ISSUE121_PHASE1_V1";
+    public static final String SEVEN_CARD_ROOT_PHASE1_1_MARKER =
+            "MORPHE_BOOST_SETTINGS_SEVEN_CARD_ROOT_ISSUE121_PHASE1_1_V1";
+    public static final String GLOBAL_SEARCH_PHASE1_2_MARKER =
+            "MORPHE_BOOST_SETTINGS_GLOBAL_SEARCH_ISSUE121_PHASE1_2_V1";
+    public static final String MATERIAL_VISUAL_FOUNDATION_MARKER =
+            "MORPHE_BOOST_SETTINGS_MATERIAL_VISUAL_FOUNDATION_"
+                    + "ISSUE121_PHASE2_1_V1";
+    public static final String ANDROID_SETTINGS_GUIDANCE_PILOT_MARKER =
+            "MORPHE_BOOST_SETTINGS_ANDROID_GUIDANCE_OVERVIEW_"
+                    + "ISSUE121_PHASE2_2_V1";
 
     private static final String ARGUMENT_PAGE =
-            "morphe_boost_settings_v4_page";
-    private static final String PAGE_ROOT = "root";
+            MorpheSettingsV4Search.ARGUMENT_PAGE;
+    private static final String PAGE_ROOT = MorpheSettingsV4Search.PAGE_ROOT;
     private static final String EXTRA_SHOW_FRAGMENT = "extra_show_fragment";
     private static final String CLASSIC_HEADER_FRAGMENT =
             "com.rubenmayayo.reddit.ui.preferences.v2."
@@ -72,14 +85,37 @@ public final class MorpheSettingsV4Fragment extends Fragment {
         tokens = MorpheSettingsV4Theme.resolve(context);
         setHasOptionsMenu(true);
 
+        boolean openSearchRequested = false;
+        boolean navigationFromArguments = false;
+        Bundle arguments = getArguments();
+        if (arguments != null && arguments.containsKey(ARGUMENT_PAGE)) {
+            String requestedPage = arguments.getString(ARGUMENT_PAGE);
+            if (!TextUtils.isEmpty(requestedPage)) {
+                page = requestedPage;
+            }
+            openSearchRequested = arguments.getBoolean(
+                    MorpheSettingsV4Search.EXTRA_OPEN_SEARCH,
+                    false
+            );
+            navigationFromArguments = true;
+        }
+
         Activity activity = hostActivity();
-        if (activity != null) {
+        if (!navigationFromArguments && activity != null) {
             Intent intent = activity.getIntent();
             String requestedPage = intent == null
                     ? null
                     : intent.getStringExtra(ARGUMENT_PAGE);
             if (!TextUtils.isEmpty(requestedPage)) {
                 page = requestedPage;
+            }
+            openSearchRequested = intent != null
+                    && intent.getBooleanExtra(
+                    MorpheSettingsV4Search.EXTRA_OPEN_SEARCH,
+                    false
+            );
+            if (openSearchRequested) {
+                intent.removeExtra(MorpheSettingsV4Search.EXTRA_OPEN_SEARCH);
             }
         }
 
@@ -102,8 +138,11 @@ public final class MorpheSettingsV4Fragment extends Fragment {
 
         if (PAGE_ROOT.equals(page)) {
             buildRoot(content);
+            if (openSearchRequested) {
+                focusSearchField();
+            }
         } else {
-            buildHub(content, page);
+            buildPage(content, page);
         }
         return scrollView;
     }
@@ -126,10 +165,19 @@ public final class MorpheSettingsV4Fragment extends Fragment {
     @Override
     public void onPrepareOptionsMenu(Menu menu) {
         super.onPrepareOptionsMenu(menu);
-        hideMenuItem(menu, "action_generic_search");
-        hideMenuItem(menu, "action_search");
-        hideMenuItem(menu, "search");
-        hideMenuItem(menu, "menu_search");
+        MorpheSettingsV4Search.prepareMenu(
+                this,
+                menu,
+                !PAGE_ROOT.equals(page)
+        );
+    }
+
+    @Override
+    public boolean onOptionsItemSelected(MenuItem item) {
+        if (MorpheSettingsV4Search.handleMenuItem(this, item)) {
+            return true;
+        }
+        return super.onOptionsItemSelected(item);
     }
 
     @Override
@@ -155,7 +203,61 @@ public final class MorpheSettingsV4Fragment extends Fragment {
         renderRootContent("");
     }
 
-    private void buildHub(LinearLayout content, String categoryId) {
+    private void buildPage(LinearLayout content, String pageId) {
+        MorpheSettingsV4Catalog.RootGroup rootGroup =
+                MorpheSettingsV4Catalog.findRootGroup(pageId);
+        if (rootGroup != null) {
+            buildRootGroup(content, rootGroup);
+            return;
+        }
+        buildTaskPage(content, pageId);
+    }
+
+    private void buildRootGroup(
+            LinearLayout content,
+            MorpheSettingsV4Catalog.RootGroup rootGroup
+    ) {
+        LinearLayout list = MorpheSettingsV14Ui.standardList(requireContext());
+        content.addView(list, new LinearLayout.LayoutParams(
+                ViewGroup.LayoutParams.MATCH_PARENT,
+                ViewGroup.LayoutParams.WRAP_CONTENT
+        ));
+
+        if (rootGroup.includesMorphe) {
+            MorpheSettingsV4Catalog.Leaf morphe =
+                    MorpheSettingsV4Catalog.morphe();
+            MorpheSettingsV14Ui.addStandardListRow(
+                    list,
+                    createStandardNavigationRow(
+                            morphe.title,
+                            "",
+                            null,
+                            view -> openLeaf(morphe, null)
+                    ),
+                    tokens
+            );
+        }
+
+        for (String categoryId : rootGroup.categoryIds) {
+            MorpheSettingsV4Catalog.Category category =
+                    MorpheSettingsV4Catalog.findCategory(categoryId);
+            if (category == null) {
+                continue;
+            }
+            MorpheSettingsV14Ui.addStandardListRow(
+                    list,
+                    createStandardNavigationRow(
+                            category.title,
+                            "",
+                            null,
+                            view -> openCategory(category)
+                    ),
+                    tokens
+            );
+        }
+    }
+
+    private void buildTaskPage(LinearLayout content, String categoryId) {
         MorpheSettingsV4Catalog.Category category =
                 MorpheSettingsV4Catalog.findCategory(categoryId);
         if (category == null) {
@@ -164,23 +266,40 @@ public final class MorpheSettingsV4Fragment extends Fragment {
             return;
         }
 
-        addSectionLabel(content, category.title);
-        addSpace(content, 10);
+        if (category.leaves.length == 0) {
+            addBodyText(
+                    content,
+                    "These controls are still available through Search or "
+                            + "classic Boost settings while this task page is organized."
+            );
+            addSpace(content, 18);
+            TextView classic = MorpheSettingsV14Ui.action(
+                    requireContext(),
+                    tokens,
+                    "Open classic Boost settings",
+                    false
+            );
+            classic.setOnClickListener(view -> openClassicSettings());
+            content.addView(classic, wrapParams());
+            return;
+        }
 
-        LinearLayout group = MorpheSettingsV14Ui.group(requireContext());
-        content.addView(group, new LinearLayout.LayoutParams(
+        LinearLayout list = MorpheSettingsV14Ui.standardList(requireContext());
+        content.addView(list, new LinearLayout.LayoutParams(
                 ViewGroup.LayoutParams.MATCH_PARENT,
                 ViewGroup.LayoutParams.WRAP_CONTENT
         ));
         for (MorpheSettingsV4Catalog.Leaf leaf : category.leaves) {
-            View row = createNavigationCard(
-                    leaf.title,
-                    leaf.summary,
-                    leaf.iconName,
-                    false,
-                    view -> openLeaf(leaf, null)
+            MorpheSettingsV14Ui.addStandardListRow(
+                    list,
+                    createStandardNavigationRow(
+                            leaf.title,
+                            "",
+                            null,
+                            view -> openLeaf(leaf, null)
+                    ),
+                    tokens
             );
-            MorpheSettingsV14Ui.addSegmentedRow(group, row, tokens);
         }
     }
 
@@ -242,6 +361,28 @@ public final class MorpheSettingsV4Fragment extends Fragment {
         });
     }
 
+    private void focusSearchField() {
+        if (searchField == null) {
+            return;
+        }
+        searchField.post(() -> {
+            if (!isAdded() || searchField == null) {
+                return;
+            }
+            searchField.requestFocus();
+            InputMethodManager inputMethodManager =
+                    (InputMethodManager) requireContext().getSystemService(
+                            Context.INPUT_METHOD_SERVICE
+                    );
+            if (inputMethodManager != null) {
+                inputMethodManager.showSoftInput(
+                        searchField,
+                        InputMethodManager.SHOW_IMPLICIT
+                );
+            }
+        });
+    }
+
     private void renderRootContent(String query) {
         if (dynamicContent == null) {
             return;
@@ -257,53 +398,30 @@ public final class MorpheSettingsV4Fragment extends Fragment {
     }
 
     private void renderCategories() {
-        addSectionLabel(dynamicContent, "Morphe");
-        addSpace(dynamicContent, 10);
-        LinearLayout morpheGroup = MorpheSettingsV14Ui.group(requireContext());
-        dynamicContent.addView(morpheGroup, new LinearLayout.LayoutParams(
+        MorpheSettingsV4Catalog.RootGroup[] rootGroups =
+                MorpheSettingsV4Catalog.rootGroups();
+        LinearLayout list = MorpheSettingsV14Ui.standardList(requireContext());
+        dynamicContent.addView(list, new LinearLayout.LayoutParams(
                 ViewGroup.LayoutParams.MATCH_PARENT,
                 ViewGroup.LayoutParams.WRAP_CONTENT
         ));
-        MorpheSettingsV4Catalog.Leaf morphe = MorpheSettingsV4Catalog.morphe();
-        MorpheSettingsV14Ui.addSegmentedRow(
-                morpheGroup,
-                createNavigationCard(
-                        "Patch features",
-                        "Media routing, recovery, search, and performance",
-                        morphe.iconName,
-                        true,
-                        view -> openLeaf(morphe, null)
-                ),
-                tokens
-        );
+        for (MorpheSettingsV4Catalog.RootGroup rootGroup : rootGroups) {
+            String supporting = "root_morphe".equals(rootGroup.id)
+                    ? "Patch features"
+                    : "";
+            MorpheSettingsV14Ui.addStandardListRow(
+                    list,
+                    createStandardNavigationRow(
+                            rootGroup.title,
+                            supporting,
+                            rootGroup.iconName,
+                            view -> openRootGroup(rootGroup)
+                    ),
+                    tokens
+            );
+        }
 
-        renderHomeSection(
-                "Look & feel",
-                "appearance_layout"
-        );
-        renderHomeSection(
-                "Reading & interaction",
-                "posts_comments",
-                "search_filters"
-        );
-        renderHomeSection(
-                "Navigation & media",
-                "navigation",
-                "media_links"
-        );
-        renderHomeSection(
-                "Data & account",
-                "notifications",
-                "data_storage",
-                "account_privacy"
-        );
-        renderHomeSection(
-                "App & support",
-                "app_legacy",
-                "about"
-        );
-
-        addSpace(dynamicContent, 12);
+        addSpace(dynamicContent, 18);
         TextView classic = MorpheSettingsV14Ui.action(
                 requireContext(),
                 tokens,
@@ -312,38 +430,6 @@ public final class MorpheSettingsV4Fragment extends Fragment {
         );
         classic.setOnClickListener(view -> openClassicSettings());
         dynamicContent.addView(classic, wrapParams());
-    }
-
-    private void renderHomeSection(String title, String... categoryIds) {
-        addSpace(dynamicContent, 24);
-        addSectionLabel(dynamicContent, title);
-        addSpace(dynamicContent, 10);
-
-        LinearLayout group = MorpheSettingsV14Ui.group(requireContext());
-        dynamicContent.addView(group, new LinearLayout.LayoutParams(
-                ViewGroup.LayoutParams.MATCH_PARENT,
-                ViewGroup.LayoutParams.WRAP_CONTENT
-        ));
-        for (String categoryId : categoryIds) {
-            MorpheSettingsV4Catalog.Category category =
-                    MorpheSettingsV4Catalog.findCategory(categoryId);
-            if (category == null) {
-                continue;
-            }
-            for (MorpheSettingsV4Catalog.Leaf leaf : category.leaves) {
-                MorpheSettingsV14Ui.addSegmentedRow(
-                        group,
-                        createNavigationCard(
-                                leaf.title,
-                                leaf.summary,
-                                leaf.iconName,
-                                false,
-                                view -> openLeaf(leaf, null)
-                        ),
-                        tokens
-                );
-            }
-        }
     }
 
     private void renderSearchResults(String normalizedQuery) {
@@ -391,6 +477,7 @@ public final class MorpheSettingsV4Fragment extends Fragment {
                     secondary,
                     item.iconName,
                     false,
+                    false,
                     view -> openSearchItem(item)
             );
             MorpheSettingsV14Ui.addSegmentedRow(group, row, tokens);
@@ -404,10 +491,72 @@ public final class MorpheSettingsV4Fragment extends Fragment {
         }
     }
 
+    private View createStandardNavigationRow(
+            String titleValue,
+            String supportingValue,
+            String iconName,
+            View.OnClickListener clickListener
+    ) {
+        Context context = requireContext();
+        LinearLayout row = MorpheSettingsV14Ui.standardListRow(
+                context,
+                tokens,
+                !TextUtils.isEmpty(supportingValue)
+        );
+        row.setOnClickListener(clickListener);
+
+        if (!TextUtils.isEmpty(iconName)) {
+            row.addView(createPlainLeadingIcon(iconName));
+        }
+
+        LinearLayout labels = MorpheSettingsV14Ui.standardListLabels(
+                context,
+                tokens,
+                titleValue,
+                supportingValue
+        );
+        LinearLayout.LayoutParams labelsParams = new LinearLayout.LayoutParams(
+                0,
+                ViewGroup.LayoutParams.WRAP_CONTENT,
+                1.0f
+        );
+        if (!TextUtils.isEmpty(iconName)) {
+            labelsParams.setMarginStart(dp(16));
+        }
+        row.addView(labels, labelsParams);
+        row.addView(MorpheSettingsV14Ui.chevron(context, tokens));
+        return row;
+    }
+
+    private View createPlainLeadingIcon(String iconName) {
+        Context context = requireContext();
+        FrameLayout slot = new FrameLayout(context);
+        ImageView image = new ImageView(context);
+        Drawable drawable = icon(
+                iconName,
+                tokens.navigationAccent().color
+        );
+        if (drawable != null) {
+            image.setImageDrawable(drawable);
+        } else {
+            image.setImageResource(android.R.drawable.ic_menu_preferences);
+            image.setColorFilter(tokens.navigationAccent().color);
+        }
+        image.setScaleType(ImageView.ScaleType.CENTER_INSIDE);
+        slot.addView(image, new FrameLayout.LayoutParams(
+                dp(24),
+                dp(24),
+                Gravity.CENTER
+        ));
+        slot.setLayoutParams(new LinearLayout.LayoutParams(dp(40), dp(40)));
+        return slot;
+    }
+
     private View createNavigationCard(
             String titleValue,
             String summaryValue,
             String iconName,
+            boolean rootLevel,
             boolean highlighted,
             View.OnClickListener clickListener
     ) {
@@ -427,7 +576,14 @@ public final class MorpheSettingsV4Fragment extends Fragment {
         int iconColor = accent.color;
 
         LinearLayout card = MorpheSettingsV14Ui.baseRow(context, tokens);
-        card.setMinimumHeight(dp(TextUtils.isEmpty(summaryValue) ? 56 : 72));
+        card.setMinimumHeight(dp(
+                rootLevel
+                        ? (TextUtils.isEmpty(summaryValue) ? 64 : 80)
+                        : (TextUtils.isEmpty(summaryValue) ? 52 : 64)
+        ));
+        if (rootLevel) {
+            card.setPadding(dp(16), dp(10), dp(12), dp(10));
+        }
         card.setClickable(true);
         card.setFocusable(true);
         card.setOnClickListener(clickListener);
@@ -436,7 +592,8 @@ public final class MorpheSettingsV4Fragment extends Fragment {
                 iconName,
                 iconColor,
                 iconBackground,
-                40
+                rootLevel ? 44 : 36,
+                rootLevel ? 24 : 20
         ));
 
         LinearLayout labels = new LinearLayout(context);
@@ -446,15 +603,23 @@ public final class MorpheSettingsV4Fragment extends Fragment {
                 ViewGroup.LayoutParams.WRAP_CONTENT,
                 1.0f
         );
-        labelsParams.setMarginStart(dp(14));
+        labelsParams.setMarginStart(dp(rootLevel ? 14 : 12));
         card.addView(labels, labelsParams);
 
-        TextView title = textView(titleValue, 16, tokens.textPrimary);
+        TextView title = textView(
+                titleValue,
+                rootLevel ? 18 : 16,
+                tokens.textPrimary
+        );
         labels.addView(title);
 
         if (!TextUtils.isEmpty(summaryValue)) {
-            TextView summary = textView(summaryValue, 14, tokens.textSecondary);
-            summary.setLineSpacing(0, 1.06f);
+            TextView summary = textView(
+                    summaryValue,
+                    rootLevel ? 15 : 13,
+                    tokens.textSecondary
+            );
+            summary.setLineSpacing(0, rootLevel ? 1.06f : 1.04f);
             summary.setMaxLines(2);
             summary.setEllipsize(TextUtils.TruncateAt.END);
             LinearLayout.LayoutParams summaryParams = wrapParams();
@@ -470,7 +635,8 @@ public final class MorpheSettingsV4Fragment extends Fragment {
             String iconName,
             int iconColor,
             int backgroundColor,
-            int sizeDp
+            int sizeDp,
+            int glyphDp
     ) {
         Context context = requireContext();
         FrameLayout container = new FrameLayout(context);
@@ -490,7 +656,7 @@ public final class MorpheSettingsV4Fragment extends Fragment {
         }
         iconView.setScaleType(ImageView.ScaleType.CENTER_INSIDE);
 
-        int iconSize = dp(24);
+        int iconSize = dp(glyphDp);
         FrameLayout.LayoutParams iconParams = new FrameLayout.LayoutParams(
                 iconSize,
                 iconSize,
@@ -502,11 +668,56 @@ public final class MorpheSettingsV4Fragment extends Fragment {
     }
 
     private void openSearchItem(MorpheSettingsV4Catalog.SearchItem item) {
+        if (!TextUtils.isEmpty(item.pageId)) {
+            MorpheSettingsV4Catalog.Category category =
+                    MorpheSettingsV4Catalog.findCategory(item.pageId);
+            if (category == null) {
+                showUnavailable();
+                return;
+            }
+            openCategory(category);
+            return;
+        }
         if (!TextUtils.isEmpty(item.activityName)) {
             openActivity(item.activityName);
             return;
         }
         openFragment(item.fragmentName, item.title);
+    }
+
+    private void openRootGroup(
+            MorpheSettingsV4Catalog.RootGroup rootGroup
+    ) {
+        if (rootGroup == null) {
+            showUnavailable();
+            return;
+        }
+        openHub(rootGroup.id);
+    }
+
+    private void openCategory(MorpheSettingsV4Catalog.Category category) {
+        if (category == null) {
+            showUnavailable();
+            return;
+        }
+        if (MorpheSettingsV4Catalog.opensDirectly(category)) {
+            openLeaf(category.leaves[0], null);
+            return;
+        }
+        openHub(category.id);
+    }
+
+    private void openHub(String categoryId) {
+        Activity activity = hostActivity();
+        if (activity == null || TextUtils.isEmpty(categoryId)) {
+            showUnavailable();
+            return;
+        }
+
+        Intent intent = new Intent(activity, activity.getClass());
+        intent.putExtra(EXTRA_SHOW_FRAGMENT, getClass().getName());
+        intent.putExtra(ARGUMENT_PAGE, categoryId);
+        activity.startActivity(intent);
     }
 
     private void openLeaf(
@@ -568,10 +779,16 @@ public final class MorpheSettingsV4Fragment extends Fragment {
 
         String title = "Settings";
         if (!PAGE_ROOT.equals(page)) {
-            MorpheSettingsV4Catalog.Category category =
-                    MorpheSettingsV4Catalog.findCategory(page);
-            if (category != null) {
-                title = category.title;
+            MorpheSettingsV4Catalog.RootGroup rootGroup =
+                    MorpheSettingsV4Catalog.findRootGroup(page);
+            if (rootGroup != null) {
+                title = rootGroup.title;
+            } else {
+                MorpheSettingsV4Catalog.Category category =
+                        MorpheSettingsV4Catalog.findCategory(page);
+                if (category != null) {
+                    title = category.title;
+                }
             }
         }
         activity.setTitle(title);
@@ -644,6 +861,14 @@ public final class MorpheSettingsV4Fragment extends Fragment {
 
     private void addBodyText(LinearLayout parent, String value) {
         parent.addView(MorpheSettingsV14Ui.supportingText(
+                requireContext(),
+                tokens,
+                value
+        ));
+    }
+
+    private void addPageIntro(LinearLayout parent, String value) {
+        parent.addView(MorpheSettingsV14Ui.pageIntro(
                 requireContext(),
                 tokens,
                 value

--- a/extensions/boostforreddit/src/main/java/app/morphe/extension/boostforreddit/settings/MorpheSettingsV4NativePages.java
+++ b/extensions/boostforreddit/src/main/java/app/morphe/extension/boostforreddit/settings/MorpheSettingsV4NativePages.java
@@ -78,6 +78,16 @@ public final class MorpheSettingsV4NativePages {
             "MORPHE_BOOST_SETTINGS_V14_EDITOR_SYSTEM_ISSUE106_V1";
     public static final String V14_NO_COMPILE_ONLY_UI_MARKER =
             "MORPHE_BOOST_SETTINGS_V14_NO_COMPILE_ONLY_UI_ABI_ISSUE106_V1";
+    public static final String NAVIGATION_IA_MARKER =
+            "MORPHE_BOOST_SETTINGS_NAVIGATION_GESTURES_ISSUE121_V1";
+    public static final String NAVIGATION_PHASE2_MARKER =
+            "MORPHE_BOOST_SETTINGS_NAVIGATION_PHASE2_LEAF_SPLIT_ISSUE121_V1";
+    public static final String MATERIAL_VISUAL_FOUNDATION_MARKER =
+            "MORPHE_BOOST_SETTINGS_NATIVE_MATERIAL_VISUAL_FOUNDATION_"
+                    + "ISSUE121_PHASE2_1_V1";
+    public static final String ANDROID_SETTINGS_GUIDANCE_PILOT_MARKER =
+            "MORPHE_BOOST_SETTINGS_NATIVE_STANDARD_PREFERENCE_LIST_"
+                    + "ISSUE121_PHASE2_2_V1";
 
     private static final String PREFIX =
             "app.morphe.extension.boostforreddit.settings."
@@ -150,6 +160,313 @@ public final class MorpheSettingsV4NativePages {
         }
     }
 
+    public static final class Headers extends NativePage {
+        public Headers() {
+            super("Community header", "pref_headers_v2");
+        }
+    }
+
+    public static final class Navigation extends NativePage {
+        public Navigation() {
+            super(
+                    "Navigation & gestures",
+                    "pref_toolbar_v2",
+                    "pref_bottom_navigation_v2",
+                    "pref_drawer_v2",
+                    "pref_general_v2"
+            );
+        }
+
+        @Override
+        protected boolean includeControl(String resourceName, String key) {
+            if (TextUtils.isEmpty(key)) {
+                return false;
+            }
+            switch (key) {
+                case "pref_toolbar_main_action":
+                case "pref_toolbar":
+                case "pref_bottom_navigation":
+                case "pref_bottom_navigation_hide_on_scroll":
+                case "pref_drawer_show_home":
+                case "pref_drawer_show_frontpage":
+                case "pref_drawer_show_popular":
+                case "pref_drawer_show_all":
+                case "pref_drawer_show_saved":
+                case "pref_drawer_show_history":
+                case "pref_drawer_show_profile":
+                case "pref_drawer_show_inbox":
+                case "pref_drawer_show_drafts":
+                case "pref_drawer_show_mod":
+                case "pref_drawer_show_search_generic":
+                case "pref_drawer_show_go_to":
+                case "pref_drawer_show_go_to_subreddit":
+                case "pref_drawer_show_go_to_user":
+                case "pref_drawer_show_night_mode":
+                case "pref_drawer_show_nsfw_switch":
+                case "pref_drawer_show_blur_switch":
+                case "pref_drawer_sticky_settings":
+                case "pref_subscriptions_drawer":
+                case "pref_subscriptions_drawer_show_icon":
+                case "pref_subscriptions_only_casual":
+                case "pref_accounts_show_avatar":
+                case "pref_accounts_show_username":
+                case "pref_drawer_end":
+                case "pref_ask_exit":
+                case "pref_double_exit":
+                    return true;
+                default:
+                    return false;
+            }
+        }
+
+        @Override
+        protected String sectionFor(
+                String resourceName,
+                String key,
+                String currentSection
+        ) {
+            if ("pref_toolbar_v2".equals(resourceName)) {
+                return "Toolbar behavior";
+            }
+            if ("pref_bottom_navigation_v2".equals(resourceName)) {
+                return "Bottom navigation";
+            }
+            if ("pref_drawer_v2".equals(resourceName)) {
+                return "Navigation drawer";
+            }
+            if ("pref_ask_exit".equals(key)
+                    || "pref_double_exit".equals(key)) {
+                return "Back & exit";
+            }
+            return currentSection;
+        }
+    }
+
+    private abstract static class NavigationSubsetPage
+            extends NativePage {
+        private final String sectionTitle;
+        private final String intro;
+        private final String[] includedKeys;
+
+        NavigationSubsetPage(
+                String title,
+                String resourceName,
+                String intro,
+                String... includedKeys
+        ) {
+            super(title, resourceName);
+            this.sectionTitle = title;
+            this.intro = intro;
+            this.includedKeys = includedKeys == null
+                    ? new String[0]
+                    : includedKeys.clone();
+        }
+
+        @Override
+        protected boolean includeControl(String resourceName, String key) {
+            if (TextUtils.isEmpty(key)) {
+                return false;
+            }
+            for (String includedKey : includedKeys) {
+                if (key.equals(includedKey)) {
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        @Override
+        protected String sectionFor(
+                String resourceName,
+                String key,
+                String currentSection
+        ) {
+            return sectionTitle;
+        }
+
+        @Override
+        protected String pageIntro() {
+            return "";
+        }
+
+        @Override
+        protected boolean useAndroidSettingsGuidanceRows() {
+            return true;
+        }
+    }
+
+    public static final class NavigationToolbar
+            extends NavigationSubsetPage {
+        public NavigationToolbar() {
+            super(
+                    "Toolbar",
+                    "pref_toolbar_v2",
+                    "Choose the toolbar's primary action and whether it "
+                            + "stays visible while scrolling.",
+                    "pref_toolbar_main_action",
+                    "pref_toolbar"
+            );
+        }
+    }
+
+    public static final class NavigationBottom
+            extends NavigationSubsetPage {
+        public NavigationBottom() {
+            super(
+                    "Bottom navigation",
+                    "pref_bottom_navigation_v2",
+                    "Control whether bottom navigation is shown and how it "
+                            + "behaves while scrolling.",
+                    "pref_bottom_navigation",
+                    "pref_bottom_navigation_hide_on_scroll"
+            );
+        }
+    }
+
+    public static final class DrawerFeedsLibrary
+            extends NavigationSubsetPage {
+        public DrawerFeedsLibrary() {
+            super(
+                    "Feeds & library",
+                    "pref_drawer_v2",
+                    "Choose which feed and library destinations appear in "
+                            + "the navigation drawer.",
+                    "pref_drawer_show_home",
+                    "pref_drawer_show_frontpage",
+                    "pref_drawer_show_popular",
+                    "pref_drawer_show_all",
+                    "pref_drawer_show_saved",
+                    "pref_drawer_show_history"
+            );
+        }
+
+        @Override
+        protected String sectionFor(
+                String resourceName,
+                String key,
+                String currentSection
+        ) {
+            return "Drawer destinations";
+        }
+
+        @Override
+        protected String displaySummary(
+                String key,
+                String currentSummary
+        ) {
+            if ("pref_drawer_show_home".equals(key)) {
+                return "Default feed";
+            }
+            if ("pref_drawer_show_frontpage".equals(key)) {
+                return "Posts from subscriptions";
+            }
+            return "";
+        }
+    }
+
+    public static final class DrawerAccountTools
+            extends NavigationSubsetPage {
+        public DrawerAccountTools() {
+            super(
+                    "Account & tools",
+                    "pref_drawer_v2",
+                    "Choose which account and utility destinations appear "
+                            + "in the navigation drawer.",
+                    "pref_drawer_show_profile",
+                    "pref_drawer_show_inbox",
+                    "pref_drawer_show_drafts",
+                    "pref_drawer_show_mod",
+                    "pref_drawer_show_search_generic"
+            );
+        }
+    }
+
+    public static final class DrawerGoToShortcuts
+            extends NavigationSubsetPage {
+        public DrawerGoToShortcuts() {
+            super(
+                    "Go-to shortcuts",
+                    "pref_drawer_v2",
+                    "Choose which direct navigation shortcuts appear in "
+                            + "the drawer.",
+                    "pref_drawer_show_go_to",
+                    "pref_drawer_show_go_to_subreddit",
+                    "pref_drawer_show_go_to_user"
+            );
+        }
+    }
+
+    public static final class DrawerQuickToggles
+            extends NavigationSubsetPage {
+        public DrawerQuickToggles() {
+            super(
+                    "Quick toggles",
+                    "pref_drawer_v2",
+                    "Choose which frequently used display controls appear "
+                            + "in the drawer.",
+                    "pref_drawer_show_night_mode",
+                    "pref_drawer_show_nsfw_switch",
+                    "pref_drawer_show_blur_switch"
+            );
+        }
+    }
+
+    public static final class DrawerSubscriptions
+            extends NavigationSubsetPage {
+        public DrawerSubscriptions() {
+            super(
+                    "Subscriptions",
+                    "pref_drawer_v2",
+                    "Configure the subscription list shown inside the "
+                            + "navigation drawer.",
+                    "pref_subscriptions_drawer",
+                    "pref_subscriptions_drawer_show_icon",
+                    "pref_subscriptions_only_casual"
+            );
+        }
+    }
+
+    public static final class DrawerAccountSwitcher
+            extends NavigationSubsetPage {
+        public DrawerAccountSwitcher() {
+            super(
+                    "Account switcher",
+                    "pref_drawer_v2",
+                    "Choose which identity details are visible in the "
+                            + "drawer's account switcher.",
+                    "pref_accounts_show_avatar",
+                    "pref_accounts_show_username"
+            );
+        }
+    }
+
+    public static final class DrawerBehavior
+            extends NavigationSubsetPage {
+        public DrawerBehavior() {
+            super(
+                    "Drawer behavior",
+                    "pref_drawer_v2",
+                    "Control persistent Settings access and which side "
+                            + "opens the navigation drawer.",
+                    "pref_drawer_sticky_settings",
+                    "pref_drawer_end"
+            );
+        }
+    }
+
+    public static final class NavigationBackExit
+            extends NavigationSubsetPage {
+        public NavigationBackExit() {
+            super(
+                    "Back & exit",
+                    "pref_general_v2",
+                    "Choose how Boost responds when Back would leave the app.",
+                    "pref_ask_exit",
+                    "pref_double_exit"
+            );
+        }
+    }
+
     public static final class BottomNavigation extends NativePage {
         public BottomNavigation() {
             super("Bottom navigation", "pref_bottom_navigation_v2");
@@ -202,6 +519,12 @@ public final class MorpheSettingsV4NativePages {
         public General() {
             super("General", "pref_general_v2");
         }
+
+        @Override
+        protected boolean includeControl(String resourceName, String key) {
+            return !"pref_ask_exit".equals(key)
+                    && !"pref_double_exit".equals(key);
+        }
     }
 
     public static final class Misc extends NativePage {
@@ -237,7 +560,7 @@ public final class MorpheSettingsV4NativePages {
         private static final int REQUEST_SYNCCIT_ACCOUNT = 1002;
 
         private final String pageTitle;
-        private final String resourceName;
+        private final String[] resourceNames;
         private final List<Binding> bindings = new ArrayList<>();
         private final Map<String, Control> controlsByKey = new LinkedHashMap<>();
 
@@ -255,8 +578,14 @@ public final class MorpheSettingsV4NativePages {
         private int editorBackStackSequence;
 
         protected NativePage(String pageTitle, String resourceName) {
+            this(pageTitle, new String[]{resourceName});
+        }
+
+        protected NativePage(String pageTitle, String... resourceNames) {
             this.pageTitle = pageTitle;
-            this.resourceName = resourceName;
+            this.resourceNames = resourceNames == null
+                    ? new String[0]
+                    : resourceNames.clone();
         }
 
         @Override
@@ -285,7 +614,7 @@ public final class MorpheSettingsV4NativePages {
 
             LinearLayout content = new LinearLayout(context);
             content.setOrientation(LinearLayout.VERTICAL);
-            content.setPadding(dp(16), dp(10), dp(16), dp(32));
+            content.setPadding(dp(16), dp(4), dp(16), dp(32));
             scrollView.addView(content, new ScrollView.LayoutParams(
                     ViewGroup.LayoutParams.MATCH_PARENT,
                     ViewGroup.LayoutParams.WRAP_CONTENT
@@ -303,6 +632,16 @@ public final class MorpheSettingsV4NativePages {
                         view -> showUnavailable()
                 );
                 return pageHost;
+            }
+
+            String intro = pageIntro();
+            if (!TextUtils.isEmpty(intro)) {
+                content.addView(MorpheSettingsV14Ui.pageIntro(
+                        requireContext(),
+                        tokens,
+                        intro
+                ));
+                addSpace(content, 14);
             }
 
             renderControls(content, controls);
@@ -372,13 +711,56 @@ public final class MorpheSettingsV4NativePages {
         @Override
         public void onPrepareOptionsMenu(Menu menu) {
             super.onPrepareOptionsMenu(menu);
-            hideMenuItem(menu, "action_generic_search");
-            hideMenuItem(menu, "action_search");
-            hideMenuItem(menu, "search");
-            hideMenuItem(menu, "menu_search");
+            MorpheSettingsV4Search.prepareMenu(this, menu, true);
+        }
+
+        @Override
+        public boolean onOptionsItemSelected(MenuItem item) {
+            if (MorpheSettingsV4Search.handleMenuItem(this, item)) {
+                return true;
+            }
+            return super.onOptionsItemSelected(item);
+        }
+
+        protected boolean includeControl(String resourceName, String key) {
+            return true;
+        }
+
+        protected String sectionFor(
+                String resourceName,
+                String key,
+                String currentSection
+        ) {
+            return currentSection;
+        }
+
+        protected String pageIntro() {
+            return "";
+        }
+
+        protected boolean useAndroidSettingsGuidanceRows() {
+            return false;
+        }
+
+        protected String displaySummary(
+                String key,
+                String currentSummary
+        ) {
+            return currentSummary;
         }
 
         private List<Control> readControls(Context context) {
+            List<Control> result = new ArrayList<>();
+            for (String resourceName : resourceNames) {
+                result.addAll(readControls(context, resourceName));
+            }
+            return result;
+        }
+
+        private List<Control> readControls(
+                Context context,
+                String resourceName
+        ) {
             int resourceId = MorpheSettingsV4Catalog.resourceId(
                     context,
                     "xml",
@@ -496,6 +878,14 @@ public final class MorpheSettingsV4NativePages {
                             "entryValues"
                     );
                     configureMorpheControl(control);
+                    if (!includeControl(resourceName, control.key)) {
+                        continue;
+                    }
+                    control.section = sectionFor(
+                            resourceName,
+                            control.key,
+                            control.section
+                    );
                     if ("pref_general_v2".equals(resourceName)
                             && !TextUtils.isEmpty(control.fragmentName)) {
                         // These six routes duplicate the dedicated Morphe hubs.
@@ -527,12 +917,18 @@ public final class MorpheSettingsV4NativePages {
             LinearLayout group = null;
             for (Control control : controls) {
                 if (!TextUtils.equals(currentSection, control.section)) {
-                    if (content.getChildCount() > 0) {
-                        addSpace(content, 24);
+                    boolean repeatedPageTitle = TextUtils.equals(
+                            control.section,
+                            pageTitle
+                    );
+                    if (group != null) {
+                        addSpace(content, 20);
                     }
                     currentSection = control.section;
-                    addSectionLabel(content, currentSection);
-                    addSpace(content, 8);
+                    if (!repeatedPageTitle) {
+                        addSectionLabel(content, currentSection);
+                        addSpace(content, 6);
+                    }
                     group = addGroup(content);
                 }
                 if (isToggle(control)) {
@@ -552,11 +948,12 @@ public final class MorpheSettingsV4NativePages {
                     control.key,
                     booleanDefault(control)
             );
-            LinearLayout row = baseRow();
+            String summaryValue = toggleSummary(control, checked);
+            LinearLayout row = baseRow(!TextUtils.isEmpty(summaryValue));
             TextView summary = addLabels(
                     row,
                     control.title,
-                    toggleSummary(control, checked)
+                    summaryValue
             );
 
             MorpheSettingsV14Ui.Toggle toggle =
@@ -587,11 +984,12 @@ public final class MorpheSettingsV4NativePages {
         }
 
         private void addChoice(LinearLayout group, Control control) {
-            LinearLayout row = baseRow();
+            String summaryValue = selectedTitle(control);
+            LinearLayout row = baseRow(!TextUtils.isEmpty(summaryValue));
             TextView summary = addLabels(
                     row,
                     control.title,
-                    selectedTitle(control)
+                    summaryValue
             );
             addChevron(row);
             row.setOnClickListener(view -> {
@@ -667,11 +1065,12 @@ public final class MorpheSettingsV4NativePages {
         }
 
         private void addAction(LinearLayout group, Control control) {
-            LinearLayout row = baseRow();
+            String summaryValue = actionSummary(control);
+            LinearLayout row = baseRow(!TextUtils.isEmpty(summaryValue));
             TextView summary = addLabels(
                     row,
                     control.title,
-                    actionSummary(control)
+                    summaryValue
             );
             addChevron(row);
             row.setOnClickListener(view -> {
@@ -689,7 +1088,7 @@ public final class MorpheSettingsV4NativePages {
                 String summary,
                 View.OnClickListener listener
         ) {
-            LinearLayout row = baseRow();
+            LinearLayout row = baseRow(!TextUtils.isEmpty(summary));
             addLabels(row, title, summary);
             addChevron(row);
             row.setOnClickListener(listener);
@@ -2090,13 +2489,13 @@ public final class MorpheSettingsV4NativePages {
         }
 
         private String toggleSummary(Control control, boolean checked) {
+            String summary = control.summary;
             if (checked && !TextUtils.isEmpty(control.summaryOn)) {
-                return control.summaryOn;
+                summary = control.summaryOn;
+            } else if (!checked && !TextUtils.isEmpty(control.summaryOff)) {
+                summary = control.summaryOff;
             }
-            if (!checked && !TextUtils.isEmpty(control.summaryOff)) {
-                return control.summaryOff;
-            }
-            return control.summary;
+            return displaySummary(control.key, summary);
         }
 
         private String selectedTitle(Control control) {
@@ -2418,13 +2817,26 @@ public final class MorpheSettingsV4NativePages {
         }
 
         private LinearLayout addGroup(LinearLayout parent) {
-            LinearLayout group = MorpheSettingsV14Ui.group(requireContext());
+            LinearLayout group = useAndroidSettingsGuidanceRows()
+                    ? MorpheSettingsV14Ui.standardList(requireContext())
+                    : MorpheSettingsV14Ui.group(requireContext());
             parent.addView(group, matchWrapParams());
             return group;
         }
 
         private LinearLayout baseRow() {
             return MorpheSettingsV14Ui.baseRow(requireContext(), tokens);
+        }
+
+        private LinearLayout baseRow(boolean hasSupportingText) {
+            if (useAndroidSettingsGuidanceRows()) {
+                return MorpheSettingsV14Ui.standardListRow(
+                        requireContext(),
+                        tokens,
+                        hasSupportingText
+                );
+            }
+            return baseRow();
         }
 
         private MorpheSettingsV14Ui.ChoiceRow materialChoiceRow(
@@ -2457,7 +2869,9 @@ public final class MorpheSettingsV4NativePages {
                     tokens.textSecondary
             );
             summary.setLineSpacing(0, 1.04f);
-            summary.setMaxLines(4);
+            summary.setMaxLines(
+                    useAndroidSettingsGuidanceRows() ? 2 : 4
+            );
             summary.setVisibility(
                     TextUtils.isEmpty(summaryValue) ? View.GONE : View.VISIBLE
             );
@@ -2476,6 +2890,10 @@ public final class MorpheSettingsV4NativePages {
         }
 
         private void addGroupedRow(LinearLayout group, View row) {
+            if (useAndroidSettingsGuidanceRows()) {
+                MorpheSettingsV14Ui.addStandardListRow(group, row, tokens);
+                return;
+            }
             MorpheSettingsV14Ui.addSegmentedRow(group, row, tokens);
         }
 

--- a/extensions/boostforreddit/src/main/java/app/morphe/extension/boostforreddit/settings/MorpheSettingsV4NavigationDrawerHubFragment.java
+++ b/extensions/boostforreddit/src/main/java/app/morphe/extension/boostforreddit/settings/MorpheSettingsV4NavigationDrawerHubFragment.java
@@ -1,0 +1,274 @@
+package app.morphe.extension.boostforreddit.settings;
+
+import android.app.Activity;
+import android.content.Context;
+import android.content.Intent;
+import android.os.Bundle;
+import android.view.LayoutInflater;
+import android.view.Menu;
+import android.view.MenuItem;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.LinearLayout;
+import android.widget.ScrollView;
+
+import androidx.fragment.app.Fragment;
+
+import app.morphe.extension.boostforreddit.utils.BoostSystemBarInsetsFix;
+
+/** Material navigation hub for the split drawer settings pages. */
+public final class MorpheSettingsV4NavigationDrawerHubFragment
+        extends Fragment {
+    public static final String CONTRACT_MARKER =
+            "MORPHE_BOOST_SETTINGS_NAVIGATION_DRAWER_HUB_ISSUE121_V1";
+    public static final String MATERIAL_VISUAL_FOUNDATION_MARKER =
+            "MORPHE_BOOST_SETTINGS_NAVIGATION_DRAWER_MATERIAL_"
+                    + "ISSUE121_PHASE2_1_V1";
+    public static final String ANDROID_SETTINGS_GUIDANCE_PILOT_MARKER =
+            "MORPHE_BOOST_SETTINGS_NAVIGATION_DRAWER_STANDARD_LIST_"
+                    + "ISSUE121_PHASE2_2_V1";
+
+    private static final String EXTRA_SHOW_FRAGMENT = "extra_show_fragment";
+
+    private static final Destination[] DESTINATIONS = new Destination[]{
+            new Destination(
+                    "Destinations",
+                    "Feeds & library",
+                    "Home, feeds, saved posts, and history",
+                    "ic_subreddit_24dp",
+                    MorpheSettingsV4Catalog.V4_DRAWER_FEEDS_LIBRARY_FRAGMENT
+            ),
+            new Destination(
+                    "Destinations",
+                    "Account & tools",
+                    "Profile, inbox, drafts, moderation, and search",
+                    "ic_person_24dp",
+                    MorpheSettingsV4Catalog.V4_DRAWER_ACCOUNT_TOOLS_FRAGMENT
+            ),
+            new Destination(
+                    "Shortcuts",
+                    "Go-to shortcuts",
+                    "Community, user, and combined go-to shortcuts",
+                    "ic_search_color_24dp",
+                    MorpheSettingsV4Catalog.V4_DRAWER_GO_TO_FRAGMENT
+            ),
+            new Destination(
+                    "Shortcuts",
+                    "Quick toggles",
+                    "Dark mode and NSFW controls in the drawer",
+                    "ic_settings_24dp",
+                    MorpheSettingsV4Catalog.V4_DRAWER_QUICK_TOGGLES_FRAGMENT
+            ),
+            new Destination(
+                    "Personalization",
+                    "Subscriptions",
+                    "Subscription list visibility, icons, and favorites",
+                    "ic_subreddit_24dp",
+                    MorpheSettingsV4Catalog.V4_DRAWER_SUBSCRIPTIONS_FRAGMENT
+            ),
+            new Destination(
+                    "Personalization",
+                    "Account switcher",
+                    "Avatar and username visibility",
+                    "ic_person_24dp",
+                    MorpheSettingsV4Catalog.V4_DRAWER_ACCOUNT_SWITCHER_FRAGMENT
+            ),
+            new Destination(
+                    "Personalization",
+                    "Drawer behavior",
+                    "Sticky Settings and which edge opens the drawer",
+                    "ic_toolbar_24dp",
+                    MorpheSettingsV4Catalog.V4_DRAWER_BEHAVIOR_FRAGMENT
+            ),
+    };
+
+    private MorpheSettingsV4Theme.Tokens tokens;
+
+    public MorpheSettingsV4NavigationDrawerHubFragment() {
+    }
+
+    @Override
+    public View onCreateView(
+            LayoutInflater inflater,
+            ViewGroup container,
+            Bundle savedInstanceState
+    ) {
+        Context context = inflater.getContext();
+        tokens = MorpheSettingsV4Theme.resolve(context);
+        setHasOptionsMenu(true);
+
+        ScrollView scrollView = new ScrollView(context);
+        scrollView.setFillViewport(true);
+        scrollView.setClipToPadding(false);
+        scrollView.setBackgroundColor(tokens.background);
+
+        LinearLayout content = new LinearLayout(context);
+        content.setOrientation(LinearLayout.VERTICAL);
+        content.setPadding(dp(16), dp(4), dp(16), dp(36));
+        scrollView.addView(
+                content,
+                new ScrollView.LayoutParams(
+                        ViewGroup.LayoutParams.MATCH_PARENT,
+                        ViewGroup.LayoutParams.WRAP_CONTENT
+                )
+        );
+
+        String currentSection = null;
+        LinearLayout group = null;
+        for (Destination destination : DESTINATIONS) {
+            if (!destination.section.equals(currentSection)) {
+                if (currentSection != null) {
+                    addSpace(content, 20);
+                }
+                currentSection = destination.section;
+                content.addView(MorpheSettingsV14Ui.sectionLabel(
+                        context,
+                        tokens,
+                        currentSection
+                ));
+                addSpace(content, 6);
+                group = MorpheSettingsV14Ui.standardList(context);
+                content.addView(
+                        group,
+                        new LinearLayout.LayoutParams(
+                                ViewGroup.LayoutParams.MATCH_PARENT,
+                                ViewGroup.LayoutParams.WRAP_CONTENT
+                        )
+                );
+            }
+
+            LinearLayout row = createDestinationRow(destination);
+            MorpheSettingsV14Ui.addStandardListRow(group, row, tokens);
+        }
+
+        return scrollView;
+    }
+
+    @Override
+    public void onResume() {
+        super.onResume();
+        styleHost();
+    }
+
+    @Override
+    public void onPause() {
+        Activity activity = hostActivity();
+        if (activity != null) {
+            BoostSystemBarInsetsFix.clearMorpheSettingsV4SystemBars(activity);
+        }
+        super.onPause();
+    }
+
+    @Override
+    public void onPrepareOptionsMenu(Menu menu) {
+        super.onPrepareOptionsMenu(menu);
+        MorpheSettingsV4Search.prepareMenu(this, menu, true);
+    }
+
+    @Override
+    public boolean onOptionsItemSelected(MenuItem item) {
+        if (MorpheSettingsV4Search.handleMenuItem(this, item)) {
+            return true;
+        }
+        return super.onOptionsItemSelected(item);
+    }
+
+    private LinearLayout createDestinationRow(
+            Destination destination
+    ) {
+        Context context = requireContext();
+        LinearLayout row = MorpheSettingsV14Ui.standardListRow(
+                context,
+                tokens,
+                false
+        );
+        LinearLayout labels = MorpheSettingsV14Ui.standardListLabels(
+                context,
+                tokens,
+                destination.title,
+                ""
+        );
+        row.addView(labels, new LinearLayout.LayoutParams(
+                0,
+                ViewGroup.LayoutParams.WRAP_CONTENT,
+                1.0f
+        ));
+        row.addView(MorpheSettingsV14Ui.chevron(context, tokens));
+        row.setOnClickListener(
+                view -> openFragment(destination.fragmentName)
+        );
+        return row;
+    }
+
+    private void openFragment(String fragmentName) {
+        Activity activity = hostActivity();
+        if (activity == null || fragmentName == null) {
+            return;
+        }
+        Intent intent = new Intent(activity, activity.getClass());
+        intent.putExtra(EXTRA_SHOW_FRAGMENT, fragmentName);
+        activity.startActivity(intent);
+    }
+
+    private void styleHost() {
+        Activity activity = hostActivity();
+        if (activity == null || tokens == null) {
+            return;
+        }
+        activity.setTitle("Navigation drawer");
+        BoostSystemBarInsetsFix.applyMorpheSettingsV4SystemBars(
+                activity,
+                tokens.background,
+                tokens.dark
+        );
+
+        int toolbarId = MorpheSettingsV4Catalog.resourceId(
+                activity,
+                "id",
+                "toolbar"
+        );
+        View toolbar = activity.findViewById(toolbarId);
+        if (toolbar != null) {
+            toolbar.setBackgroundColor(tokens.background);
+            toolbar.setElevation(0);
+        }
+    }
+
+    private Activity hostActivity() {
+        Context context = getContext();
+        return context instanceof Activity ? (Activity) context : null;
+    }
+
+    private void addSpace(LinearLayout parent, int heightDp) {
+        parent.addView(
+                new View(requireContext()),
+                new LinearLayout.LayoutParams(1, dp(heightDp))
+        );
+    }
+
+    private int dp(float value) {
+        return MorpheSettingsV4Theme.dp(requireContext(), value);
+    }
+
+    private static final class Destination {
+        final String section;
+        final String title;
+        final String summary;
+        final String iconName;
+        final String fragmentName;
+
+        Destination(
+                String section,
+                String title,
+                String summary,
+                String iconName,
+                String fragmentName
+        ) {
+            this.section = section;
+            this.title = title;
+            this.summary = summary;
+            this.iconName = iconName;
+            this.fragmentName = fragmentName;
+        }
+    }
+}

--- a/extensions/boostforreddit/src/main/java/app/morphe/extension/boostforreddit/settings/MorpheSettingsV4PostViewsFragment.java
+++ b/extensions/boostforreddit/src/main/java/app/morphe/extension/boostforreddit/settings/MorpheSettingsV4PostViewsFragment.java
@@ -263,9 +263,15 @@ public final class MorpheSettingsV4PostViewsFragment extends Fragment {
     @Override
     public void onPrepareOptionsMenu(Menu menu) {
         super.onPrepareOptionsMenu(menu);
-        hideMenuItem(menu, "action_generic_search");
-        hideMenuItem(menu, "action_search");
-        hideMenuItem(menu, "search");
+        MorpheSettingsV4Search.prepareMenu(this, menu, true);
+    }
+
+    @Override
+    public boolean onOptionsItemSelected(MenuItem item) {
+        if (MorpheSettingsV4Search.handleMenuItem(this, item)) {
+            return true;
+        }
+        return super.onOptionsItemSelected(item);
     }
 
     private LinearLayout addGroup(LinearLayout parent) {

--- a/extensions/boostforreddit/src/main/java/app/morphe/extension/boostforreddit/settings/MorpheSettingsV4SavedViewsFragment.java
+++ b/extensions/boostforreddit/src/main/java/app/morphe/extension/boostforreddit/settings/MorpheSettingsV4SavedViewsFragment.java
@@ -123,9 +123,15 @@ public final class MorpheSettingsV4SavedViewsFragment extends Fragment {
     @Override
     public void onPrepareOptionsMenu(Menu menu) {
         super.onPrepareOptionsMenu(menu);
-        hideMenuItem(menu, "action_generic_search");
-        hideMenuItem(menu, "action_search");
-        hideMenuItem(menu, "search");
+        MorpheSettingsV4Search.prepareMenu(this, menu, true);
+    }
+
+    @Override
+    public boolean onOptionsItemSelected(MenuItem item) {
+        if (MorpheSettingsV4Search.handleMenuItem(this, item)) {
+            return true;
+        }
+        return super.onOptionsItemSelected(item);
     }
 
     private void rebuildEntries() {

--- a/extensions/boostforreddit/src/main/java/app/morphe/extension/boostforreddit/settings/MorpheSettingsV4Search.java
+++ b/extensions/boostforreddit/src/main/java/app/morphe/extension/boostforreddit/settings/MorpheSettingsV4Search.java
@@ -1,0 +1,574 @@
+package app.morphe.extension.boostforreddit.settings;
+
+import android.app.Activity;
+import android.app.Dialog;
+import android.content.Context;
+import android.content.Intent;
+import android.content.res.ColorStateList;
+import android.graphics.drawable.ColorDrawable;
+import android.graphics.drawable.Drawable;
+import android.os.Build;
+import android.text.Editable;
+import android.text.TextUtils;
+import android.text.TextWatcher;
+import android.view.Gravity;
+import android.view.KeyEvent;
+import android.view.Menu;
+import android.view.MenuItem;
+import android.view.View;
+import android.view.ViewGroup;
+import android.view.Window;
+import android.view.WindowManager;
+import android.view.inputmethod.EditorInfo;
+import android.view.inputmethod.InputMethodManager;
+import android.widget.EditText;
+import android.widget.ImageButton;
+import android.widget.LinearLayout;
+import android.widget.ScrollView;
+import android.widget.TextView;
+import android.window.OnBackInvokedCallback;
+import android.window.OnBackInvokedDispatcher;
+
+import androidx.fragment.app.Fragment;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/** Global Settings search entry available from every Morphe-owned page. */
+final class MorpheSettingsV4Search {
+    static final String CONTRACT_MARKER =
+            "MORPHE_BOOST_SETTINGS_GLOBAL_SEARCH_ISSUE121_PHASE1_2_V1";
+    static final String FRAGMENT_ABI_COMPAT_MARKER =
+            "MORPHE_BOOST_SETTINGS_GLOBAL_SEARCH_FRAGMENT_ABI_COMPAT_"
+                    + "ISSUE121_PHASE1_2_1_V1";
+    static final String PLATFORM_DIALOG_MARKER =
+            "MORPHE_BOOST_SETTINGS_GLOBAL_SEARCH_PLATFORM_DIALOG_"
+                    + "ISSUE121_PHASE1_2_3_V1";
+    static final String SINGLE_BACK_DISMISS_MARKER =
+            "MORPHE_BOOST_SETTINGS_GLOBAL_SEARCH_SINGLE_BACK_DISMISS_"
+                    + "ISSUE121_PHASE1_2_4_V2";
+
+    static final String ARGUMENT_PAGE =
+            "morphe_boost_settings_v4_page";
+    static final String PAGE_ROOT = "root";
+    static final String EXTRA_OPEN_SEARCH =
+            "morphe_boost_settings_v4_open_search";
+
+    private static final String EXTRA_SHOW_FRAGMENT = "extra_show_fragment";
+    private static final int MENU_ID_GLOBAL_SEARCH = 0x4d535312;
+    private static final int RESULT_LIMIT = 80;
+    private static final String[] BOOST_SEARCH_ITEM_NAMES = new String[]{
+            "action_generic_search",
+            "action_search",
+            "search",
+            "menu_search",
+    };
+
+    private MorpheSettingsV4Search() {
+    }
+
+    static void prepareMenu(
+            Fragment fragment,
+            Menu menu,
+            boolean showGlobalSearch
+    ) {
+        if (fragment == null || menu == null || !fragment.isAdded()) {
+            return;
+        }
+
+        Context context = fragment.requireContext();
+        for (String resourceName : BOOST_SEARCH_ITEM_NAMES) {
+            hideMenuItem(context, menu, resourceName);
+        }
+        menu.removeItem(MENU_ID_GLOBAL_SEARCH);
+
+        if (!showGlobalSearch) {
+            return;
+        }
+
+        MorpheSettingsV4Theme.Tokens tokens =
+                MorpheSettingsV4Theme.resolve(context);
+        MenuItem item = menu.add(
+                Menu.NONE,
+                MENU_ID_GLOBAL_SEARCH,
+                Menu.FIRST,
+                "Search all settings"
+        );
+        item.setShowAsAction(MenuItem.SHOW_AS_ACTION_ALWAYS);
+
+        int iconId = MorpheSettingsV4Catalog.resourceId(
+                context,
+                "drawable",
+                "ic_search_color_24dp"
+        );
+        if (iconId != 0) {
+            Drawable drawable = context.getDrawable(iconId);
+            if (drawable != null) {
+                drawable = drawable.mutate();
+                drawable.setTintList(ColorStateList.valueOf(tokens.primary));
+                item.setIcon(drawable);
+            }
+        }
+    }
+
+    static boolean handleMenuItem(Fragment fragment, MenuItem item) {
+        if (fragment == null || item == null
+                || item.getItemId() != MENU_ID_GLOBAL_SEARCH) {
+            return false;
+        }
+        openGlobalSearch(fragment);
+        return true;
+    }
+
+    private static void openGlobalSearch(Fragment fragment) {
+        Context context;
+        try {
+            context = fragment.requireContext();
+        } catch (Throwable ignored) {
+            return;
+        }
+        if (!(context instanceof Activity)) {
+            return;
+        }
+
+        Activity activity = (Activity) context;
+        MorpheSettingsV4Theme.Tokens tokens =
+                MorpheSettingsV4Theme.resolve(context);
+        List<MorpheSettingsV4Catalog.SearchItem> searchIndex =
+                MorpheSettingsV4Catalog.buildSearchIndex(context);
+
+        Dialog dialog = new Dialog(activity);
+        dialog.requestWindowFeature(Window.FEATURE_NO_TITLE);
+        dialog.setCanceledOnTouchOutside(false);
+
+        LinearLayout shell = new LinearLayout(context);
+        shell.setOrientation(LinearLayout.VERTICAL);
+        shell.setBackgroundColor(tokens.background);
+        shell.setPadding(dp(context, 12), dp(context, 8), dp(context, 12), 0);
+
+        LinearLayout toolbar = new LinearLayout(context);
+        toolbar.setOrientation(LinearLayout.HORIZONTAL);
+        toolbar.setGravity(Gravity.CENTER_VERTICAL);
+        shell.addView(
+                toolbar,
+                new LinearLayout.LayoutParams(
+                        ViewGroup.LayoutParams.MATCH_PARENT,
+                        dp(context, 64)
+                )
+        );
+
+        ImageButton close = new ImageButton(context);
+        close.setImageResource(android.R.drawable.ic_menu_close_clear_cancel);
+        close.setColorFilter(tokens.primary);
+        close.setBackgroundColor(0x00000000);
+        close.setContentDescription("Close search");
+        close.setOnClickListener(
+                view -> dismissSearch(dialog, null)
+        );
+        toolbar.addView(
+                close,
+                new LinearLayout.LayoutParams(dp(context, 48), dp(context, 48))
+        );
+
+        EditText searchField = new EditText(context);
+        searchField.setSingleLine(true);
+        searchField.setTextSize(16);
+        searchField.setTextColor(tokens.textPrimary);
+        searchField.setHintTextColor(tokens.textSecondary);
+        searchField.setHint("Search all settings");
+        searchField.setImeOptions(EditorInfo.IME_ACTION_SEARCH);
+        searchField.setPadding(
+                dp(context, 18),
+                0,
+                dp(context, 18),
+                0
+        );
+        searchField.setBackground(MorpheSettingsV4Theme.rounded(
+                context,
+                tokens.surfaceContainerHigh,
+                28
+        ));
+        LinearLayout.LayoutParams searchParams =
+                new LinearLayout.LayoutParams(
+                        0,
+                        dp(context, 56),
+                        1.0f
+                );
+        searchParams.setMarginStart(dp(context, 8));
+        toolbar.addView(searchField, searchParams);
+
+        ScrollView scrollView = new ScrollView(context);
+        scrollView.setFillViewport(true);
+        scrollView.setClipToPadding(false);
+        LinearLayout results = new LinearLayout(context);
+        results.setOrientation(LinearLayout.VERTICAL);
+        results.setPadding(
+                dp(context, 4),
+                dp(context, 14),
+                dp(context, 4),
+                dp(context, 36)
+        );
+        scrollView.addView(
+                results,
+                new ScrollView.LayoutParams(
+                        ViewGroup.LayoutParams.MATCH_PARENT,
+                        ViewGroup.LayoutParams.WRAP_CONTENT
+                )
+        );
+        shell.addView(
+                scrollView,
+                new LinearLayout.LayoutParams(
+                        ViewGroup.LayoutParams.MATCH_PARENT,
+                        0,
+                        1.0f
+                )
+        );
+
+        searchField.addTextChangedListener(new TextWatcher() {
+            @Override
+            public void beforeTextChanged(
+                    CharSequence value,
+                    int start,
+                    int count,
+                    int after
+            ) {
+            }
+
+            @Override
+            public void onTextChanged(
+                    CharSequence value,
+                    int start,
+                    int before,
+                    int count
+            ) {
+                renderResults(
+                        dialog,
+                        fragment,
+                        results,
+                        searchIndex,
+                        value == null ? "" : value.toString(),
+                        tokens
+                );
+            }
+
+            @Override
+            public void afterTextChanged(Editable value) {
+            }
+        });
+
+        renderResults(
+                dialog,
+                fragment,
+                results,
+                searchIndex,
+                "",
+                tokens
+        );
+
+        dialog.setContentView(shell);
+        dialog.show();
+
+        installSingleBackDismiss(dialog, searchField);
+
+        Window window = dialog.getWindow();
+        if (window != null) {
+            window.setBackgroundDrawable(new ColorDrawable(tokens.background));
+            window.setLayout(
+                    ViewGroup.LayoutParams.MATCH_PARENT,
+                    ViewGroup.LayoutParams.MATCH_PARENT
+            );
+            window.setSoftInputMode(
+                    WindowManager.LayoutParams.SOFT_INPUT_ADJUST_RESIZE
+                            | WindowManager.LayoutParams.SOFT_INPUT_STATE_ALWAYS_VISIBLE
+            );
+        }
+
+        searchField.post(() -> {
+            searchField.requestFocus();
+            InputMethodManager inputMethodManager =
+                    (InputMethodManager) context.getSystemService(
+                            Context.INPUT_METHOD_SERVICE
+                    );
+            if (inputMethodManager != null) {
+                inputMethodManager.showSoftInput(
+                        searchField,
+                        InputMethodManager.SHOW_IMPLICIT
+                );
+            }
+        });
+    }
+
+    private static void renderResults(
+            Dialog dialog,
+            Fragment fragment,
+            LinearLayout results,
+            List<MorpheSettingsV4Catalog.SearchItem> searchIndex,
+            String query,
+            MorpheSettingsV4Theme.Tokens tokens
+    ) {
+        results.removeAllViews();
+        Context context = results.getContext();
+        String normalized = MorpheSettingsV4Catalog.normalize(query);
+
+        if (TextUtils.isEmpty(normalized)) {
+            addSupportingText(
+                    results,
+                    "Type a setting name, category, summary, or preference key.",
+                    tokens
+            );
+            return;
+        }
+
+        List<MorpheSettingsV4Catalog.SearchItem> matches = new ArrayList<>();
+        for (MorpheSettingsV4Catalog.SearchItem item : searchIndex) {
+            if (item.matches(normalized)) {
+                matches.add(item);
+            }
+        }
+
+        addSupportingText(
+                results,
+                matches.isEmpty()
+                        ? "No matching settings"
+                        : matches.size()
+                        + (matches.size() == 1 ? " result" : " results"),
+                tokens
+        );
+
+        int limit = Math.min(matches.size(), RESULT_LIMIT);
+        for (int index = 0; index < limit; index++) {
+            MorpheSettingsV4Catalog.SearchItem item = matches.get(index);
+            results.addView(createResultRow(
+                    dialog,
+                    fragment,
+                    item,
+                    tokens
+            ));
+        }
+
+        if (matches.size() > limit) {
+            addSupportingText(
+                    results,
+                    "Showing the first "
+                            + limit
+                            + " results. Keep typing to narrow the search.",
+                    tokens
+            );
+        }
+    }
+
+    private static View createResultRow(
+            Dialog dialog,
+            Fragment fragment,
+            MorpheSettingsV4Catalog.SearchItem item,
+            MorpheSettingsV4Theme.Tokens tokens
+    ) {
+        Context context = fragment.requireContext();
+        LinearLayout row = new LinearLayout(context);
+        row.setOrientation(LinearLayout.VERTICAL);
+        row.setPadding(
+                dp(context, 18),
+                dp(context, 14),
+                dp(context, 18),
+                dp(context, 14)
+        );
+        row.setBackground(MorpheSettingsV4Theme.interactive(
+                context,
+                tokens.surfaceContainer,
+                18,
+                tokens.primary
+        ));
+        row.setClickable(true);
+        row.setFocusable(true);
+
+        TextView title = new TextView(context);
+        title.setText(item.title);
+        title.setTextSize(16);
+        title.setTextColor(tokens.textPrimary);
+        row.addView(title);
+
+        String secondary = item.category;
+        if (!TextUtils.isEmpty(item.summary)) {
+            secondary += "\n" + item.summary;
+        }
+        TextView summary = new TextView(context);
+        summary.setText(secondary);
+        summary.setTextSize(14);
+        summary.setTextColor(tokens.textSecondary);
+        summary.setLineSpacing(0, 1.06f);
+        LinearLayout.LayoutParams summaryParams =
+                new LinearLayout.LayoutParams(
+                        ViewGroup.LayoutParams.MATCH_PARENT,
+                        ViewGroup.LayoutParams.WRAP_CONTENT
+                );
+        summaryParams.topMargin = dp(context, 4);
+        row.addView(summary, summaryParams);
+
+        row.setOnClickListener(view -> openSearchItem(
+                dialog,
+                fragment,
+                item
+        ));
+
+        LinearLayout.LayoutParams rowParams =
+                new LinearLayout.LayoutParams(
+                        ViewGroup.LayoutParams.MATCH_PARENT,
+                        ViewGroup.LayoutParams.WRAP_CONTENT
+                );
+        rowParams.bottomMargin = dp(context, 8);
+        row.setLayoutParams(rowParams);
+        return row;
+    }
+
+    private static void openSearchItem(
+            Dialog dialog,
+            Fragment fragment,
+            MorpheSettingsV4Catalog.SearchItem item
+    ) {
+        Context context;
+        try {
+            context = fragment.requireContext();
+        } catch (Throwable ignored) {
+            return;
+        }
+        if (!(context instanceof Activity)) {
+            return;
+        }
+
+        Activity activity = (Activity) context;
+        Intent intent;
+
+        if (!TextUtils.isEmpty(item.activityName)) {
+            intent = new Intent();
+            intent.setClassName(context.getPackageName(), item.activityName);
+        } else {
+            String fragmentName = item.fragmentName;
+            if (!TextUtils.isEmpty(item.pageId)) {
+                fragmentName = MorpheSettingsV4Fragment.class.getName();
+            }
+            if (TextUtils.isEmpty(fragmentName)) {
+                return;
+            }
+
+            intent = new Intent(activity, activity.getClass());
+            intent.putExtra(EXTRA_SHOW_FRAGMENT, fragmentName);
+            if (!TextUtils.isEmpty(item.pageId)) {
+                intent.putExtra(ARGUMENT_PAGE, item.pageId);
+            }
+        }
+
+        dismissSearch(dialog, null);
+        activity.startActivity(intent);
+    }
+
+    private static void installSingleBackDismiss(
+            Dialog dialog,
+            EditText searchField
+    ) {
+        if (Build.VERSION.SDK_INT >= 33) {
+            OnBackInvokedCallback callback = () ->
+                    dismissSearch(dialog, searchField);
+            Api33.registerOverlayBack(dialog, callback);
+            dialog.setOnDismissListener(
+                    ignored -> Api33.unregisterBack(dialog, callback)
+            );
+            return;
+        }
+
+        dialog.setOnKeyListener((ignored, keyCode, event) -> {
+            if (keyCode != KeyEvent.KEYCODE_BACK
+                    || event == null
+                    || event.getAction() != KeyEvent.ACTION_UP) {
+                return false;
+            }
+            dismissSearch(dialog, searchField);
+            return true;
+        });
+    }
+
+    private static void dismissSearch(
+            Dialog dialog,
+            EditText searchField
+    ) {
+        if (searchField != null) {
+            InputMethodManager inputMethodManager =
+                    (InputMethodManager) searchField.getContext()
+                            .getSystemService(Context.INPUT_METHOD_SERVICE);
+            if (inputMethodManager != null) {
+                inputMethodManager.hideSoftInputFromWindow(
+                        searchField.getWindowToken(),
+                        0
+                );
+            }
+        }
+        dialog.dismiss();
+    }
+
+    private static final class Api33 {
+        private Api33() {
+        }
+
+        static void registerOverlayBack(
+                Dialog dialog,
+                OnBackInvokedCallback callback
+        ) {
+            dialog.getOnBackInvokedDispatcher()
+                    .registerOnBackInvokedCallback(
+                            OnBackInvokedDispatcher.PRIORITY_OVERLAY,
+                            callback
+                    );
+        }
+
+        static void unregisterBack(
+                Dialog dialog,
+                OnBackInvokedCallback callback
+        ) {
+            dialog.getOnBackInvokedDispatcher()
+                    .unregisterOnBackInvokedCallback(callback);
+        }
+    }
+
+    private static void addSupportingText(
+            LinearLayout parent,
+            String value,
+            MorpheSettingsV4Theme.Tokens tokens
+    ) {
+        TextView text = new TextView(parent.getContext());
+        text.setText(value);
+        text.setTextSize(14);
+        text.setTextColor(tokens.textSecondary);
+        text.setPadding(
+                dp(parent.getContext(), 10),
+                dp(parent.getContext(), 8),
+                dp(parent.getContext(), 10),
+                dp(parent.getContext(), 16)
+        );
+        parent.addView(text);
+    }
+
+    private static int dp(Context context, float value) {
+        return MorpheSettingsV4Theme.dp(context, value);
+    }
+
+    private static void hideMenuItem(
+            Context context,
+            Menu menu,
+            String resourceName
+    ) {
+        if (context == null || menu == null || TextUtils.isEmpty(resourceName)) {
+            return;
+        }
+        int resourceId = MorpheSettingsV4Catalog.resourceId(
+                context,
+                "id",
+                resourceName
+        );
+        if (resourceId == 0) {
+            return;
+        }
+        MenuItem item = menu.findItem(resourceId);
+        if (item != null) {
+            item.setVisible(false);
+        }
+    }
+}

--- a/extensions/boostforreddit/src/main/java/app/morphe/extension/boostforreddit/settings/MorpheSettingsV4ToolbarFragment.java
+++ b/extensions/boostforreddit/src/main/java/app/morphe/extension/boostforreddit/settings/MorpheSettingsV4ToolbarFragment.java
@@ -191,9 +191,15 @@ public final class MorpheSettingsV4ToolbarFragment extends Fragment {
     @Override
     public void onPrepareOptionsMenu(Menu menu) {
         super.onPrepareOptionsMenu(menu);
-        hideMenuItem(menu, "action_generic_search");
-        hideMenuItem(menu, "action_search");
-        hideMenuItem(menu, "search");
+        MorpheSettingsV4Search.prepareMenu(this, menu, true);
+    }
+
+    @Override
+    public boolean onOptionsItemSelected(MenuItem item) {
+        if (MorpheSettingsV4Search.handleMenuItem(this, item)) {
+            return true;
+        }
+        return super.onOptionsItemSelected(item);
     }
 
     private LinearLayout addGroup(LinearLayout parent) {

--- a/extensions/boostforreddit/src/main/java/app/morphe/extension/boostforreddit/settings/MorpheSettingsV5AppearanceBindings.java
+++ b/extensions/boostforreddit/src/main/java/app/morphe/extension/boostforreddit/settings/MorpheSettingsV5AppearanceBindings.java
@@ -1,0 +1,1750 @@
+package app.morphe.extension.boostforreddit.settings;
+
+import android.app.Activity;
+import android.app.Dialog;
+import android.app.TimePickerDialog;
+import android.content.ComponentName;
+import android.content.Context;
+import android.content.SharedPreferences;
+import android.content.pm.PackageManager;
+import android.content.res.ColorStateList;
+import android.graphics.Color;
+import android.graphics.Typeface;
+import android.graphics.drawable.ColorDrawable;
+import android.os.Build;
+import android.preference.PreferenceManager;
+import android.text.InputType;
+import android.text.TextUtils;
+import android.text.format.DateFormat;
+import android.view.Gravity;
+import android.view.View;
+import android.view.ViewGroup;
+import android.view.Window;
+import android.widget.CheckBox;
+import android.widget.EditText;
+import android.widget.LinearLayout;
+import android.widget.SeekBar;
+import android.widget.TextView;
+import android.widget.Toast;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+
+/** Canonical bindings for all 39 Appearance controls in the hidden V5 wave. */
+final class MorpheSettingsV5AppearanceBindings {
+    static final String CONTRACT_MARKER =
+            "MORPHE_BOOST_SETTINGS_V5_APPEARANCE_BINDINGS_ISSUE121_V1";
+    static final String CANONICAL_STORAGE_MARKER =
+            "MORPHE_BOOST_SETTINGS_V5_APPEARANCE_CANONICAL_STORAGE_ISSUE121_V1";
+    static final String SPECIAL_CONTROL_MARKER =
+            "MORPHE_BOOST_SETTINGS_V5_APPEARANCE_SPECIAL_CONTROLS_ISSUE121_V1";
+    static final String SIDE_EFFECT_MARKER =
+            "MORPHE_BOOST_SETTINGS_V5_APPEARANCE_SIDE_EFFECTS_ISSUE121_V1";
+    static final String FONT_PREVIEW_MARKER =
+            "MORPHE_BOOST_SETTINGS_V5_FONT_PREVIEW_ISSUE121_V1";
+    static final String FONT_RESOLVER_MARKER =
+            "MORPHE_BOOST_SETTINGS_V5_FONT_RESOLVER_ISSUE121_V1";
+
+    private static final String SAVED_VIEWS_PREFERENCES =
+            "com.rubenmayayo.reddit.VIEW_PER_SUBSCRIPTION";
+    private static final String MULTI_SUFFIX = ".multi";
+    private static final String FRONT_PAGE_KEY =
+            "_load_front_page_this_is_not_a_subreddit";
+    private static final String SAVED_KEY =
+            "_load_saved_this_is_not_a_subreddit";
+    private static final String HISTORY_KEY =
+            "_load_history_this_is_not_a_subreddit";
+    private static final String ALIAS_PREFIX = "com.rubenmayayo.reddit.";
+
+    private static final String[] VIEW_TITLES = new String[]{
+            "Cards", "Cards 2.0", "Compact", "Small cards",
+            "Dense", "Columns", "Images", "Swipe",
+    };
+    private static final String[] VIEW_VALUES = new String[]{
+            "0", "7", "1", "4", "5", "2", "6", "3",
+    };
+    private static final int[] SAVED_VIEW_VALUES = new int[]{
+            0, 7, 1, 4, 5, 2, 6, 3,
+    };
+    private static final String[] FONT_TITLES = new String[]{
+            "Default", "Thin", "Light", "Regular", "Medium", "Black",
+            "Condensed Light", "Condensed Regular", "Serif", "Monospace",
+            "Serif Monospace", "Small Caps", "Roboto Slab",
+    };
+    private static final String[] FONT_VALUES = new String[]{
+            "", "sans-serif-thin", "sans-serif-light", "sans-serif",
+            "sans-serif-medium", "sans-serif-black",
+            "sans-serif-condensed-light", "sans-serif-condensed", "serif",
+            "monospace", "serif-monospace", "sans-serif-smallcaps",
+            "RobotoSlab-Regular.ttf",
+    };
+    private static final String[] FONT_SIZE_TITLES = new String[]{
+            "Extra small", "Small", "Medium", "Large", "Extra large",
+            "Extra extra large",
+    };
+    private static final String[] FONT_SIZE_VALUES = new String[]{
+            "XSmall", "Small", "Medium", "Large", "XLarge", "XXLarge",
+    };
+    private static final String[] ICON_TITLES = new String[]{
+            "Default", "Grey", "Vivid", "Metal", "Yellow",
+    };
+    private static final String[] ICON_ALIASES = new String[]{
+            "", "grey", "vivid", "metal", "yellow",
+    };
+
+    private MorpheSettingsV5AppearanceBindings() {
+    }
+
+    static void renderPage(
+            MorpheSettingsV5AppearanceFragment host,
+            LinearLayout content,
+            MorpheSettingsV5Registry.V5PageSpec page,
+            MorpheSettingsV4Theme.Tokens tokens
+    ) {
+        Session session = new Session(host, content, tokens);
+        session.render(page);
+    }
+
+    static String titleFor(Context context, String key) {
+        switch (key) {
+            case "pref_toolbar_header_type":
+                return "Community info alignment";
+            case "pref_header_show_description":
+                return "Show community description";
+            case "pref_show_subreddit_header":
+                return "Show community header";
+            case "morphe_boost_prefer_high_refresh_rate":
+                return "Prefer high refresh rate";
+            case "pref_cards_gallery_carousel":
+                return "Carousel for multiple images";
+            case "pref_cards_full":
+                return "Fill the screen width";
+            case "pref_cards_full_preview":
+                return "Full height images";
+            case "pref_cards_preview_self_lines":
+                return "Lines to preview";
+            case "pref_cards_preview_self":
+                return "Preview text from posts";
+            case "pref_cards_rounded_corners":
+                return "Rounded corners";
+            case "pref_cards_subreddit_icon":
+                return "Show community icon";
+            case "pref_cards_links_as_thumbnails":
+                return "Show thumbnails for link posts";
+            case "pref_dense_buttons_visible":
+            case "pref_mini_cards_buttons_visible":
+                return "Buttons always visible";
+            case "pref_mini_cards_full":
+                return "Fill the screen width";
+            case "pref_mini_cards_rounded_corners":
+                return "Rounded corners";
+            case "pref_mini_cards_truncate_title":
+                return "Truncate title";
+            case "pref_show_subreddit_prefix":
+                return "Communities start with r/";
+            case "pref_view":
+                return "Default view";
+            case "pref_view_per_sub":
+                return "Manage saved views";
+            case "pref_view_per_subscription":
+                return "Remember per community";
+            case "pref_left_handed":
+                return "Thumbnails on left";
+            case "action:saved_views:add":
+                return "Add saved view";
+            case "action:saved_views:clear_all":
+                return "Clear all saved views";
+            case "pref_split_screen":
+                return "Tablet split screen mode";
+            case "pref_colored_nav_bar":
+                return "Colored navigation bar";
+            case "pref_colored_status_bar":
+                return "Colored status bar";
+            case "pref_app_icon":
+                return "App icon";
+            case "pref_theme":
+                return "Customize colors";
+            case "pref_theme_night_start_minutes":
+                return "Dark start time";
+            case "pref_theme_night":
+                return "Dark theme";
+            case "pref_dynamic_colors":
+                return "Dynamic color";
+            case "pref_theme_night_end_minutes":
+                return "Light start time";
+            case "pref_theme_mode_type":
+                return "Theme";
+            case "pref_comments_font":
+                return "Comments font";
+            case "pref_font_size":
+                return "Comments text size";
+            case "pref_title_font":
+                return "Title font";
+            case "pref_font_size_title":
+                return "Title text size";
+            case "action:typography:restore_defaults":
+                return "Restore font defaults";
+            default:
+                return key;
+        }
+    }
+
+    static String searchSummaryFor(Context context, String key) {
+        String summary = consequenceFor(key);
+        return TextUtils.isEmpty(summary)
+                ? MorpheSettingsV5Registry.titleFor(
+                MorpheSettingsV5Registry.pageIdForKey(key)
+        )
+                : summary;
+    }
+
+    private static String consequenceFor(String key) {
+        switch (key) {
+            case "pref_show_subreddit_header":
+                return "Show banner and icon in communities";
+            case "morphe_boost_prefer_high_refresh_rate":
+                return "Request a high refresh rate on supported displays";
+            case "pref_cards_full":
+            case "pref_mini_cards_full":
+                return "Remove horizontal margins";
+            case "pref_cards_full_preview":
+                return "Disable for a fixed image-preview height";
+            case "pref_cards_links_as_thumbnails":
+                return "Disable to use large image previews";
+            case "pref_mini_cards_truncate_title":
+                return "Limit the title to two lines";
+            case "pref_view_per_subscription":
+                return "Remember the last selected view for each community";
+            case "action:saved_views:add":
+                return "Choose a community or custom feed and its view";
+            case "action:saved_views:clear_all":
+                return "Remove every per-community saved view";
+            case "pref_split_screen":
+                return "Show posts and comments together in landscape";
+            case "pref_colored_nav_bar":
+            case "pref_colored_status_bar":
+                return "Use the toolbar color";
+            case "pref_dynamic_colors":
+                return "Use the color palette from Android";
+            case "action:typography:restore_defaults":
+                return "Reset post and comment fonts and sizes";
+            default:
+                return "";
+        }
+    }
+
+    private enum Kind {
+        TOGGLE,
+        LIST,
+        SEEK,
+        TIME,
+        THEME,
+        FONT,
+        APP_ICON,
+        SAVED_MANAGER,
+        SAVED_ADD,
+        SAVED_CLEAR,
+        RESET
+    }
+
+    private static final class Spec {
+        final String key;
+        final Kind kind;
+        final String dependency;
+        final boolean inverseDependency;
+
+        Spec(String key, Kind kind) {
+            this(key, kind, "", false);
+        }
+
+        Spec(
+                String key,
+                Kind kind,
+                String dependency,
+                boolean inverseDependency
+        ) {
+            this.key = key;
+            this.kind = kind;
+            this.dependency = dependency;
+            this.inverseDependency = inverseDependency;
+        }
+    }
+
+    private static Spec specFor(String key) {
+        if ("pref_toolbar_header_type".equals(key)) {
+            return new Spec(key, Kind.LIST, "pref_show_subreddit_header", false);
+        }
+        if ("pref_header_show_description".equals(key)) {
+            return new Spec(key, Kind.TOGGLE, "pref_show_subreddit_header", false);
+        }
+        if ("pref_cards_preview_self_lines".equals(key)) {
+            return new Spec(key, Kind.SEEK, "pref_cards_preview_self", false);
+        }
+        if ("pref_view_per_sub".equals(key)) {
+            return new Spec(
+                    key,
+                    Kind.SAVED_MANAGER,
+                    "pref_view_per_subscription",
+                    false
+            );
+        }
+        if ("action:saved_views:add".equals(key)) {
+            return new Spec(
+                    key,
+                    Kind.SAVED_ADD,
+                    "pref_view_per_subscription",
+                    false
+            );
+        }
+        if ("action:saved_views:clear_all".equals(key)) {
+            return new Spec(key, Kind.SAVED_CLEAR, "saved_views_not_empty", false);
+        }
+        if ("pref_theme".equals(key)) {
+            return new Spec(key, Kind.THEME, "pref_dynamic_colors", true);
+        }
+        if ("pref_theme_night".equals(key)) {
+            return new Spec(key, Kind.THEME);
+        }
+        if ("pref_theme_night_start_minutes".equals(key)
+                || "pref_theme_night_end_minutes".equals(key)) {
+            return new Spec(key, Kind.TIME);
+        }
+        if ("pref_comments_font".equals(key)
+                || "pref_title_font".equals(key)) {
+            return new Spec(key, Kind.FONT);
+        }
+        if ("pref_app_icon".equals(key)) {
+            return new Spec(key, Kind.APP_ICON);
+        }
+        if ("action:typography:restore_defaults".equals(key)) {
+            return new Spec(key, Kind.RESET);
+        }
+        if ("pref_theme_mode_type".equals(key)
+                || "pref_font_size".equals(key)
+                || "pref_font_size_title".equals(key)
+                || "pref_view".equals(key)) {
+            return new Spec(key, Kind.LIST);
+        }
+        return new Spec(key, Kind.TOGGLE);
+    }
+
+    private static final class Session {
+        final MorpheSettingsV5AppearanceFragment host;
+        final Context context;
+        final LinearLayout content;
+        final MorpheSettingsV4Theme.Tokens tokens;
+        final SharedPreferences preferences;
+        final SharedPreferences savedViews;
+        final Map<String, Binding> bindings = new LinkedHashMap<>();
+        LinearLayout savedEntries;
+
+        Session(
+                MorpheSettingsV5AppearanceFragment host,
+                LinearLayout content,
+                MorpheSettingsV4Theme.Tokens tokens
+        ) {
+            this.host = host;
+            this.context = host.requireContext();
+            this.content = content;
+            this.tokens = tokens;
+            this.preferences = PreferenceManager.getDefaultSharedPreferences(
+                    context
+            );
+            this.savedViews = context.getSharedPreferences(
+                    SAVED_VIEWS_PREFERENCES,
+                    Context.MODE_PRIVATE
+            );
+        }
+
+        void render(MorpheSettingsV5Registry.V5PageSpec page) {
+            LinearLayout list = MorpheSettingsV14Ui.standardList(context);
+            content.addView(
+                    list,
+                    new LinearLayout.LayoutParams(
+                            ViewGroup.LayoutParams.MATCH_PARENT,
+                            ViewGroup.LayoutParams.WRAP_CONTENT
+                    )
+            );
+            for (String key : page.keys) {
+                addControl(list, specFor(key));
+            }
+            updateRows();
+
+            if ("v5/appearance/post_layout/layout_and_saved_views/"
+                    .concat("saved_community_views").equals(page.pageId)) {
+                addSpace(content, 22);
+                content.addView(MorpheSettingsV14Ui.sectionLabel(
+                        context,
+                        tokens,
+                        "Saved views"
+                ));
+                addSpace(content, 6);
+                savedEntries = MorpheSettingsV14Ui.standardList(context);
+                content.addView(
+                        savedEntries,
+                        new LinearLayout.LayoutParams(
+                                ViewGroup.LayoutParams.MATCH_PARENT,
+                                ViewGroup.LayoutParams.WRAP_CONTENT
+                        )
+                );
+                renderSavedEntries();
+            }
+        }
+
+        private void addControl(LinearLayout list, Spec spec) {
+            switch (spec.kind) {
+                case TOGGLE:
+                    addToggle(list, spec);
+                    break;
+                case LIST:
+                    addList(list, spec);
+                    break;
+                case SEEK:
+                    addSeek(list, spec);
+                    break;
+                case TIME:
+                    addTime(list, spec);
+                    break;
+                case THEME:
+                    addTheme(list, spec);
+                    break;
+                case FONT:
+                    addFont(list, spec);
+                    break;
+                case APP_ICON:
+                    addAppIcon(list, spec);
+                    break;
+                case SAVED_MANAGER:
+                case SAVED_ADD:
+                case SAVED_CLEAR:
+                case RESET:
+                    addAction(list, spec);
+                    break;
+                default:
+                    throw new IllegalStateException("Unhandled " + spec.key);
+            }
+        }
+
+        private void addToggle(LinearLayout list, Spec spec) {
+            boolean checked = preferences.getBoolean(
+                    spec.key,
+                    booleanDefault(spec.key)
+            );
+            String supporting = consequenceFor(spec.key);
+            LinearLayout row = standardRow(!TextUtils.isEmpty(supporting));
+            TextView summary = addLabels(
+                    row,
+                    titleFor(context, spec.key),
+                    supporting
+            );
+            MorpheSettingsV14Ui.Toggle toggle =
+                    new MorpheSettingsV14Ui.Toggle(context, tokens, checked);
+            toggle.setOnCheckedChangeListener((button, value) -> {
+                preferences.edit().putBoolean(spec.key, value).apply();
+                applySideEffects(spec.key);
+                updateRows();
+            });
+            row.setOnClickListener(view -> {
+                if (row.isEnabled()) {
+                    toggle.toggle();
+                }
+            });
+            row.addView(toggle, wrapParams());
+            addRow(list, row);
+            bindings.put(
+                    spec.key,
+                    new Binding(spec, row, summary, toggle)
+            );
+        }
+
+        private void addList(LinearLayout list, Spec spec) {
+            String summaryValue = selectedTitle(spec.key);
+            LinearLayout row = standardRow(true);
+            TextView summary = addLabels(
+                    row,
+                    titleFor(context, spec.key),
+                    summaryValue
+            );
+            row.addView(MorpheSettingsV14Ui.chevron(context, tokens));
+            row.setOnClickListener(view -> {
+                if (row.isEnabled()) {
+                    showListDialog(spec.key);
+                }
+            });
+            addRow(list, row);
+            bindings.put(spec.key, new Binding(spec, row, summary, null));
+        }
+
+        private void addSeek(LinearLayout list, Spec spec) {
+            LinearLayout row = standardRow(true);
+            TextView summary = addLabels(
+                    row,
+                    titleFor(context, spec.key),
+                    linesSummary(preferences.getInt(spec.key, 5))
+            );
+            row.addView(MorpheSettingsV14Ui.chevron(context, tokens));
+            row.setOnClickListener(view -> {
+                if (row.isEnabled()) {
+                    showSeekDialog(spec.key);
+                }
+            });
+            addRow(list, row);
+            bindings.put(spec.key, new Binding(spec, row, summary, null));
+        }
+
+        private void addTime(LinearLayout list, Spec spec) {
+            LinearLayout row = standardRow(true);
+            TextView summary = addLabels(
+                    row,
+                    titleFor(context, spec.key),
+                    timeSummary(preferences.getInt(
+                            spec.key,
+                            intDefault(spec.key)
+                    ))
+            );
+            row.addView(MorpheSettingsV14Ui.chevron(context, tokens));
+            row.setOnClickListener(view -> showTimeDialog(spec.key));
+            addRow(list, row);
+            bindings.put(spec.key, new Binding(spec, row, summary, null));
+        }
+
+        private void addTheme(LinearLayout list, Spec spec) {
+            LinearLayout row = standardRow(true);
+            TextView summary = addLabels(
+                    row,
+                    titleFor(context, spec.key),
+                    themeSummary(spec.key)
+            );
+            row.addView(MorpheSettingsV14Ui.chevron(context, tokens));
+            row.setOnClickListener(view -> {
+                if (row.isEnabled()) {
+                    showThemeDialog(spec.key);
+                }
+            });
+            addRow(list, row);
+            bindings.put(spec.key, new Binding(spec, row, summary, null));
+        }
+
+        private void addFont(LinearLayout list, Spec spec) {
+            LinearLayout row = standardRow(true);
+            TextView summary = addLabels(
+                    row,
+                    titleFor(context, spec.key),
+                    selectedFontTitle(spec.key)
+            );
+            if (summary != null) {
+                summary.setTypeface(resolveFontTypeface(
+                        preferences.getString(spec.key, "")
+                ));
+            }
+            row.addView(MorpheSettingsV14Ui.chevron(context, tokens));
+            row.setOnClickListener(view -> showFontDialog(spec.key));
+            addRow(list, row);
+            bindings.put(spec.key, new Binding(spec, row, summary, null));
+        }
+
+        private void addAppIcon(LinearLayout list, Spec spec) {
+            LinearLayout row = standardRow(true);
+            TextView summary = addLabels(
+                    row,
+                    titleFor(context, spec.key),
+                    selectedIconTitle()
+            );
+            row.addView(MorpheSettingsV14Ui.chevron(context, tokens));
+            row.setOnClickListener(view -> showAppIconDialog());
+            addRow(list, row);
+            bindings.put(spec.key, new Binding(spec, row, summary, null));
+        }
+
+        private void addAction(LinearLayout list, Spec spec) {
+            String summaryValue = actionSummary(spec.key);
+            LinearLayout row = standardRow(!TextUtils.isEmpty(summaryValue));
+            TextView summary = addLabels(
+                    row,
+                    titleFor(context, spec.key),
+                    summaryValue
+            );
+            row.addView(MorpheSettingsV14Ui.chevron(context, tokens));
+            row.setOnClickListener(view -> {
+                if (!row.isEnabled()) {
+                    return;
+                }
+                if (spec.kind == Kind.SAVED_MANAGER) {
+                    host.openPage(
+                            "v5/appearance/post_layout/layout_and_saved_views/"
+                                    + "saved_community_views"
+                    );
+                } else if (spec.kind == Kind.SAVED_ADD) {
+                    showAddSavedViewDialog();
+                } else if (spec.kind == Kind.SAVED_CLEAR) {
+                    confirmClearSavedViews();
+                } else if (spec.kind == Kind.RESET) {
+                    confirmResetTypography();
+                }
+            });
+            addRow(list, row);
+            bindings.put(spec.key, new Binding(spec, row, summary, null));
+        }
+
+        private LinearLayout standardRow(boolean hasSupportingText) {
+            return MorpheSettingsV14Ui.standardListRow(
+                    context,
+                    tokens,
+                    hasSupportingText
+            );
+        }
+
+        private TextView addLabels(
+                LinearLayout row,
+                String title,
+                String summary
+        ) {
+            LinearLayout labels = MorpheSettingsV14Ui.standardListLabels(
+                    context,
+                    tokens,
+                    title,
+                    summary
+            );
+            row.addView(
+                    labels,
+                    new LinearLayout.LayoutParams(
+                            0,
+                            ViewGroup.LayoutParams.WRAP_CONTENT,
+                            1.0f
+                    )
+            );
+            return labels.getChildCount() > 1
+                    ? (TextView) labels.getChildAt(1)
+                    : null;
+        }
+
+        private void addRow(LinearLayout list, View row) {
+            MorpheSettingsV14Ui.addStandardListRow(list, row, tokens);
+        }
+
+        private void updateRows() {
+            for (Binding binding : bindings.values()) {
+                boolean enabled = dependencySatisfied(binding.spec);
+                setEnabledRecursive(binding.row, enabled);
+                binding.row.setAlpha(enabled ? 1.0f : 0.48f);
+                if (binding.toggle != null) {
+                    binding.toggle.setCheckedSilently(preferences.getBoolean(
+                            binding.spec.key,
+                            booleanDefault(binding.spec.key)
+                    ));
+                }
+                if (binding.summary != null) {
+                    String summary = currentSummary(binding.spec);
+                    binding.summary.setText(summary);
+                    binding.summary.setVisibility(
+                            TextUtils.isEmpty(summary) ? View.GONE : View.VISIBLE
+                    );
+                    if (binding.spec.kind == Kind.FONT) {
+                        binding.summary.setTypeface(resolveFontTypeface(
+                                preferences.getString(binding.spec.key, "")
+                        ));
+                    }
+                }
+            }
+            if (savedEntries != null) {
+                renderSavedEntries();
+            }
+        }
+
+        private boolean dependencySatisfied(Spec spec) {
+            if (TextUtils.isEmpty(spec.dependency)) {
+                return true;
+            }
+            if ("saved_views_not_empty".equals(spec.dependency)) {
+                return !savedViews.getAll().isEmpty();
+            }
+            boolean state = preferences.getBoolean(spec.dependency, false);
+            return spec.inverseDependency ? !state : state;
+        }
+
+        private String currentSummary(Spec spec) {
+            switch (spec.kind) {
+                case LIST:
+                    return selectedTitle(spec.key);
+                case SEEK:
+                    return linesSummary(preferences.getInt(spec.key, 5));
+                case TIME:
+                    return timeSummary(preferences.getInt(
+                            spec.key,
+                            intDefault(spec.key)
+                    ));
+                case THEME:
+                    return themeSummary(spec.key);
+                case FONT:
+                    return selectedFontTitle(spec.key);
+                case APP_ICON:
+                    return selectedIconTitle();
+                case SAVED_MANAGER:
+                    return savedViewsSummary();
+                case SAVED_ADD:
+                    return consequenceFor(spec.key);
+                case SAVED_CLEAR:
+                    return savedViewsSummary();
+                case RESET:
+                    return consequenceFor(spec.key);
+                case TOGGLE:
+                default:
+                    return consequenceFor(spec.key);
+            }
+        }
+
+        private String actionSummary(String key) {
+            if ("pref_view_per_sub".equals(key)
+                    || "action:saved_views:clear_all".equals(key)) {
+                return savedViewsSummary();
+            }
+            return consequenceFor(key);
+        }
+
+        private String savedViewsSummary() {
+            int count = savedViews.getAll().size();
+            return count + (count == 1 ? " saved view" : " saved views");
+        }
+
+        private void showListDialog(String key) {
+            String[] entries;
+            String[] values;
+            if ("pref_toolbar_header_type".equals(key)) {
+                entries = stringArray(
+                        "pref_toolbar_header_type_titles",
+                        new String[]{"Centered", "Left aligned"}
+                );
+                values = stringArray(
+                        "pref_toolbar_header_type_values",
+                        new String[]{"center", "left"}
+                );
+            } else if ("pref_view".equals(key)) {
+                entries = stringArray("pref_view_titles", VIEW_TITLES);
+                values = stringArray("pref_view_values", VIEW_VALUES);
+            } else if ("pref_theme_mode_type".equals(key)) {
+                entries = stringArray(
+                        "dark_theme_type_titles",
+                        new String[]{"Off", "On", "Follow system", "Scheduled"}
+                );
+                values = stringArray(
+                        "dark_theme_type_values",
+                        new String[]{"off", "on", "system", "scheduled"}
+                );
+            } else if ("pref_font_size".equals(key)
+                    || "pref_font_size_title".equals(key)) {
+                entries = stringArray("pref_font_size_titles", FONT_SIZE_TITLES);
+                values = stringArray("pref_font_size_values", FONT_SIZE_VALUES);
+            } else {
+                return;
+            }
+            String selected = preferences.getString(key, stringDefault(key));
+            showChoiceDialog(
+                    titleFor(context, key),
+                    entries,
+                    values,
+                    selected,
+                    value -> {
+                        preferences.edit().putString(key, value).apply();
+                        applySideEffects(key);
+                        updateRows();
+                    }
+            );
+        }
+
+        private void showThemeDialog(String key) {
+            String valuesResource = "pref_theme_night".equals(key)
+                    ? "pref_theme_values_night"
+                    : "pref_theme_values";
+            String[] values = stringArray(valuesResource, new String[]{
+                    "0", "5", "3", "6", "1", "2",
+            });
+            String[] entries = new String[values.length];
+            for (int index = 0; index < values.length; index++) {
+                entries[index] = themeTitle(values[index]);
+            }
+            String selected = preferences.getString(key, stringDefault(key));
+            showChoiceDialog(
+                    titleFor(context, key),
+                    entries,
+                    values,
+                    selected,
+                    value -> {
+                        preferences.edit().putString(key, value).apply();
+                        applySideEffects(key);
+                        updateRows();
+                    }
+            );
+        }
+
+        private void showFontDialog(String key) {
+            String[] entries = stringArray("font_options", FONT_TITLES);
+            String[] values = stringArray("font_values", FONT_VALUES);
+            String selected = preferences.getString(key, "");
+            showFontChoiceDialog(
+                    titleFor(context, key),
+                    entries,
+                    values,
+                    selected,
+                    value -> {
+                        preferences.edit().putString(key, value).apply();
+                        applySideEffects(key);
+                        updateRows();
+                    }
+            );
+        }
+
+        private void showAppIconDialog() {
+            String selected = selectedIconAlias();
+            showChoiceDialog(
+                    "App icon",
+                    ICON_TITLES,
+                    ICON_ALIASES,
+                    selected == null ? "" : selected,
+                    value -> {
+                        applyIconSelection(TextUtils.isEmpty(value) ? null : value);
+                        updateRows();
+                        Toast.makeText(
+                                context,
+                                "App icon updated",
+                                Toast.LENGTH_SHORT
+                        ).show();
+                    }
+            );
+        }
+
+        private void showSeekDialog(String key) {
+            Dialog dialog = new Dialog(context);
+            LinearLayout body = dialogBody();
+            addDialogHeading(body, titleFor(context, key));
+
+            int current = preferences.getInt(key, 5);
+            TextView value = textView(linesSummary(current), 15, tokens.textSecondary);
+            value.setGravity(Gravity.CENTER_HORIZONTAL);
+            body.addView(value, matchWrapParams());
+
+            SeekBar seekBar = new SeekBar(context);
+            seekBar.setMax(100);
+            seekBar.setProgress(Math.max(0, Math.min(100, current)));
+            if (Build.VERSION.SDK_INT >= 21) {
+                seekBar.setProgressTintList(ColorStateList.valueOf(
+                        tokens.navigationAccent().color
+                ));
+                seekBar.setThumbTintList(ColorStateList.valueOf(
+                        tokens.navigationAccent().color
+                ));
+            }
+            seekBar.setOnSeekBarChangeListener(new SeekBar.OnSeekBarChangeListener() {
+                @Override
+                public void onProgressChanged(
+                        SeekBar bar,
+                        int progress,
+                        boolean fromUser
+                ) {
+                    value.setText(linesSummary(progress));
+                }
+
+                @Override
+                public void onStartTrackingTouch(SeekBar bar) {
+                }
+
+                @Override
+                public void onStopTrackingTouch(SeekBar bar) {
+                }
+            });
+            LinearLayout.LayoutParams seekParams = matchWrapParams();
+            seekParams.topMargin = dp(10);
+            body.addView(seekBar, seekParams);
+            addDialogActions(
+                    body,
+                    dialog,
+                    "Save",
+                    () -> {
+                        int selected = seekBar.getProgress();
+                        preferences.edit().putInt(key, selected).apply();
+                        applySideEffects(key);
+                        dialog.dismiss();
+                        updateRows();
+                    }
+            );
+            showDialog(dialog, body);
+        }
+
+        private void showTimeDialog(String key) {
+            int minutes = preferences.getInt(key, intDefault(key));
+            int hour = Math.max(0, Math.min(23, minutes / 60));
+            int minute = Math.max(0, Math.min(59, minutes % 60));
+            TimePickerDialog dialog = new TimePickerDialog(
+                    context,
+                    (view, selectedHour, selectedMinute) -> {
+                        preferences.edit()
+                                .putInt(key, selectedHour * 60 + selectedMinute)
+                                .apply();
+                        applySideEffects(key);
+                        updateRows();
+                    },
+                    hour,
+                    minute,
+                    DateFormat.is24HourFormat(context)
+            );
+            dialog.setTitle(titleFor(context, key));
+            dialog.show();
+        }
+
+        private void showChoiceDialog(
+                String title,
+                String[] entries,
+                String[] values,
+                String selected,
+                ValueConsumer consumer
+        ) {
+            if (entries.length == 0 || entries.length != values.length) {
+                Toast.makeText(context, "This option is unavailable", Toast.LENGTH_SHORT)
+                        .show();
+                return;
+            }
+            Dialog dialog = new Dialog(context);
+            LinearLayout body = dialogBody();
+            addDialogHeading(body, title);
+            LinearLayout group = MorpheSettingsV14Ui.group(context);
+            body.addView(group, matchWrapParams());
+            for (int index = 0; index < entries.length; index++) {
+                final String value = values[index];
+                MorpheSettingsV14Ui.ChoiceRow row =
+                        MorpheSettingsV14Ui.choiceRow(
+                                context,
+                                tokens,
+                                entries[index],
+                                "",
+                                TextUtils.equals(selected, value)
+                        );
+                row.setOnClickListener(view -> {
+                    consumer.accept(value);
+                    dialog.dismiss();
+                });
+                MorpheSettingsV14Ui.addSegmentedRow(group, row, tokens);
+            }
+            addDialogActions(body, dialog, null, null);
+            showDialog(dialog, body);
+        }
+
+        private void showFontChoiceDialog(
+                String title,
+                String[] entries,
+                String[] values,
+                String selected,
+                ValueConsumer consumer
+        ) {
+            if (entries.length == 0 || entries.length != values.length) {
+                Toast.makeText(context, "This option is unavailable", Toast.LENGTH_SHORT)
+                        .show();
+                return;
+            }
+            Dialog dialog = new Dialog(context);
+            LinearLayout body = dialogBody();
+            addDialogHeading(body, title);
+            LinearLayout group = MorpheSettingsV14Ui.group(context);
+            body.addView(group, matchWrapParams());
+            for (int index = 0; index < entries.length; index++) {
+                final String value = values[index];
+                MorpheSettingsV14Ui.ChoiceRow row =
+                        MorpheSettingsV14Ui.choiceRow(
+                                context,
+                                tokens,
+                                entries[index],
+                                "",
+                                TextUtils.equals(selected, value)
+                        );
+                row.setTitleTypeface(resolveFontTypeface(value));
+                row.setTitleSize(18);
+                row.setOnClickListener(view -> {
+                    consumer.accept(value);
+                    dialog.dismiss();
+                });
+                MorpheSettingsV14Ui.addSegmentedRow(group, row, tokens);
+            }
+            addDialogActions(body, dialog, null, null);
+            showDialog(dialog, body);
+        }
+
+        private Typeface resolveFontTypeface(String value) {
+            try {
+                Class<?> settingsClass = Class.forName("id.b");
+                Method instanceMethod = settingsClass.getDeclaredMethod("v0");
+                instanceMethod.setAccessible(true);
+                Object settings = instanceMethod.invoke(null);
+                Method resolver = settingsClass.getDeclaredMethod(
+                        "p4",
+                        Context.class,
+                        String.class
+                );
+                resolver.setAccessible(true);
+                Object result = resolver.invoke(settings, context, value);
+                if (result instanceof Typeface) {
+                    return (Typeface) result;
+                }
+            } catch (Throwable ignored) {
+            }
+
+            if (TextUtils.isEmpty(value)) {
+                return Typeface.DEFAULT;
+            }
+            if (value.endsWith(".ttf")) {
+                String[] assetPaths = new String[]{value, "fonts/" + value};
+                for (String assetPath : assetPaths) {
+                    try {
+                        return Typeface.createFromAsset(
+                                context.getAssets(),
+                                assetPath
+                        );
+                    } catch (Throwable ignored) {
+                    }
+                }
+            }
+            return Typeface.create(value, Typeface.NORMAL);
+        }
+
+        private void showAddSavedViewDialog() {
+            Dialog dialog = new Dialog(context);
+            LinearLayout body = dialogBody();
+            addDialogHeading(body, "Add saved view");
+
+            MorpheSettingsV14Ui.Field field = MorpheSettingsV14Ui.outlinedField(
+                    context,
+                    tokens,
+                    "Community or custom feed",
+                    ""
+            );
+            field.input.setInputType(InputType.TYPE_CLASS_TEXT);
+            body.addView(field.root, matchWrapParams());
+
+            CheckBox customFeed = new CheckBox(context);
+            customFeed.setText("Custom feed");
+            customFeed.setTextColor(tokens.textPrimary);
+            customFeed.setPadding(dp(4), dp(8), dp(4), dp(8));
+            body.addView(customFeed, matchWrapParams());
+
+            addDialogActions(
+                    body,
+                    dialog,
+                    "Continue",
+                    () -> {
+                        String key = normalizeSavedViewKey(
+                                field.input.getText().toString(),
+                                customFeed.isChecked()
+                        );
+                        if (TextUtils.isEmpty(key)) {
+                            Toast.makeText(
+                                    context,
+                                    "Enter a community or custom feed",
+                                    Toast.LENGTH_SHORT
+                            ).show();
+                            return;
+                        }
+                        dialog.dismiss();
+                        showSavedViewTypeDialog(key);
+                    }
+            );
+            showDialog(dialog, body);
+        }
+
+        private void showSavedViewTypeDialog(String key) {
+            int selected = parseViewType(savedViews.getAll().get(key));
+            String[] values = new String[SAVED_VIEW_VALUES.length];
+            for (int index = 0; index < SAVED_VIEW_VALUES.length; index++) {
+                values[index] = String.valueOf(SAVED_VIEW_VALUES[index]);
+            }
+            showChoiceDialog(
+                    displayName(key),
+                    VIEW_TITLES,
+                    values,
+                    String.valueOf(selected),
+                    value -> {
+                        int selectedView = Integer.parseInt(value);
+                        savedViews.edit().putInt(key, selectedView).apply();
+                        updateRows();
+                    }
+            );
+        }
+
+        private void confirmClearSavedViews() {
+            showConfirmation(
+                    "Clear all saved views?",
+                    "Every community will use the default view again.",
+                    "Clear",
+                    () -> {
+                        savedViews.edit().clear().apply();
+                        updateRows();
+                    }
+            );
+        }
+
+        private void confirmResetTypography() {
+            showConfirmation(
+                    "Restore font defaults?",
+                    "Post titles and comments will use Boost's default fonts and sizes.",
+                    "Restore",
+                    () -> {
+                        preferences.edit()
+                                .remove("pref_title_font")
+                                .remove("pref_font_size_title")
+                                .remove("pref_comments_font")
+                                .remove("pref_font_size")
+                                .apply();
+                        setBoostStaticBoolean("d");
+                        setBoostStaticBoolean("h");
+                        updateRows();
+                    }
+            );
+        }
+
+        private void showConfirmation(
+                String title,
+                String message,
+                String confirmLabel,
+                Runnable confirmation
+        ) {
+            Dialog dialog = new Dialog(context);
+            LinearLayout body = dialogBody();
+            addDialogHeading(body, title);
+            TextView text = textView(message, 15, tokens.textSecondary);
+            text.setLineSpacing(0, 1.08f);
+            LinearLayout.LayoutParams textParams = matchWrapParams();
+            textParams.topMargin = dp(6);
+            body.addView(text, textParams);
+            addDialogActions(
+                    body,
+                    dialog,
+                    confirmLabel,
+                    () -> {
+                        confirmation.run();
+                        dialog.dismiss();
+                    }
+            );
+            showDialog(dialog, body);
+        }
+
+        private void renderSavedEntries() {
+            if (savedEntries == null) {
+                return;
+            }
+            savedEntries.removeAllViews();
+            List<SavedEntry> entries = new ArrayList<>();
+            for (Map.Entry<String, ?> entry : savedViews.getAll().entrySet()) {
+                entries.add(new SavedEntry(
+                        entry.getKey(),
+                        parseViewType(entry.getValue())
+                ));
+            }
+            Collections.sort(entries, Comparator.comparing(
+                    left -> left.key.toLowerCase(Locale.ROOT)
+            ));
+            if (entries.isEmpty()) {
+                TextView empty = MorpheSettingsV14Ui.supportingText(
+                        context,
+                        tokens,
+                        "No saved views yet"
+                );
+                savedEntries.addView(empty);
+                return;
+            }
+
+            for (SavedEntry entry : entries) {
+                LinearLayout row = standardRow(true);
+                addLabels(
+                        row,
+                        displayName(entry.key),
+                        savedViewTitle(entry.viewType)
+                );
+                TextView remove = textView("Remove", 14, tokens.primary);
+                remove.setGravity(Gravity.CENTER);
+                remove.setMinimumWidth(dp(72));
+                remove.setMinimumHeight(dp(48));
+                remove.setClickable(true);
+                remove.setFocusable(true);
+                remove.setOnClickListener(view -> showConfirmation(
+                        "Remove saved view?",
+                        displayName(entry.key)
+                                + " will use the default view again.",
+                        "Remove",
+                        () -> {
+                            savedViews.edit().remove(entry.key).apply();
+                            updateRows();
+                        }
+                ));
+                row.addView(remove, wrapParams());
+                row.setOnClickListener(view -> showSavedViewTypeDialog(entry.key));
+                addRow(savedEntries, row);
+            }
+        }
+
+        private String[] stringArray(String resourceName, String[] fallback) {
+            int resourceId = MorpheSettingsV4Catalog.resourceId(
+                    context,
+                    "array",
+                    resourceName
+            );
+            if (resourceId == 0) {
+                return fallback.clone();
+            }
+            try {
+                return context.getResources().getStringArray(resourceId);
+            } catch (Throwable ignored) {
+                return fallback.clone();
+            }
+        }
+
+        private String selectedTitle(String key) {
+            String selected = preferences.getString(key, stringDefault(key));
+            if ("pref_toolbar_header_type".equals(key)) {
+                return valueTitle(
+                        selected,
+                        stringArray(
+                                "pref_toolbar_header_type_titles",
+                                new String[]{"Centered", "Left aligned"}
+                        ),
+                        stringArray(
+                                "pref_toolbar_header_type_values",
+                                new String[]{"center", "left"}
+                        )
+                );
+            }
+            if ("pref_view".equals(key)) {
+                return valueTitle(
+                        selected,
+                        stringArray("pref_view_titles", VIEW_TITLES),
+                        stringArray("pref_view_values", VIEW_VALUES)
+                );
+            }
+            if ("pref_theme_mode_type".equals(key)) {
+                return valueTitle(
+                        selected,
+                        stringArray(
+                                "dark_theme_type_titles",
+                                new String[]{"Off", "On", "Follow system", "Scheduled"}
+                        ),
+                        stringArray(
+                                "dark_theme_type_values",
+                                new String[]{"off", "on", "system", "scheduled"}
+                        )
+                );
+            }
+            if ("pref_font_size".equals(key)
+                    || "pref_font_size_title".equals(key)) {
+                return valueTitle(
+                        selected,
+                        stringArray("pref_font_size_titles", FONT_SIZE_TITLES),
+                        stringArray("pref_font_size_values", FONT_SIZE_VALUES)
+                );
+            }
+            return selected;
+        }
+
+        private String themeSummary(String key) {
+            return themeTitle(preferences.getString(key, stringDefault(key)));
+        }
+
+        private String themeTitle(String value) {
+            try {
+                int theme = Integer.parseInt(value);
+                Method method = Class.forName("he.f0").getDeclaredMethod(
+                        "z",
+                        int.class,
+                        Context.class
+                );
+                method.setAccessible(true);
+                Object result = method.invoke(null, theme, context);
+                if (result instanceof String
+                        && !TextUtils.isEmpty((String) result)) {
+                    return (String) result;
+                }
+            } catch (Throwable ignored) {
+            }
+            return "Theme " + value;
+        }
+
+        private String selectedFontTitle(String key) {
+            return valueTitle(
+                    preferences.getString(key, ""),
+                    stringArray("font_options", FONT_TITLES),
+                    stringArray("font_values", FONT_VALUES)
+            );
+        }
+
+        private String selectedIconTitle() {
+            String selected = selectedIconAlias();
+            return valueTitle(
+                    selected == null ? "" : selected,
+                    ICON_TITLES,
+                    ICON_ALIASES
+            );
+        }
+
+        private String selectedIconAlias() {
+            PackageManager packageManager = context.getPackageManager();
+            for (int index = 1; index < ICON_ALIASES.length; index++) {
+                String alias = ICON_ALIASES[index];
+                int state = packageManager.getComponentEnabledSetting(
+                        aliasComponent(alias)
+                );
+                if (state == PackageManager.COMPONENT_ENABLED_STATE_ENABLED) {
+                    return alias;
+                }
+            }
+            return null;
+        }
+
+        private void applyIconSelection(String selectedAlias) {
+            PackageManager packageManager = context.getPackageManager();
+            for (int index = 1; index < ICON_ALIASES.length; index++) {
+                String alias = ICON_ALIASES[index];
+                int state = TextUtils.equals(alias, selectedAlias)
+                        ? PackageManager.COMPONENT_ENABLED_STATE_ENABLED
+                        : PackageManager.COMPONENT_ENABLED_STATE_DISABLED;
+                packageManager.setComponentEnabledSetting(
+                        aliasComponent(alias),
+                        state,
+                        PackageManager.DONT_KILL_APP
+                );
+            }
+        }
+
+        private ComponentName aliasComponent(String alias) {
+            return new ComponentName(
+                    context.getPackageName(),
+                    ALIAS_PREFIX + alias
+            );
+        }
+
+        private String timeSummary(int minutes) {
+            int hour = Math.max(0, Math.min(23, minutes / 60));
+            int minute = Math.max(0, Math.min(59, minutes % 60));
+            if (DateFormat.is24HourFormat(context)) {
+                return String.format(Locale.getDefault(), "%02d:%02d", hour, minute);
+            }
+            String suffix = hour >= 12 ? "PM" : "AM";
+            int displayHour = hour % 12;
+            if (displayHour == 0) {
+                displayHour = 12;
+            }
+            return String.format(
+                    Locale.getDefault(),
+                    "%d:%02d %s",
+                    displayHour,
+                    minute,
+                    suffix
+            );
+        }
+
+        private String linesSummary(int value) {
+            return value + (value == 1 ? " line" : " lines");
+        }
+
+        private String valueTitle(
+                String value,
+                String[] titles,
+                String[] values
+        ) {
+            int count = Math.min(titles.length, values.length);
+            for (int index = 0; index < count; index++) {
+                if (TextUtils.equals(value, values[index])) {
+                    return titles[index];
+                }
+            }
+            return TextUtils.isEmpty(value) ? "Default" : value;
+        }
+
+        private String stringDefault(String key) {
+            if ("pref_toolbar_header_type".equals(key)) {
+                return "center";
+            }
+            if ("pref_view".equals(key)) {
+                return "0";
+            }
+            if ("pref_theme".equals(key)) {
+                return "0";
+            }
+            if ("pref_theme_night".equals(key)) {
+                return "8";
+            }
+            if ("pref_theme_mode_type".equals(key)) {
+                return "system";
+            }
+            if ("pref_font_size".equals(key)
+                    || "pref_font_size_title".equals(key)) {
+                return "Medium";
+            }
+            return "";
+        }
+
+        private int intDefault(String key) {
+            if ("pref_theme_night_start_minutes".equals(key)) {
+                return 1140;
+            }
+            if ("pref_theme_night_end_minutes".equals(key)) {
+                return 420;
+            }
+            if ("pref_cards_preview_self_lines".equals(key)) {
+                return 5;
+            }
+            return 0;
+        }
+
+        private boolean booleanDefault(String key) {
+            switch (key) {
+                case "pref_header_show_description":
+                case "morphe_boost_prefer_high_refresh_rate":
+                case "pref_cards_gallery_carousel":
+                case "pref_cards_full":
+                case "pref_cards_preview_self":
+                case "pref_cards_subreddit_icon":
+                case "pref_cards_links_as_thumbnails":
+                case "pref_mini_cards_rounded_corners":
+                case "pref_mini_cards_truncate_title":
+                case "pref_split_screen":
+                case "pref_colored_status_bar":
+                    return true;
+                default:
+                    return false;
+            }
+        }
+
+        private void applySideEffects(String key) {
+            if (key.startsWith("pref_cards_")
+                    || key.startsWith("pref_mini_cards_")) {
+                setBoostStaticBoolean("g");
+            }
+            if ("pref_dense_buttons_visible".equals(key)
+                    || "pref_left_handed".equals(key)) {
+                setBoostStaticBoolean("h");
+            }
+            if ("pref_show_subreddit_header".equals(key)
+                    || "pref_header_show_description".equals(key)
+                    || "pref_toolbar_header_type".equals(key)) {
+                setBoostStaticBoolean("e");
+            }
+            if ("pref_show_subreddit_prefix".equals(key)) {
+                setBoostStaticString(
+                        "c",
+                        preferences.getBoolean(key, false) ? "r/" : ""
+                );
+                setBoostStaticBoolean("i");
+            }
+            if ("pref_colored_nav_bar".equals(key)
+                    || "pref_colored_status_bar".equals(key)) {
+                setBoostStaticBoolean("h");
+                recreateHost();
+            }
+            if ("pref_dynamic_colors".equals(key)) {
+                setBoostStaticBoolean("i");
+                recreateHost();
+            }
+            if ("pref_theme".equals(key)
+                    || "pref_theme_night".equals(key)
+                    || "pref_theme_mode_type".equals(key)
+                    || "pref_theme_night_start_minutes".equals(key)
+                    || "pref_theme_night_end_minutes".equals(key)) {
+                invokeStaticNoArgs("kb.a", "d");
+                setBoostStaticBoolean("i");
+                recreateHost();
+            }
+            if ("pref_font_size".equals(key)
+                    || "pref_font_size_title".equals(key)) {
+                setBoostStaticBoolean("d");
+            }
+            if ("pref_title_font".equals(key)) {
+                setBoostStaticBoolean("h");
+            }
+            if ("morphe_boost_prefer_high_refresh_rate".equals(key)) {
+                recreateHost();
+            }
+        }
+
+        private void recreateHost() {
+            Activity activity = context instanceof Activity
+                    ? (Activity) context
+                    : null;
+            if (activity != null) {
+                activity.recreate();
+            }
+        }
+
+        private void setEnabledRecursive(View view, boolean enabled) {
+            view.setEnabled(enabled);
+            if (view instanceof ViewGroup) {
+                ViewGroup group = (ViewGroup) view;
+                for (int index = 0; index < group.getChildCount(); index++) {
+                    setEnabledRecursive(group.getChildAt(index), enabled);
+                }
+            }
+        }
+
+        private LinearLayout dialogBody() {
+            LinearLayout body = new LinearLayout(context);
+            body.setOrientation(LinearLayout.VERTICAL);
+            body.setPadding(dp(22), dp(20), dp(22), dp(16));
+            body.setBackground(MorpheSettingsV4Theme.rounded(
+                    context,
+                    tokens.surfaceContainer,
+                    28
+            ));
+            return body;
+        }
+
+        private void addDialogHeading(LinearLayout body, String value) {
+            TextView title = textView(value, 20, tokens.textPrimary);
+            title.setTypeface(Typeface.create(
+                    "sans-serif-medium",
+                    Typeface.NORMAL
+            ));
+            LinearLayout.LayoutParams params = matchWrapParams();
+            params.bottomMargin = dp(12);
+            body.addView(title, params);
+        }
+
+        private void addDialogActions(
+                LinearLayout body,
+                Dialog dialog,
+                String positiveLabel,
+                Runnable positive
+        ) {
+            LinearLayout actions = new LinearLayout(context);
+            actions.setGravity(Gravity.END | Gravity.CENTER_VERTICAL);
+            TextView cancel = MorpheSettingsV14Ui.action(
+                    context,
+                    tokens,
+                    "Cancel",
+                    false
+            );
+            cancel.setOnClickListener(view -> dialog.dismiss());
+            actions.addView(cancel, wrapParams());
+            if (!TextUtils.isEmpty(positiveLabel) && positive != null) {
+                TextView confirm = MorpheSettingsV14Ui.action(
+                        context,
+                        tokens,
+                        positiveLabel,
+                        true
+                );
+                LinearLayout.LayoutParams confirmParams = wrapParams();
+                confirmParams.setMarginStart(dp(8));
+                actions.addView(confirm, confirmParams);
+                confirm.setOnClickListener(view -> positive.run());
+            }
+            LinearLayout.LayoutParams actionsParams = matchWrapParams();
+            actionsParams.topMargin = dp(14);
+            body.addView(actions, actionsParams);
+        }
+
+        private void showDialog(Dialog dialog, LinearLayout body) {
+            dialog.setContentView(body);
+            Window window = dialog.getWindow();
+            if (window != null) {
+                window.setBackgroundDrawable(new ColorDrawable(Color.TRANSPARENT));
+            }
+            dialog.show();
+            window = dialog.getWindow();
+            if (window != null) {
+                int width = context.getResources().getDisplayMetrics().widthPixels
+                        - dp(40);
+                window.setLayout(width, ViewGroup.LayoutParams.WRAP_CONTENT);
+            }
+        }
+
+        private TextView textView(String value, int sizeSp, int color) {
+            TextView view = new TextView(context);
+            view.setText(value);
+            view.setTextSize(sizeSp);
+            view.setTextColor(color);
+            return view;
+        }
+
+        private void addSpace(LinearLayout parent, int heightDp) {
+            parent.addView(
+                    new View(context),
+                    new LinearLayout.LayoutParams(1, dp(heightDp))
+            );
+        }
+
+        private int dp(float value) {
+            return MorpheSettingsV4Theme.dp(context, value);
+        }
+
+        private LinearLayout.LayoutParams wrapParams() {
+            return new LinearLayout.LayoutParams(
+                    ViewGroup.LayoutParams.WRAP_CONTENT,
+                    ViewGroup.LayoutParams.WRAP_CONTENT
+            );
+        }
+
+        private LinearLayout.LayoutParams matchWrapParams() {
+            return new LinearLayout.LayoutParams(
+                    ViewGroup.LayoutParams.MATCH_PARENT,
+                    ViewGroup.LayoutParams.WRAP_CONTENT
+            );
+        }
+
+        private String normalizeSavedViewKey(
+                String rawValue,
+                boolean customFeed
+        ) {
+            String value = rawValue == null ? "" : rawValue.trim();
+            while (value.startsWith("/")) {
+                value = value.substring(1);
+            }
+            if (value.regionMatches(true, 0, "r/", 0, 2)) {
+                value = value.substring(2);
+            }
+            if (value.regionMatches(true, 0, "u/", 0, 2)) {
+                int multi = value.toLowerCase(Locale.ROOT).indexOf("/m/");
+                value = multi >= 0
+                        ? value.substring(multi + 3)
+                        : value.substring(2);
+            }
+            value = value.trim();
+            if (TextUtils.isEmpty(value)) {
+                return null;
+            }
+            if (customFeed) {
+                return value.endsWith(MULTI_SUFFIX)
+                        ? value
+                        : value + MULTI_SUFFIX;
+            }
+            if ("home".equalsIgnoreCase(value)
+                    || "front page".equalsIgnoreCase(value)
+                    || "frontpage".equalsIgnoreCase(value)) {
+                return FRONT_PAGE_KEY;
+            }
+            if ("saved".equalsIgnoreCase(value)) {
+                return SAVED_KEY;
+            }
+            if ("history".equalsIgnoreCase(value)) {
+                return HISTORY_KEY;
+            }
+            return value;
+        }
+
+        private int parseViewType(Object value) {
+            if (value instanceof Number) {
+                return ((Number) value).intValue();
+            }
+            try {
+                return Integer.parseInt(String.valueOf(value));
+            } catch (NumberFormatException ignored) {
+                return 0;
+            }
+        }
+
+        private String displayName(String key) {
+            if (FRONT_PAGE_KEY.equals(key)) {
+                return "Front page";
+            }
+            if (SAVED_KEY.equals(key)) {
+                return "Saved";
+            }
+            if (HISTORY_KEY.equals(key)) {
+                return "History";
+            }
+            if ("all".equalsIgnoreCase(key)
+                    || "popular".equalsIgnoreCase(key)) {
+                return "r/" + key;
+            }
+            if (key.endsWith(MULTI_SUFFIX)) {
+                return "Custom feed · "
+                        + key.substring(0, key.length() - MULTI_SUFFIX.length());
+            }
+            return key.startsWith("r/") ? key : "r/" + key;
+        }
+
+        private String savedViewTitle(int viewType) {
+            try {
+                Method method = Class.forName("he.h0").getDeclaredMethod(
+                        "a1",
+                        Context.class,
+                        int.class
+                );
+                method.setAccessible(true);
+                Object result = method.invoke(null, context, viewType);
+                if (result instanceof String
+                        && !TextUtils.isEmpty((String) result)) {
+                    return (String) result;
+                }
+            } catch (Throwable ignored) {
+            }
+            for (int index = 0; index < SAVED_VIEW_VALUES.length; index++) {
+                if (SAVED_VIEW_VALUES[index] == viewType) {
+                    return VIEW_TITLES[index];
+                }
+            }
+            return "View " + viewType;
+        }
+    }
+
+    private static void setBoostStaticBoolean(String fieldName) {
+        try {
+            Field field = Class.forName("id.b").getDeclaredField(fieldName);
+            field.setAccessible(true);
+            field.setBoolean(null, true);
+        } catch (Throwable ignored) {
+        }
+    }
+
+    private static void setBoostStaticString(
+            String fieldName,
+            String value
+    ) {
+        try {
+            Field field = Class.forName("id.b").getDeclaredField(fieldName);
+            field.setAccessible(true);
+            field.set(null, value);
+        } catch (Throwable ignored) {
+        }
+    }
+
+    private static void invokeStaticNoArgs(String className, String methodName) {
+        try {
+            Method method = Class.forName(className).getDeclaredMethod(methodName);
+            method.setAccessible(true);
+            method.invoke(null);
+        } catch (Throwable ignored) {
+        }
+    }
+
+    private interface ValueConsumer {
+        void accept(String value);
+    }
+
+    private static final class Binding {
+        final Spec spec;
+        final View row;
+        final TextView summary;
+        final MorpheSettingsV14Ui.Toggle toggle;
+
+        Binding(
+                Spec spec,
+                View row,
+                TextView summary,
+                MorpheSettingsV14Ui.Toggle toggle
+        ) {
+            this.spec = spec;
+            this.row = row;
+            this.summary = summary;
+            this.toggle = toggle;
+        }
+    }
+
+    private static final class SavedEntry {
+        final String key;
+        final int viewType;
+
+        SavedEntry(String key, int viewType) {
+            this.key = key;
+            this.viewType = viewType;
+        }
+    }
+}

--- a/extensions/boostforreddit/src/main/java/app/morphe/extension/boostforreddit/settings/MorpheSettingsV5AppearanceFragment.java
+++ b/extensions/boostforreddit/src/main/java/app/morphe/extension/boostforreddit/settings/MorpheSettingsV5AppearanceFragment.java
@@ -1,0 +1,221 @@
+package app.morphe.extension.boostforreddit.settings;
+
+import android.app.Activity;
+import android.content.Context;
+import android.content.Intent;
+import android.os.Bundle;
+import android.text.TextUtils;
+import android.view.LayoutInflater;
+import android.view.Menu;
+import android.view.MenuItem;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.LinearLayout;
+import android.widget.ScrollView;
+
+import androidx.fragment.app.Fragment;
+
+import app.morphe.extension.boostforreddit.utils.BoostSystemBarInsetsFix;
+
+/** Hidden, complete Appearance wave for the parallel Settings V5 tree. */
+public final class MorpheSettingsV5AppearanceFragment extends Fragment {
+    public static final String CONTRACT_MARKER =
+            "MORPHE_BOOST_SETTINGS_V5_APPEARANCE_FRAGMENT_ISSUE121_V1";
+    public static final String HIDDEN_WAVE_MARKER =
+            "MORPHE_BOOST_SETTINGS_V5_APPEARANCE_HIDDEN_WAVE_ISSUE121_V1";
+
+    private MorpheSettingsV4Theme.Tokens tokens;
+    private MorpheSettingsV5Registry.V5PageSpec page;
+    private String pageId = MorpheSettingsV5Registry.DEFAULT_PAGE_ID;
+
+    public MorpheSettingsV5AppearanceFragment() {
+    }
+
+    @Override
+    public View onCreateView(
+            LayoutInflater inflater,
+            ViewGroup container,
+            Bundle savedInstanceState
+    ) {
+        Context context = inflater.getContext();
+        tokens = MorpheSettingsV4Theme.resolve(context);
+        setHasOptionsMenu(true);
+        resolvePageId();
+        page = MorpheSettingsV5Registry.requirePage(pageId);
+
+        ScrollView scrollView = new ScrollView(context);
+        scrollView.setFillViewport(true);
+        scrollView.setClipToPadding(false);
+        scrollView.setBackgroundColor(tokens.background);
+
+        LinearLayout content = new LinearLayout(context);
+        content.setOrientation(LinearLayout.VERTICAL);
+        content.setPadding(dp(16), dp(12), dp(16), dp(36));
+        scrollView.addView(
+                content,
+                new ScrollView.LayoutParams(
+                        ViewGroup.LayoutParams.MATCH_PARENT,
+                        ViewGroup.LayoutParams.WRAP_CONTENT
+                )
+        );
+
+        String intro = MorpheSettingsV5Registry.introFor(pageId);
+        if (!TextUtils.isEmpty(intro)) {
+            content.addView(MorpheSettingsV14Ui.pageIntro(
+                    context,
+                    tokens,
+                    intro
+            ));
+            addSpace(content, 16);
+        }
+
+        String[] children = MorpheSettingsV5Registry.childrenFor(pageId);
+        if (children.length > 0) {
+            renderDestinations(content, children);
+        } else {
+            MorpheSettingsV5AppearanceBindings.renderPage(
+                    this,
+                    content,
+                    page,
+                    tokens
+            );
+        }
+        return scrollView;
+    }
+
+    @Override
+    public void onResume() {
+        super.onResume();
+        styleHost();
+    }
+
+    @Override
+    public void onPause() {
+        Activity activity = hostActivity();
+        if (activity != null) {
+            BoostSystemBarInsetsFix.clearMorpheSettingsV4SystemBars(activity);
+        }
+        super.onPause();
+    }
+
+    @Override
+    public void onPrepareOptionsMenu(Menu menu) {
+        super.onPrepareOptionsMenu(menu);
+        MorpheSettingsV5Search.prepareMenu(this, menu);
+    }
+
+    @Override
+    public boolean onOptionsItemSelected(MenuItem item) {
+        if (MorpheSettingsV5Search.handleMenuItem(this, item)) {
+            return true;
+        }
+        return super.onOptionsItemSelected(item);
+    }
+
+    void openPage(String targetPageId) {
+        MorpheSettingsV5Navigation.openPage(this, targetPageId);
+    }
+
+    String currentPageId() {
+        return pageId;
+    }
+
+    private void renderDestinations(
+            LinearLayout content,
+            String[] children
+    ) {
+        LinearLayout list = MorpheSettingsV14Ui.standardList(requireContext());
+        content.addView(
+                list,
+                new LinearLayout.LayoutParams(
+                        ViewGroup.LayoutParams.MATCH_PARENT,
+                        ViewGroup.LayoutParams.WRAP_CONTENT
+                )
+        );
+        for (String childId : children) {
+            String title = MorpheSettingsV5Registry.titleFor(childId);
+            LinearLayout row = MorpheSettingsV14Ui.standardListRow(
+                    requireContext(),
+                    tokens,
+                    false
+            );
+            row.addView(
+                    MorpheSettingsV14Ui.standardListLabels(
+                            requireContext(),
+                            tokens,
+                            title,
+                            ""
+                    ),
+                    new LinearLayout.LayoutParams(
+                            0,
+                            ViewGroup.LayoutParams.WRAP_CONTENT,
+                            1.0f
+                    )
+            );
+            row.addView(MorpheSettingsV14Ui.chevron(requireContext(), tokens));
+            row.setOnClickListener(view -> openPage(childId));
+            MorpheSettingsV14Ui.addStandardListRow(list, row, tokens);
+        }
+    }
+
+    private void resolvePageId() {
+        Bundle arguments = getArguments();
+        if (arguments != null) {
+            String requested = arguments.getString(
+                    MorpheSettingsV5Registry.EXTRA_PAGE_ID
+            );
+            if (!TextUtils.isEmpty(requested)) {
+                pageId = requested;
+                return;
+            }
+        }
+
+        Activity activity = hostActivity();
+        Intent intent = activity == null ? null : activity.getIntent();
+        String requested = intent == null
+                ? null
+                : intent.getStringExtra(MorpheSettingsV5Registry.EXTRA_PAGE_ID);
+        if (!TextUtils.isEmpty(requested)) {
+            pageId = requested;
+        }
+    }
+
+    private void styleHost() {
+        Activity activity = hostActivity();
+        if (activity == null || tokens == null) {
+            return;
+        }
+        activity.setTitle(MorpheSettingsV5Registry.titleFor(pageId));
+        BoostSystemBarInsetsFix.applyMorpheSettingsV4SystemBars(
+                activity,
+                tokens.background,
+                tokens.dark
+        );
+        int toolbarId = MorpheSettingsV4Catalog.resourceId(
+                activity,
+                "id",
+                "toolbar"
+        );
+        View toolbar = toolbarId == 0 ? null : activity.findViewById(toolbarId);
+        if (toolbar != null) {
+            toolbar.setBackgroundColor(tokens.background);
+            toolbar.setElevation(0);
+        }
+    }
+
+    private Activity hostActivity() {
+        Context context = getContext();
+        return context instanceof Activity ? (Activity) context : null;
+    }
+
+    private void addSpace(LinearLayout parent, int heightDp) {
+        parent.addView(
+                new View(requireContext()),
+                new LinearLayout.LayoutParams(1, dp(heightDp))
+        );
+    }
+
+    private int dp(float value) {
+        return MorpheSettingsV4Theme.dp(requireContext(), value);
+    }
+}

--- a/extensions/boostforreddit/src/main/java/app/morphe/extension/boostforreddit/settings/MorpheSettingsV5BackupRestoreFragment.java
+++ b/extensions/boostforreddit/src/main/java/app/morphe/extension/boostforreddit/settings/MorpheSettingsV5BackupRestoreFragment.java
@@ -1,0 +1,142 @@
+package app.morphe.extension.boostforreddit.settings;
+
+import android.app.Activity;
+import android.content.Context;
+import android.content.Intent;
+import android.os.Bundle;
+import android.view.LayoutInflater;
+import android.view.Menu;
+import android.view.MenuItem;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.LinearLayout;
+import android.widget.ScrollView;
+
+import androidx.fragment.app.Fragment;
+
+import app.morphe.extension.boostforreddit.utils.BoostSystemBarInsetsFix;
+
+/** V5-owned route into Boost's existing backup and restore activity. */
+public final class MorpheSettingsV5BackupRestoreFragment extends Fragment {
+    public static final String CONTRACT_MARKER =
+            "MORPHE_BOOST_SETTINGS_V5_BACKUP_RESTORE_ROUTE_ISSUE121_V1";
+    public static final String ZERO_CANONICAL_CONTROLS_MARKER =
+            "MORPHE_BOOST_SETTINGS_V5_BACKUP_RESTORE_ZERO_CONTROLS_ISSUE121_V1";
+
+    private static final String PAGE_ID =
+            "v5/data_and_app/backup_and_restore";
+
+    private MorpheSettingsV4Theme.Tokens tokens;
+    private boolean launched;
+
+    public MorpheSettingsV5BackupRestoreFragment() {
+    }
+
+    @Override
+    public View onCreateView(
+            LayoutInflater inflater,
+            ViewGroup container,
+            Bundle savedInstanceState
+    ) {
+        Context context = inflater.getContext();
+        tokens = MorpheSettingsV4Theme.resolve(context);
+        setHasOptionsMenu(true);
+
+        MorpheSettingsV5Registry.V5PageSpec page =
+                MorpheSettingsV5Registry.requirePage(PAGE_ID);
+        if (!"MorpheSettingsV5BackupRestoreFragment".equals(page.renderer)
+                || page.keys.length != 0
+                || !page.isLeaf()) {
+            throw new IllegalStateException(
+                    "Backup & restore V5 page contract is invalid"
+            );
+        }
+
+        ScrollView scrollView = new ScrollView(context);
+        scrollView.setFillViewport(true);
+        scrollView.setBackgroundColor(tokens.background);
+        LinearLayout content = new LinearLayout(context);
+        content.setOrientation(LinearLayout.VERTICAL);
+        content.setPadding(dp(16), dp(12), dp(16), dp(36));
+        scrollView.addView(content);
+        content.addView(MorpheSettingsV14Ui.pageIntro(
+                context,
+                tokens,
+                MorpheSettingsV5Registry.introFor(PAGE_ID)
+        ));
+        content.addView(MorpheSettingsV14Ui.supportingText(
+                context,
+                tokens,
+                "Returning from Boost's backup tool brings you back here."
+        ));
+        return scrollView;
+    }
+
+    @Override
+    public void onResume() {
+        super.onResume();
+        styleHost();
+        if (!launched) {
+            launched = true;
+            openBackupActivity();
+        }
+    }
+
+    @Override
+    public void onPause() {
+        Activity activity = hostActivity();
+        if (activity != null) {
+            BoostSystemBarInsetsFix.clearMorpheSettingsV4SystemBars(activity);
+        }
+        super.onPause();
+    }
+
+    @Override
+    public void onPrepareOptionsMenu(Menu menu) {
+        super.onPrepareOptionsMenu(menu);
+        MorpheSettingsV5Search.prepareMenu(this, menu);
+    }
+
+    @Override
+    public boolean onOptionsItemSelected(MenuItem item) {
+        if (MorpheSettingsV5Search.handleMenuItem(this, item)) {
+            return true;
+        }
+        return super.onOptionsItemSelected(item);
+    }
+
+    private void openBackupActivity() {
+        try {
+            Intent intent = new Intent();
+            intent.setClassName(
+                    requireContext().getPackageName(),
+                    "com.rubenmayayo.reddit.BackupActivity"
+            );
+            startActivity(intent);
+        } catch (Throwable throwable) {
+            launched = false;
+        }
+    }
+
+    private void styleHost() {
+        Activity activity = hostActivity();
+        if (activity == null || tokens == null) {
+            return;
+        }
+        activity.setTitle(MorpheSettingsV5Registry.titleFor(PAGE_ID));
+        BoostSystemBarInsetsFix.applyMorpheSettingsV4SystemBars(
+                activity,
+                tokens.background,
+                tokens.dark
+        );
+    }
+
+    private Activity hostActivity() {
+        Context context = getContext();
+        return context instanceof Activity ? (Activity) context : null;
+    }
+
+    private int dp(float value) {
+        return MorpheSettingsV4Theme.dp(requireContext(), value);
+    }
+}

--- a/extensions/boostforreddit/src/main/java/app/morphe/extension/boostforreddit/settings/MorpheSettingsV5DataAppFragment.java
+++ b/extensions/boostforreddit/src/main/java/app/morphe/extension/boostforreddit/settings/MorpheSettingsV5DataAppFragment.java
@@ -1,0 +1,224 @@
+package app.morphe.extension.boostforreddit.settings;
+
+import android.app.Activity;
+import android.content.Context;
+import android.content.Intent;
+import android.os.Bundle;
+import android.text.TextUtils;
+import android.view.LayoutInflater;
+import android.view.Menu;
+import android.view.MenuItem;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.LinearLayout;
+import android.widget.ScrollView;
+
+import androidx.fragment.app.Fragment;
+
+import app.morphe.extension.boostforreddit.utils.BoostSystemBarInsetsFix;
+
+/** Hidden Data & app hubs for the parallel Settings V5 tree. */
+public final class MorpheSettingsV5DataAppFragment extends Fragment {
+    public static final String CONTRACT_MARKER =
+            "MORPHE_BOOST_SETTINGS_V5_DATA_APP_FRAGMENT_ISSUE121_V1";
+    public static final String HIDDEN_WAVE_MARKER =
+            "MORPHE_BOOST_SETTINGS_V5_DATA_APP_HIDDEN_WAVE_ISSUE121_V1";
+
+    private static final String DEFAULT_PAGE_ID = "v5/data_and_app";
+
+    private MorpheSettingsV4Theme.Tokens tokens;
+    private MorpheSettingsV5Registry.V5PageSpec page;
+    private String pageId = DEFAULT_PAGE_ID;
+
+    public MorpheSettingsV5DataAppFragment() {
+    }
+
+    @Override
+    public View onCreateView(
+            LayoutInflater inflater,
+            ViewGroup container,
+            Bundle savedInstanceState
+    ) {
+        Context context = inflater.getContext();
+        tokens = MorpheSettingsV4Theme.resolve(context);
+        setHasOptionsMenu(true);
+        resolvePageId();
+        page = MorpheSettingsV5Registry.requirePage(pageId);
+        if (page.isLeaf()
+                || !"MorpheSettingsV5DataAppFragment".equals(page.renderer)
+                || !pageId.startsWith("v5/data_and_app")) {
+            throw new IllegalArgumentException(
+                    "Data & app hub renderer cannot open " + pageId
+            );
+        }
+
+        ScrollView scrollView = new ScrollView(context);
+        scrollView.setFillViewport(true);
+        scrollView.setClipToPadding(false);
+        scrollView.setBackgroundColor(tokens.background);
+
+        LinearLayout content = new LinearLayout(context);
+        content.setOrientation(LinearLayout.VERTICAL);
+        content.setPadding(dp(16), dp(12), dp(16), dp(36));
+        scrollView.addView(
+                content,
+                new ScrollView.LayoutParams(
+                        ViewGroup.LayoutParams.MATCH_PARENT,
+                        ViewGroup.LayoutParams.WRAP_CONTENT
+                )
+        );
+
+        String intro = MorpheSettingsV5Registry.introFor(pageId);
+        if (!TextUtils.isEmpty(intro)) {
+            content.addView(MorpheSettingsV14Ui.pageIntro(
+                    context,
+                    tokens,
+                    intro
+            ));
+            addSpace(content, 16);
+        }
+
+        String[] children = MorpheSettingsV5Registry.childrenFor(pageId);
+        if (children.length == 0) {
+            throw new IllegalStateException(
+                    "Data & app hub has no children: " + pageId
+            );
+        }
+        renderDestinations(content, children);
+        return scrollView;
+    }
+
+    @Override
+    public void onResume() {
+        super.onResume();
+        styleHost();
+    }
+
+    @Override
+    public void onPause() {
+        Activity activity = hostActivity();
+        if (activity != null) {
+            BoostSystemBarInsetsFix.clearMorpheSettingsV4SystemBars(activity);
+        }
+        super.onPause();
+    }
+
+    @Override
+    public void onPrepareOptionsMenu(Menu menu) {
+        super.onPrepareOptionsMenu(menu);
+        MorpheSettingsV5Search.prepareMenu(this, menu);
+    }
+
+    @Override
+    public boolean onOptionsItemSelected(MenuItem item) {
+        if (MorpheSettingsV5Search.handleMenuItem(this, item)) {
+            return true;
+        }
+        return super.onOptionsItemSelected(item);
+    }
+
+    void openPage(String targetPageId) {
+        MorpheSettingsV5Navigation.openPage(this, targetPageId);
+    }
+
+    String currentPageId() {
+        return pageId;
+    }
+
+    private void renderDestinations(
+            LinearLayout content,
+            String[] children
+    ) {
+        LinearLayout list = MorpheSettingsV14Ui.standardList(requireContext());
+        content.addView(
+                list,
+                new LinearLayout.LayoutParams(
+                        ViewGroup.LayoutParams.MATCH_PARENT,
+                        ViewGroup.LayoutParams.WRAP_CONTENT
+                )
+        );
+        for (String childId : children) {
+            LinearLayout row = MorpheSettingsV14Ui.standardListRow(
+                    requireContext(),
+                    tokens,
+                    false
+            );
+            row.addView(
+                    MorpheSettingsV14Ui.standardListLabels(
+                            requireContext(),
+                            tokens,
+                            MorpheSettingsV5Registry.titleFor(childId),
+                            ""
+                    ),
+                    new LinearLayout.LayoutParams(
+                            0,
+                            ViewGroup.LayoutParams.WRAP_CONTENT,
+                            1.0f
+                    )
+            );
+            row.addView(MorpheSettingsV14Ui.chevron(requireContext(), tokens));
+            row.setOnClickListener(view -> openPage(childId));
+            MorpheSettingsV14Ui.addStandardListRow(list, row, tokens);
+        }
+    }
+
+    private void resolvePageId() {
+        Bundle arguments = getArguments();
+        if (arguments != null) {
+            String requested = arguments.getString(
+                    MorpheSettingsV5Registry.EXTRA_PAGE_ID
+            );
+            if (!TextUtils.isEmpty(requested)) {
+                pageId = requested;
+                return;
+            }
+        }
+        Activity activity = hostActivity();
+        Intent intent = activity == null ? null : activity.getIntent();
+        String requested = intent == null
+                ? null
+                : intent.getStringExtra(MorpheSettingsV5Registry.EXTRA_PAGE_ID);
+        if (!TextUtils.isEmpty(requested)) {
+            pageId = requested;
+        }
+    }
+
+    private void styleHost() {
+        Activity activity = hostActivity();
+        if (activity == null || tokens == null) {
+            return;
+        }
+        activity.setTitle(MorpheSettingsV5Registry.titleFor(pageId));
+        BoostSystemBarInsetsFix.applyMorpheSettingsV4SystemBars(
+                activity,
+                tokens.background,
+                tokens.dark
+        );
+        int toolbarId = MorpheSettingsV4Catalog.resourceId(
+                activity,
+                "id",
+                "toolbar"
+        );
+        View toolbar = toolbarId == 0 ? null : activity.findViewById(toolbarId);
+        if (toolbar != null) {
+            toolbar.setBackgroundColor(tokens.background);
+            toolbar.setElevation(0);
+        }
+    }
+
+    private Activity hostActivity() {
+        Context context = getContext();
+        return context instanceof Activity ? (Activity) context : null;
+    }
+
+    private void addSpace(LinearLayout parent, int heightDp) {
+        parent.addView(
+                new View(requireContext()),
+                new LinearLayout.LayoutParams(1, dp(heightDp))
+        );
+    }
+
+    private int dp(float value) {
+        return MorpheSettingsV4Theme.dp(requireContext(), value);
+    }
+}

--- a/extensions/boostforreddit/src/main/java/app/morphe/extension/boostforreddit/settings/MorpheSettingsV5DataAppLeafFragment.java
+++ b/extensions/boostforreddit/src/main/java/app/morphe/extension/boostforreddit/settings/MorpheSettingsV5DataAppLeafFragment.java
@@ -1,0 +1,128 @@
+package app.morphe.extension.boostforreddit.settings;
+
+import android.app.Activity;
+import android.content.Context;
+import android.content.Intent;
+import android.os.Bundle;
+import android.text.TextUtils;
+
+/** Complete hidden Data & app leaves for Settings V5. */
+public final class MorpheSettingsV5DataAppLeafFragment
+        extends MorpheSettingsV5XmlPreferenceFragment {
+    public static final String CONTRACT_MARKER =
+            "MORPHE_BOOST_SETTINGS_V5_DATA_APP_LEAF_ISSUE121_V1";
+    public static final String CANONICAL_BINDINGS_MARKER =
+            "MORPHE_BOOST_SETTINGS_V5_DATA_APP_BINDINGS_ISSUE121_V1";
+    public static final String SPECIAL_HANDLER_MARKER =
+            "MORPHE_BOOST_SETTINGS_V5_DATA_APP_HANDLER_BINDINGS_ISSUE121_V1";
+
+    private static final String DEFAULT_PAGE_ID =
+            "v5/data_and_app/storage_and_bandwidth/cache";
+
+    private String pageId = DEFAULT_PAGE_ID;
+    private MorpheSettingsV5Registry.V5PageSpec page;
+
+    public MorpheSettingsV5DataAppLeafFragment() {
+        super(
+                "pref_headers_v2",
+                "pref_about_v2",
+                "pref_misc_v2",
+                "pref_data_v2",
+                "morphe_boost_settings_skeleton"
+        );
+    }
+
+    @Override
+    protected void preparePage() {
+        resolvePageId();
+        page = MorpheSettingsV5Registry.requirePage(pageId);
+        if (!page.isLeaf()
+                || !"MorpheSettingsV5DataAppLeafFragment".equals(
+                page.renderer
+        )
+                || !pageId.startsWith("v5/data_and_app/")) {
+            throw new IllegalArgumentException(
+                    "Data & app leaf renderer cannot open " + pageId
+            );
+        }
+        setPageTitle(MorpheSettingsV5Registry.titleFor(pageId));
+    }
+
+    @Override
+    protected boolean includeControl(String resourceName, String key) {
+        return page != null && page.containsKey(key);
+    }
+
+    @Override
+    protected boolean includeHiddenControl(
+            String resourceName,
+            String key
+    ) {
+        return page != null && page.containsKey(key);
+    }
+
+    @Override
+    protected String sectionFor(
+            String resourceName,
+            String key,
+            String currentSection
+    ) {
+        return MorpheSettingsV5Registry.titleFor(pageId);
+    }
+
+    @Override
+    protected String pageIntro() {
+        return MorpheSettingsV5Registry.introFor(pageId);
+    }
+
+    @Override
+    protected String displaySummary(
+            String key,
+            String currentSummary
+    ) {
+        return MorpheSettingsV5DataAppMetadata.toggleSummaryFor(
+                key,
+                currentSummary
+        );
+    }
+
+    @Override
+    protected String displayActionSummary(
+            String key,
+            String currentSummary,
+            String tag
+    ) {
+        return MorpheSettingsV5DataAppMetadata.actionSummaryFor(
+                key,
+                currentSummary
+        );
+    }
+
+    String currentPageId() {
+        return pageId;
+    }
+
+    private void resolvePageId() {
+        Bundle arguments = getArguments();
+        if (arguments != null) {
+            String requested = arguments.getString(
+                    MorpheSettingsV5Registry.EXTRA_PAGE_ID
+            );
+            if (!TextUtils.isEmpty(requested)) {
+                pageId = requested;
+                return;
+            }
+        }
+        Context context = getContext();
+        Activity activity = context instanceof Activity
+                ? (Activity) context
+                : null;
+        Intent intent = activity == null ? null : activity.getIntent();
+        String requested = intent == null
+                ? null
+                : intent.getStringExtra(MorpheSettingsV5Registry.EXTRA_PAGE_ID);
+        if (!TextUtils.isEmpty(requested)) {
+            pageId = requested;
+        }
+    }
+}

--- a/extensions/boostforreddit/src/main/java/app/morphe/extension/boostforreddit/settings/MorpheSettingsV5DataAppMetadata.java
+++ b/extensions/boostforreddit/src/main/java/app/morphe/extension/boostforreddit/settings/MorpheSettingsV5DataAppMetadata.java
@@ -1,0 +1,207 @@
+package app.morphe.extension.boostforreddit.settings;
+
+import android.content.Context;
+import android.text.TextUtils;
+
+/** Titles and supporting text for Settings V5 Data & app. */
+final class MorpheSettingsV5DataAppMetadata {
+    static final String CONTRACT_MARKER =
+            "MORPHE_BOOST_SETTINGS_V5_DATA_APP_METADATA_ISSUE121_V1";
+
+    private MorpheSettingsV5DataAppMetadata() {
+    }
+
+    static String titleFor(Context context, String key) {
+        switch (key) {
+            case "buy_pro":
+                return "Boost PRO";
+            case "remove_ads":
+                return "Remove ads";
+            case "about_version":
+                return "Changelog";
+            case "rate_app":
+                return "Do you like this app?";
+            case "about_subreddit":
+                return "Feedback and support";
+            case "about_faq":
+                return "Help/FAQ";
+            case "support_launch":
+                return "Launch the rocket";
+            case "licenses_preference":
+                return "Licenses";
+            case "contact_dev_key":
+                return "Email";
+            case "about_reddit":
+                return "reddit";
+            case "about_twitter":
+                return "Twitter";
+            case "privacy_policy":
+                return "Privacy policy";
+            case "pref_gdpr_revoke":
+                return "Revoke GDPR consent";
+            case "pref_statistics":
+                return "Send statistics";
+            case "pref_shortcut_icon_crop":
+                return "Crop community icon";
+            case "pref_autoplay_swipe":
+                return "Autoplay videos in Swipe view";
+            case "pref_info_color_indicators":
+                return "Colored link type indicators";
+            case "pref_go_to_sub_dialog":
+                return "Go to community in a dialog";
+            case "pref_cards_preview_top":
+                return "Previews on top";
+            case "pref_info_post_shorten_score":
+                return "Shorten score";
+            case "pref_send_floating_button":
+                return "Show floating send button";
+            case "pref_info_post_self_image":
+                return "Show images from text posts";
+            case "pref_info_post_view_count":
+                return "Show view count";
+            case "pref_toolbar_dropdown":
+                return "Subscriptions dropdown in toolbar";
+            case "pref_toolbar_tap_to_go":
+                return "Tap toolbar to show subs";
+            case "pref_cards_legacy":
+                return "Use legacy cards layout";
+            case "pref_ad_format":
+                return "Preferred Ad format";
+            case "reset_tips":
+                return "Reset tips";
+            case "morphe_boost_settings_v4_enabled":
+                return "Material settings";
+            case "pref_cache_current_size":
+                return "Clear cache";
+            case "pref_cache_max_size":
+                return "Maximum cache size";
+            case "pref_reduce_mobile":
+                return "Mobile data saver";
+            case "pref_reduce_wifi":
+                return "Wifi data saver";
+            case "pref_download_folders":
+                return "Configure downloads";
+            case "pref_load_images":
+                return "Load images";
+            case "pref_video_quality_max":
+                return "Maximum quality";
+            case "pref_video_quality_min":
+                return "Minimum quality";
+            case "pref_video_quality":
+                return "Video quality";
+            default:
+                return key == null ? "" : key;
+        }
+    }
+
+    static String toggleSummaryFor(String key, String currentSummary) {
+        switch (key) {
+            case "pref_statistics":
+                return "Automatically send usage statistics and crash reports to help improve Boost.";
+            case "pref_shortcut_icon_crop":
+                return "Crop community launcher shortcut icons into circles.";
+            case "pref_info_color_indicators":
+                return "Color image tags to indicate the detected link type.";
+            case "pref_go_to_sub_dialog":
+                return "Show the community chooser in a dialog.";
+            case "pref_cards_preview_top":
+                return "Show image previews above post titles.";
+            case "pref_info_post_shorten_score":
+                return "Use shortened vote scores in post metadata.";
+            case "pref_send_floating_button":
+                return "Show a floating send button while composing.";
+            case "pref_info_post_self_image":
+                return "Show images found inside text posts.";
+            case "pref_info_post_view_count":
+                return "Show view counts on your own and moderated posts.";
+            case "pref_toolbar_dropdown":
+                return "Show subscriptions from the toolbar dropdown.";
+            case "pref_toolbar_tap_to_go":
+                return "Tap the toolbar to open subscriptions.";
+            case "pref_cards_legacy":
+                return "Use the legacy card layout with metadata below the title.";
+            case "morphe_boost_settings_v4_enabled":
+                return "Use Morphe's Material task-based settings. Reopen Settings to apply.";
+            case "pref_reduce_mobile":
+                return "Load lower-size media while using mobile data.";
+            case "pref_reduce_wifi":
+                return "Load lower-size media while using Wi-Fi.";
+            default:
+                return TextUtils.isEmpty(currentSummary)
+                        ? ""
+                        : currentSummary;
+        }
+    }
+
+    static String actionSummaryFor(String key, String currentSummary) {
+        switch (key) {
+            case "buy_pro":
+                return "Unlock Boost PRO.";
+            case "remove_ads":
+                return "Support Boost and remove advertising.";
+            case "about_version":
+                return "View the installed version and changelog.";
+            case "rate_app":
+                return "Rate Boost in Google Play.";
+            case "about_subreddit":
+                return "Open r/BoostForReddit for feedback and support.";
+            case "about_faq":
+                return "Open Boost help and frequently asked questions.";
+            case "support_launch":
+                return "Give Boost some love.";
+            case "licenses_preference":
+                return "View open-source licenses used by Boost.";
+            case "contact_dev_key":
+                return "Email mayayo.dev@gmail.com.";
+            case "about_reddit":
+                return "Open u/rmayayo on Reddit.";
+            case "about_twitter":
+                return "Open @rmayayo on Twitter.";
+            case "privacy_policy":
+                return "Open the Boost privacy policy.";
+            case "pref_gdpr_revoke":
+                return "Withdraw consent and reopen the privacy consent flow.";
+            case "reset_tips":
+                return "Restore Boost guidance tips that were previously dismissed.";
+            case "pref_cache_current_size":
+                return "Delete cached images and videos.";
+            case "pref_download_folders":
+                return "Open Boost download-folder configuration.";
+            default:
+                return TextUtils.isEmpty(currentSummary)
+                        ? ""
+                        : currentSummary;
+        }
+    }
+
+    static String searchSummaryFor(Context context, String key) {
+        String summary = actionSummaryFor(key, "");
+        if (TextUtils.isEmpty(summary)) {
+            summary = toggleSummaryFor(key, "");
+        }
+        if (!TextUtils.isEmpty(summary)) {
+            return summary;
+        }
+        switch (key) {
+            case "pref_autoplay_swipe":
+                return "Choose when videos autoplay in Swipe view.";
+            case "pref_ad_format":
+                return "Choose the preferred advertisement layout.";
+            case "pref_cache_max_size":
+                return "Choose the maximum disk space used by cached media.";
+            case "pref_load_images":
+                return "Choose when Boost loads images.";
+            case "pref_video_quality_max":
+                return "Choose the upper bound used by automatic video quality.";
+            case "pref_video_quality_min":
+                return "Choose the lower bound used by automatic video quality.";
+            case "pref_video_quality":
+                return "Choose fixed or automatic video quality behavior.";
+            default:
+                String pageId = MorpheSettingsV5Registry.pageIdForKey(key);
+                return TextUtils.isEmpty(pageId)
+                        ? ""
+                        : MorpheSettingsV5Registry.titleFor(pageId);
+        }
+    }
+}

--- a/extensions/boostforreddit/src/main/java/app/morphe/extension/boostforreddit/settings/MorpheSettingsV5MediaDownloadFoldersFragment.java
+++ b/extensions/boostforreddit/src/main/java/app/morphe/extension/boostforreddit/settings/MorpheSettingsV5MediaDownloadFoldersFragment.java
@@ -27,10 +27,12 @@ import app.morphe.extension.boostforreddit.utils.BoostSystemBarInsetsFix;
 
 import java.lang.reflect.Method;
 
-/** Morphe-owned M3 surface for Boost's complete download-folder contract. */
-public final class MorpheSettingsV4DownloadsFragment extends Fragment {
+/** Complete hidden download-folder leaf for Settings V5 Media. */
+public final class MorpheSettingsV5MediaDownloadFoldersFragment extends Fragment {
     public static final String CONTRACT_MARKER =
-            "MORPHE_BOOST_SETTINGS_V4_DOWNLOADS_ISSUE106_V1";
+            "MORPHE_BOOST_SETTINGS_V5_MEDIA_DOWNLOAD_FOLDERS_ISSUE121_V1";
+    public static final String CANONICAL_BINDINGS_MARKER =
+            "MORPHE_BOOST_SETTINGS_V5_MEDIA_DOWNLOAD_BINDINGS_ISSUE121_V1";
 
     private static final int REQUEST_FOLDER = 0x4ee9;
     private static final int FOLDER_DEFAULT = 0;
@@ -52,7 +54,7 @@ public final class MorpheSettingsV4DownloadsFragment extends Fragment {
     private SharedPreferences preferences;
     private int pendingFolderType = -1;
 
-    public MorpheSettingsV4DownloadsFragment() {
+    public MorpheSettingsV5MediaDownloadFoldersFragment() {
     }
 
     @Override
@@ -89,6 +91,14 @@ public final class MorpheSettingsV4DownloadsFragment extends Fragment {
                 )
         );
 
+        content.addView(MorpheSettingsV14Ui.pageIntro(
+                context,
+                tokens,
+                MorpheSettingsV5Registry.introFor(
+                        "v5/media/downloads_and_cache/download_folders"
+                )
+        ));
+        addSpace(content, 16);
         addSectionLabel(content, "Download folders");
         addSpace(content, 8);
         LinearLayout foldersGroup = addGroup(content);
@@ -155,12 +165,12 @@ public final class MorpheSettingsV4DownloadsFragment extends Fragment {
     @Override
     public void onPrepareOptionsMenu(Menu menu) {
         super.onPrepareOptionsMenu(menu);
-        MorpheSettingsV4Search.prepareMenu(this, menu, true);
+        MorpheSettingsV5Search.prepareMenu(this, menu);
     }
 
     @Override
     public boolean onOptionsItemSelected(MenuItem item) {
-        if (MorpheSettingsV4Search.handleMenuItem(this, item)) {
+        if (MorpheSettingsV5Search.handleMenuItem(this, item)) {
             return true;
         }
         return super.onOptionsItemSelected(item);
@@ -514,7 +524,7 @@ public final class MorpheSettingsV4DownloadsFragment extends Fragment {
         if (activity == null || tokens == null) {
             return;
         }
-        activity.setTitle("Configure downloads");
+        activity.setTitle("Download folders");
         BoostSystemBarInsetsFix.applyMorpheSettingsV4SystemBars(
                 activity,
                 tokens.background,

--- a/extensions/boostforreddit/src/main/java/app/morphe/extension/boostforreddit/settings/MorpheSettingsV5MediaFragment.java
+++ b/extensions/boostforreddit/src/main/java/app/morphe/extension/boostforreddit/settings/MorpheSettingsV5MediaFragment.java
@@ -1,0 +1,223 @@
+package app.morphe.extension.boostforreddit.settings;
+
+import android.app.Activity;
+import android.content.Context;
+import android.content.Intent;
+import android.os.Bundle;
+import android.text.TextUtils;
+import android.view.LayoutInflater;
+import android.view.Menu;
+import android.view.MenuItem;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.LinearLayout;
+import android.widget.ScrollView;
+
+import androidx.fragment.app.Fragment;
+
+import app.morphe.extension.boostforreddit.utils.BoostSystemBarInsetsFix;
+
+/** Hidden Media hubs for the parallel Settings V5 tree. */
+public final class MorpheSettingsV5MediaFragment extends Fragment {
+    public static final String CONTRACT_MARKER =
+            "MORPHE_BOOST_SETTINGS_V5_MEDIA_FRAGMENT_ISSUE121_V1";
+    public static final String HIDDEN_WAVE_MARKER =
+            "MORPHE_BOOST_SETTINGS_V5_MEDIA_HIDDEN_WAVE_ISSUE121_V1";
+
+    private static final String DEFAULT_PAGE_ID = "v5/media";
+
+    private MorpheSettingsV4Theme.Tokens tokens;
+    private MorpheSettingsV5Registry.V5PageSpec page;
+    private String pageId = DEFAULT_PAGE_ID;
+
+    public MorpheSettingsV5MediaFragment() {
+    }
+
+    @Override
+    public View onCreateView(
+            LayoutInflater inflater,
+            ViewGroup container,
+            Bundle savedInstanceState
+    ) {
+        Context context = inflater.getContext();
+        tokens = MorpheSettingsV4Theme.resolve(context);
+        setHasOptionsMenu(true);
+        resolvePageId();
+        page = MorpheSettingsV5Registry.requirePage(pageId);
+        if (page.isLeaf()
+                || !"MorpheSettingsV5MediaFragment".equals(page.renderer)) {
+            throw new IllegalArgumentException(
+                    "Media hub renderer cannot open " + pageId
+            );
+        }
+
+        ScrollView scrollView = new ScrollView(context);
+        scrollView.setFillViewport(true);
+        scrollView.setClipToPadding(false);
+        scrollView.setBackgroundColor(tokens.background);
+
+        LinearLayout content = new LinearLayout(context);
+        content.setOrientation(LinearLayout.VERTICAL);
+        content.setPadding(dp(16), dp(12), dp(16), dp(36));
+        scrollView.addView(
+                content,
+                new ScrollView.LayoutParams(
+                        ViewGroup.LayoutParams.MATCH_PARENT,
+                        ViewGroup.LayoutParams.WRAP_CONTENT
+                )
+        );
+
+        String intro = MorpheSettingsV5Registry.introFor(pageId);
+        if (!TextUtils.isEmpty(intro)) {
+            content.addView(MorpheSettingsV14Ui.pageIntro(
+                    context,
+                    tokens,
+                    intro
+            ));
+            addSpace(content, 16);
+        }
+
+        String[] children = MorpheSettingsV5Registry.childrenFor(pageId);
+        if (children.length == 0) {
+            throw new IllegalStateException(
+                    "Media hub has no destination children: " + pageId
+            );
+        }
+        renderDestinations(content, children);
+        return scrollView;
+    }
+
+    @Override
+    public void onResume() {
+        super.onResume();
+        styleHost();
+    }
+
+    @Override
+    public void onPause() {
+        Activity activity = hostActivity();
+        if (activity != null) {
+            BoostSystemBarInsetsFix.clearMorpheSettingsV4SystemBars(activity);
+        }
+        super.onPause();
+    }
+
+    @Override
+    public void onPrepareOptionsMenu(Menu menu) {
+        super.onPrepareOptionsMenu(menu);
+        MorpheSettingsV5Search.prepareMenu(this, menu);
+    }
+
+    @Override
+    public boolean onOptionsItemSelected(MenuItem item) {
+        if (MorpheSettingsV5Search.handleMenuItem(this, item)) {
+            return true;
+        }
+        return super.onOptionsItemSelected(item);
+    }
+
+    void openPage(String targetPageId) {
+        MorpheSettingsV5Navigation.openPage(this, targetPageId);
+    }
+
+    String currentPageId() {
+        return pageId;
+    }
+
+    private void renderDestinations(
+            LinearLayout content,
+            String[] children
+    ) {
+        LinearLayout list = MorpheSettingsV14Ui.standardList(requireContext());
+        content.addView(
+                list,
+                new LinearLayout.LayoutParams(
+                        ViewGroup.LayoutParams.MATCH_PARENT,
+                        ViewGroup.LayoutParams.WRAP_CONTENT
+                )
+        );
+        for (String childId : children) {
+            LinearLayout row = MorpheSettingsV14Ui.standardListRow(
+                    requireContext(),
+                    tokens,
+                    false
+            );
+            row.addView(
+                    MorpheSettingsV14Ui.standardListLabels(
+                            requireContext(),
+                            tokens,
+                            MorpheSettingsV5Registry.titleFor(childId),
+                            ""
+                    ),
+                    new LinearLayout.LayoutParams(
+                            0,
+                            ViewGroup.LayoutParams.WRAP_CONTENT,
+                            1.0f
+                    )
+            );
+            row.addView(MorpheSettingsV14Ui.chevron(requireContext(), tokens));
+            row.setOnClickListener(view -> openPage(childId));
+            MorpheSettingsV14Ui.addStandardListRow(list, row, tokens);
+        }
+    }
+
+    private void resolvePageId() {
+        Bundle arguments = getArguments();
+        if (arguments != null) {
+            String requested = arguments.getString(
+                    MorpheSettingsV5Registry.EXTRA_PAGE_ID
+            );
+            if (!TextUtils.isEmpty(requested)) {
+                pageId = requested;
+                return;
+            }
+        }
+        Activity activity = hostActivity();
+        Intent intent = activity == null ? null : activity.getIntent();
+        String requested = intent == null
+                ? null
+                : intent.getStringExtra(MorpheSettingsV5Registry.EXTRA_PAGE_ID);
+        if (!TextUtils.isEmpty(requested)) {
+            pageId = requested;
+        }
+    }
+
+    private void styleHost() {
+        Activity activity = hostActivity();
+        if (activity == null || tokens == null) {
+            return;
+        }
+        activity.setTitle(MorpheSettingsV5Registry.titleFor(pageId));
+        BoostSystemBarInsetsFix.applyMorpheSettingsV4SystemBars(
+                activity,
+                tokens.background,
+                tokens.dark
+        );
+        int toolbarId = MorpheSettingsV4Catalog.resourceId(
+                activity,
+                "id",
+                "toolbar"
+        );
+        View toolbar = toolbarId == 0 ? null : activity.findViewById(toolbarId);
+        if (toolbar != null) {
+            toolbar.setBackgroundColor(tokens.background);
+            toolbar.setElevation(0);
+        }
+    }
+
+    private Activity hostActivity() {
+        Context context = getContext();
+        return context instanceof Activity ? (Activity) context : null;
+    }
+
+    private void addSpace(LinearLayout parent, int heightDp) {
+        parent.addView(
+                new View(requireContext()),
+                new LinearLayout.LayoutParams(1, dp(heightDp))
+        );
+    }
+
+    private int dp(float value) {
+        return MorpheSettingsV4Theme.dp(requireContext(), value);
+    }
+}

--- a/extensions/boostforreddit/src/main/java/app/morphe/extension/boostforreddit/settings/MorpheSettingsV5MediaLeafFragment.java
+++ b/extensions/boostforreddit/src/main/java/app/morphe/extension/boostforreddit/settings/MorpheSettingsV5MediaLeafFragment.java
@@ -1,0 +1,117 @@
+package app.morphe.extension.boostforreddit.settings;
+
+import android.app.Activity;
+import android.content.Context;
+import android.content.Intent;
+import android.os.Bundle;
+import android.text.TextUtils;
+
+/** Complete hidden Media leaf pages for Settings V5. */
+public final class MorpheSettingsV5MediaLeafFragment
+        extends MorpheSettingsV5XmlPreferenceFragment {
+    public static final String CONTRACT_MARKER =
+            "MORPHE_BOOST_SETTINGS_V5_MEDIA_LEAF_ISSUE121_V1";
+    public static final String CANONICAL_BINDINGS_MARKER =
+            "MORPHE_BOOST_SETTINGS_V5_MEDIA_CANONICAL_BINDINGS_ISSUE121_V1";
+
+    private static final String DEFAULT_PAGE_ID =
+            "v5/media/images_gifs_and_previews/native_image_behavior";
+
+    private String pageId = DEFAULT_PAGE_ID;
+    private MorpheSettingsV5Registry.V5PageSpec page;
+
+    public MorpheSettingsV5MediaLeafFragment() {
+        super(
+                "pref_views_v2",
+                "pref_media_v2",
+                "pref_general_v2",
+                "pref_links_v2",
+                "pref_data_v2",
+                "morphe_boost_settings_skeleton"
+        );
+    }
+
+    @Override
+    protected void preparePage() {
+        resolvePageId();
+        page = MorpheSettingsV5Registry.requirePage(pageId);
+        if (!page.isLeaf()
+                || !"MorpheSettingsV5MediaLeafFragment".equals(page.renderer)
+                || !pageId.startsWith("v5/media/")) {
+            throw new IllegalArgumentException(
+                    "Media leaf renderer cannot open " + pageId
+            );
+        }
+        setPageTitle(MorpheSettingsV5Registry.titleFor(pageId));
+    }
+
+    @Override
+    protected boolean includeControl(String resourceName, String key) {
+        return page != null && page.containsKey(key);
+    }
+
+    @Override
+    protected String sectionFor(
+            String resourceName,
+            String key,
+            String currentSection
+    ) {
+        return MorpheSettingsV5Registry.titleFor(pageId);
+    }
+
+    @Override
+    protected String pageIntro() {
+        return MorpheSettingsV5Registry.introFor(pageId);
+    }
+
+    @Override
+    protected String displaySummary(
+            String key,
+            String currentSummary
+    ) {
+        return MorpheSettingsV5MediaMetadata.toggleSummaryFor(
+                key,
+                currentSummary
+        );
+    }
+
+    @Override
+    protected String displayActionSummary(
+            String key,
+            String currentSummary,
+            String tag
+    ) {
+        return MorpheSettingsV5MediaMetadata.actionSummaryFor(
+                key,
+                currentSummary
+        );
+    }
+
+    String currentPageId() {
+        return pageId;
+    }
+
+    private void resolvePageId() {
+        Bundle arguments = getArguments();
+        if (arguments != null) {
+            String requested = arguments.getString(
+                    MorpheSettingsV5Registry.EXTRA_PAGE_ID
+            );
+            if (!TextUtils.isEmpty(requested)) {
+                pageId = requested;
+                return;
+            }
+        }
+        Context context = getContext();
+        Activity activity = context instanceof Activity
+                ? (Activity) context
+                : null;
+        Intent intent = activity == null ? null : activity.getIntent();
+        String requested = intent == null
+                ? null
+                : intent.getStringExtra(MorpheSettingsV5Registry.EXTRA_PAGE_ID);
+        if (!TextUtils.isEmpty(requested)) {
+            pageId = requested;
+        }
+    }
+}

--- a/extensions/boostforreddit/src/main/java/app/morphe/extension/boostforreddit/settings/MorpheSettingsV5MediaMetadata.java
+++ b/extensions/boostforreddit/src/main/java/app/morphe/extension/boostforreddit/settings/MorpheSettingsV5MediaMetadata.java
@@ -1,0 +1,199 @@
+package app.morphe.extension.boostforreddit.settings;
+
+import android.content.Context;
+import android.text.TextUtils;
+
+/** Titles and supporting text for the hidden Settings V5 Media wave. */
+final class MorpheSettingsV5MediaMetadata {
+    static final String CONTRACT_MARKER =
+            "MORPHE_BOOST_SETTINGS_V5_MEDIA_METADATA_ISSUE121_V1";
+
+    private MorpheSettingsV5MediaMetadata() {
+    }
+
+    static String titleFor(Context context, String key) {
+        switch (key) {
+            case "pref_load_readability":
+                return "Preview external links";
+            case "pref_download_folder_per_subreddit":
+                return "Community subfolders";
+            case "pref_download_folder_default":
+                return "Default folder";
+            case "pref_download_folder_gif":
+                return "GIFs";
+            case "pref_download_folder_img":
+                return "Images";
+            case "pref_download_folder_mp4":
+                return "Videos";
+            case "pref_image_loader":
+                return "Image loader";
+            case "pref_images_deepzoom":
+                return "Load HQ images";
+            case "pref_images_fit":
+                return "Load zoomed in";
+            case "pref_swipe_up_to_dismiss_image":
+                return "Swipe to dismiss";
+            case "pref_swipe_dismiss_direction_mode_image":
+                return "Swipe to dismiss direction";
+            case "pref_tap_to_dismiss_image":
+                return "Tap to dismiss";
+            case "morphe_boost_direct_reddit_gif_tap_action":
+                return "Direct Reddit GIF tap action";
+            case "morphe_boost_giphy_preview_tap_action":
+                return "Giphy preview tap action";
+            case "morphe_boost_static_preview_tap_action":
+                return "Static preview tap action";
+            case "morphe_boost_inline_media_previews_enabled":
+                return "Enable inline media previews";
+            case "morphe_boost_inline_media_preview_show_source_text":
+                return "Show source text with preview";
+            case "morphe_boost_inline_media_preview_alignment":
+                return "Preview alignment";
+            case "morphe_boost_inline_media_preview_size":
+                return "Preview size";
+            case "pref_browser":
+                return "Default browser";
+            case "pref_domain_exceptions":
+                return "Domain exceptions";
+            case "pref_link_album":
+                return "Albums";
+            case "pref_link_deviant":
+                return "Deviant Art";
+            case "pref_link_gif":
+                return "Gifs";
+            case "pref_link_image":
+                return "Images";
+            case "pref_link_neatclip":
+                return "NeatClip";
+            case "pref_link_vreddit":
+                return "Reddit videos";
+            case "pref_link_streamable":
+                return "Streamable";
+            case "pref_link_xkcd":
+                return "XKCD";
+            case "pref_link_video":
+                return "Internal Youtube player";
+            case "pref_video_audio_start_muted":
+                return "Mute audio";
+            case "pref_autoplay_cards":
+                return "Autoplay videos";
+            case "pref_media_viewer":
+                return "Media viewer";
+            case "pref_media_overlay_visibility":
+                return "Overlay elements";
+            case "pref_tap_to_dismiss_youtube_videos":
+                return "Tap to dismiss Youtube";
+            case "pref_video_player":
+                return "Video player";
+            default:
+                return key == null ? "" : key;
+        }
+    }
+
+    static String toggleSummaryFor(String key, String currentSummary) {
+        switch (key) {
+            case "pref_load_readability":
+                return "Show a readable preview for supported external links.";
+            case "pref_download_folder_per_subreddit":
+                return "Organize downloaded media into community folders.";
+            case "pref_images_deepzoom":
+                return "Load high-resolution images in Boost\u2019s native viewer.";
+            case "pref_images_fit":
+                return "Open native images zoomed to fill the available space.";
+            case "pref_swipe_up_to_dismiss_image":
+                return "Swipe the native image viewer to close it.";
+            case "pref_tap_to_dismiss_image":
+                return "Tap the image to close the native viewer.";
+            case "morphe_boost_inline_media_previews_enabled":
+                return "Show supported media directly inside comments.";
+            case "morphe_boost_inline_media_preview_show_source_text":
+                return "Keep the original source text visible with the preview.";
+            case "pref_link_album":
+                return "Open supported album links inside Boost.";
+            case "pref_link_deviant":
+                return "Open supported Deviant Art links inside Boost.";
+            case "pref_link_gif":
+                return "Open supported GIF links inside Boost.";
+            case "pref_link_image":
+                return "Open supported image links inside Boost.";
+            case "pref_link_neatclip":
+                return "Open supported NeatClip links inside Boost.";
+            case "pref_link_vreddit":
+                return "Open Reddit-hosted videos inside Boost.";
+            case "pref_link_streamable":
+                return "Open supported Streamable links inside Boost.";
+            case "pref_link_xkcd":
+                return "Open XKCD links inside Boost.";
+            case "pref_link_video":
+                return "Open supported YouTube links with Boost\u2019s internal player.";
+            case "pref_video_audio_start_muted":
+                return "Start video playback with audio muted.";
+            case "pref_tap_to_dismiss_youtube_videos":
+                return "Tap an internal YouTube video to close the player.";
+            default:
+                return TextUtils.isEmpty(currentSummary)
+                        ? ""
+                        : currentSummary;
+        }
+    }
+
+    static String actionSummaryFor(String key, String currentSummary) {
+        switch (key) {
+            case "pref_download_folder_default":
+                return "Choose the fallback destination for downloaded media.";
+            case "pref_download_folder_img":
+                return "Choose the destination used for downloaded images.";
+            case "pref_download_folder_mp4":
+                return "Choose the destination used for downloaded videos.";
+            case "pref_download_folder_gif":
+                return "Choose the destination used for downloaded GIFs.";
+            case "pref_domain_exceptions":
+                return "Choose domains that bypass Boost\u2019s in-app link handling.";
+            default:
+                return TextUtils.isEmpty(currentSummary)
+                        ? ""
+                        : currentSummary;
+        }
+    }
+
+    static String searchSummaryFor(Context context, String key) {
+        String summary = actionSummaryFor(key, "");
+        if (TextUtils.isEmpty(summary)) {
+            summary = toggleSummaryFor(key, "");
+        }
+        if (!TextUtils.isEmpty(summary)) {
+            return summary;
+        }
+        switch (key) {
+            case "pref_image_loader":
+                return "Choose the image-loading implementation used by Boost.";
+            case "pref_swipe_dismiss_direction_mode_image":
+                return "Choose which swipe direction closes the native image viewer.";
+            case "morphe_boost_direct_reddit_gif_tap_action":
+                return "Choose what opens when a direct Reddit GIF is tapped.";
+            case "morphe_boost_giphy_preview_tap_action":
+                return "Choose what opens when an inline Giphy preview is tapped.";
+            case "morphe_boost_static_preview_tap_action":
+                return "Choose what opens when a static inline preview is tapped.";
+            case "morphe_boost_inline_media_preview_alignment":
+                return "Choose the horizontal alignment of inline previews.";
+            case "morphe_boost_inline_media_preview_size":
+                return "Choose the size of inline media previews.";
+            case "pref_browser":
+                return "Choose the browser used for links opened outside Boost.";
+            case "pref_autoplay_cards":
+                return "Choose when videos autoplay while browsing feeds.";
+            case "pref_media_viewer":
+                return "Choose the viewer used for supported media.";
+            case "pref_media_overlay_visibility":
+                return "Choose when controls and metadata are shown over media.";
+            case "pref_video_player":
+                return "Choose the player used for video playback.";
+            default:
+                String pageId = MorpheSettingsV5Registry.pageIdForKey(key);
+                return TextUtils.isEmpty(pageId)
+                        ? ""
+                        : MorpheSettingsV5Registry.titleFor(pageId);
+        }
+    }
+}

--- a/extensions/boostforreddit/src/main/java/app/morphe/extension/boostforreddit/settings/MorpheSettingsV5MorpheFragment.java
+++ b/extensions/boostforreddit/src/main/java/app/morphe/extension/boostforreddit/settings/MorpheSettingsV5MorpheFragment.java
@@ -1,0 +1,119 @@
+package app.morphe.extension.boostforreddit.settings;
+
+import android.app.Activity;
+import android.content.Context;
+import android.content.res.Resources;
+import android.os.Bundle;
+import android.view.Menu;
+import android.view.MenuItem;
+import android.view.View;
+
+import androidx.preference.PreferenceFragmentCompat;
+
+import app.morphe.extension.boostforreddit.utils.BoostSystemBarInsetsFix;
+
+/** V5-owned renderer for configurable Morphe feature preferences. */
+public final class MorpheSettingsV5MorpheFragment
+        extends PreferenceFragmentCompat {
+    public static final String CONTRACT_MARKER =
+            "MORPHE_BOOST_SETTINGS_V5_MORPHE_CONTROLS_ISSUE121_V1";
+    public static final String REFERENCE_COUNT_MARKER =
+            "MORPHE_BOOST_SETTINGS_V5_MORPHE_CONFIGURABLE_REFERENCE_COUNT_12_ISSUE121_V1";
+    public static final String ROOT_FLATTEN_MARKER =
+            "MORPHE_BOOST_SETTINGS_V5_MORPHE_ROOT_FLATTEN_ISSUE121_V1";
+
+    private static final String RESOURCE_NAME =
+            "morphe_boost_settings_skeleton";
+    private static final String BOOST_PACKAGE = "com.rubenmayayo.reddit";
+
+    private MorpheSettingsV4Theme.Tokens tokens;
+
+    public MorpheSettingsV5MorpheFragment() {
+    }
+
+    @Override
+    public void onCreatePreferences(Bundle savedInstanceState, String rootKey) {
+        setHasOptionsMenu(true);
+        Context context = requireContext();
+        tokens = MorpheSettingsV4Theme.resolve(context);
+        Resources resources = context.getResources();
+
+        int resourceId = resources.getIdentifier(
+                RESOURCE_NAME,
+                "xml",
+                context.getPackageName()
+        );
+        if (resourceId == 0) {
+            resourceId = resources.getIdentifier(
+                    RESOURCE_NAME,
+                    "xml",
+                    BOOST_PACKAGE
+            );
+        }
+        if (resourceId == 0) {
+            throw new IllegalStateException(
+                    "Missing Morphe patch-feature resource: " + RESOURCE_NAME
+            );
+        }
+        setPreferencesFromResource(resourceId, rootKey);
+    }
+
+    @Override
+    public void onResume() {
+        super.onResume();
+        styleHost();
+    }
+
+    @Override
+    public void onPause() {
+        Activity activity = hostActivity();
+        if (activity != null) {
+            BoostSystemBarInsetsFix.clearMorpheSettingsV4SystemBars(activity);
+        }
+        super.onPause();
+    }
+
+    @Override
+    public void onPrepareOptionsMenu(Menu menu) {
+        super.onPrepareOptionsMenu(menu);
+        MorpheSettingsV5Search.prepareMenu(this, menu);
+    }
+
+    @Override
+    public boolean onOptionsItemSelected(MenuItem item) {
+        if (MorpheSettingsV5Search.handleMenuItem(this, item)) {
+            return true;
+        }
+        return super.onOptionsItemSelected(item);
+    }
+
+    private void styleHost() {
+        Activity activity = hostActivity();
+        if (activity == null || tokens == null) {
+            return;
+        }
+
+        activity.setTitle("Morphe");
+        BoostSystemBarInsetsFix.applyMorpheSettingsV4SystemBars(
+                activity,
+                tokens.background,
+                tokens.dark
+        );
+
+        int toolbarId = MorpheSettingsV4Catalog.resourceId(
+                activity,
+                "id",
+                "toolbar"
+        );
+        View toolbar = toolbarId == 0 ? null : activity.findViewById(toolbarId);
+        if (toolbar != null) {
+            toolbar.setBackgroundColor(tokens.background);
+            toolbar.setElevation(0);
+        }
+    }
+
+    private Activity hostActivity() {
+        Context context = getContext();
+        return context instanceof Activity ? (Activity) context : null;
+    }
+}

--- a/extensions/boostforreddit/src/main/java/app/morphe/extension/boostforreddit/settings/MorpheSettingsV5Navigation.java
+++ b/extensions/boostforreddit/src/main/java/app/morphe/extension/boostforreddit/settings/MorpheSettingsV5Navigation.java
@@ -1,0 +1,52 @@
+package app.morphe.extension.boostforreddit.settings;
+
+import android.app.Activity;
+import android.content.Context;
+import android.content.Intent;
+import android.text.TextUtils;
+
+import androidx.fragment.app.Fragment;
+
+/** In-app navigation between hidden V5 pages without a legacy Settings route. */
+final class MorpheSettingsV5Navigation {
+    static final String CONTRACT_MARKER =
+            "MORPHE_BOOST_SETTINGS_V5_NAVIGATION_ISSUE121_V1";
+
+    private static final String EXTRA_SHOW_FRAGMENT = "extra_show_fragment";
+    private static final String SETTINGS_PACKAGE =
+            "app.morphe.extension.boostforreddit.settings.";
+
+    private MorpheSettingsV5Navigation() {
+    }
+
+    static void openPage(Fragment host, String targetPageId) {
+        if (host == null || TextUtils.isEmpty(targetPageId)) {
+            return;
+        }
+        MorpheSettingsV5Registry.V5PageSpec page =
+                MorpheSettingsV5Registry.findPage(targetPageId);
+        if (page == null) {
+            return;
+        }
+
+        Context context;
+        try {
+            context = host.requireContext();
+        } catch (Throwable ignored) {
+            return;
+        }
+        if (!(context instanceof Activity)) {
+            return;
+        }
+
+        Activity activity = (Activity) context;
+        String renderer = page.renderer;
+        String className = renderer.indexOf('.') >= 0
+                ? renderer
+                : SETTINGS_PACKAGE + renderer;
+        Intent intent = new Intent(activity, activity.getClass());
+        intent.putExtra(EXTRA_SHOW_FRAGMENT, className);
+        intent.putExtra(MorpheSettingsV5Registry.EXTRA_PAGE_ID, targetPageId);
+        activity.startActivity(intent);
+    }
+}

--- a/extensions/boostforreddit/src/main/java/app/morphe/extension/boostforreddit/settings/MorpheSettingsV5NavigationFragment.java
+++ b/extensions/boostforreddit/src/main/java/app/morphe/extension/boostforreddit/settings/MorpheSettingsV5NavigationFragment.java
@@ -1,0 +1,225 @@
+package app.morphe.extension.boostforreddit.settings;
+
+import android.app.Activity;
+import android.content.Context;
+import android.content.Intent;
+import android.os.Bundle;
+import android.text.TextUtils;
+import android.view.LayoutInflater;
+import android.view.Menu;
+import android.view.MenuItem;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.LinearLayout;
+import android.widget.ScrollView;
+
+import androidx.fragment.app.Fragment;
+
+import app.morphe.extension.boostforreddit.utils.BoostSystemBarInsetsFix;
+
+/** Hidden Navigation hubs for the parallel Settings V5 tree. */
+public final class MorpheSettingsV5NavigationFragment extends Fragment {
+    public static final String CONTRACT_MARKER =
+            "MORPHE_BOOST_SETTINGS_V5_NAVIGATION_FRAGMENT_ISSUE121_V1";
+    public static final String HIDDEN_WAVE_MARKER =
+            "MORPHE_BOOST_SETTINGS_V5_NAVIGATION_HIDDEN_WAVE_ISSUE121_V1";
+
+    private static final String DEFAULT_PAGE_ID = "v5/navigation";
+
+    private MorpheSettingsV4Theme.Tokens tokens;
+    private MorpheSettingsV5Registry.V5PageSpec page;
+    private String pageId = DEFAULT_PAGE_ID;
+
+    public MorpheSettingsV5NavigationFragment() {
+    }
+
+    @Override
+    public View onCreateView(
+            LayoutInflater inflater,
+            ViewGroup container,
+            Bundle savedInstanceState
+    ) {
+        Context context = inflater.getContext();
+        tokens = MorpheSettingsV4Theme.resolve(context);
+        setHasOptionsMenu(true);
+        resolvePageId();
+        page = MorpheSettingsV5Registry.requirePage(pageId);
+        if (page.isLeaf()
+                || !"MorpheSettingsV5NavigationFragment".equals(
+                page.renderer
+        )) {
+            throw new IllegalArgumentException(
+                    "Navigation hub renderer cannot open " + pageId
+            );
+        }
+
+        ScrollView scrollView = new ScrollView(context);
+        scrollView.setFillViewport(true);
+        scrollView.setClipToPadding(false);
+        scrollView.setBackgroundColor(tokens.background);
+
+        LinearLayout content = new LinearLayout(context);
+        content.setOrientation(LinearLayout.VERTICAL);
+        content.setPadding(dp(16), dp(12), dp(16), dp(36));
+        scrollView.addView(
+                content,
+                new ScrollView.LayoutParams(
+                        ViewGroup.LayoutParams.MATCH_PARENT,
+                        ViewGroup.LayoutParams.WRAP_CONTENT
+                )
+        );
+
+        String intro = MorpheSettingsV5Registry.introFor(pageId);
+        if (!TextUtils.isEmpty(intro)) {
+            content.addView(MorpheSettingsV14Ui.pageIntro(
+                    context,
+                    tokens,
+                    intro
+            ));
+            addSpace(content, 16);
+        }
+
+        String[] children = MorpheSettingsV5Registry.childrenFor(pageId);
+        if (children.length == 0) {
+            throw new IllegalStateException(
+                    "Navigation hub has no children: " + pageId
+            );
+        }
+        renderDestinations(content, children);
+        return scrollView;
+    }
+
+    @Override
+    public void onResume() {
+        super.onResume();
+        styleHost();
+    }
+
+    @Override
+    public void onPause() {
+        Activity activity = hostActivity();
+        if (activity != null) {
+            BoostSystemBarInsetsFix.clearMorpheSettingsV4SystemBars(activity);
+        }
+        super.onPause();
+    }
+
+    @Override
+    public void onPrepareOptionsMenu(Menu menu) {
+        super.onPrepareOptionsMenu(menu);
+        MorpheSettingsV5Search.prepareMenu(this, menu);
+    }
+
+    @Override
+    public boolean onOptionsItemSelected(MenuItem item) {
+        if (MorpheSettingsV5Search.handleMenuItem(this, item)) {
+            return true;
+        }
+        return super.onOptionsItemSelected(item);
+    }
+
+    void openPage(String targetPageId) {
+        MorpheSettingsV5Navigation.openPage(this, targetPageId);
+    }
+
+    String currentPageId() {
+        return pageId;
+    }
+
+    private void renderDestinations(
+            LinearLayout content,
+            String[] children
+    ) {
+        LinearLayout list = MorpheSettingsV14Ui.standardList(requireContext());
+        content.addView(
+                list,
+                new LinearLayout.LayoutParams(
+                        ViewGroup.LayoutParams.MATCH_PARENT,
+                        ViewGroup.LayoutParams.WRAP_CONTENT
+                )
+        );
+        for (String childId : children) {
+            LinearLayout row = MorpheSettingsV14Ui.standardListRow(
+                    requireContext(),
+                    tokens,
+                    false
+            );
+            row.addView(
+                    MorpheSettingsV14Ui.standardListLabels(
+                            requireContext(),
+                            tokens,
+                            MorpheSettingsV5Registry.titleFor(childId),
+                            ""
+                    ),
+                    new LinearLayout.LayoutParams(
+                            0,
+                            ViewGroup.LayoutParams.WRAP_CONTENT,
+                            1.0f
+                    )
+            );
+            row.addView(MorpheSettingsV14Ui.chevron(requireContext(), tokens));
+            row.setOnClickListener(view -> openPage(childId));
+            MorpheSettingsV14Ui.addStandardListRow(list, row, tokens);
+        }
+    }
+
+    private void resolvePageId() {
+        Bundle arguments = getArguments();
+        if (arguments != null) {
+            String requested = arguments.getString(
+                    MorpheSettingsV5Registry.EXTRA_PAGE_ID
+            );
+            if (!TextUtils.isEmpty(requested)) {
+                pageId = requested;
+                return;
+            }
+        }
+        Activity activity = hostActivity();
+        Intent intent = activity == null ? null : activity.getIntent();
+        String requested = intent == null
+                ? null
+                : intent.getStringExtra(MorpheSettingsV5Registry.EXTRA_PAGE_ID);
+        if (!TextUtils.isEmpty(requested)) {
+            pageId = requested;
+        }
+    }
+
+    private void styleHost() {
+        Activity activity = hostActivity();
+        if (activity == null || tokens == null) {
+            return;
+        }
+        activity.setTitle(MorpheSettingsV5Registry.titleFor(pageId));
+        BoostSystemBarInsetsFix.applyMorpheSettingsV4SystemBars(
+                activity,
+                tokens.background,
+                tokens.dark
+        );
+        int toolbarId = MorpheSettingsV4Catalog.resourceId(
+                activity,
+                "id",
+                "toolbar"
+        );
+        View toolbar = toolbarId == 0 ? null : activity.findViewById(toolbarId);
+        if (toolbar != null) {
+            toolbar.setBackgroundColor(tokens.background);
+            toolbar.setElevation(0);
+        }
+    }
+
+    private Activity hostActivity() {
+        Context context = getContext();
+        return context instanceof Activity ? (Activity) context : null;
+    }
+
+    private void addSpace(LinearLayout parent, int heightDp) {
+        parent.addView(
+                new View(requireContext()),
+                new LinearLayout.LayoutParams(1, dp(heightDp))
+        );
+    }
+
+    private int dp(float value) {
+        return MorpheSettingsV4Theme.dp(requireContext(), value);
+    }
+}

--- a/extensions/boostforreddit/src/main/java/app/morphe/extension/boostforreddit/settings/MorpheSettingsV5NavigationLeafFragment.java
+++ b/extensions/boostforreddit/src/main/java/app/morphe/extension/boostforreddit/settings/MorpheSettingsV5NavigationLeafFragment.java
@@ -1,0 +1,108 @@
+package app.morphe.extension.boostforreddit.settings;
+
+import android.app.Activity;
+import android.content.Context;
+import android.content.Intent;
+import android.os.Bundle;
+import android.text.TextUtils;
+
+/** Complete hidden Navigation leaves for Settings V5. */
+public final class MorpheSettingsV5NavigationLeafFragment
+        extends MorpheSettingsV5XmlPreferenceFragment {
+    public static final String CONTRACT_MARKER =
+            "MORPHE_BOOST_SETTINGS_V5_NAVIGATION_LEAF_ISSUE121_V1";
+    public static final String CANONICAL_BINDINGS_MARKER =
+            "MORPHE_BOOST_SETTINGS_V5_NAVIGATION_BINDINGS_ISSUE121_V1";
+    public static final String WITHHELD_FRIENDS_MARKER =
+            "MORPHE_BOOST_SETTINGS_V5_NAVIGATION_WITHHELD_FRIENDS_ISSUE121_V1";
+
+    private static final String DEFAULT_PAGE_ID =
+            "v5/navigation/bottom_navigation";
+
+    private String pageId = DEFAULT_PAGE_ID;
+    private MorpheSettingsV5Registry.V5PageSpec page;
+
+    public MorpheSettingsV5NavigationLeafFragment() {
+        super(
+                "pref_views_v2",
+                "pref_general_v2",
+                "pref_bottom_navigation_v2",
+                "pref_drawer_v2",
+                "pref_toolbar_v2"
+        );
+    }
+
+    @Override
+    protected void preparePage() {
+        resolvePageId();
+        page = MorpheSettingsV5Registry.requirePage(pageId);
+        if (!page.isLeaf()
+                || !"MorpheSettingsV5NavigationLeafFragment".equals(
+                page.renderer
+        )
+                || !pageId.startsWith("v5/navigation/")) {
+            throw new IllegalArgumentException(
+                    "Navigation leaf renderer cannot open " + pageId
+            );
+        }
+        setPageTitle(MorpheSettingsV5Registry.titleFor(pageId));
+    }
+
+    @Override
+    protected boolean includeControl(String resourceName, String key) {
+        return page != null && page.containsKey(key);
+    }
+
+    @Override
+    protected String sectionFor(
+            String resourceName,
+            String key,
+            String currentSection
+    ) {
+        return MorpheSettingsV5Registry.titleFor(pageId);
+    }
+
+    @Override
+    protected String pageIntro() {
+        return MorpheSettingsV5Registry.introFor(pageId);
+    }
+
+    @Override
+    protected String displaySummary(
+            String key,
+            String currentSummary
+    ) {
+        return MorpheSettingsV5NavigationMetadata.toggleSummaryFor(
+                key,
+                currentSummary
+        );
+    }
+
+    String currentPageId() {
+        return pageId;
+    }
+
+    private void resolvePageId() {
+        Bundle arguments = getArguments();
+        if (arguments != null) {
+            String requested = arguments.getString(
+                    MorpheSettingsV5Registry.EXTRA_PAGE_ID
+            );
+            if (!TextUtils.isEmpty(requested)) {
+                pageId = requested;
+                return;
+            }
+        }
+        Context context = getContext();
+        Activity activity = context instanceof Activity
+                ? (Activity) context
+                : null;
+        Intent intent = activity == null ? null : activity.getIntent();
+        String requested = intent == null
+                ? null
+                : intent.getStringExtra(MorpheSettingsV5Registry.EXTRA_PAGE_ID);
+        if (!TextUtils.isEmpty(requested)) {
+            pageId = requested;
+        }
+    }
+}

--- a/extensions/boostforreddit/src/main/java/app/morphe/extension/boostforreddit/settings/MorpheSettingsV5NavigationMetadata.java
+++ b/extensions/boostforreddit/src/main/java/app/morphe/extension/boostforreddit/settings/MorpheSettingsV5NavigationMetadata.java
@@ -1,0 +1,140 @@
+package app.morphe.extension.boostforreddit.settings;
+
+import android.content.Context;
+import android.text.TextUtils;
+
+/** Titles and supporting text for Settings V5 Navigation. */
+final class MorpheSettingsV5NavigationMetadata {
+    static final String CONTRACT_MARKER =
+            "MORPHE_BOOST_SETTINGS_V5_NAVIGATION_METADATA_ISSUE121_V1";
+
+    private MorpheSettingsV5NavigationMetadata() {
+    }
+
+    static String titleFor(Context context, String key) {
+        switch (key) {
+            case "pref_lock_sidebar":
+                return "Lock sidebar";
+            case "pref_ask_exit":
+                return "Confirm exit";
+            case "pref_double_exit":
+                return "Double tap to exit";
+            case "pref_bottom_navigation_hide_on_scroll":
+                return "Hide on scroll";
+            case "pref_bottom_navigation":
+                return "Show bottom navigation";
+            case "pref_accounts_show_avatar":
+                return "Show avatar";
+            case "pref_accounts_show_username":
+                return "Show username";
+            case "pref_drawer_show_drafts":
+                return "Drafts";
+            case "pref_drawer_show_history":
+                return "History";
+            case "pref_drawer_show_frontpage":
+                return "Home feed";
+            case "pref_drawer_show_inbox":
+                return "Inbox";
+            case "pref_drawer_show_mod":
+                return "Moderation";
+            case "pref_drawer_show_popular":
+                return "Popular";
+            case "pref_drawer_show_profile":
+                return "Profile";
+            case "pref_drawer_show_saved":
+                return "Saved";
+            case "pref_drawer_show_search_generic":
+                return "Search";
+            case "pref_drawer_show_all":
+                return "All";
+            case "pref_drawer_sticky_settings":
+                return "Sticky Settings";
+            case "pref_drawer_end":
+                return "Switch side";
+            case "pref_drawer_show_go_to_subreddit":
+                return "Go to community";
+            case "pref_drawer_show_go_to":
+                return "Go to dropdown";
+            case "pref_drawer_show_go_to_user":
+                return "Go to user";
+            case "pref_drawer_show_blur_switch":
+                return "Blur NSFW";
+            case "pref_drawer_show_night_mode":
+                return "Dark mode";
+            case "pref_drawer_show_nsfw_switch":
+                return "Show NSFW";
+            case "pref_drawer_show_home":
+                return "Home";
+            case "pref_subscriptions_drawer_show_icon":
+                return "Show icons";
+            case "pref_subscriptions_drawer":
+                return "Show in menu";
+            case "pref_subscriptions_only_casual":
+                return "Show only favorites";
+            case "pref_toolbar":
+                return "Hide on scroll";
+            case "pref_toolbar_main_action":
+                return "Main action";
+            default:
+                return key == null ? "" : key;
+        }
+    }
+
+    static String toggleSummaryFor(String key, String currentSummary) {
+        switch (key) {
+            case "pref_lock_sidebar":
+                return "Disable opening the navigation drawer with a swipe.";
+            case "pref_ask_exit":
+                return "Show a confirmation dialog before leaving Boost.";
+            case "pref_double_exit":
+                return "Require two Back presses to leave Boost.";
+            case "pref_bottom_navigation":
+                return "Show the bottom navigation bar on supported Boost screens.";
+            case "pref_bottom_navigation_hide_on_scroll":
+                return "Hide the bottom navigation while scrolling down.";
+            case "pref_accounts_show_avatar":
+                return "Show the active account avatar in the account switcher.";
+            case "pref_accounts_show_username":
+                return "Show the active Reddit username in the account switcher.";
+            case "pref_drawer_show_home":
+                return "Show the selected default feed in the navigation drawer.";
+            case "pref_drawer_show_frontpage":
+                return "Show the feed built from your Reddit subscriptions.";
+            case "pref_drawer_show_go_to":
+                return "Show the combined community, user, and random shortcut.";
+            case "pref_drawer_show_go_to_subreddit":
+                return "Show a direct shortcut for opening a community.";
+            case "pref_drawer_show_go_to_user":
+                return "Show a direct shortcut for opening a user profile.";
+            case "pref_drawer_sticky_settings":
+                return "Keep Settings and the theme toggle pinned to the drawer footer.";
+            case "pref_drawer_end":
+                return "Open the navigation drawer from the opposite edge.";
+            case "pref_subscriptions_drawer":
+                return "Show the subscriptions section in the navigation drawer.";
+            case "pref_subscriptions_drawer_show_icon":
+                return "Show community icons in the subscriptions section.";
+            case "pref_subscriptions_only_casual":
+                return "Limit the subscriptions section to favorite communities.";
+            case "pref_toolbar":
+                return "Hide the toolbar while scrolling down.";
+            case "pref_toolbar_main_action":
+                return "Choose the primary toolbar shortcut.";
+            default:
+                return TextUtils.isEmpty(currentSummary)
+                        ? ""
+                        : currentSummary;
+        }
+    }
+
+    static String searchSummaryFor(Context context, String key) {
+        String summary = toggleSummaryFor(key, "");
+        if (!TextUtils.isEmpty(summary)) {
+            return summary;
+        }
+        String pageId = MorpheSettingsV5Registry.pageIdForKey(key);
+        return TextUtils.isEmpty(pageId)
+                ? ""
+                : MorpheSettingsV5Registry.titleFor(pageId);
+    }
+}

--- a/extensions/boostforreddit/src/main/java/app/morphe/extension/boostforreddit/settings/MorpheSettingsV5NotificationsAccountFragment.java
+++ b/extensions/boostforreddit/src/main/java/app/morphe/extension/boostforreddit/settings/MorpheSettingsV5NotificationsAccountFragment.java
@@ -1,0 +1,226 @@
+package app.morphe.extension.boostforreddit.settings;
+
+import android.app.Activity;
+import android.content.Context;
+import android.content.Intent;
+import android.os.Bundle;
+import android.text.TextUtils;
+import android.view.LayoutInflater;
+import android.view.Menu;
+import android.view.MenuItem;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.LinearLayout;
+import android.widget.ScrollView;
+
+import androidx.fragment.app.Fragment;
+
+import app.morphe.extension.boostforreddit.utils.BoostSystemBarInsetsFix;
+
+/** Hidden Notifications & account hubs for the parallel Settings V5 tree. */
+public final class MorpheSettingsV5NotificationsAccountFragment extends Fragment {
+    public static final String CONTRACT_MARKER =
+            "MORPHE_BOOST_SETTINGS_V5_NOTIFICATIONS_ACCOUNT_FRAGMENT_ISSUE121_V1";
+    public static final String HIDDEN_WAVE_MARKER =
+            "MORPHE_BOOST_SETTINGS_V5_NOTIFICATIONS_ACCOUNT_HIDDEN_WAVE_ISSUE121_V1";
+
+    private static final String DEFAULT_PAGE_ID =
+            "v5/notifications_and_account";
+
+    private MorpheSettingsV4Theme.Tokens tokens;
+    private MorpheSettingsV5Registry.V5PageSpec page;
+    private String pageId = DEFAULT_PAGE_ID;
+
+    public MorpheSettingsV5NotificationsAccountFragment() {
+    }
+
+    @Override
+    public View onCreateView(
+            LayoutInflater inflater,
+            ViewGroup container,
+            Bundle savedInstanceState
+    ) {
+        Context context = inflater.getContext();
+        tokens = MorpheSettingsV4Theme.resolve(context);
+        setHasOptionsMenu(true);
+        resolvePageId();
+        page = MorpheSettingsV5Registry.requirePage(pageId);
+        if (page.isLeaf()
+                || !"MorpheSettingsV5NotificationsAccountFragment".equals(
+                page.renderer
+        )) {
+            throw new IllegalArgumentException(
+                    "Notifications & account hub renderer cannot open " + pageId
+            );
+        }
+
+        ScrollView scrollView = new ScrollView(context);
+        scrollView.setFillViewport(true);
+        scrollView.setClipToPadding(false);
+        scrollView.setBackgroundColor(tokens.background);
+
+        LinearLayout content = new LinearLayout(context);
+        content.setOrientation(LinearLayout.VERTICAL);
+        content.setPadding(dp(16), dp(12), dp(16), dp(36));
+        scrollView.addView(
+                content,
+                new ScrollView.LayoutParams(
+                        ViewGroup.LayoutParams.MATCH_PARENT,
+                        ViewGroup.LayoutParams.WRAP_CONTENT
+                )
+        );
+
+        String intro = MorpheSettingsV5Registry.introFor(pageId);
+        if (!TextUtils.isEmpty(intro)) {
+            content.addView(MorpheSettingsV14Ui.pageIntro(
+                    context,
+                    tokens,
+                    intro
+            ));
+            addSpace(content, 16);
+        }
+
+        String[] children = MorpheSettingsV5Registry.childrenFor(pageId);
+        if (children.length == 0) {
+            throw new IllegalStateException(
+                    "Notifications & account hub has no children: " + pageId
+            );
+        }
+        renderDestinations(content, children);
+        return scrollView;
+    }
+
+    @Override
+    public void onResume() {
+        super.onResume();
+        styleHost();
+    }
+
+    @Override
+    public void onPause() {
+        Activity activity = hostActivity();
+        if (activity != null) {
+            BoostSystemBarInsetsFix.clearMorpheSettingsV4SystemBars(activity);
+        }
+        super.onPause();
+    }
+
+    @Override
+    public void onPrepareOptionsMenu(Menu menu) {
+        super.onPrepareOptionsMenu(menu);
+        MorpheSettingsV5Search.prepareMenu(this, menu);
+    }
+
+    @Override
+    public boolean onOptionsItemSelected(MenuItem item) {
+        if (MorpheSettingsV5Search.handleMenuItem(this, item)) {
+            return true;
+        }
+        return super.onOptionsItemSelected(item);
+    }
+
+    void openPage(String targetPageId) {
+        MorpheSettingsV5Navigation.openPage(this, targetPageId);
+    }
+
+    String currentPageId() {
+        return pageId;
+    }
+
+    private void renderDestinations(
+            LinearLayout content,
+            String[] children
+    ) {
+        LinearLayout list = MorpheSettingsV14Ui.standardList(requireContext());
+        content.addView(
+                list,
+                new LinearLayout.LayoutParams(
+                        ViewGroup.LayoutParams.MATCH_PARENT,
+                        ViewGroup.LayoutParams.WRAP_CONTENT
+                )
+        );
+        for (String childId : children) {
+            LinearLayout row = MorpheSettingsV14Ui.standardListRow(
+                    requireContext(),
+                    tokens,
+                    false
+            );
+            row.addView(
+                    MorpheSettingsV14Ui.standardListLabels(
+                            requireContext(),
+                            tokens,
+                            MorpheSettingsV5Registry.titleFor(childId),
+                            ""
+                    ),
+                    new LinearLayout.LayoutParams(
+                            0,
+                            ViewGroup.LayoutParams.WRAP_CONTENT,
+                            1.0f
+                    )
+            );
+            row.addView(MorpheSettingsV14Ui.chevron(requireContext(), tokens));
+            row.setOnClickListener(view -> openPage(childId));
+            MorpheSettingsV14Ui.addStandardListRow(list, row, tokens);
+        }
+    }
+
+    private void resolvePageId() {
+        Bundle arguments = getArguments();
+        if (arguments != null) {
+            String requested = arguments.getString(
+                    MorpheSettingsV5Registry.EXTRA_PAGE_ID
+            );
+            if (!TextUtils.isEmpty(requested)) {
+                pageId = requested;
+                return;
+            }
+        }
+        Activity activity = hostActivity();
+        Intent intent = activity == null ? null : activity.getIntent();
+        String requested = intent == null
+                ? null
+                : intent.getStringExtra(MorpheSettingsV5Registry.EXTRA_PAGE_ID);
+        if (!TextUtils.isEmpty(requested)) {
+            pageId = requested;
+        }
+    }
+
+    private void styleHost() {
+        Activity activity = hostActivity();
+        if (activity == null || tokens == null) {
+            return;
+        }
+        activity.setTitle(MorpheSettingsV5Registry.titleFor(pageId));
+        BoostSystemBarInsetsFix.applyMorpheSettingsV4SystemBars(
+                activity,
+                tokens.background,
+                tokens.dark
+        );
+        int toolbarId = MorpheSettingsV4Catalog.resourceId(
+                activity,
+                "id",
+                "toolbar"
+        );
+        View toolbar = toolbarId == 0 ? null : activity.findViewById(toolbarId);
+        if (toolbar != null) {
+            toolbar.setBackgroundColor(tokens.background);
+            toolbar.setElevation(0);
+        }
+    }
+
+    private Activity hostActivity() {
+        Context context = getContext();
+        return context instanceof Activity ? (Activity) context : null;
+    }
+
+    private void addSpace(LinearLayout parent, int heightDp) {
+        parent.addView(
+                new View(requireContext()),
+                new LinearLayout.LayoutParams(1, dp(heightDp))
+        );
+    }
+
+    private int dp(float value) {
+        return MorpheSettingsV4Theme.dp(requireContext(), value);
+    }
+}

--- a/extensions/boostforreddit/src/main/java/app/morphe/extension/boostforreddit/settings/MorpheSettingsV5NotificationsAccountLeafFragment.java
+++ b/extensions/boostforreddit/src/main/java/app/morphe/extension/boostforreddit/settings/MorpheSettingsV5NotificationsAccountLeafFragment.java
@@ -1,0 +1,130 @@
+package app.morphe.extension.boostforreddit.settings;
+
+import android.app.Activity;
+import android.content.Context;
+import android.content.Intent;
+import android.os.Bundle;
+import android.text.TextUtils;
+
+/** Complete hidden Notifications & account leaves for Settings V5. */
+public final class MorpheSettingsV5NotificationsAccountLeafFragment
+        extends MorpheSettingsV5XmlPreferenceFragment {
+    public static final String CONTRACT_MARKER =
+            "MORPHE_BOOST_SETTINGS_V5_NOTIFICATIONS_ACCOUNT_LEAF_ISSUE121_V1";
+    public static final String CANONICAL_BINDINGS_MARKER =
+            "MORPHE_BOOST_SETTINGS_V5_NOTIFICATIONS_ACCOUNT_BINDINGS_ISSUE121_V1";
+    public static final String HIDDEN_HISTORY_MARKER =
+            "MORPHE_BOOST_SETTINGS_V5_NOTIFICATIONS_ACCOUNT_HIDDEN_HISTORY_ISSUE121_V1";
+
+    private static final String DEFAULT_PAGE_ID =
+            "v5/notifications_and_account/notifications_and_inbox/notifications";
+
+    private String pageId = DEFAULT_PAGE_ID;
+    private MorpheSettingsV5Registry.V5PageSpec page;
+
+    public MorpheSettingsV5NotificationsAccountLeafFragment() {
+        super(
+                "pref_privacy_v2",
+                "pref_messages_v2",
+                "morphe_boost_settings_skeleton"
+        );
+    }
+
+    @Override
+    protected void preparePage() {
+        resolvePageId();
+        page = MorpheSettingsV5Registry.requirePage(pageId);
+        if (!page.isLeaf()
+                || !"MorpheSettingsV5NotificationsAccountLeafFragment".equals(
+                page.renderer
+        )
+                || !pageId.startsWith("v5/notifications_and_account/")) {
+            throw new IllegalArgumentException(
+                    "Notifications & account leaf renderer cannot open " + pageId
+            );
+        }
+        setPageTitle(MorpheSettingsV5Registry.titleFor(pageId));
+    }
+
+    @Override
+    protected boolean includeControl(String resourceName, String key) {
+        return page != null && page.containsKey(key);
+    }
+
+    @Override
+    protected boolean includeHiddenControl(
+            String resourceName,
+            String key
+    ) {
+        return "pref_privacy_v2".equals(resourceName)
+                && ("pref_search_history_save".equals(key)
+                || "pref_searches_delete".equals(key))
+                && page != null
+                && page.containsKey(key);
+    }
+
+    @Override
+    protected String sectionFor(
+            String resourceName,
+            String key,
+            String currentSection
+    ) {
+        return MorpheSettingsV5Registry.titleFor(pageId);
+    }
+
+    @Override
+    protected String pageIntro() {
+        return MorpheSettingsV5Registry.introFor(pageId);
+    }
+
+    @Override
+    protected String displaySummary(
+            String key,
+            String currentSummary
+    ) {
+        return MorpheSettingsV5NotificationsAccountMetadata.toggleSummaryFor(
+                key,
+                currentSummary
+        );
+    }
+
+    @Override
+    protected String displayActionSummary(
+            String key,
+            String currentSummary,
+            String tag
+    ) {
+        return MorpheSettingsV5NotificationsAccountMetadata.actionSummaryFor(
+                key,
+                currentSummary
+        );
+    }
+
+    String currentPageId() {
+        return pageId;
+    }
+
+    private void resolvePageId() {
+        Bundle arguments = getArguments();
+        if (arguments != null) {
+            String requested = arguments.getString(
+                    MorpheSettingsV5Registry.EXTRA_PAGE_ID
+            );
+            if (!TextUtils.isEmpty(requested)) {
+                pageId = requested;
+                return;
+            }
+        }
+        Context context = getContext();
+        Activity activity = context instanceof Activity
+                ? (Activity) context
+                : null;
+        Intent intent = activity == null ? null : activity.getIntent();
+        String requested = intent == null
+                ? null
+                : intent.getStringExtra(MorpheSettingsV5Registry.EXTRA_PAGE_ID);
+        if (!TextUtils.isEmpty(requested)) {
+            pageId = requested;
+        }
+    }
+}

--- a/extensions/boostforreddit/src/main/java/app/morphe/extension/boostforreddit/settings/MorpheSettingsV5NotificationsAccountMetadata.java
+++ b/extensions/boostforreddit/src/main/java/app/morphe/extension/boostforreddit/settings/MorpheSettingsV5NotificationsAccountMetadata.java
@@ -1,0 +1,117 @@
+package app.morphe.extension.boostforreddit.settings;
+
+import android.content.Context;
+import android.text.TextUtils;
+
+/** Titles and supporting text for Settings V5 Notifications & account. */
+final class MorpheSettingsV5NotificationsAccountMetadata {
+    static final String CONTRACT_MARKER =
+            "MORPHE_BOOST_SETTINGS_V5_NOTIFICATIONS_ACCOUNT_METADATA_ISSUE121_V1";
+
+    private MorpheSettingsV5NotificationsAccountMetadata() {
+    }
+
+    static String titleFor(Context context, String key) {
+        switch (key) {
+            case "pref_all_delete":
+                return "Clear all history";
+            case "pref_history_delete":
+                return "Clear community history";
+            case "pref_recent_posts_delete":
+                return "Clear post history";
+            case "pref_searches_delete":
+                return "Clear search history";
+            case "pref_recent_posts_save_nsfw":
+                return "Include NSFW posts";
+            case "pref_history_save":
+                return "Save recent communities";
+            case "pref_recent_posts_save":
+                return "Save recent posts";
+            case "pref_search_history_save":
+                return "Show recent searches";
+            case "morphe_boost_imgur_undelete_enabled":
+                return "Automatically undelete Imgur images";
+            case "morphe_boost_reddit_undelete_enabled":
+                return "Automatically undelete Reddit content";
+            case "pref_check_messages_push_clear":
+                return "Clear source notification";
+            case "pref_check_messages_push":
+                return "Reddit push";
+            case "pref_check_messages_interval":
+                return "Check interval";
+            case "pref_check_modmail":
+                return "Check moderator mail";
+            case "pref_check_messages":
+                return "Check notifications";
+            case "pref_notifications_configure":
+                return "Configure notifications";
+            default:
+                return key == null ? "" : key;
+        }
+    }
+
+    static String toggleSummaryFor(String key, String currentSummary) {
+        switch (key) {
+            case "pref_recent_posts_save_nsfw":
+                return "Include NSFW posts in local post history.";
+            case "pref_history_save":
+                return "Visited communities appear in autocomplete fields.";
+            case "pref_recent_posts_save":
+                return "Visited posts appear in Boost’s History screen.";
+            case "pref_search_history_save":
+                return "Keep recent searches available while Boost is running.";
+            case "morphe_boost_imgur_undelete_enabled":
+                return "Try to restore supported missing Imgur media from archive sources. Disabled by default.";
+            case "morphe_boost_reddit_undelete_enabled":
+                return "Try to restore supported deleted Reddit posts and comments from archive sources. Disabled by default.";
+            case "pref_check_messages":
+                return "Periodically check Reddit for new inbox notifications.";
+            case "pref_check_modmail":
+                return "Include moderator mail when checking for new inbox notifications.";
+            case "pref_check_messages_push":
+                return "Bridge notifications received by the official Reddit app into Boost. Android notification access is required.";
+            case "pref_check_messages_push_clear":
+                return "Remove the source Reddit notification after Boost creates its own.";
+            default:
+                return TextUtils.isEmpty(currentSummary)
+                        ? ""
+                        : currentSummary;
+        }
+    }
+
+    static String actionSummaryFor(String key, String currentSummary) {
+        switch (key) {
+            case "pref_all_delete":
+                return "Remove saved post, community, and search history from this device.";
+            case "pref_history_delete":
+                return "Remove saved community history from this device.";
+            case "pref_recent_posts_delete":
+                return "Remove saved post history from this device.";
+            case "pref_searches_delete":
+                return "Remove recent search history from this device.";
+            case "pref_notifications_configure":
+                return "Open Android notification settings for Boost.";
+            default:
+                return TextUtils.isEmpty(currentSummary)
+                        ? ""
+                        : currentSummary;
+        }
+    }
+
+    static String searchSummaryFor(Context context, String key) {
+        String summary = actionSummaryFor(key, "");
+        if (TextUtils.isEmpty(summary)) {
+            summary = toggleSummaryFor(key, "");
+        }
+        if (!TextUtils.isEmpty(summary)) {
+            return summary;
+        }
+        if ("pref_check_messages_interval".equals(key)) {
+            return "Choose how often Boost checks Reddit for new inbox notifications.";
+        }
+        String pageId = MorpheSettingsV5Registry.pageIdForKey(key);
+        return TextUtils.isEmpty(pageId)
+                ? ""
+                : MorpheSettingsV5Registry.titleFor(pageId);
+    }
+}

--- a/extensions/boostforreddit/src/main/java/app/morphe/extension/boostforreddit/settings/MorpheSettingsV5ReadingFragment.java
+++ b/extensions/boostforreddit/src/main/java/app/morphe/extension/boostforreddit/settings/MorpheSettingsV5ReadingFragment.java
@@ -1,0 +1,224 @@
+package app.morphe.extension.boostforreddit.settings;
+
+import android.app.Activity;
+import android.content.Context;
+import android.content.Intent;
+import android.os.Bundle;
+import android.text.TextUtils;
+import android.view.LayoutInflater;
+import android.view.Menu;
+import android.view.MenuItem;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.LinearLayout;
+import android.widget.ScrollView;
+
+import androidx.fragment.app.Fragment;
+
+import app.morphe.extension.boostforreddit.utils.BoostSystemBarInsetsFix;
+
+/** Hidden Reading & interaction hubs for the parallel Settings V5 tree. */
+public final class MorpheSettingsV5ReadingFragment extends Fragment {
+    public static final String CONTRACT_MARKER =
+            "MORPHE_BOOST_SETTINGS_V5_READING_FRAGMENT_ISSUE121_V1";
+    public static final String HIDDEN_WAVE_MARKER =
+            "MORPHE_BOOST_SETTINGS_V5_READING_HIDDEN_WAVE_ISSUE121_V1";
+
+    private static final String DEFAULT_PAGE_ID =
+            "v5/reading_and_interaction";
+
+    private MorpheSettingsV4Theme.Tokens tokens;
+    private MorpheSettingsV5Registry.V5PageSpec page;
+    private String pageId = DEFAULT_PAGE_ID;
+
+    public MorpheSettingsV5ReadingFragment() {
+    }
+
+    @Override
+    public View onCreateView(
+            LayoutInflater inflater,
+            ViewGroup container,
+            Bundle savedInstanceState
+    ) {
+        Context context = inflater.getContext();
+        tokens = MorpheSettingsV4Theme.resolve(context);
+        setHasOptionsMenu(true);
+        resolvePageId();
+        page = MorpheSettingsV5Registry.requirePage(pageId);
+        if (page.isLeaf()
+                || !"MorpheSettingsV5ReadingFragment".equals(page.renderer)) {
+            throw new IllegalArgumentException(
+                    "Reading hub renderer cannot open " + pageId
+            );
+        }
+
+        ScrollView scrollView = new ScrollView(context);
+        scrollView.setFillViewport(true);
+        scrollView.setClipToPadding(false);
+        scrollView.setBackgroundColor(tokens.background);
+
+        LinearLayout content = new LinearLayout(context);
+        content.setOrientation(LinearLayout.VERTICAL);
+        content.setPadding(dp(16), dp(12), dp(16), dp(36));
+        scrollView.addView(
+                content,
+                new ScrollView.LayoutParams(
+                        ViewGroup.LayoutParams.MATCH_PARENT,
+                        ViewGroup.LayoutParams.WRAP_CONTENT
+                )
+        );
+
+        String intro = MorpheSettingsV5Registry.introFor(pageId);
+        if (!TextUtils.isEmpty(intro)) {
+            content.addView(MorpheSettingsV14Ui.pageIntro(
+                    context,
+                    tokens,
+                    intro
+            ));
+            addSpace(content, 16);
+        }
+
+        String[] children = MorpheSettingsV5Registry.childrenFor(pageId);
+        if (children.length == 0) {
+            throw new IllegalStateException(
+                    "Reading hub has no destination children: " + pageId
+            );
+        }
+        renderDestinations(content, children);
+        return scrollView;
+    }
+
+    @Override
+    public void onResume() {
+        super.onResume();
+        styleHost();
+    }
+
+    @Override
+    public void onPause() {
+        Activity activity = hostActivity();
+        if (activity != null) {
+            BoostSystemBarInsetsFix.clearMorpheSettingsV4SystemBars(activity);
+        }
+        super.onPause();
+    }
+
+    @Override
+    public void onPrepareOptionsMenu(Menu menu) {
+        super.onPrepareOptionsMenu(menu);
+        MorpheSettingsV5Search.prepareMenu(this, menu);
+    }
+
+    @Override
+    public boolean onOptionsItemSelected(MenuItem item) {
+        if (MorpheSettingsV5Search.handleMenuItem(this, item)) {
+            return true;
+        }
+        return super.onOptionsItemSelected(item);
+    }
+
+    void openPage(String targetPageId) {
+        MorpheSettingsV5Navigation.openPage(this, targetPageId);
+    }
+
+    String currentPageId() {
+        return pageId;
+    }
+
+    private void renderDestinations(
+            LinearLayout content,
+            String[] children
+    ) {
+        LinearLayout list = MorpheSettingsV14Ui.standardList(requireContext());
+        content.addView(
+                list,
+                new LinearLayout.LayoutParams(
+                        ViewGroup.LayoutParams.MATCH_PARENT,
+                        ViewGroup.LayoutParams.WRAP_CONTENT
+                )
+        );
+        for (String childId : children) {
+            LinearLayout row = MorpheSettingsV14Ui.standardListRow(
+                    requireContext(),
+                    tokens,
+                    false
+            );
+            row.addView(
+                    MorpheSettingsV14Ui.standardListLabels(
+                            requireContext(),
+                            tokens,
+                            MorpheSettingsV5Registry.titleFor(childId),
+                            ""
+                    ),
+                    new LinearLayout.LayoutParams(
+                            0,
+                            ViewGroup.LayoutParams.WRAP_CONTENT,
+                            1.0f
+                    )
+            );
+            row.addView(MorpheSettingsV14Ui.chevron(requireContext(), tokens));
+            row.setOnClickListener(view -> openPage(childId));
+            MorpheSettingsV14Ui.addStandardListRow(list, row, tokens);
+        }
+    }
+
+    private void resolvePageId() {
+        Bundle arguments = getArguments();
+        if (arguments != null) {
+            String requested = arguments.getString(
+                    MorpheSettingsV5Registry.EXTRA_PAGE_ID
+            );
+            if (!TextUtils.isEmpty(requested)) {
+                pageId = requested;
+                return;
+            }
+        }
+        Activity activity = hostActivity();
+        Intent intent = activity == null ? null : activity.getIntent();
+        String requested = intent == null
+                ? null
+                : intent.getStringExtra(MorpheSettingsV5Registry.EXTRA_PAGE_ID);
+        if (!TextUtils.isEmpty(requested)) {
+            pageId = requested;
+        }
+    }
+
+    private void styleHost() {
+        Activity activity = hostActivity();
+        if (activity == null || tokens == null) {
+            return;
+        }
+        activity.setTitle(MorpheSettingsV5Registry.titleFor(pageId));
+        BoostSystemBarInsetsFix.applyMorpheSettingsV4SystemBars(
+                activity,
+                tokens.background,
+                tokens.dark
+        );
+        int toolbarId = MorpheSettingsV4Catalog.resourceId(
+                activity,
+                "id",
+                "toolbar"
+        );
+        View toolbar = toolbarId == 0 ? null : activity.findViewById(toolbarId);
+        if (toolbar != null) {
+            toolbar.setBackgroundColor(tokens.background);
+            toolbar.setElevation(0);
+        }
+    }
+
+    private Activity hostActivity() {
+        Context context = getContext();
+        return context instanceof Activity ? (Activity) context : null;
+    }
+
+    private void addSpace(LinearLayout parent, int heightDp) {
+        parent.addView(
+                new View(requireContext()),
+                new LinearLayout.LayoutParams(1, dp(heightDp))
+        );
+    }
+
+    private int dp(float value) {
+        return MorpheSettingsV4Theme.dp(requireContext(), value);
+    }
+}

--- a/extensions/boostforreddit/src/main/java/app/morphe/extension/boostforreddit/settings/MorpheSettingsV5ReadingLeafFragment.java
+++ b/extensions/boostforreddit/src/main/java/app/morphe/extension/boostforreddit/settings/MorpheSettingsV5ReadingLeafFragment.java
@@ -1,0 +1,118 @@
+package app.morphe.extension.boostforreddit.settings;
+
+import android.app.Activity;
+import android.content.Context;
+import android.content.Intent;
+import android.os.Bundle;
+import android.text.TextUtils;
+
+/** Complete hidden Reading leaf pages for Settings V5. */
+public final class MorpheSettingsV5ReadingLeafFragment
+        extends MorpheSettingsV5XmlPreferenceFragment {
+    public static final String CONTRACT_MARKER =
+            "MORPHE_BOOST_SETTINGS_V5_READING_LEAF_ISSUE121_V1";
+    public static final String CANONICAL_BINDINGS_MARKER =
+            "MORPHE_BOOST_SETTINGS_V5_READING_CANONICAL_BINDINGS_ISSUE121_V1";
+
+    private static final String DEFAULT_PAGE_ID =
+            "v5/reading_and_interaction/comments/comment_actions";
+
+    private String pageId = DEFAULT_PAGE_ID;
+    private MorpheSettingsV5Registry.V5PageSpec page;
+
+    public MorpheSettingsV5ReadingLeafFragment() {
+        super(
+                "pref_comments_v2",
+                "pref_general_v2",
+                "pref_posts_v2",
+                "pref_privacy_v2",
+                "pref_filters_v2",
+                "pref_search_v2",
+                "morphe_boost_settings_skeleton"
+        );
+    }
+
+    @Override
+    protected void preparePage() {
+        resolvePageId();
+        page = MorpheSettingsV5Registry.requirePage(pageId);
+        if (!page.isLeaf()
+                || !"MorpheSettingsV5ReadingLeafFragment".equals(page.renderer)
+                || !pageId.startsWith("v5/reading_and_interaction/")) {
+            throw new IllegalArgumentException(
+                    "Reading leaf renderer cannot open " + pageId
+            );
+        }
+        setPageTitle(MorpheSettingsV5Registry.titleFor(pageId));
+    }
+
+    @Override
+    protected boolean includeControl(String resourceName, String key) {
+        return page != null && page.containsKey(key);
+    }
+
+    @Override
+    protected String sectionFor(
+            String resourceName,
+            String key,
+            String currentSection
+    ) {
+        return MorpheSettingsV5Registry.titleFor(pageId);
+    }
+
+    @Override
+    protected String pageIntro() {
+        return MorpheSettingsV5Registry.introFor(pageId);
+    }
+
+    @Override
+    protected String displaySummary(
+            String key,
+            String currentSummary
+    ) {
+        return MorpheSettingsV5ReadingMetadata.toggleSummaryFor(
+                key,
+                currentSummary
+        );
+    }
+
+    @Override
+    protected String displayActionSummary(
+            String key,
+            String currentSummary,
+            String tag
+    ) {
+        return MorpheSettingsV5ReadingMetadata.actionSummaryFor(
+                key,
+                currentSummary
+        );
+    }
+
+    String currentPageId() {
+        return pageId;
+    }
+
+    private void resolvePageId() {
+        Bundle arguments = getArguments();
+        if (arguments != null) {
+            String requested = arguments.getString(
+                    MorpheSettingsV5Registry.EXTRA_PAGE_ID
+            );
+            if (!TextUtils.isEmpty(requested)) {
+                pageId = requested;
+                return;
+            }
+        }
+        Context context = getContext();
+        Activity activity = context instanceof Activity
+                ? (Activity) context
+                : null;
+        Intent intent = activity == null ? null : activity.getIntent();
+        String requested = intent == null
+                ? null
+                : intent.getStringExtra(MorpheSettingsV5Registry.EXTRA_PAGE_ID);
+        if (!TextUtils.isEmpty(requested)) {
+            pageId = requested;
+        }
+    }
+}

--- a/extensions/boostforreddit/src/main/java/app/morphe/extension/boostforreddit/settings/MorpheSettingsV5ReadingMetadata.java
+++ b/extensions/boostforreddit/src/main/java/app/morphe/extension/boostforreddit/settings/MorpheSettingsV5ReadingMetadata.java
@@ -1,0 +1,288 @@
+package app.morphe.extension.boostforreddit.settings;
+
+import android.content.Context;
+import android.text.TextUtils;
+
+/** Titles and consequence-oriented supporting text for V5 Reading pages. */
+final class MorpheSettingsV5ReadingMetadata {
+    static final String CONTRACT_MARKER =
+            "MORPHE_BOOST_SETTINGS_V5_READING_METADATA_ISSUE121_V1";
+    static final String SUPPORTING_TEXT_MARKER =
+            "MORPHE_BOOST_SETTINGS_V5_READING_STATUS_VALUE_CONSEQUENCE_ISSUE121_V1";
+
+    private MorpheSettingsV5ReadingMetadata() {
+    }
+
+    static String titleFor(Context context, String key) {
+        switch (key) {
+            case "pref_comments_buttons":
+                return "Buttons always visible";
+            case "pref_swipe_threshold_percentage":
+                return "Distance threshold";
+            case "pref_comments_buttons_collapse_after_action":
+                return "Hide buttons after voting/saving";
+            case "pref_comments_button_save":
+                return "Save";
+            case "pref_comments_floating_button":
+                return "Show floating button";
+            case "pref_info_post_upvote_percentage":
+                return "Show post upvote percentage";
+            case "pref_swipe_sensitivity_percentage":
+                return "Swipe sensitivity";
+            case "pref_swipe_back":
+                return "Swipe to close";
+            case "pref_comments_button_parent":
+                return "Up button";
+            case "pref_comments_color_pattern":
+                return "Color pattern";
+            case "pref_user_flair_emojis":
+                return "Show emojis";
+            case "pref_user_flair_colors":
+                return "Show flair colors";
+            case "pref_comments_show_avatar":
+                return "Show user avatar";
+            case "pref_comments_user_flair":
+                return "Show user flair";
+            case "pref_clickable_awards_comments":
+                return "Clickable awards";
+            case "pref_default_comment_sorting":
+                return "Default sort";
+            case "pref_comments_highlight_mine":
+                return "Highlight my username";
+            case "pref_comments_image":
+                return "Post media preview size";
+            case "pref_show_awards_comments":
+                return "Show awards";
+            case "pref_comments_clickable_username":
+                return "Tap username to view profile";
+            case "pref_suggested_comment_sorting":
+                return "Use suggested sort";
+            case "pref_comments_scroll_animation":
+                return "Animate navigation";
+            case "pref_comments_click":
+                return "Click to collapse comment";
+            case "pref_comments_collapse_automoderator":
+                return "Collapse AutoModerator";
+            case "pref_comments_collapse_collapsed":
+                return "Collapse disruptive comments";
+            case "pref_comments_default_navigation":
+                return "Default navigation mode";
+            case "pref_comments_animation":
+                return "Expand/collapse animation";
+            case "pref_comments_full_collapse":
+                return "Hide text of collapsed comments";
+            case "pref_comments_highlight_new_comments":
+                return "Highlight new comments";
+            case "pref_comments_load_collapsed":
+                return "Load collapsed by default";
+            case "pref_comments_navigation_bar":
+                return "Show navigation bar";
+            case "pref_indent_style":
+                return "Thread level indicator";
+            case "pref_comments_volume_scroll":
+                return "Volume key navigation";
+            case "pref_manage_drafts":
+                return "Post drafts";
+            case "pref_drafts":
+                return "Save drafts";
+            case "pref_use_advanced_editor":
+                return "Advanced fullscreen editor";
+            case "pref_imgur_uploads":
+                return "Uploaded images";
+            case "pref_edit_subscriptions":
+                return "Subscriptions";
+            case "pref_default_sort":
+                return "Default sort";
+            case "pref_sort_per_subscription":
+                return "Remember per community";
+            case "pref_frontpage_sort":
+                return "Sort Home posts by";
+            case "pref_post_show_comments_button":
+                return "Comments";
+            case "pref_show_hide":
+                return "Hide";
+            case "pref_sort_per_sub":
+                return "Manage saved sorts";
+            case "pref_show_read":
+                return "Mark read";
+            case "pref_post_show_open_button":
+                return "Open in external app";
+            case "pref_post_show_share_button":
+                return "Share";
+            case "pref_posts_floating_button":
+                return "Show floating button";
+            case "pref_upvote_on_save":
+                return "Upvote on save";
+            case "pref_clickable_awards_posts":
+                return "Clickable awards";
+            case "pref_info_username":
+                return "Show author";
+            case "pref_show_awards_posts":
+                return "Show awards";
+            case "pref_flair_emojis":
+                return "Show emojis";
+            case "pref_flair_colors":
+                return "Show flair colors";
+            case "pref_info_post_flair":
+                return "Show post flair";
+            case "pref_post_clickable_subreddit":
+                return "Tap community to visit";
+            case "pref_flair_clickable":
+                return "Tap flair to search";
+            case "pref_post_clickable_username":
+                return "Tap username to view profile";
+            case "synncit_config":
+                return "Configure Synccit";
+            case "pref_mark_read_dim_images":
+                return "Dim images in read posts";
+            case "pref_hide_read_permanently":
+                return "Hide read permanently";
+            case "pref_mark_read_on_scroll":
+                return "Mark as read on scroll";
+            case "pref_mark_read":
+                return "Mark posts as read";
+            case "pref_history_delete_read":
+                return "Reset read posts";
+            case "pref_blur_nsfw_images":
+                return "Blur images in NSFW posts";
+            case "pref_load_nsfw_images":
+                return "Show images in NSFW posts";
+            case "pref_nsfw":
+                return "Show NSFW";
+            case "pref_filter_subreddit":
+                return "Communities";
+            case "pref_filter_domain":
+                return "Domains";
+            case "pref_filter_flair":
+                return "Flairs";
+            case "pref_filter_username":
+                return "Users";
+            case "pref_filter_keyword":
+                return "Words";
+            case "pref_album":
+                return "Albums";
+            case "pref_gif":
+                return "Gifs";
+            case "pref_image":
+                return "Images";
+            case "pref_link":
+                return "Links";
+            case "pref_self":
+                return "Text";
+            case "pref_video":
+                return "Videos";
+            case "pref_search_advanced_help":
+                return "Field search help";
+            case "pref_default_search_period":
+                return "Default period";
+            case "pref_default_search_sorting":
+                return "Default sort";
+            case "morphe_boost_search_open_keyboard_on_entry":
+                return "Open keyboard when entering Search";
+            case "pref_saved_searches":
+                return "Saved searches";
+            case "pref_search_show_random":
+                return "Show random";
+            case "pref_search_show_random_nsfw":
+                return "Show random NSFW";
+            case "pref_search_show_trending":
+                return "Show trending communities";
+            case "pref_search_show_trending_searches":
+                return "Show trending today";
+            default:
+                return key == null ? "" : key;
+        }
+    }
+
+    static String toggleSummaryFor(String key, String currentSummary) {
+        switch (key) {
+            case "pref_swipe_back":
+                return "Swipe right from the edge to return.";
+            case "pref_suggested_comment_sorting":
+                return "Use the sort recommended by the community or post.";
+            case "pref_comments_click":
+                return "When disabled, long-press a comment to collapse it.";
+            case "pref_comments_collapse_collapsed":
+                return "Includes crowd-controlled, downvoted, and deleted comments.";
+            case "pref_comments_full_collapse":
+                return "Show only the comment header while collapsed.";
+            case "pref_comments_load_collapsed":
+                return "Start top-level comments with their replies collapsed.";
+            case "pref_comments_volume_scroll":
+                return "Use volume keys to move between comments.";
+            case "pref_comments_scroll_animation":
+                return "Animate movement between comments.";
+            case "pref_use_advanced_editor":
+                return "Disable to use the compact reply dialog.";
+            case "pref_sort_per_subscription":
+                return "Each community remembers the most recently selected sort.";
+            case "pref_mark_read":
+                return "Opening a post records it as read.";
+            case "pref_mark_read_on_scroll":
+                return "Record a post as read after it leaves the screen.";
+            case "pref_hide_read_permanently":
+                return "Hide read posts through Reddit\u2019s hidden-post list; login required.";
+            case "pref_mark_read_dim_images":
+                return "Dim media after a post is marked read.";
+            case "pref_nsfw":
+                return "Show content labeled Not Safe For Work.";
+            case "morphe_boost_search_open_keyboard_on_entry":
+                return "Focus Search and show the keyboard immediately.";
+            default:
+                return "";
+        }
+    }
+
+    static String actionSummaryFor(String key, String currentSummary) {
+        switch (key) {
+            case "pref_manage_drafts":
+                return "Open drafts saved on Reddit.";
+            case "pref_imgur_uploads":
+                return "Open images uploaded to Imgur through Boost.";
+            case "pref_edit_subscriptions":
+                return "Manage communities and custom feeds.";
+            case "pref_default_sort":
+                return "Choose the default sort used outside Home.";
+            case "pref_frontpage_sort":
+                return "Choose the default sort used for Home.";
+            case "pref_sort_per_sub":
+                return "Edit sorts remembered for individual communities.";
+            case "synncit_config":
+                return "Sync read-post state between supported clients.";
+            case "pref_history_delete_read":
+                return "Clear the read-post history stored on this device.";
+            case "pref_saved_searches":
+                return "View and manage searches saved in Boost.";
+            case "pref_search_advanced_help":
+                return "See supported field prefixes and search examples.";
+            case "pref_comments_color_pattern":
+                return "Choose colors used to show comment nesting.";
+            case "pref_filter_subreddit":
+                return "Hide posts from selected communities.";
+            case "pref_filter_domain":
+                return "Hide posts from selected domains.";
+            case "pref_filter_username":
+                return "Hide posts from selected users.";
+            case "pref_filter_keyword":
+                return "Hide posts containing selected words in the title.";
+            case "pref_filter_flair":
+                return "Hide posts with selected flairs.";
+            default:
+                return TextUtils.isEmpty(currentSummary) ? "" : currentSummary;
+        }
+    }
+
+    static String searchSummaryFor(Context context, String key) {
+        String summary = actionSummaryFor(key, "");
+        if (TextUtils.isEmpty(summary)) {
+            summary = toggleSummaryFor(key, "");
+        }
+        if (!TextUtils.isEmpty(summary)) {
+            return summary;
+        }
+        String pageId = MorpheSettingsV5Registry.pageIdForKey(key);
+        return TextUtils.isEmpty(pageId)
+                ? ""
+                : MorpheSettingsV5Registry.titleFor(pageId);
+    }
+}

--- a/extensions/boostforreddit/src/main/java/app/morphe/extension/boostforreddit/settings/MorpheSettingsV5RedditAccountFragment.java
+++ b/extensions/boostforreddit/src/main/java/app/morphe/extension/boostforreddit/settings/MorpheSettingsV5RedditAccountFragment.java
@@ -1,0 +1,157 @@
+package app.morphe.extension.boostforreddit.settings;
+
+import android.app.Activity;
+import android.content.Context;
+import android.os.Bundle;
+import android.view.LayoutInflater;
+import android.view.Menu;
+import android.view.MenuItem;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.LinearLayout;
+import android.widget.ScrollView;
+
+import androidx.fragment.app.Fragment;
+
+import app.morphe.extension.boostforreddit.utils.BoostSystemBarInsetsFix;
+
+/** V5-owned status page for Reddit-hosted account preferences. */
+public final class MorpheSettingsV5RedditAccountFragment extends Fragment {
+    public static final String CONTRACT_MARKER =
+            "MORPHE_BOOST_SETTINGS_V5_REDDIT_ACCOUNT_ISSUE121_V1";
+    public static final String ZERO_CANONICAL_CONTROLS_MARKER =
+            "MORPHE_BOOST_SETTINGS_V5_REDDIT_ACCOUNT_ZERO_CANONICAL_CONTROLS_ISSUE121_V1";
+
+    private static final String PAGE_ID =
+            "v5/notifications_and_account/reddit_account";
+
+    private MorpheSettingsV4Theme.Tokens tokens;
+
+    public MorpheSettingsV5RedditAccountFragment() {
+    }
+
+    @Override
+    public View onCreateView(
+            LayoutInflater inflater,
+            ViewGroup container,
+            Bundle savedInstanceState
+    ) {
+        Context context = inflater.getContext();
+        tokens = MorpheSettingsV4Theme.resolve(context);
+        setHasOptionsMenu(true);
+
+        MorpheSettingsV5Registry.V5PageSpec page =
+                MorpheSettingsV5Registry.requirePage(PAGE_ID);
+        if (!"MorpheSettingsV5RedditAccountFragment".equals(page.renderer)
+                || page.keys.length != 0
+                || !page.isLeaf()) {
+            throw new IllegalStateException(
+                    "Reddit account V5 page contract is invalid"
+            );
+        }
+
+        ScrollView scrollView = new ScrollView(context);
+        scrollView.setFillViewport(true);
+        scrollView.setClipToPadding(false);
+        scrollView.setBackgroundColor(tokens.background);
+
+        LinearLayout content = new LinearLayout(context);
+        content.setOrientation(LinearLayout.VERTICAL);
+        content.setPadding(dp(16), dp(12), dp(16), dp(36));
+        scrollView.addView(
+                content,
+                new ScrollView.LayoutParams(
+                        ViewGroup.LayoutParams.MATCH_PARENT,
+                        ViewGroup.LayoutParams.WRAP_CONTENT
+                )
+        );
+
+        content.addView(MorpheSettingsV14Ui.pageIntro(
+                context,
+                tokens,
+                MorpheSettingsV5Registry.introFor(PAGE_ID)
+        ));
+        addSpace(content, 20);
+        content.addView(MorpheSettingsV14Ui.sectionLabel(
+                context,
+                tokens,
+                "Account preferences"
+        ));
+        content.addView(MorpheSettingsV14Ui.supportingText(
+                context,
+                tokens,
+                "Boost has no app-local controls in this category. "
+                        + "Reddit-hosted preferences follow the active account "
+                        + "and are managed through Reddit."
+        ));
+        return scrollView;
+    }
+
+    @Override
+    public void onResume() {
+        super.onResume();
+        styleHost();
+    }
+
+    @Override
+    public void onPause() {
+        Activity activity = hostActivity();
+        if (activity != null) {
+            BoostSystemBarInsetsFix.clearMorpheSettingsV4SystemBars(activity);
+        }
+        super.onPause();
+    }
+
+    @Override
+    public void onPrepareOptionsMenu(Menu menu) {
+        super.onPrepareOptionsMenu(menu);
+        MorpheSettingsV5Search.prepareMenu(this, menu);
+    }
+
+    @Override
+    public boolean onOptionsItemSelected(MenuItem item) {
+        if (MorpheSettingsV5Search.handleMenuItem(this, item)) {
+            return true;
+        }
+        return super.onOptionsItemSelected(item);
+    }
+
+    private void styleHost() {
+        Activity activity = hostActivity();
+        if (activity == null || tokens == null) {
+            return;
+        }
+        activity.setTitle(MorpheSettingsV5Registry.titleFor(PAGE_ID));
+        BoostSystemBarInsetsFix.applyMorpheSettingsV4SystemBars(
+                activity,
+                tokens.background,
+                tokens.dark
+        );
+        int toolbarId = MorpheSettingsV4Catalog.resourceId(
+                activity,
+                "id",
+                "toolbar"
+        );
+        View toolbar = toolbarId == 0 ? null : activity.findViewById(toolbarId);
+        if (toolbar != null) {
+            toolbar.setBackgroundColor(tokens.background);
+            toolbar.setElevation(0);
+        }
+    }
+
+    private Activity hostActivity() {
+        Context context = getContext();
+        return context instanceof Activity ? (Activity) context : null;
+    }
+
+    private void addSpace(LinearLayout parent, int heightDp) {
+        parent.addView(
+                new View(requireContext()),
+                new LinearLayout.LayoutParams(1, dp(heightDp))
+        );
+    }
+
+    private int dp(float value) {
+        return MorpheSettingsV4Theme.dp(requireContext(), value);
+    }
+}

--- a/extensions/boostforreddit/src/main/java/app/morphe/extension/boostforreddit/settings/MorpheSettingsV5Registry.java
+++ b/extensions/boostforreddit/src/main/java/app/morphe/extension/boostforreddit/settings/MorpheSettingsV5Registry.java
@@ -1,0 +1,750 @@
+package app.morphe.extension.boostforreddit.settings;
+import android.text.TextUtils;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/** Hidden Settings V5 registry for parallel migration waves. */
+final class MorpheSettingsV5Registry {
+    static final String CONTRACT_MARKER =
+            "MORPHE_BOOST_SETTINGS_V5_REGISTRY_ISSUE121_V1";
+    static final String APPEARANCE_WAVE_MARKER =
+            "MORPHE_BOOST_SETTINGS_V5_APPEARANCE_WAVE_ISSUE121_V1";
+    static final String READING_WAVE_MARKER =
+            "MORPHE_BOOST_SETTINGS_V5_READING_WAVE_ISSUE121_V1";
+    static final String MEDIA_WAVE_MARKER =
+            "MORPHE_BOOST_SETTINGS_V5_MEDIA_WAVE_ISSUE121_V1";
+    static final String NOTIFICATIONS_ACCOUNT_WAVE_MARKER =
+            "MORPHE_BOOST_SETTINGS_V5_NOTIFICATIONS_ACCOUNT_WAVE_ISSUE121_V1";
+    static final String NAVIGATION_WAVE_MARKER =
+            "MORPHE_BOOST_SETTINGS_V5_NAVIGATION_WAVE_ISSUE121_V1";
+    static final String NAVIGATION_ROOT_FLATTEN_MARKER =
+            "MORPHE_BOOST_SETTINGS_V5_NAVIGATION_ROOT_FLATTEN_ISSUE121_V1";
+    static final String DATA_APP_WAVE_MARKER =
+            "MORPHE_BOOST_SETTINGS_V5_DATA_APP_WAVE_ISSUE121_V1";
+    static final String ROOT_OVERVIEW_WAVE_MARKER =
+            "MORPHE_BOOST_SETTINGS_V5_ROOT_OVERVIEW_WAVE_ISSUE121_V1";
+    static final String MORPHE_ROOT_FLATTEN_MARKER =
+            "MORPHE_BOOST_SETTINGS_V5_MORPHE_ROOT_FLATTEN_ISSUE121_V1";
+    static final String WITHHELD_FRIENDS_MARKER =
+            "MORPHE_BOOST_SETTINGS_V5_WITHHELD_FRIENDS_ISSUE121_V1";
+    static final boolean V5_VISIBLE_BY_DEFAULT = true;
+    static final String EXTRA_PAGE_ID =
+            "morphe_boost_settings_v5_page_id";
+    static final String DEFAULT_PAGE_ID = "v5/appearance";
+
+    private static final V5PageSpec[] PAGES = new V5PageSpec[]{
+            new V5PageSpec("v5/morphe", "MorpheSettingsV5MorpheFragment", new String[]{}),
+            new V5PageSpec("v5/appearance", "MorpheSettingsV5AppearanceFragment", new String[]{}),
+            new V5PageSpec("v5/appearance/community_header", "MorpheSettingsV5AppearanceFragment", new String[]{}),
+            new V5PageSpec("v5/appearance/display_and_motion", "MorpheSettingsV5AppearanceFragment", new String[]{}),
+            new V5PageSpec("v5/appearance/post_layout", "MorpheSettingsV5AppearanceFragment", new String[]{}),
+            new V5PageSpec("v5/appearance/theme_and_colors", "MorpheSettingsV5AppearanceFragment", new String[]{}),
+            new V5PageSpec("v5/appearance/typography", "MorpheSettingsV5AppearanceFragment", new String[]{}),
+            new V5PageSpec("v5/appearance/community_header/community_header", "MorpheSettingsV5AppearanceFragment", new String[]{"pref_toolbar_header_type", "pref_header_show_description", "pref_show_subreddit_header"}),
+            new V5PageSpec("v5/appearance/display_and_motion/display_performance", "MorpheSettingsV5AppearanceFragment", new String[]{"morphe_boost_prefer_high_refresh_rate"}),
+            new V5PageSpec("v5/appearance/post_layout/cards", "MorpheSettingsV5AppearanceFragment", new String[]{"pref_cards_gallery_carousel", "pref_cards_full", "pref_cards_full_preview", "pref_cards_preview_self_lines", "pref_cards_preview_self", "pref_cards_rounded_corners", "pref_cards_subreddit_icon", "pref_cards_links_as_thumbnails"}),
+            new V5PageSpec("v5/appearance/post_layout/compact_layouts", "MorpheSettingsV5AppearanceFragment", new String[]{}),
+            new V5PageSpec("v5/appearance/post_layout/layout_and_saved_views", "MorpheSettingsV5AppearanceFragment", new String[]{}),
+            new V5PageSpec("v5/appearance/post_layout/tablet_layout", "MorpheSettingsV5AppearanceFragment", new String[]{"pref_split_screen"}),
+            new V5PageSpec("v5/appearance/theme_and_colors/advanced_appearance", "MorpheSettingsV5AppearanceFragment", new String[]{"pref_colored_nav_bar", "pref_colored_status_bar"}),
+            new V5PageSpec("v5/appearance/theme_and_colors/personalization", "MorpheSettingsV5AppearanceFragment", new String[]{"pref_app_icon"}),
+            new V5PageSpec("v5/appearance/theme_and_colors/theme", "MorpheSettingsV5AppearanceFragment", new String[]{"pref_theme", "pref_theme_night_start_minutes", "pref_theme_night", "pref_dynamic_colors", "pref_theme_night_end_minutes", "pref_theme_mode_type"}),
+            new V5PageSpec("v5/appearance/typography/comments", "MorpheSettingsV5AppearanceFragment", new String[]{"pref_comments_font", "pref_font_size"}),
+            new V5PageSpec("v5/appearance/typography/posts", "MorpheSettingsV5AppearanceFragment", new String[]{"pref_title_font", "pref_font_size_title"}),
+            new V5PageSpec("v5/appearance/typography/reset", "MorpheSettingsV5AppearanceFragment", new String[]{"action:typography:restore_defaults"}),
+            new V5PageSpec("v5/appearance/post_layout/compact_layouts/dense", "MorpheSettingsV5AppearanceFragment", new String[]{"pref_dense_buttons_visible"}),
+            new V5PageSpec("v5/appearance/post_layout/compact_layouts/small_cards", "MorpheSettingsV5AppearanceFragment", new String[]{"pref_mini_cards_buttons_visible", "pref_mini_cards_full", "pref_mini_cards_rounded_corners", "pref_mini_cards_truncate_title"}),
+            new V5PageSpec("v5/appearance/post_layout/layout_and_saved_views/post_layout", "MorpheSettingsV5AppearanceFragment", new String[]{"pref_show_subreddit_prefix", "pref_view", "pref_view_per_sub", "pref_view_per_subscription", "pref_left_handed"}),
+            new V5PageSpec("v5/appearance/post_layout/layout_and_saved_views/saved_community_views", "MorpheSettingsV5AppearanceFragment", new String[]{"action:saved_views:add", "action:saved_views:clear_all"}),
+            new V5PageSpec("v5/reading_and_interaction", "MorpheSettingsV5ReadingFragment", new String[]{}),
+            new V5PageSpec("v5/reading_and_interaction/comments", "MorpheSettingsV5ReadingFragment", new String[]{}),
+            new V5PageSpec("v5/reading_and_interaction/composing_and_drafts", "MorpheSettingsV5ReadingFragment", new String[]{}),
+            new V5PageSpec("v5/reading_and_interaction/feeds_and_subscriptions", "MorpheSettingsV5ReadingFragment", new String[]{}),
+            new V5PageSpec("v5/reading_and_interaction/posts", "MorpheSettingsV5ReadingFragment", new String[]{}),
+            new V5PageSpec("v5/reading_and_interaction/search_and_filters", "MorpheSettingsV5ReadingFragment", new String[]{}),
+            new V5PageSpec("v5/reading_and_interaction/comments/comment_actions", "MorpheSettingsV5ReadingLeafFragment", new String[]{"pref_comments_buttons", "pref_swipe_threshold_percentage", "pref_comments_buttons_collapse_after_action", "pref_comments_button_save", "pref_comments_floating_button", "pref_info_post_upvote_percentage", "pref_swipe_sensitivity_percentage", "pref_swipe_back", "pref_comments_button_parent"}),
+            new V5PageSpec("v5/reading_and_interaction/comments/comment_appearance", "MorpheSettingsV5ReadingLeafFragment", new String[]{"pref_comments_color_pattern", "pref_user_flair_emojis", "pref_user_flair_colors", "pref_comments_show_avatar", "pref_comments_user_flair"}),
+            new V5PageSpec("v5/reading_and_interaction/comments/comment_behavior", "MorpheSettingsV5ReadingLeafFragment", new String[]{"pref_clickable_awards_comments", "pref_default_comment_sorting", "pref_comments_highlight_mine", "pref_comments_image", "pref_show_awards_comments", "pref_comments_clickable_username", "pref_suggested_comment_sorting"}),
+            new V5PageSpec("v5/reading_and_interaction/comments/thread_navigation", "MorpheSettingsV5ReadingLeafFragment", new String[]{"pref_comments_scroll_animation", "pref_comments_click", "pref_comments_collapse_automoderator", "pref_comments_collapse_collapsed", "pref_comments_default_navigation", "pref_comments_animation", "pref_comments_full_collapse", "pref_comments_highlight_new_comments", "pref_comments_load_collapsed", "pref_comments_navigation_bar", "pref_indent_style", "pref_comments_volume_scroll"}),
+            new V5PageSpec("v5/reading_and_interaction/composing_and_drafts/drafts", "MorpheSettingsV5ReadingLeafFragment", new String[]{"pref_manage_drafts", "pref_drafts"}),
+            new V5PageSpec("v5/reading_and_interaction/composing_and_drafts/editor", "MorpheSettingsV5ReadingLeafFragment", new String[]{"pref_use_advanced_editor"}),
+            new V5PageSpec("v5/reading_and_interaction/composing_and_drafts/uploads", "MorpheSettingsV5ReadingLeafFragment", new String[]{"pref_imgur_uploads"}),
+            new V5PageSpec("v5/reading_and_interaction/feeds_and_subscriptions/manage_subscriptions", "MorpheSettingsV5ReadingLeafFragment", new String[]{"pref_edit_subscriptions"}),
+            new V5PageSpec("v5/reading_and_interaction/posts/feed_behavior", "MorpheSettingsV5ReadingLeafFragment", new String[]{"pref_default_sort", "pref_sort_per_subscription", "pref_frontpage_sort"}),
+            new V5PageSpec("v5/reading_and_interaction/posts/post_actions", "MorpheSettingsV5ReadingLeafFragment", new String[]{"pref_post_show_comments_button", "pref_show_hide", "pref_sort_per_sub", "pref_show_read", "pref_post_show_open_button", "pref_post_show_share_button", "pref_posts_floating_button", "pref_upvote_on_save"}),
+            new V5PageSpec("v5/reading_and_interaction/posts/post_behavior", "MorpheSettingsV5ReadingLeafFragment", new String[]{"pref_clickable_awards_posts", "pref_info_username", "pref_show_awards_posts", "pref_flair_emojis", "pref_flair_colors", "pref_info_post_flair", "pref_post_clickable_subreddit", "pref_flair_clickable", "pref_post_clickable_username"}),
+            new V5PageSpec("v5/reading_and_interaction/posts/reading_state", "MorpheSettingsV5ReadingLeafFragment", new String[]{"synncit_config", "pref_mark_read_dim_images", "pref_hide_read_permanently", "pref_mark_read_on_scroll", "pref_mark_read", "pref_history_delete_read"}),
+            new V5PageSpec("v5/reading_and_interaction/search_and_filters/content_filters", "MorpheSettingsV5ReadingFragment", new String[]{}),
+            new V5PageSpec("v5/reading_and_interaction/search_and_filters/search", "MorpheSettingsV5ReadingFragment", new String[]{}),
+            new V5PageSpec("v5/reading_and_interaction/search_and_filters/content_filters/filter_behavior", "MorpheSettingsV5ReadingLeafFragment", new String[]{"pref_blur_nsfw_images", "pref_load_nsfw_images", "pref_nsfw"}),
+            new V5PageSpec("v5/reading_and_interaction/search_and_filters/content_filters/muted_content", "MorpheSettingsV5ReadingLeafFragment", new String[]{"pref_filter_subreddit", "pref_filter_domain", "pref_filter_flair", "pref_filter_username", "pref_filter_keyword"}),
+            new V5PageSpec("v5/reading_and_interaction/search_and_filters/content_filters/post_matching", "MorpheSettingsV5ReadingLeafFragment", new String[]{"pref_album", "pref_gif", "pref_image", "pref_link", "pref_self", "pref_video"}),
+            new V5PageSpec("v5/reading_and_interaction/search_and_filters/search/advanced_search", "MorpheSettingsV5ReadingLeafFragment", new String[]{"pref_search_advanced_help"}),
+            new V5PageSpec("v5/reading_and_interaction/search_and_filters/search/search_behavior", "MorpheSettingsV5ReadingLeafFragment", new String[]{"pref_default_search_period", "pref_default_search_sorting", "morphe_boost_search_open_keyboard_on_entry"}),
+            new V5PageSpec("v5/reading_and_interaction/search_and_filters/search/suggestions", "MorpheSettingsV5ReadingLeafFragment", new String[]{"pref_saved_searches", "pref_search_show_random", "pref_search_show_random_nsfw", "pref_search_show_trending", "pref_search_show_trending_searches"}),
+            new V5PageSpec("v5/navigation", "MorpheSettingsV5NavigationFragment", new String[]{}),
+            new V5PageSpec("v5/navigation/back_and_exit", "MorpheSettingsV5NavigationLeafFragment", new String[]{"pref_ask_exit", "pref_double_exit"}),
+            new V5PageSpec("v5/navigation/bottom_navigation", "MorpheSettingsV5NavigationLeafFragment", new String[]{"pref_bottom_navigation_hide_on_scroll", "pref_bottom_navigation"}),
+            new V5PageSpec("v5/navigation/navigation_drawer", "MorpheSettingsV5NavigationFragment", new String[]{}),
+            new V5PageSpec("v5/navigation/toolbar", "MorpheSettingsV5NavigationLeafFragment", new String[]{"pref_toolbar", "pref_toolbar_main_action"}),
+            new V5PageSpec("v5/navigation/navigation_drawer/account_and_tools", "MorpheSettingsV5NavigationLeafFragment", new String[]{"pref_drawer_show_drafts", "pref_drawer_show_inbox", "pref_drawer_show_mod", "pref_drawer_show_profile", "pref_drawer_show_search_generic"}),
+            new V5PageSpec("v5/navigation/navigation_drawer/account_switcher", "MorpheSettingsV5NavigationLeafFragment", new String[]{"pref_accounts_show_avatar", "pref_accounts_show_username"}),
+            new V5PageSpec("v5/navigation/navigation_drawer/drawer_behavior", "MorpheSettingsV5NavigationLeafFragment", new String[]{"pref_lock_sidebar", "pref_drawer_sticky_settings", "pref_drawer_end"}),
+            new V5PageSpec("v5/navigation/navigation_drawer/feeds_and_library", "MorpheSettingsV5NavigationLeafFragment", new String[]{"pref_drawer_show_history", "pref_drawer_show_frontpage", "pref_drawer_show_popular", "pref_drawer_show_saved", "pref_drawer_show_all", "pref_drawer_show_home"}),
+            new V5PageSpec("v5/navigation/navigation_drawer/go_to_shortcuts", "MorpheSettingsV5NavigationLeafFragment", new String[]{"pref_drawer_show_go_to_subreddit", "pref_drawer_show_go_to", "pref_drawer_show_go_to_user"}),
+            new V5PageSpec("v5/navigation/navigation_drawer/quick_toggles", "MorpheSettingsV5NavigationLeafFragment", new String[]{"pref_drawer_show_blur_switch", "pref_drawer_show_night_mode", "pref_drawer_show_nsfw_switch"}),
+            new V5PageSpec("v5/navigation/navigation_drawer/subscriptions", "MorpheSettingsV5NavigationLeafFragment", new String[]{"pref_subscriptions_drawer_show_icon", "pref_subscriptions_drawer", "pref_subscriptions_only_casual"}),
+            new V5PageSpec("v5/data_and_app", "MorpheSettingsV5DataAppFragment", new String[]{}),
+            new V5PageSpec("v5/data_and_app/about_and_support", "MorpheSettingsV5DataAppFragment", new String[]{}),
+            new V5PageSpec("v5/data_and_app/app_behavior_and_compatibility", "MorpheSettingsV5DataAppFragment", new String[]{}),
+            new V5PageSpec("v5/data_and_app/backup_and_restore", "MorpheSettingsV5BackupRestoreFragment", new String[]{}),
+            new V5PageSpec("v5/data_and_app/settings_experience", "MorpheSettingsV5DataAppFragment", new String[]{}),
+            new V5PageSpec("v5/data_and_app/storage_and_bandwidth", "MorpheSettingsV5DataAppFragment", new String[]{}),
+            new V5PageSpec("v5/data_and_app/about_and_support/about_boost", "MorpheSettingsV5DataAppLeafFragment", new String[]{"buy_pro", "remove_ads", "about_version", "rate_app", "about_subreddit", "about_faq", "support_launch", "licenses_preference"}),
+            new V5PageSpec("v5/data_and_app/about_and_support/author", "MorpheSettingsV5DataAppLeafFragment", new String[]{"contact_dev_key", "about_reddit", "about_twitter"}),
+            new V5PageSpec("v5/data_and_app/about_and_support/privacy", "MorpheSettingsV5DataAppLeafFragment", new String[]{"privacy_policy", "pref_gdpr_revoke", "pref_statistics"}),
+            new V5PageSpec("v5/data_and_app/app_behavior_and_compatibility/community_shortcuts", "MorpheSettingsV5DataAppLeafFragment", new String[]{"pref_shortcut_icon_crop"}),
+            new V5PageSpec("v5/data_and_app/app_behavior_and_compatibility/compatibility_and_legacy", "MorpheSettingsV5DataAppLeafFragment", new String[]{"pref_autoplay_swipe", "pref_info_color_indicators", "pref_go_to_sub_dialog", "pref_cards_preview_top", "pref_info_post_shorten_score", "pref_send_floating_button", "pref_info_post_self_image", "pref_info_post_view_count", "pref_toolbar_dropdown", "pref_toolbar_tap_to_go", "pref_cards_legacy"}),
+            new V5PageSpec("v5/data_and_app/app_behavior_and_compatibility/other_app_behavior", "MorpheSettingsV5DataAppLeafFragment", new String[]{"pref_ad_format", "reset_tips"}),
+            new V5PageSpec("v5/data_and_app/settings_experience/settings_presentation", "MorpheSettingsV5DataAppLeafFragment", new String[]{"morphe_boost_settings_v4_enabled"}),
+            new V5PageSpec("v5/data_and_app/storage_and_bandwidth/cache", "MorpheSettingsV5DataAppLeafFragment", new String[]{"pref_cache_current_size", "pref_cache_max_size"}),
+            new V5PageSpec("v5/data_and_app/storage_and_bandwidth/data_saver", "MorpheSettingsV5DataAppLeafFragment", new String[]{"pref_reduce_mobile", "pref_reduce_wifi"}),
+            new V5PageSpec("v5/data_and_app/storage_and_bandwidth/data_usage", "MorpheSettingsV5DataAppLeafFragment", new String[]{"pref_download_folders"}),
+            new V5PageSpec("v5/data_and_app/storage_and_bandwidth/images", "MorpheSettingsV5DataAppLeafFragment", new String[]{"pref_load_images"}),
+            new V5PageSpec("v5/data_and_app/storage_and_bandwidth/videos", "MorpheSettingsV5DataAppLeafFragment", new String[]{"pref_video_quality_max", "pref_video_quality_min", "pref_video_quality"}),
+            new V5PageSpec("v5/media", "MorpheSettingsV5MediaFragment", new String[]{}),
+            new V5PageSpec("v5/media/downloads_and_cache", "MorpheSettingsV5MediaFragment", new String[]{}),
+            new V5PageSpec("v5/media/images_gifs_and_previews", "MorpheSettingsV5MediaFragment", new String[]{}),
+            new V5PageSpec("v5/media/links_and_browser", "MorpheSettingsV5MediaFragment", new String[]{}),
+            new V5PageSpec("v5/media/playback_and_autoplay", "MorpheSettingsV5MediaFragment", new String[]{}),
+            new V5PageSpec("v5/media/downloads_and_cache/download_folders", "MorpheSettingsV5MediaDownloadFoldersFragment", new String[]{"pref_download_folder_default", "pref_download_folder_gif", "pref_download_folder_img", "pref_download_folder_mp4", "pref_download_folder_per_subreddit"}),
+            new V5PageSpec("v5/media/images_gifs_and_previews/native_image_behavior", "MorpheSettingsV5MediaLeafFragment", new String[]{"pref_image_loader", "pref_images_deepzoom", "pref_images_fit", "pref_swipe_up_to_dismiss_image", "pref_swipe_dismiss_direction_mode_image", "pref_tap_to_dismiss_image"}),
+            new V5PageSpec("v5/media/images_gifs_and_previews/open_behavior", "MorpheSettingsV5MediaLeafFragment", new String[]{"morphe_boost_direct_reddit_gif_tap_action", "morphe_boost_giphy_preview_tap_action", "morphe_boost_static_preview_tap_action"}),
+            new V5PageSpec("v5/media/images_gifs_and_previews/preview_behavior", "MorpheSettingsV5MediaLeafFragment", new String[]{"morphe_boost_inline_media_previews_enabled", "morphe_boost_inline_media_preview_show_source_text"}),
+            new V5PageSpec("v5/media/images_gifs_and_previews/preview_layout", "MorpheSettingsV5MediaLeafFragment", new String[]{"morphe_boost_inline_media_preview_alignment", "morphe_boost_inline_media_preview_size"}),
+            new V5PageSpec("v5/media/links_and_browser/browser", "MorpheSettingsV5MediaLeafFragment", new String[]{"pref_browser"}),
+            new V5PageSpec("v5/media/links_and_browser/link_handling", "MorpheSettingsV5MediaLeafFragment", new String[]{"pref_domain_exceptions", "pref_load_readability"}),
+            new V5PageSpec("v5/media/links_and_browser/links_to_open_in_app", "MorpheSettingsV5MediaLeafFragment", new String[]{"pref_link_album", "pref_link_deviant", "pref_link_gif", "pref_link_image", "pref_link_neatclip", "pref_link_streamable", "pref_link_vreddit", "pref_link_xkcd"}),
+            new V5PageSpec("v5/media/links_and_browser/video_links", "MorpheSettingsV5MediaLeafFragment", new String[]{"pref_link_video"}),
+            new V5PageSpec("v5/media/playback_and_autoplay/audio", "MorpheSettingsV5MediaLeafFragment", new String[]{"pref_video_audio_start_muted"}),
+            new V5PageSpec("v5/media/playback_and_autoplay/autoplay", "MorpheSettingsV5MediaLeafFragment", new String[]{"pref_autoplay_cards"}),
+            new V5PageSpec("v5/media/playback_and_autoplay/media_behavior", "MorpheSettingsV5MediaLeafFragment", new String[]{"pref_media_overlay_visibility", "pref_media_viewer"}),
+            new V5PageSpec("v5/media/playback_and_autoplay/playback_and_autoplay", "MorpheSettingsV5MediaLeafFragment", new String[]{"pref_tap_to_dismiss_youtube_videos", "pref_video_player"}),
+            new V5PageSpec("v5/notifications_and_account", "MorpheSettingsV5NotificationsAccountFragment", new String[]{}),
+            new V5PageSpec("v5/notifications_and_account/history_privacy_and_recovery", "MorpheSettingsV5NotificationsAccountFragment", new String[]{}),
+            new V5PageSpec("v5/notifications_and_account/notifications_and_inbox", "MorpheSettingsV5NotificationsAccountFragment", new String[]{}),
+            new V5PageSpec("v5/notifications_and_account/reddit_account", "MorpheSettingsV5RedditAccountFragment", new String[]{}),
+            new V5PageSpec("v5/notifications_and_account/history_privacy_and_recovery/history", "MorpheSettingsV5NotificationsAccountLeafFragment", new String[]{"pref_all_delete", "pref_history_delete", "pref_recent_posts_delete", "pref_searches_delete", "pref_recent_posts_save_nsfw", "pref_history_save", "pref_recent_posts_save", "pref_search_history_save"}),
+            new V5PageSpec("v5/notifications_and_account/history_privacy_and_recovery/recovery_and_archives", "MorpheSettingsV5NotificationsAccountLeafFragment", new String[]{"morphe_boost_imgur_undelete_enabled", "morphe_boost_reddit_undelete_enabled"}),
+            new V5PageSpec("v5/notifications_and_account/notifications_and_inbox/advanced", "MorpheSettingsV5NotificationsAccountLeafFragment", new String[]{"pref_check_messages_push_clear", "pref_check_messages_push"}),
+            new V5PageSpec("v5/notifications_and_account/notifications_and_inbox/notifications", "MorpheSettingsV5NotificationsAccountLeafFragment", new String[]{"pref_check_messages_interval", "pref_check_modmail", "pref_check_messages", "pref_notifications_configure"}),
+    };
+
+    private static final Map<String, V5PageSpec> PAGE_MAP;
+
+    static {
+        Map<String, V5PageSpec> pages = new LinkedHashMap<>();
+        for (V5PageSpec page : PAGES) {
+            pages.put(page.pageId, page);
+        }
+        PAGE_MAP = Collections.unmodifiableMap(pages);
+    }
+
+    private MorpheSettingsV5Registry() {
+    }
+
+    static V5PageSpec findPage(String pageId) {
+        return PAGE_MAP.get(pageId);
+    }
+
+    static V5PageSpec requirePage(String pageId) {
+        V5PageSpec page = findPage(pageId);
+        if (page == null) {
+            throw new IllegalArgumentException("Unknown V5 page " + pageId);
+        }
+        return page;
+    }
+
+    private static final V5WithheldSpec[] WITHHELD = new V5WithheldSpec[]{
+            new V5WithheldSpec(
+                    "pref_drawer_show_friends",
+                    "Static implementation exists, but the Friends destination was not proven to return functional Reddit data at runtime."
+            )
+    };
+
+    static V5WithheldSpec[] allWithheld() {
+        return WITHHELD.clone();
+    }
+
+    static V5PageSpec[] allPages() {
+        return PAGES.clone();
+    }
+
+    static String pageIdForKey(String key) {
+        if (TextUtils.isEmpty(key)) {
+            return null;
+        }
+        for (V5PageSpec page : PAGES) {
+            for (String pageKey : page.keys) {
+                if (key.equals(pageKey)) {
+                    return page.pageId;
+                }
+            }
+        }
+        return null;
+    }
+
+    static String titleFor(String pageId) {
+        switch (pageId) {
+            case "v5/root":
+                return "Settings";
+            case "v5/morphe":
+                return "Morphe";
+            case "v5/appearance":
+                return "Appearance";
+            case "v5/appearance/community_header":
+                return "Community header";
+            case "v5/appearance/display_and_motion":
+                return "Display & motion";
+            case "v5/appearance/post_layout":
+                return "Post layout";
+            case "v5/appearance/theme_and_colors":
+                return "Theme & colors";
+            case "v5/appearance/typography":
+                return "Typography";
+            case "v5/appearance/community_header/community_header":
+                return "Community header";
+            case "v5/appearance/display_and_motion/display_performance":
+                return "Display performance";
+            case "v5/appearance/post_layout/cards":
+                return "Cards";
+            case "v5/appearance/post_layout/compact_layouts":
+                return "Compact layouts";
+            case "v5/appearance/post_layout/layout_and_saved_views":
+                return "Layout & saved views";
+            case "v5/appearance/post_layout/tablet_layout":
+                return "Tablet layout";
+            case "v5/appearance/theme_and_colors/advanced_appearance":
+                return "Advanced appearance";
+            case "v5/appearance/theme_and_colors/personalization":
+                return "Personalization";
+            case "v5/appearance/theme_and_colors/theme":
+                return "Theme";
+            case "v5/appearance/typography/comments":
+                return "Comments";
+            case "v5/appearance/typography/posts":
+                return "Posts";
+            case "v5/appearance/typography/reset":
+                return "Reset";
+            case "v5/appearance/post_layout/compact_layouts/dense":
+                return "Dense";
+            case "v5/appearance/post_layout/compact_layouts/small_cards":
+                return "Small cards";
+            case "v5/appearance/post_layout/layout_and_saved_views/post_layout":
+                return "Post layout";
+            case "v5/appearance/post_layout/layout_and_saved_views/saved_community_views":
+                return "Saved community views";
+            case "v5/reading_and_interaction":
+                return "Reading & interaction";
+            case "v5/reading_and_interaction/comments":
+                return "Comments";
+            case "v5/reading_and_interaction/composing_and_drafts":
+                return "Composing & drafts";
+            case "v5/reading_and_interaction/feeds_and_subscriptions":
+                return "Feeds & subscriptions";
+            case "v5/reading_and_interaction/posts":
+                return "Posts";
+            case "v5/reading_and_interaction/search_and_filters":
+                return "Search & filters";
+            case "v5/reading_and_interaction/comments/comment_actions":
+                return "Comment actions";
+            case "v5/reading_and_interaction/comments/comment_appearance":
+                return "Comment appearance";
+            case "v5/reading_and_interaction/comments/comment_behavior":
+                return "Comment behavior";
+            case "v5/reading_and_interaction/comments/thread_navigation":
+                return "Thread navigation";
+            case "v5/reading_and_interaction/composing_and_drafts/drafts":
+                return "Drafts";
+            case "v5/reading_and_interaction/composing_and_drafts/editor":
+                return "Editor";
+            case "v5/reading_and_interaction/composing_and_drafts/uploads":
+                return "Uploads";
+            case "v5/reading_and_interaction/feeds_and_subscriptions/manage_subscriptions":
+                return "Manage subscriptions";
+            case "v5/reading_and_interaction/posts/feed_behavior":
+                return "Feed behavior";
+            case "v5/reading_and_interaction/posts/post_actions":
+                return "Post actions";
+            case "v5/reading_and_interaction/posts/post_behavior":
+                return "Post behavior";
+            case "v5/reading_and_interaction/posts/reading_state":
+                return "Reading state";
+            case "v5/reading_and_interaction/search_and_filters/content_filters":
+                return "Content filters";
+            case "v5/reading_and_interaction/search_and_filters/search":
+                return "Search";
+            case "v5/reading_and_interaction/search_and_filters/content_filters/filter_behavior":
+                return "Filter behavior";
+            case "v5/reading_and_interaction/search_and_filters/content_filters/muted_content":
+                return "Muted content";
+            case "v5/reading_and_interaction/search_and_filters/content_filters/post_matching":
+                return "Post matching";
+            case "v5/reading_and_interaction/search_and_filters/search/advanced_search":
+                return "Advanced search";
+            case "v5/reading_and_interaction/search_and_filters/search/search_behavior":
+                return "Search behavior";
+            case "v5/reading_and_interaction/search_and_filters/search/suggestions":
+                return "Suggestions";
+            case "v5/navigation":
+                return "Navigation & gestures";
+            case "v5/navigation/back_and_exit":
+                return "Back & exit";
+            case "v5/navigation/bottom_navigation":
+                return "Bottom navigation";
+            case "v5/navigation/navigation_drawer":
+                return "Navigation drawer";
+            case "v5/navigation/toolbar":
+                return "Toolbar";
+            case "v5/navigation/navigation_drawer/account_and_tools":
+                return "Account & tools";
+            case "v5/navigation/navigation_drawer/account_switcher":
+                return "Account switcher";
+            case "v5/navigation/navigation_drawer/drawer_behavior":
+                return "Drawer behavior";
+            case "v5/navigation/navigation_drawer/feeds_and_library":
+                return "Feeds & library";
+            case "v5/navigation/navigation_drawer/go_to_shortcuts":
+                return "Go-to shortcuts";
+            case "v5/navigation/navigation_drawer/quick_toggles":
+                return "Quick toggles";
+            case "v5/navigation/navigation_drawer/subscriptions":
+                return "Subscriptions";
+            case "v5/data_and_app":
+                return "Data & app";
+            case "v5/data_and_app/about_and_support":
+                return "About & support";
+            case "v5/data_and_app/app_behavior_and_compatibility":
+                return "App behavior & compatibility";
+            case "v5/data_and_app/backup_and_restore":
+                return "Backup & restore";
+            case "v5/data_and_app/settings_experience":
+                return "Settings experience";
+            case "v5/data_and_app/storage_and_bandwidth":
+                return "Storage & bandwidth";
+            case "v5/data_and_app/about_and_support/about_boost":
+                return "About Boost";
+            case "v5/data_and_app/about_and_support/author":
+                return "Author";
+            case "v5/data_and_app/about_and_support/privacy":
+                return "Privacy";
+            case "v5/data_and_app/app_behavior_and_compatibility/community_shortcuts":
+                return "Community shortcuts";
+            case "v5/data_and_app/app_behavior_and_compatibility/compatibility_and_legacy":
+                return "Compatibility & legacy";
+            case "v5/data_and_app/app_behavior_and_compatibility/other_app_behavior":
+                return "Other app behavior";
+            case "v5/data_and_app/settings_experience/settings_presentation":
+                return "Settings presentation";
+            case "v5/data_and_app/storage_and_bandwidth/cache":
+                return "Cache";
+            case "v5/data_and_app/storage_and_bandwidth/data_saver":
+                return "Data saver";
+            case "v5/data_and_app/storage_and_bandwidth/data_usage":
+                return "Data usage";
+            case "v5/data_and_app/storage_and_bandwidth/images":
+                return "Images";
+            case "v5/data_and_app/storage_and_bandwidth/videos":
+                return "Videos";
+            case "v5/media":
+                return "Media";
+            case "v5/media/downloads_and_cache":
+                return "Downloads & cache";
+            case "v5/media/images_gifs_and_previews":
+                return "Images, GIFs & previews";
+            case "v5/media/links_and_browser":
+                return "Links & browser";
+            case "v5/media/playback_and_autoplay":
+                return "Playback & autoplay";
+            case "v5/media/downloads_and_cache/download_folders":
+                return "Download folders";
+            case "v5/media/images_gifs_and_previews/native_image_behavior":
+                return "Native image behavior";
+            case "v5/media/images_gifs_and_previews/open_behavior":
+                return "Open behavior";
+            case "v5/media/images_gifs_and_previews/preview_behavior":
+                return "Preview behavior";
+            case "v5/media/images_gifs_and_previews/preview_layout":
+                return "Preview layout";
+            case "v5/media/links_and_browser/browser":
+                return "Browser";
+            case "v5/media/links_and_browser/link_handling":
+                return "Link handling";
+            case "v5/media/links_and_browser/links_to_open_in_app":
+                return "Links to open in app";
+            case "v5/media/links_and_browser/video_links":
+                return "Video links";
+            case "v5/media/playback_and_autoplay/audio":
+                return "Audio";
+            case "v5/media/playback_and_autoplay/autoplay":
+                return "Autoplay";
+            case "v5/media/playback_and_autoplay/media_behavior":
+                return "Media behavior";
+            case "v5/media/playback_and_autoplay/playback_and_autoplay":
+                return "Playback & autoplay";
+            case "v5/notifications_and_account":
+                return "Notifications & account";
+            case "v5/notifications_and_account/history_privacy_and_recovery":
+                return "History, privacy & recovery";
+            case "v5/notifications_and_account/notifications_and_inbox":
+                return "Notifications & inbox";
+            case "v5/notifications_and_account/reddit_account":
+                return "Reddit account";
+            case "v5/notifications_and_account/history_privacy_and_recovery/history":
+                return "History";
+            case "v5/notifications_and_account/history_privacy_and_recovery/recovery_and_archives":
+                return "Recovery & archives";
+            case "v5/notifications_and_account/notifications_and_inbox/advanced":
+                return "Advanced";
+            case "v5/notifications_and_account/notifications_and_inbox/notifications":
+                return "Notifications";
+            default:
+                return "Appearance";
+        }
+    }
+
+    static String introFor(String pageId) {
+        switch (pageId) {
+            case "v5/root":
+                return "Browse every Boost and Morphe setting from one complete overview.";
+            case "v5/morphe":
+                return "Configure user-facing behavior added by Morphe and the Settings experience.";
+            case "v5/appearance":
+                return "Control themes, layout, typography, and visual presentation.";
+            case "v5/appearance/community_header":
+                return "Control the identity and description shown above community feeds.";
+            case "v5/appearance/display_and_motion":
+                return "Adjust display performance and motion-related behavior.";
+            case "v5/appearance/post_layout":
+                return "Choose how posts and feed cards are arranged.";
+            case "v5/appearance/theme_and_colors":
+                return "Choose theme mode, colors, system bars, and app personalization.";
+            case "v5/appearance/typography":
+                return "Adjust post and comment fonts and text sizes.";
+            case "v5/appearance/community_header/community_header":
+                return "Choose what community identity appears above community feeds.";
+            case "v5/appearance/display_and_motion/display_performance":
+                return "Control refresh-rate behavior for smoother scrolling on supported displays.";
+            case "v5/appearance/post_layout/cards":
+                return "Configure the standard card layout used in feeds.";
+            case "v5/appearance/post_layout/compact_layouts":
+                return "Configure Boost’s compact feed layouts.";
+            case "v5/appearance/post_layout/layout_and_saved_views":
+                return "Choose the default layout and per-community layout behavior.";
+            case "v5/appearance/post_layout/tablet_layout":
+                return "Control the landscape master-detail layout on larger screens.";
+            case "v5/appearance/theme_and_colors/advanced_appearance":
+                return "Control how app colors extend into Android system bars.";
+            case "v5/appearance/theme_and_colors/personalization":
+                return "Choose the launcher icon used for Boost.";
+            case "v5/appearance/theme_and_colors/theme":
+                return "Choose light and dark theme behavior, schedules, and colors.";
+            case "v5/appearance/typography/comments":
+                return "Choose the font and size used for comment text.";
+            case "v5/appearance/typography/posts":
+                return "Choose the font and size used for post titles.";
+            case "v5/appearance/typography/reset":
+                return "Restore all typography settings to their defaults.";
+            case "v5/appearance/post_layout/compact_layouts/dense":
+                return "Configure controls shown in the Dense layout.";
+            case "v5/appearance/post_layout/compact_layouts/small_cards":
+                return "Configure the Small cards layout.";
+            case "v5/appearance/post_layout/layout_and_saved_views/post_layout":
+                return "Choose the default feed layout and whether each community remembers its own layout.";
+            case "v5/appearance/post_layout/layout_and_saved_views/saved_community_views":
+                return "Add, edit, or remove layouts saved for individual communities and custom feeds.";
+            case "v5/reading_and_interaction":
+                return "Choose how posts, comments, feeds, search, and composing behave.";
+            case "v5/reading_and_interaction/comments":
+                return "Control comment actions, appearance, behavior, and thread navigation.";
+            case "v5/reading_and_interaction/composing_and_drafts":
+                return "Configure editors, drafts, and uploaded composing media.";
+            case "v5/reading_and_interaction/feeds_and_subscriptions":
+                return "Manage communities, custom feeds, and subscription behavior.";
+            case "v5/reading_and_interaction/posts":
+                return "Choose how posts behave while browsing and reading.";
+            case "v5/reading_and_interaction/search_and_filters":
+                return "Configure search behavior and which content appears in feeds.";
+            case "v5/reading_and_interaction/comments/comment_actions":
+                return "Choose visible comment actions and swipe-to-close behavior.";
+            case "v5/reading_and_interaction/comments/comment_appearance":
+                return "Choose identity and thread-color details shown with comments.";
+            case "v5/reading_and_interaction/comments/comment_behavior":
+                return "Control sorting, media previews, awards, and profile actions.";
+            case "v5/reading_and_interaction/comments/thread_navigation":
+                return "Control collapsing, navigation controls, and movement through a thread.";
+            case "v5/reading_and_interaction/composing_and_drafts/drafts":
+                return "Control draft saving and open drafts stored by Boost or Reddit.";
+            case "v5/reading_and_interaction/composing_and_drafts/editor":
+                return "Choose the composing interface used for posts and comments.";
+            case "v5/reading_and_interaction/composing_and_drafts/uploads":
+                return "Open media previously uploaded while composing.";
+            case "v5/reading_and_interaction/feeds_and_subscriptions/manage_subscriptions":
+                return "Open community and custom-feed management.";
+            case "v5/reading_and_interaction/posts/feed_behavior":
+                return "Choose default sorting and whether communities remember their own sort.";
+            case "v5/reading_and_interaction/posts/post_actions":
+                return "Choose actions available directly from post rows and menus.";
+            case "v5/reading_and_interaction/posts/post_behavior":
+                return "Choose post identity, flair, awards, and tap behavior.";
+            case "v5/reading_and_interaction/posts/reading_state":
+                return "Control read-state tracking, hiding, Synccit, and local reset.";
+            case "v5/reading_and_interaction/search_and_filters/content_filters":
+                return "Control NSFW visibility, muted content, and matching post types.";
+            case "v5/reading_and_interaction/search_and_filters/search":
+                return "Configure search defaults, suggestions, and field-search help.";
+            case "v5/reading_and_interaction/search_and_filters/content_filters/filter_behavior":
+                return "Control whether NSFW content and its images are shown or blurred.";
+            case "v5/reading_and_interaction/search_and_filters/content_filters/muted_content":
+                return "Hide posts by community, domain, user, word, or flair.";
+            case "v5/reading_and_interaction/search_and_filters/content_filters/post_matching":
+                return "Choose which post types are included by content filters.";
+            case "v5/reading_and_interaction/search_and_filters/search/advanced_search":
+                return "See the field prefixes supported by Boost search.";
+            case "v5/reading_and_interaction/search_and_filters/search/search_behavior":
+                return "Choose search defaults and keyboard behavior.";
+            case "v5/reading_and_interaction/search_and_filters/search/suggestions":
+                return "Choose saved, random, and trending suggestions shown in Search.";
+            case "v5/navigation":
+                return "Configure back behavior, bars, and the navigation drawer.";
+            case "v5/navigation/back_and_exit":
+                return "Choose how Boost confirms or handles leaving the app.";
+            case "v5/navigation/bottom_navigation":
+                return "Control whether the bottom navigation is shown and how it behaves while scrolling.";
+            case "v5/navigation/navigation_drawer":
+                return "Choose the drawer layout, shortcuts, feeds, account display, and quick toggles.";
+            case "v5/navigation/toolbar":
+                return "Control toolbar visibility and its primary action.";
+            case "v5/navigation/navigation_drawer/account_and_tools":
+                return "Choose account and utility destinations shown in the navigation drawer.";
+            case "v5/navigation/navigation_drawer/account_switcher":
+                return "Choose the identity details shown in the account switcher.";
+            case "v5/navigation/navigation_drawer/drawer_behavior":
+                return "Control drawer gestures, placement, and the pinned Settings footer.";
+            case "v5/navigation/navigation_drawer/feeds_and_library":
+                return "Choose feed and library destinations shown in the navigation drawer.";
+            case "v5/navigation/navigation_drawer/go_to_shortcuts":
+                return "Choose direct navigation shortcuts shown in the drawer.";
+            case "v5/navigation/navigation_drawer/quick_toggles":
+                return "Choose display and content toggles shown in the drawer.";
+            case "v5/navigation/navigation_drawer/subscriptions":
+                return "Configure the subscriptions section in the navigation drawer.";
+            case "v5/data_and_app":
+                return "Manage storage, compatibility, app behavior, backup, and support.";
+            case "v5/data_and_app/about_and_support":
+                return "View app information, legal information, and support actions.";
+            case "v5/data_and_app/app_behavior_and_compatibility":
+                return "Manage app-wide compatibility options and remaining global behavior.";
+            case "v5/data_and_app/backup_and_restore":
+                return "Open Boost's existing backup and restore tool.";
+            case "v5/data_and_app/settings_experience":
+                return "Choose which Settings presentation Boost uses.";
+            case "v5/data_and_app/storage_and_bandwidth":
+                return "Control data usage, caching, and bandwidth-sensitive behavior.";
+            case "v5/data_and_app/about_and_support/about_boost":
+                return "View Boost information, support the app, and open legal details.";
+            case "v5/data_and_app/about_and_support/author":
+                return "Contact the developer and open the official social profiles.";
+            case "v5/data_and_app/about_and_support/privacy":
+                return "Control privacy reporting and consent-related actions.";
+            case "v5/data_and_app/app_behavior_and_compatibility/community_shortcuts":
+                return "Configure the icon used by community launcher shortcuts.";
+            case "v5/data_and_app/app_behavior_and_compatibility/compatibility_and_legacy":
+                return "Manage remaining compatibility options retained from classic Boost.";
+            case "v5/data_and_app/app_behavior_and_compatibility/other_app_behavior":
+                return "Configure remaining app-wide behavior and reset guidance tips.";
+            case "v5/data_and_app/settings_experience/settings_presentation":
+                return "Choose between Morphe Material settings and the classic Boost presentation.";
+            case "v5/data_and_app/storage_and_bandwidth/cache":
+                return "Clear cached media and choose the maximum cache size.";
+            case "v5/data_and_app/storage_and_bandwidth/data_saver":
+                return "Reduce media size on mobile data or Wi-Fi.";
+            case "v5/data_and_app/storage_and_bandwidth/data_usage":
+                return "Open Boost download-folder configuration.";
+            case "v5/data_and_app/storage_and_bandwidth/images":
+                return "Choose when images are loaded.";
+            case "v5/data_and_app/storage_and_bandwidth/videos":
+                return "Choose automatic and bounded video quality behavior.";
+            case "v5/media":
+                return "Control downloads, image previews, link handling, and playback.";
+            case "v5/media/downloads_and_cache":
+                return "Choose where downloaded media is stored and organized.";
+            case "v5/media/images_gifs_and_previews":
+                return "Control native image behavior and inline media previews.";
+            case "v5/media/links_and_browser":
+                return "Choose how links and supported domains open.";
+            case "v5/media/playback_and_autoplay":
+                return "Configure media viewers, video playback, audio, and autoplay.";
+            case "v5/media/downloads_and_cache/download_folders":
+                return "Choose destinations for images, videos, GIFs, and other downloads.";
+            case "v5/media/images_gifs_and_previews/native_image_behavior":
+                return "Control loading, zoom, and dismissal in Boost’s native image viewer.";
+            case "v5/media/images_gifs_and_previews/open_behavior":
+                return "Choose what opens when supported inline previews and GIFs are tapped.";
+            case "v5/media/images_gifs_and_previews/preview_behavior":
+                return "Choose whether inline media previews and their source text are shown.";
+            case "v5/media/images_gifs_and_previews/preview_layout":
+                return "Choose the size and horizontal alignment of inline previews.";
+            case "v5/media/links_and_browser/browser":
+                return "Choose the browser used when a link opens outside Boost.";
+            case "v5/media/links_and_browser/link_handling":
+                return "Control readable previews and domains excluded from in-app handling.";
+            case "v5/media/links_and_browser/links_to_open_in_app":
+                return "Choose which supported link types open directly inside Boost.";
+            case "v5/media/links_and_browser/video_links":
+                return "Choose whether supported YouTube links use Boost’s internal player.";
+            case "v5/media/playback_and_autoplay/audio":
+                return "Choose the initial audio state for video playback.";
+            case "v5/media/playback_and_autoplay/autoplay":
+                return "Choose when videos start automatically while browsing.";
+            case "v5/media/playback_and_autoplay/media_behavior":
+                return "Choose the media viewer and when overlay controls are visible.";
+            case "v5/media/playback_and_autoplay/playback_and_autoplay":
+                return "Choose the video player and tap-to-dismiss behavior.";
+            case "v5/notifications_and_account":
+                return "Control inbox checks, Android notifications, local history, and archive recovery.";
+            case "v5/notifications_and_account/history_privacy_and_recovery":
+                return "Manage local browsing history and supported archive recovery.";
+            case "v5/notifications_and_account/notifications_and_inbox":
+                return "Control inbox polling, Reddit push integration, and Android notifications.";
+            case "v5/notifications_and_account/reddit_account":
+                return "Review how Reddit-hosted account preferences relate to Boost.";
+            case "v5/notifications_and_account/history_privacy_and_recovery/history":
+                return "Choose which local history Boost keeps and clear stored history when needed.";
+            case "v5/notifications_and_account/history_privacy_and_recovery/recovery_and_archives":
+                return "Choose whether supported missing Reddit and Imgur content is restored from archives.";
+            case "v5/notifications_and_account/notifications_and_inbox/advanced":
+                return "Configure optional Reddit push bridging and source-notification cleanup.";
+            case "v5/notifications_and_account/notifications_and_inbox/notifications":
+                return "Choose how Boost checks the inbox and open Android notification settings.";
+            default:
+                return "";
+        }
+    }
+
+    static String[] childrenFor(String pageId) {
+        switch (pageId) {
+            case "v5/root":
+                return new String[]{"v5/morphe", "v5/appearance", "v5/reading_and_interaction", "v5/navigation", "v5/media", "v5/notifications_and_account", "v5/data_and_app"};
+            case "v5/appearance":
+                return new String[]{"v5/appearance/community_header", "v5/appearance/display_and_motion", "v5/appearance/post_layout", "v5/appearance/theme_and_colors", "v5/appearance/typography"};
+            case "v5/appearance/community_header":
+                return new String[]{"v5/appearance/community_header/community_header"};
+            case "v5/appearance/display_and_motion":
+                return new String[]{"v5/appearance/display_and_motion/display_performance"};
+            case "v5/appearance/post_layout":
+                return new String[]{"v5/appearance/post_layout/cards", "v5/appearance/post_layout/compact_layouts", "v5/appearance/post_layout/layout_and_saved_views", "v5/appearance/post_layout/tablet_layout"};
+            case "v5/appearance/theme_and_colors":
+                return new String[]{"v5/appearance/theme_and_colors/advanced_appearance", "v5/appearance/theme_and_colors/personalization", "v5/appearance/theme_and_colors/theme"};
+            case "v5/appearance/typography":
+                return new String[]{"v5/appearance/typography/comments", "v5/appearance/typography/posts", "v5/appearance/typography/reset"};
+            case "v5/appearance/post_layout/compact_layouts":
+                return new String[]{"v5/appearance/post_layout/compact_layouts/dense", "v5/appearance/post_layout/compact_layouts/small_cards"};
+            case "v5/appearance/post_layout/layout_and_saved_views":
+                return new String[]{"v5/appearance/post_layout/layout_and_saved_views/post_layout", "v5/appearance/post_layout/layout_and_saved_views/saved_community_views"};
+            case "v5/reading_and_interaction":
+                return new String[]{"v5/reading_and_interaction/comments", "v5/reading_and_interaction/composing_and_drafts", "v5/reading_and_interaction/feeds_and_subscriptions", "v5/reading_and_interaction/posts", "v5/reading_and_interaction/search_and_filters"};
+            case "v5/reading_and_interaction/comments":
+                return new String[]{"v5/reading_and_interaction/comments/comment_actions", "v5/reading_and_interaction/comments/comment_appearance", "v5/reading_and_interaction/comments/comment_behavior", "v5/reading_and_interaction/comments/thread_navigation"};
+            case "v5/reading_and_interaction/composing_and_drafts":
+                return new String[]{"v5/reading_and_interaction/composing_and_drafts/drafts", "v5/reading_and_interaction/composing_and_drafts/editor", "v5/reading_and_interaction/composing_and_drafts/uploads"};
+            case "v5/reading_and_interaction/feeds_and_subscriptions":
+                return new String[]{"v5/reading_and_interaction/feeds_and_subscriptions/manage_subscriptions"};
+            case "v5/reading_and_interaction/posts":
+                return new String[]{"v5/reading_and_interaction/posts/feed_behavior", "v5/reading_and_interaction/posts/post_actions", "v5/reading_and_interaction/posts/post_behavior", "v5/reading_and_interaction/posts/reading_state"};
+            case "v5/reading_and_interaction/search_and_filters":
+                return new String[]{"v5/reading_and_interaction/search_and_filters/content_filters", "v5/reading_and_interaction/search_and_filters/search"};
+            case "v5/reading_and_interaction/search_and_filters/content_filters":
+                return new String[]{"v5/reading_and_interaction/search_and_filters/content_filters/filter_behavior", "v5/reading_and_interaction/search_and_filters/content_filters/muted_content", "v5/reading_and_interaction/search_and_filters/content_filters/post_matching"};
+            case "v5/reading_and_interaction/search_and_filters/search":
+                return new String[]{"v5/reading_and_interaction/search_and_filters/search/advanced_search", "v5/reading_and_interaction/search_and_filters/search/search_behavior", "v5/reading_and_interaction/search_and_filters/search/suggestions"};
+            case "v5/navigation":
+                return new String[]{"v5/navigation/back_and_exit", "v5/navigation/bottom_navigation", "v5/navigation/navigation_drawer", "v5/navigation/toolbar"};
+            case "v5/navigation/navigation_drawer":
+                return new String[]{"v5/navigation/navigation_drawer/account_and_tools", "v5/navigation/navigation_drawer/account_switcher", "v5/navigation/navigation_drawer/drawer_behavior", "v5/navigation/navigation_drawer/feeds_and_library", "v5/navigation/navigation_drawer/go_to_shortcuts", "v5/navigation/navigation_drawer/quick_toggles", "v5/navigation/navigation_drawer/subscriptions"};
+            case "v5/data_and_app":
+                return new String[]{"v5/data_and_app/about_and_support", "v5/data_and_app/app_behavior_and_compatibility", "v5/data_and_app/backup_and_restore", "v5/data_and_app/settings_experience", "v5/data_and_app/storage_and_bandwidth"};
+            case "v5/data_and_app/about_and_support":
+                return new String[]{"v5/data_and_app/about_and_support/about_boost", "v5/data_and_app/about_and_support/author", "v5/data_and_app/about_and_support/privacy"};
+            case "v5/data_and_app/app_behavior_and_compatibility":
+                return new String[]{"v5/data_and_app/app_behavior_and_compatibility/community_shortcuts", "v5/data_and_app/app_behavior_and_compatibility/compatibility_and_legacy", "v5/data_and_app/app_behavior_and_compatibility/other_app_behavior"};
+            case "v5/data_and_app/settings_experience":
+                return new String[]{"v5/data_and_app/settings_experience/settings_presentation"};
+            case "v5/data_and_app/storage_and_bandwidth":
+                return new String[]{"v5/data_and_app/storage_and_bandwidth/cache", "v5/data_and_app/storage_and_bandwidth/data_saver", "v5/data_and_app/storage_and_bandwidth/data_usage", "v5/data_and_app/storage_and_bandwidth/images", "v5/data_and_app/storage_and_bandwidth/videos"};
+            case "v5/media":
+                return new String[]{"v5/media/downloads_and_cache", "v5/media/images_gifs_and_previews", "v5/media/links_and_browser", "v5/media/playback_and_autoplay"};
+            case "v5/media/downloads_and_cache":
+                return new String[]{"v5/media/downloads_and_cache/download_folders"};
+            case "v5/media/images_gifs_and_previews":
+                return new String[]{"v5/media/images_gifs_and_previews/native_image_behavior", "v5/media/images_gifs_and_previews/open_behavior", "v5/media/images_gifs_and_previews/preview_behavior", "v5/media/images_gifs_and_previews/preview_layout"};
+            case "v5/media/links_and_browser":
+                return new String[]{"v5/media/links_and_browser/browser", "v5/media/links_and_browser/link_handling", "v5/media/links_and_browser/links_to_open_in_app", "v5/media/links_and_browser/video_links"};
+            case "v5/media/playback_and_autoplay":
+                return new String[]{"v5/media/playback_and_autoplay/audio", "v5/media/playback_and_autoplay/autoplay", "v5/media/playback_and_autoplay/media_behavior", "v5/media/playback_and_autoplay/playback_and_autoplay"};
+            case "v5/notifications_and_account":
+                return new String[]{"v5/notifications_and_account/history_privacy_and_recovery", "v5/notifications_and_account/notifications_and_inbox", "v5/notifications_and_account/reddit_account"};
+            case "v5/notifications_and_account/history_privacy_and_recovery":
+                return new String[]{"v5/notifications_and_account/history_privacy_and_recovery/history", "v5/notifications_and_account/history_privacy_and_recovery/recovery_and_archives"};
+            case "v5/notifications_and_account/notifications_and_inbox":
+                return new String[]{"v5/notifications_and_account/notifications_and_inbox/notifications", "v5/notifications_and_account/notifications_and_inbox/advanced"};
+            default:
+                return new String[0];
+        }
+    }
+
+    static final class V5WithheldSpec {
+        final String key;
+        final String reason;
+
+        V5WithheldSpec(String key, String reason) {
+            this.key = key;
+            this.reason = reason;
+        }
+    }
+
+    static final class V5PageSpec {
+        final String pageId;
+        final String renderer;
+        final String[] keys;
+
+        V5PageSpec(String pageId, String renderer, String[] keys) {
+            this.pageId = pageId;
+            this.renderer = renderer;
+            this.keys = keys == null ? new String[0] : keys.clone();
+        }
+
+        boolean isLeaf() {
+            return childrenFor(pageId).length == 0;
+        }
+
+        boolean containsKey(String key) {
+            if (TextUtils.isEmpty(key)) {
+                return false;
+            }
+            for (String pageKey : keys) {
+                if (key.equals(pageKey)) {
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        @Override
+        public String toString() {
+            return pageId + ":" + Arrays.toString(keys);
+        }
+    }
+}

--- a/extensions/boostforreddit/src/main/java/app/morphe/extension/boostforreddit/settings/MorpheSettingsV5RootFragment.java
+++ b/extensions/boostforreddit/src/main/java/app/morphe/extension/boostforreddit/settings/MorpheSettingsV5RootFragment.java
@@ -1,0 +1,407 @@
+package app.morphe.extension.boostforreddit.settings;
+
+import android.app.Activity;
+import android.content.Context;
+import android.content.Intent;
+import android.content.res.ColorStateList;
+import android.graphics.drawable.Drawable;
+import android.os.Bundle;
+import android.text.TextUtils;
+import android.view.Gravity;
+import android.view.LayoutInflater;
+import android.view.Menu;
+import android.view.MenuItem;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.EditText;
+import android.widget.FrameLayout;
+import android.widget.ImageView;
+import android.widget.LinearLayout;
+import android.widget.ScrollView;
+import android.widget.TextView;
+
+import androidx.fragment.app.Fragment;
+
+import app.morphe.extension.boostforreddit.utils.BoostSystemBarInsetsFix;
+
+/** Complete Settings V5 overview. */
+public final class MorpheSettingsV5RootFragment extends Fragment {
+    public static final String ROOT_OVERVIEW_MARKER =
+            "MORPHE_BOOST_SETTINGS_V5_ROOT_OVERVIEW_ISSUE121_V1";
+    public static final String COMPLETENESS_MARKER =
+            "MORPHE_BOOST_SETTINGS_V5_COMPLETE_ISSUE121_V1";
+    public static final String HIDDEN_ROOT_WAVE_MARKER =
+            "MORPHE_BOOST_SETTINGS_V5_ROOT_HIDDEN_WAVE_ISSUE121_V1";
+    public static final String CLASSIC_FALLBACK_MARKER =
+            "MORPHE_V5_ROOT_CLASSIC_FALLBACK";
+
+    private static final String PAGE_ROOT = "v5/root";
+    private static final String EXTRA_SHOW_FRAGMENT = "extra_show_fragment";
+    private static final String CLASSIC_HEADER_FRAGMENT =
+            "com.rubenmayayo.reddit.ui.preferences.v2."
+                    + "SettingsActivityCompat$HeaderFragment";
+
+    private MorpheSettingsV4Theme.Tokens tokens;
+    private String pageId = PAGE_ROOT;
+
+    public MorpheSettingsV5RootFragment() {
+    }
+
+    @Override
+    public View onCreateView(
+            LayoutInflater inflater,
+            ViewGroup container,
+            Bundle savedInstanceState
+    ) {
+        Context context = inflater.getContext();
+        tokens = MorpheSettingsV4Theme.resolve(context);
+        setHasOptionsMenu(true);
+        resolvePageId();
+
+        if (!PAGE_ROOT.equals(pageId)) {
+            throw new IllegalArgumentException(
+                    "V5 root renderer cannot open " + pageId
+            );
+        }
+
+        ScrollView scrollView = new ScrollView(context);
+        scrollView.setFillViewport(true);
+        scrollView.setClipToPadding(false);
+        scrollView.setBackgroundColor(tokens.background);
+
+        LinearLayout content = new LinearLayout(context);
+        content.setOrientation(LinearLayout.VERTICAL);
+        content.setPadding(dp(16), dp(12), dp(16), dp(36));
+        scrollView.addView(
+                content,
+                new ScrollView.LayoutParams(
+                        ViewGroup.LayoutParams.MATCH_PARENT,
+                        ViewGroup.LayoutParams.WRAP_CONTENT
+                )
+        );
+
+        buildOverview(content);
+        return scrollView;
+    }
+
+    @Override
+    public void onResume() {
+        super.onResume();
+        styleHost();
+    }
+
+    @Override
+    public void onPause() {
+        Activity activity = hostActivity();
+        if (activity != null) {
+            BoostSystemBarInsetsFix.clearMorpheSettingsV4SystemBars(activity);
+        }
+        super.onPause();
+    }
+
+    @Override
+    public void onPrepareOptionsMenu(Menu menu) {
+        super.onPrepareOptionsMenu(menu);
+        if (!PAGE_ROOT.equals(pageId)) {
+            MorpheSettingsV5Search.prepareMenu(this, menu);
+        }
+    }
+
+    @Override
+    public boolean onOptionsItemSelected(MenuItem item) {
+        if (MorpheSettingsV5Search.handleMenuItem(this, item)) {
+            return true;
+        }
+        return super.onOptionsItemSelected(item);
+    }
+
+    private void buildOverview(LinearLayout content) {
+        addSearchLauncher(content);
+        addSpace(content, 18);
+        renderDestinations(
+                content,
+                MorpheSettingsV5Registry.childrenFor(PAGE_ROOT),
+                true
+        );
+        addSpace(content, 18);
+
+        TextView classic = MorpheSettingsV14Ui.action(
+                requireContext(),
+                tokens,
+                "Open classic Boost settings",
+                false
+        );
+        classic.setContentDescription("Open classic Boost settings");
+        classic.setOnClickListener(view -> openClassicSettings());
+        content.addView(
+                classic,
+                new LinearLayout.LayoutParams(
+                        ViewGroup.LayoutParams.MATCH_PARENT,
+                        ViewGroup.LayoutParams.WRAP_CONTENT
+                )
+        );
+    }
+
+    private void addSearchLauncher(LinearLayout parent) {
+        Context context = requireContext();
+        EditText search = new EditText(context);
+        search.setSingleLine(true);
+        search.setTextSize(16);
+        search.setTextColor(tokens.textPrimary);
+        search.setHintTextColor(tokens.textSecondary);
+        search.setHint("Search all settings");
+        search.setFocusable(false);
+        search.setCursorVisible(false);
+        search.setClickable(true);
+        search.setContentDescription("Search all settings");
+        search.setPadding(dp(18), 0, dp(18), 0);
+        search.setBackground(MorpheSettingsV4Theme.rounded(
+                context,
+                MorpheSettingsV4Theme.blend(
+                        tokens.surfaceContainerHigh,
+                        tokens.primaryContainer,
+                        tokens.dark ? 0.06f : 0.08f
+                ),
+                28
+        ));
+
+        Drawable searchIcon = icon("ic_search_color_24dp", tokens.primary);
+        if (searchIcon != null) {
+            searchIcon.setBounds(0, 0, dp(22), dp(22));
+            search.setCompoundDrawablePadding(dp(12));
+            search.setCompoundDrawables(searchIcon, null, null, null);
+        }
+
+        search.setOnClickListener(
+                view -> MorpheSettingsV5Search.openGlobalSearch(this)
+        );
+        parent.addView(
+                search,
+                new LinearLayout.LayoutParams(
+                        ViewGroup.LayoutParams.MATCH_PARENT,
+                        dp(56)
+                )
+        );
+    }
+
+    private void renderDestinations(
+            LinearLayout content,
+            String[] children,
+            boolean rootOverview
+    ) {
+        if (children.length == 0) {
+            throw new IllegalStateException(
+                    "V5 root page has no children: " + pageId
+            );
+        }
+
+        LinearLayout list = MorpheSettingsV14Ui.standardList(requireContext());
+        content.addView(
+                list,
+                new LinearLayout.LayoutParams(
+                        ViewGroup.LayoutParams.MATCH_PARENT,
+                        ViewGroup.LayoutParams.WRAP_CONTENT
+                )
+        );
+
+        for (String childId : children) {
+            String supporting = rootOverview
+                    ? summaryFor(childId)
+                    : MorpheSettingsV5Registry.introFor(childId);
+            LinearLayout row = MorpheSettingsV14Ui.standardListRow(
+                    requireContext(),
+                    tokens,
+                    !TextUtils.isEmpty(supporting)
+            );
+
+            String iconName = iconFor(childId);
+            if (!TextUtils.isEmpty(iconName)) {
+                row.addView(createLeadingIcon(iconName));
+            }
+
+            LinearLayout labels = MorpheSettingsV14Ui.standardListLabels(
+                    requireContext(),
+                    tokens,
+                    MorpheSettingsV5Registry.titleFor(childId),
+                    supporting
+            );
+            LinearLayout.LayoutParams labelParams =
+                    new LinearLayout.LayoutParams(
+                            0,
+                            ViewGroup.LayoutParams.WRAP_CONTENT,
+                            1.0f
+                    );
+            if (!TextUtils.isEmpty(iconName)) {
+                labelParams.setMarginStart(dp(16));
+            }
+            row.addView(labels, labelParams);
+            row.addView(MorpheSettingsV14Ui.chevron(
+                    requireContext(),
+                    tokens
+            ));
+            row.setOnClickListener(
+                    view -> MorpheSettingsV5Navigation.openPage(this, childId)
+            );
+            MorpheSettingsV14Ui.addStandardListRow(list, row, tokens);
+        }
+    }
+
+    private View createLeadingIcon(String iconName) {
+        Context context = requireContext();
+        FrameLayout slot = new FrameLayout(context);
+        ImageView image = new ImageView(context);
+        Drawable drawable = icon(
+                iconName,
+                tokens.navigationAccent().color
+        );
+        if (drawable != null) {
+            image.setImageDrawable(drawable);
+        } else {
+            image.setImageResource(android.R.drawable.ic_menu_preferences);
+            image.setColorFilter(tokens.navigationAccent().color);
+        }
+        image.setScaleType(ImageView.ScaleType.CENTER_INSIDE);
+        slot.addView(
+                image,
+                new FrameLayout.LayoutParams(
+                        dp(24),
+                        dp(24),
+                        Gravity.CENTER
+                )
+        );
+        slot.setLayoutParams(new LinearLayout.LayoutParams(dp(40), dp(40)));
+        return slot;
+    }
+
+    private String summaryFor(String targetPageId) {
+        switch (targetPageId) {
+            case "v5/morphe":
+                return "Configurable Morphe features and Settings behavior";
+            case "v5/appearance":
+                return "Themes, layout, typography, and visual presentation";
+            case "v5/reading_and_interaction":
+                return "Posts, comments, feeds, search, and composing";
+            case "v5/navigation":
+                return "Back behavior, bars, drawer, and gestures";
+            case "v5/media":
+                return "Playback, previews, links, and downloads";
+            case "v5/notifications_and_account":
+                return "Inbox, notifications, history, recovery, and account";
+            case "v5/data_and_app":
+                return "Storage, compatibility, backup, and app information";
+            default:
+                return MorpheSettingsV5Registry.introFor(targetPageId);
+        }
+    }
+
+    private String iconFor(String targetPageId) {
+        switch (targetPageId) {
+            case "v5/morphe":
+                return "ic_puzzle_24dp";
+            case "v5/appearance":
+                return "ic_color_lens_24dp";
+            case "v5/reading_and_interaction":
+                return "ic_post_24dp";
+            case "v5/navigation":
+                return "ic_toolbar_24dp";
+            case "v5/media":
+                return "ic_photo_outline_24dp";
+            case "v5/notifications_and_account":
+                return "ic_notifications_black_24dp";
+            case "v5/data_and_app":
+                return "ic_settings_24dp";
+            default:
+                return "";
+        }
+    }
+
+    private void openClassicSettings() {
+        Activity activity = hostActivity();
+        if (activity == null) {
+            return;
+        }
+        Intent intent = new Intent(activity, activity.getClass());
+        intent.putExtra(EXTRA_SHOW_FRAGMENT, CLASSIC_HEADER_FRAGMENT);
+        activity.startActivity(intent);
+    }
+
+    private void resolvePageId() {
+        Bundle arguments = getArguments();
+        if (arguments != null) {
+            String requested = arguments.getString(
+                    MorpheSettingsV5Registry.EXTRA_PAGE_ID
+            );
+            if (!TextUtils.isEmpty(requested)) {
+                pageId = requested;
+                return;
+            }
+        }
+
+        Activity activity = hostActivity();
+        Intent intent = activity == null ? null : activity.getIntent();
+        String requested = intent == null
+                ? null
+                : intent.getStringExtra(MorpheSettingsV5Registry.EXTRA_PAGE_ID);
+        if (!TextUtils.isEmpty(requested)) {
+            pageId = requested;
+        }
+    }
+
+    private void styleHost() {
+        Activity activity = hostActivity();
+        if (activity == null || tokens == null) {
+            return;
+        }
+
+        activity.setTitle("Settings");
+        BoostSystemBarInsetsFix.applyMorpheSettingsV4SystemBars(
+                activity,
+                tokens.background,
+                tokens.dark
+        );
+
+        int toolbarId = MorpheSettingsV4Catalog.resourceId(
+                activity,
+                "id",
+                "toolbar"
+        );
+        View toolbar = toolbarId == 0 ? null : activity.findViewById(toolbarId);
+        if (toolbar != null) {
+            toolbar.setBackgroundColor(tokens.background);
+            toolbar.setElevation(0);
+        }
+    }
+
+    private Drawable icon(String resourceName, int color) {
+        int resourceId = MorpheSettingsV4Catalog.resourceId(
+                requireContext(),
+                "drawable",
+                resourceName
+        );
+        if (resourceId == 0) {
+            return null;
+        }
+        Drawable drawable = requireContext().getDrawable(resourceId);
+        if (drawable != null) {
+            drawable = drawable.mutate();
+            drawable.setTintList(ColorStateList.valueOf(color));
+        }
+        return drawable;
+    }
+
+    private Activity hostActivity() {
+        Context context = getContext();
+        return context instanceof Activity ? (Activity) context : null;
+    }
+
+    private void addSpace(LinearLayout parent, int heightDp) {
+        parent.addView(
+                new View(requireContext()),
+                new LinearLayout.LayoutParams(1, dp(heightDp))
+        );
+    }
+
+    private int dp(float value) {
+        return MorpheSettingsV4Theme.dp(requireContext(), value);
+    }
+}

--- a/extensions/boostforreddit/src/main/java/app/morphe/extension/boostforreddit/settings/MorpheSettingsV5Search.java
+++ b/extensions/boostforreddit/src/main/java/app/morphe/extension/boostforreddit/settings/MorpheSettingsV5Search.java
@@ -1,0 +1,574 @@
+package app.morphe.extension.boostforreddit.settings;
+
+import android.app.Activity;
+import android.app.Dialog;
+import android.content.Context;
+import android.content.res.ColorStateList;
+import android.graphics.drawable.ColorDrawable;
+import android.graphics.drawable.Drawable;
+import android.os.Build;
+import android.text.Editable;
+import android.text.TextUtils;
+import android.text.TextWatcher;
+import android.view.Gravity;
+import android.view.KeyEvent;
+import android.view.Menu;
+import android.view.MenuItem;
+import android.view.View;
+import android.view.ViewGroup;
+import android.view.Window;
+import android.view.WindowManager;
+import android.view.inputmethod.EditorInfo;
+import android.view.inputmethod.InputMethodManager;
+import android.widget.EditText;
+import android.widget.ImageButton;
+import android.widget.LinearLayout;
+import android.widget.ScrollView;
+import android.widget.TextView;
+import android.window.OnBackInvokedCallback;
+import android.window.OnBackInvokedDispatcher;
+
+import androidx.fragment.app.Fragment;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+
+/** Platform-only global search for the hidden Settings V5 tree. */
+final class MorpheSettingsV5Search {
+    static final String CONTRACT_MARKER =
+            "MORPHE_BOOST_SETTINGS_V5_SEARCH_ISSUE121_V1";
+    static final String PLATFORM_DIALOG_MARKER =
+            "MORPHE_BOOST_SETTINGS_V5_SEARCH_PLATFORM_DIALOG_ISSUE121_V1";
+    static final String SINGLE_BACK_MARKER =
+            "MORPHE_BOOST_SETTINGS_V5_SEARCH_SINGLE_BACK_ISSUE121_V1";
+    static final String MULTI_WAVE_MARKER =
+            "MORPHE_BOOST_SETTINGS_V5_SEARCH_MULTI_WAVE_ISSUE121_V1";
+    static final String MEDIA_WAVE_MARKER =
+            "MORPHE_BOOST_SETTINGS_V5_SEARCH_MEDIA_WAVE_ISSUE121_V1";
+    static final String NOTIFICATIONS_ACCOUNT_WAVE_MARKER =
+            "MORPHE_BOOST_SETTINGS_V5_SEARCH_NOTIFICATIONS_ACCOUNT_WAVE_ISSUE121_V1";
+    static final String NAVIGATION_WAVE_MARKER =
+            "MORPHE_BOOST_SETTINGS_V5_SEARCH_NAVIGATION_WAVE_ISSUE121_V1";
+    static final String DATA_APP_WAVE_MARKER =
+            "MORPHE_BOOST_SETTINGS_V5_SEARCH_DATA_APP_WAVE_ISSUE121_V1";
+
+    private static final int MENU_ID_GLOBAL_SEARCH = 0x4d535521;
+    private static final int RESULT_LIMIT = 80;
+    private static final String[] BOOST_SEARCH_ITEM_NAMES = new String[]{
+            "action_generic_search",
+            "action_search",
+            "search",
+            "menu_search",
+    };
+
+    private MorpheSettingsV5Search() {
+    }
+
+    static void prepareMenu(Fragment fragment, Menu menu) {
+        if (fragment == null || menu == null || !fragment.isAdded()) {
+            return;
+        }
+        Context context = fragment.requireContext();
+        for (String resourceName : BOOST_SEARCH_ITEM_NAMES) {
+            hideMenuItem(context, menu, resourceName);
+        }
+        menu.removeItem(MENU_ID_GLOBAL_SEARCH);
+
+        MorpheSettingsV4Theme.Tokens tokens =
+                MorpheSettingsV4Theme.resolve(context);
+        MenuItem item = menu.add(
+                Menu.NONE,
+                MENU_ID_GLOBAL_SEARCH,
+                Menu.FIRST,
+                "Search all settings"
+        );
+        item.setShowAsAction(MenuItem.SHOW_AS_ACTION_ALWAYS);
+        int iconId = MorpheSettingsV4Catalog.resourceId(
+                context,
+                "drawable",
+                "ic_search_color_24dp"
+        );
+        if (iconId != 0) {
+            Drawable drawable = context.getDrawable(iconId);
+            if (drawable != null) {
+                drawable = drawable.mutate();
+                drawable.setTintList(ColorStateList.valueOf(tokens.primary));
+                item.setIcon(drawable);
+            }
+        }
+    }
+
+    static boolean handleMenuItem(Fragment fragment, MenuItem item) {
+        if (fragment == null || item == null
+                || item.getItemId() != MENU_ID_GLOBAL_SEARCH) {
+            return false;
+        }
+        openGlobalSearch(fragment);
+        return true;
+    }
+
+    static void openGlobalSearch(Fragment host) {
+        Context context;
+        try {
+            context = host.requireContext();
+        } catch (Throwable ignored) {
+            return;
+        }
+        if (!(context instanceof Activity)) {
+            return;
+        }
+
+        Activity activity = (Activity) context;
+        MorpheSettingsV4Theme.Tokens tokens =
+                MorpheSettingsV4Theme.resolve(context);
+        List<SearchEntry> index = buildIndex(context);
+
+        Dialog dialog = new Dialog(activity);
+        dialog.requestWindowFeature(Window.FEATURE_NO_TITLE);
+        dialog.setCanceledOnTouchOutside(false);
+
+        LinearLayout shell = new LinearLayout(context);
+        shell.setOrientation(LinearLayout.VERTICAL);
+        shell.setBackgroundColor(tokens.background);
+        shell.setPadding(dp(context, 12), dp(context, 8), dp(context, 12), 0);
+
+        LinearLayout toolbar = new LinearLayout(context);
+        toolbar.setOrientation(LinearLayout.HORIZONTAL);
+        toolbar.setGravity(Gravity.CENTER_VERTICAL);
+        shell.addView(
+                toolbar,
+                new LinearLayout.LayoutParams(
+                        ViewGroup.LayoutParams.MATCH_PARENT,
+                        dp(context, 64)
+                )
+        );
+
+        ImageButton close = new ImageButton(context);
+        close.setImageResource(android.R.drawable.ic_menu_close_clear_cancel);
+        close.setColorFilter(tokens.primary);
+        close.setBackgroundColor(0x00000000);
+        close.setContentDescription("Close search");
+        toolbar.addView(
+                close,
+                new LinearLayout.LayoutParams(dp(context, 48), dp(context, 48))
+        );
+
+        EditText searchField = new EditText(context);
+        searchField.setSingleLine(true);
+        searchField.setTextSize(16);
+        searchField.setTextColor(tokens.textPrimary);
+        searchField.setHintTextColor(tokens.textSecondary);
+        searchField.setHint("Search all settings");
+        searchField.setImeOptions(EditorInfo.IME_ACTION_SEARCH);
+        searchField.setPadding(dp(context, 18), 0, dp(context, 18), 0);
+        searchField.setBackground(MorpheSettingsV4Theme.rounded(
+                context,
+                tokens.surfaceContainerHigh,
+                28
+        ));
+        LinearLayout.LayoutParams searchParams =
+                new LinearLayout.LayoutParams(0, dp(context, 56), 1.0f);
+        searchParams.setMarginStart(dp(context, 8));
+        toolbar.addView(searchField, searchParams);
+
+        ScrollView scrollView = new ScrollView(context);
+        scrollView.setFillViewport(true);
+        scrollView.setClipToPadding(false);
+        LinearLayout results = new LinearLayout(context);
+        results.setOrientation(LinearLayout.VERTICAL);
+        results.setPadding(
+                dp(context, 4),
+                dp(context, 14),
+                dp(context, 4),
+                dp(context, 36)
+        );
+        scrollView.addView(
+                results,
+                new ScrollView.LayoutParams(
+                        ViewGroup.LayoutParams.MATCH_PARENT,
+                        ViewGroup.LayoutParams.WRAP_CONTENT
+                )
+        );
+        shell.addView(
+                scrollView,
+                new LinearLayout.LayoutParams(
+                        ViewGroup.LayoutParams.MATCH_PARENT,
+                        0,
+                        1.0f
+                )
+        );
+
+        close.setOnClickListener(view -> dismissSearch(dialog, searchField));
+        searchField.addTextChangedListener(new TextWatcher() {
+            @Override
+            public void beforeTextChanged(
+                    CharSequence value,
+                    int start,
+                    int count,
+                    int after
+            ) {
+            }
+
+            @Override
+            public void onTextChanged(
+                    CharSequence value,
+                    int start,
+                    int before,
+                    int count
+            ) {
+                renderResults(
+                        dialog,
+                        host,
+                        results,
+                        index,
+                        value == null ? "" : value.toString(),
+                        tokens
+                );
+            }
+
+            @Override
+            public void afterTextChanged(Editable value) {
+            }
+        });
+
+        renderResults(dialog, host, results, index, "", tokens);
+        dialog.setContentView(shell);
+        dialog.show();
+        installSingleBackDismiss(dialog, searchField);
+
+        Window window = dialog.getWindow();
+        if (window != null) {
+            window.setBackgroundDrawable(new ColorDrawable(tokens.background));
+            window.setLayout(
+                    ViewGroup.LayoutParams.MATCH_PARENT,
+                    ViewGroup.LayoutParams.MATCH_PARENT
+            );
+            window.setSoftInputMode(
+                    WindowManager.LayoutParams.SOFT_INPUT_ADJUST_RESIZE
+                            | WindowManager.LayoutParams.SOFT_INPUT_STATE_ALWAYS_VISIBLE
+            );
+        }
+
+        searchField.post(() -> {
+            searchField.requestFocus();
+            InputMethodManager manager =
+                    (InputMethodManager) context.getSystemService(
+                            Context.INPUT_METHOD_SERVICE
+                    );
+            if (manager != null) {
+                manager.showSoftInput(
+                        searchField,
+                        InputMethodManager.SHOW_IMPLICIT
+                );
+            }
+        });
+    }
+
+    private static List<SearchEntry> buildIndex(Context context) {
+        List<SearchEntry> result = new ArrayList<>();
+        for (MorpheSettingsV5Registry.V5PageSpec page
+                : MorpheSettingsV5Registry.allPages()) {
+            if (!MorpheSettingsV5Registry.DEFAULT_PAGE_ID.equals(page.pageId)) {
+                result.add(new SearchEntry(
+                        MorpheSettingsV5Registry.titleFor(page.pageId),
+                        MorpheSettingsV5Registry.introFor(page.pageId),
+                        page.pageId,
+                        null
+                ));
+            }
+            for (String key : page.keys) {
+                result.add(new SearchEntry(
+                        titleForKey(context, page.pageId, key),
+                        summaryForKey(context, page.pageId, key),
+                        page.pageId,
+                        key
+                ));
+            }
+        }
+        return result;
+    }
+
+    private static String titleForKey(
+            Context context,
+            String pageId,
+            String key
+    ) {
+        if (pageId.startsWith("v5/reading_and_interaction")) {
+            return MorpheSettingsV5ReadingMetadata.titleFor(context, key);
+        }
+        if (pageId.startsWith("v5/navigation")) {
+            return MorpheSettingsV5NavigationMetadata.titleFor(context, key);
+        }
+        if (pageId.startsWith("v5/media")) {
+            return MorpheSettingsV5MediaMetadata.titleFor(context, key);
+        }
+        if (pageId.startsWith("v5/data_and_app")) {
+            return MorpheSettingsV5DataAppMetadata.titleFor(context, key);
+        }
+        if (pageId.startsWith("v5/notifications_and_account")) {
+            return MorpheSettingsV5NotificationsAccountMetadata.titleFor(
+                    context,
+                    key
+            );
+        }
+        return MorpheSettingsV5AppearanceBindings.titleFor(context, key);
+    }
+
+    private static String summaryForKey(
+            Context context,
+            String pageId,
+            String key
+    ) {
+        if (pageId.startsWith("v5/reading_and_interaction")) {
+            return MorpheSettingsV5ReadingMetadata.searchSummaryFor(
+                    context,
+                    key
+            );
+        }
+        if (pageId.startsWith("v5/navigation")) {
+            return MorpheSettingsV5NavigationMetadata.searchSummaryFor(
+                    context,
+                    key
+            );
+        }
+        if (pageId.startsWith("v5/media")) {
+            return MorpheSettingsV5MediaMetadata.searchSummaryFor(
+                    context,
+                    key
+            );
+        }
+        if (pageId.startsWith("v5/data_and_app")) {
+            return MorpheSettingsV5DataAppMetadata.searchSummaryFor(
+                    context,
+                    key
+            );
+        }
+        if (pageId.startsWith("v5/notifications_and_account")) {
+            return MorpheSettingsV5NotificationsAccountMetadata.searchSummaryFor(
+                    context,
+                    key
+            );
+        }
+        return MorpheSettingsV5AppearanceBindings.searchSummaryFor(
+                context,
+                key
+        );
+    }
+
+    private static void renderResults(
+            Dialog dialog,
+            Fragment host,
+            LinearLayout results,
+            List<SearchEntry> index,
+            String query,
+            MorpheSettingsV4Theme.Tokens tokens
+    ) {
+        results.removeAllViews();
+        String normalized = normalize(query);
+        if (TextUtils.isEmpty(normalized)) {
+            addSupportingText(
+                    results,
+                    "Type a setting name, value, or category.",
+                    tokens
+            );
+            return;
+        }
+
+        List<SearchEntry> matches = new ArrayList<>();
+        for (SearchEntry entry : index) {
+            if (entry.matches(normalized)) {
+                matches.add(entry);
+            }
+        }
+        addSupportingText(
+                results,
+                matches.isEmpty()
+                        ? "No matching settings"
+                        : matches.size()
+                        + (matches.size() == 1 ? " result" : " results"),
+                tokens
+        );
+
+        LinearLayout list = MorpheSettingsV14Ui.standardList(
+                results.getContext()
+        );
+        results.addView(
+                list,
+                new LinearLayout.LayoutParams(
+                        ViewGroup.LayoutParams.MATCH_PARENT,
+                        ViewGroup.LayoutParams.WRAP_CONTENT
+                )
+        );
+        int limit = Math.min(matches.size(), RESULT_LIMIT);
+        for (int indexValue = 0; indexValue < limit; indexValue++) {
+            SearchEntry entry = matches.get(indexValue);
+            LinearLayout row = MorpheSettingsV14Ui.standardListRow(
+                    results.getContext(),
+                    tokens,
+                    !TextUtils.isEmpty(entry.summary)
+            );
+            row.addView(
+                    MorpheSettingsV14Ui.standardListLabels(
+                            results.getContext(),
+                            tokens,
+                            entry.title,
+                            entry.summary
+                    ),
+                    new LinearLayout.LayoutParams(
+                            0,
+                            ViewGroup.LayoutParams.WRAP_CONTENT,
+                            1.0f
+                    )
+            );
+            row.addView(MorpheSettingsV14Ui.chevron(
+                    results.getContext(),
+                    tokens
+            ));
+            row.setOnClickListener(view -> {
+                dismissSearch(dialog, null);
+                MorpheSettingsV5Navigation.openPage(host, entry.pageId);
+            });
+            MorpheSettingsV14Ui.addStandardListRow(list, row, tokens);
+        }
+    }
+
+    private static void installSingleBackDismiss(
+            Dialog dialog,
+            EditText searchField
+    ) {
+        if (Build.VERSION.SDK_INT >= 33) {
+            OnBackInvokedCallback callback = () ->
+                    dismissSearch(dialog, searchField);
+            Api33.registerOverlayBack(dialog, callback);
+            dialog.setOnDismissListener(
+                    ignored -> Api33.unregisterBack(dialog, callback)
+            );
+            return;
+        }
+        dialog.setOnKeyListener((ignored, keyCode, event) -> {
+            if (keyCode != KeyEvent.KEYCODE_BACK
+                    || event == null
+                    || event.getAction() != KeyEvent.ACTION_UP) {
+                return false;
+            }
+            dismissSearch(dialog, searchField);
+            return true;
+        });
+    }
+
+    private static void dismissSearch(
+            Dialog dialog,
+            EditText searchField
+    ) {
+        if (searchField != null) {
+            InputMethodManager manager =
+                    (InputMethodManager) searchField.getContext()
+                            .getSystemService(Context.INPUT_METHOD_SERVICE);
+            if (manager != null) {
+                manager.hideSoftInputFromWindow(
+                        searchField.getWindowToken(),
+                        0
+                );
+            }
+        }
+        dialog.dismiss();
+    }
+
+    private static final class Api33 {
+        private Api33() {
+        }
+
+        static void registerOverlayBack(
+                Dialog dialog,
+                OnBackInvokedCallback callback
+        ) {
+            dialog.getOnBackInvokedDispatcher()
+                    .registerOnBackInvokedCallback(
+                            OnBackInvokedDispatcher.PRIORITY_OVERLAY,
+                            callback
+                    );
+        }
+
+        static void unregisterBack(
+                Dialog dialog,
+                OnBackInvokedCallback callback
+        ) {
+            dialog.getOnBackInvokedDispatcher()
+                    .unregisterOnBackInvokedCallback(callback);
+        }
+    }
+
+    private static void addSupportingText(
+            LinearLayout parent,
+            String value,
+            MorpheSettingsV4Theme.Tokens tokens
+    ) {
+        TextView text = new TextView(parent.getContext());
+        text.setText(value);
+        text.setTextSize(14);
+        text.setTextColor(tokens.textSecondary);
+        text.setPadding(
+                dp(parent.getContext(), 10),
+                dp(parent.getContext(), 8),
+                dp(parent.getContext(), 10),
+                dp(parent.getContext(), 16)
+        );
+        parent.addView(text);
+    }
+
+    private static void hideMenuItem(
+            Context context,
+            Menu menu,
+            String resourceName
+    ) {
+        int resourceId = MorpheSettingsV4Catalog.resourceId(
+                context,
+                "id",
+                resourceName
+        );
+        if (resourceId == 0) {
+            return;
+        }
+        MenuItem item = menu.findItem(resourceId);
+        if (item != null) {
+            item.setVisible(false);
+        }
+    }
+
+    private static String normalize(String value) {
+        return value == null
+                ? ""
+                : value.trim().toLowerCase(Locale.ROOT);
+    }
+
+    private static int dp(Context context, float value) {
+        return MorpheSettingsV4Theme.dp(context, value);
+    }
+
+    private static final class SearchEntry {
+        final String title;
+        final String summary;
+        final String pageId;
+        final String key;
+
+        SearchEntry(
+                String title,
+                String summary,
+                String pageId,
+                String key
+        ) {
+            this.title = title == null ? "" : title;
+            this.summary = summary == null ? "" : summary;
+            this.pageId = pageId;
+            this.key = key;
+        }
+
+        boolean matches(String normalizedQuery) {
+            return normalize(title).contains(normalizedQuery)
+                    || normalize(summary).contains(normalizedQuery)
+                    || normalize(pageId).contains(normalizedQuery)
+                    || normalize(key).contains(normalizedQuery);
+        }
+    }
+}

--- a/extensions/boostforreddit/src/main/java/app/morphe/extension/boostforreddit/settings/MorpheSettingsV5XmlPreferenceFragment.java
+++ b/extensions/boostforreddit/src/main/java/app/morphe/extension/boostforreddit/settings/MorpheSettingsV5XmlPreferenceFragment.java
@@ -1,0 +1,3061 @@
+package app.morphe.extension.boostforreddit.settings;
+
+import android.app.Activity;
+import android.content.ComponentName;
+import android.content.Context;
+import android.content.Intent;
+import android.content.SharedPreferences;
+import android.content.pm.PackageInfo;
+import android.content.res.ColorStateList;
+import android.content.res.Resources;
+import android.content.res.XmlResourceParser;
+import android.graphics.Typeface;
+import android.net.Uri;
+import android.os.Build;
+import android.os.Bundle;
+import android.preference.PreferenceManager;
+import android.provider.Settings;
+import android.text.InputType;
+import android.text.TextUtils;
+import android.view.Gravity;
+import android.view.LayoutInflater;
+import android.view.Menu;
+import android.view.MenuItem;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.EditText;
+import android.widget.FrameLayout;
+import android.widget.LinearLayout;
+import android.widget.ScrollView;
+import android.widget.SeekBar;
+import android.widget.TextView;
+import android.widget.Toast;
+
+import androidx.fragment.app.Fragment;
+
+import app.morphe.extension.boostforreddit.utils.BoostSystemBarInsetsFix;
+
+import org.xmlpull.v1.XmlPullParser;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.lang.reflect.Proxy;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * V5-owned XML preference renderer.
+ *
+ * <p>Boost XML is used only as canonical metadata. This Fragment owns every
+ * visible row and writes the canonical preference keys directly.</p>
+ */
+abstract class MorpheSettingsV5XmlPreferenceFragment extends Fragment {
+    static final String CONTRACT_MARKER =
+            "MORPHE_BOOST_SETTINGS_V5_XML_PREFERENCE_ENGINE_ISSUE121_V1";
+    static final String NO_LEGACY_ROUTE_MARKER =
+            "MORPHE_BOOST_SETTINGS_V5_XML_ENGINE_NO_LEGACY_ROUTE_ISSUE121_V1";
+    static final String HIDDEN_CANONICAL_OVERRIDE_MARKER =
+            "MORPHE_BOOST_SETTINGS_V5_HIDDEN_CANONICAL_OVERRIDE_ISSUE121_V1";
+    static final String DATA_APP_SPECIAL_HANDLERS_MARKER =
+            "MORPHE_BOOST_SETTINGS_V5_DATA_APP_SPECIAL_HANDLERS_ISSUE121_V1";
+    private static final String EDITOR_BACK_STACK_MARKER =
+            "morphe_v5_native_editor_back_stack";
+    private static final String ANDROID_NS =
+            "http://schemas.android.com/apk/res/android";
+    private static final String APP_NS =
+            "http://schemas.android.com/apk/res-auto";
+    private static final int REQUEST_SYNCCIT_DEVICE = 1001;
+    private static final int REQUEST_SYNCCIT_ACCOUNT = 1002;
+
+    private String pageTitle = "";
+    private final String[] resourceNames;
+    private final List<Binding> bindings = new ArrayList<>();
+    private final Map<String, Control> controlsByKey = new LinkedHashMap<>();
+
+    private MorpheSettingsV4Theme.Tokens tokens;
+    private SharedPreferences preferences;
+    private EditText synccitUsernameInput;
+    private EditText synccitAuthInput;
+    private Object savedSearchObserver;
+    private FrameLayout pageHost;
+    private View settingsPage;
+    private final List<EditorPage> editorPages = new ArrayList<>();
+    private Object editorFragmentManager;
+    private Object editorBackStackListener;
+    private int editorBackStackBaseCount = -1;
+    private int editorBackStackSequence;
+
+    protected MorpheSettingsV5XmlPreferenceFragment(
+            String... resourceNames
+    ) {
+        this.resourceNames = resourceNames == null
+                ? new String[0]
+                : resourceNames.clone();
+    }
+
+    protected void preparePage() {
+    }
+
+    protected final void setPageTitle(String value) {
+        pageTitle = value == null ? "" : value;
+    }
+
+    @Override
+    public View onCreateView(
+            LayoutInflater inflater,
+            ViewGroup container,
+            Bundle savedInstanceState
+    ) {
+        preparePage();
+        if (TextUtils.isEmpty(pageTitle)) {
+            throw new IllegalStateException("V5 page title is unresolved");
+        }
+        Context context = inflater.getContext();
+        tokens = MorpheSettingsV4Theme.resolve(context);
+        preferences = PreferenceManager.getDefaultSharedPreferences(context);
+        setHasOptionsMenu(true);
+
+        pageHost = new FrameLayout(context);
+        pageHost.setBackgroundColor(tokens.background);
+
+        ScrollView scrollView = new ScrollView(context);
+        scrollView.setFillViewport(true);
+        scrollView.setClipToPadding(false);
+        scrollView.setBackgroundColor(tokens.background);
+        settingsPage = scrollView;
+        pageHost.addView(scrollView, new FrameLayout.LayoutParams(
+                ViewGroup.LayoutParams.MATCH_PARENT,
+                ViewGroup.LayoutParams.MATCH_PARENT
+        ));
+
+        LinearLayout content = new LinearLayout(context);
+        content.setOrientation(LinearLayout.VERTICAL);
+        content.setPadding(dp(16), dp(4), dp(16), dp(32));
+        scrollView.addView(content, new ScrollView.LayoutParams(
+                ViewGroup.LayoutParams.MATCH_PARENT,
+                ViewGroup.LayoutParams.WRAP_CONTENT
+        ));
+
+        List<Control> controls = readControls(context);
+        if (controls.isEmpty()) {
+            addSectionLabel(content, pageTitle);
+            addSpace(content, 8);
+            LinearLayout group = addGroup(content);
+            addActionRow(
+                    group,
+                    "This settings page is unavailable",
+                    "Boost's packaged preference contract could not be read.",
+                    view -> showUnavailable()
+            );
+            return pageHost;
+        }
+
+        String intro = pageIntro();
+        if (!TextUtils.isEmpty(intro)) {
+            content.addView(MorpheSettingsV14Ui.pageIntro(
+                    requireContext(),
+                    tokens,
+                    intro
+            ));
+            addSpace(content, 14);
+        }
+
+        renderControls(content, controls);
+        updateDependencies();
+        return pageHost;
+    }
+
+    @Override
+    public void onResume() {
+        super.onResume();
+        syncRows();
+        styleHost();
+    }
+
+    @Override
+    public void onPause() {
+        Activity activity = hostActivity();
+        if (activity != null) {
+            BoostSystemBarInsetsFix.clearMorpheSettingsV4SystemBars(activity);
+        }
+        super.onPause();
+    }
+
+    @Override
+    public void onDestroyView() {
+        bindings.clear();
+        controlsByKey.clear();
+        synccitUsernameInput = null;
+        synccitAuthInput = null;
+        savedSearchObserver = null;
+        editorPages.clear();
+        pageHost = null;
+        settingsPage = null;
+        editorFragmentManager = null;
+        editorBackStackListener = null;
+        editorBackStackBaseCount = -1;
+        super.onDestroyView();
+    }
+
+    @Override
+    public void onActivityResult(
+            int requestCode,
+            int resultCode,
+            Intent data
+    ) {
+        super.onActivityResult(requestCode, resultCode, data);
+        if ((requestCode != REQUEST_SYNCCIT_DEVICE
+                && requestCode != REQUEST_SYNCCIT_ACCOUNT)
+                || resultCode != Activity.RESULT_OK
+                || data == null) {
+            return;
+        }
+        String username = data.getStringExtra("username");
+        String auth = data.getStringExtra("auth");
+        if (username == null || auth == null) {
+            return;
+        }
+        saveSynccitCredentials(username, auth);
+        if (synccitUsernameInput != null) {
+            synccitUsernameInput.setText(username);
+        }
+        if (synccitAuthInput != null) {
+            synccitAuthInput.setText(auth);
+        }
+    }
+
+    @Override
+    public void onPrepareOptionsMenu(Menu menu) {
+        super.onPrepareOptionsMenu(menu);
+        MorpheSettingsV5Search.prepareMenu(this, menu);
+    }
+
+    @Override
+    public boolean onOptionsItemSelected(MenuItem item) {
+        if (MorpheSettingsV5Search.handleMenuItem(this, item)) {
+            return true;
+        }
+        return super.onOptionsItemSelected(item);
+    }
+
+    protected boolean includeControl(String resourceName, String key) {
+        return true;
+    }
+
+    protected boolean includeHiddenControl(
+            String resourceName,
+            String key
+    ) {
+        return false;
+    }
+
+    protected String sectionFor(
+            String resourceName,
+            String key,
+            String currentSection
+    ) {
+        return currentSection;
+    }
+
+    protected String pageIntro() {
+        return "";
+    }
+
+    protected boolean useAndroidSettingsGuidanceRows() {
+        return true;
+    }
+
+    protected String displaySummary(
+            String key,
+            String currentSummary
+    ) {
+        return currentSummary;
+    }
+
+    protected String displayActionSummary(
+            String key,
+            String currentSummary,
+            String tag
+    ) {
+        return currentSummary;
+    }
+
+    private List<Control> readControls(Context context) {
+        List<Control> result = new ArrayList<>();
+        java.util.Set<String> seenKeys = new java.util.LinkedHashSet<>();
+        for (String resourceName : resourceNames) {
+            for (Control control : readControls(context, resourceName)) {
+                if (TextUtils.isEmpty(control.key) || seenKeys.add(control.key)) {
+                    result.add(control);
+                }
+            }
+        }
+        return result;
+    }
+
+    private List<Control> readControls(
+            Context context,
+            String resourceName
+    ) {
+        int resourceId = MorpheSettingsV4Catalog.resourceId(
+                context,
+                "xml",
+                resourceName
+        );
+        if (resourceId == 0) {
+            return Collections.emptyList();
+        }
+
+        Resources resources = context.getResources();
+        List<Control> result = new ArrayList<>();
+        XmlResourceParser parser = null;
+        String section = pageTitle;
+        int categoryDepth = -1;
+        int hiddenDepth = -1;
+        try {
+            parser = resources.getXml(resourceId);
+            int event;
+            while ((event = parser.next()) != XmlPullParser.END_DOCUMENT) {
+                int depth = parser.getDepth();
+                if (event == XmlPullParser.END_TAG) {
+                    if (depth == hiddenDepth) {
+                        hiddenDepth = -1;
+                    }
+                    if (depth == categoryDepth) {
+                        section = pageTitle;
+                        categoryDepth = -1;
+                    }
+                    continue;
+                }
+                if (event != XmlPullParser.START_TAG) {
+                    continue;
+                }
+                if (hiddenDepth >= 0 && depth > hiddenDepth) {
+                    continue;
+                }
+
+                String rawTag = parser.getName();
+                String tag = simpleTag(rawTag);
+                if ("PreferenceScreen".equals(tag)
+                        || "intent".equalsIgnoreCase(tag)) {
+                    continue;
+                }
+                boolean visible = parser.getAttributeBooleanValue(
+                        APP_NS,
+                        "isPreferenceVisible",
+                        true
+                );
+                String rawKey = attributeText(resources, parser, "key");
+                boolean forcedVisible = !visible
+                        && includeHiddenControl(resourceName, rawKey);
+                if ("PreferenceCategory".equals(tag)) {
+                    if (!visible) {
+                        hiddenDepth = depth;
+                        continue;
+                    }
+                    String categoryTitle = attributeText(
+                            resources,
+                            parser,
+                            "title"
+                    );
+                    section = TextUtils.isEmpty(categoryTitle)
+                            ? pageTitle
+                            : categoryTitle;
+                    categoryDepth = depth;
+                    continue;
+                }
+                if (!visible && !forcedVisible) {
+                    continue;
+                }
+
+                Control control = new Control();
+                control.tag = tag;
+                control.section = section;
+                control.key = rawKey;
+                control.title = attributeText(resources, parser, "title");
+                control.summary = attributeText(resources, parser, "summary");
+                control.summaryOn = attributeText(resources, parser, "summaryOn");
+                control.summaryOff = attributeText(resources, parser, "summaryOff");
+                control.defaultValue = attributeText(
+                        resources,
+                        parser,
+                        "defaultValue"
+                );
+                control.dependency = attributeText(
+                        resources,
+                        parser,
+                        "dependency"
+                );
+                control.fragmentName = parser.getAttributeValue(
+                        ANDROID_NS,
+                        "fragment"
+                );
+                control.disableDependentsState =
+                        parser.getAttributeBooleanValue(
+                                ANDROID_NS,
+                                "disableDependentsState",
+                                false
+                        );
+                control.min = parser.getAttributeIntValue(
+                        ANDROID_NS,
+                        "min",
+                        0
+                );
+                control.max = parser.getAttributeIntValue(
+                        ANDROID_NS,
+                        "max",
+                        100
+                );
+                control.entries = attributeArray(
+                        resources,
+                        parser,
+                        "entries"
+                );
+                control.entryValues = attributeArray(
+                        resources,
+                        parser,
+                        "entryValues"
+                );
+                configureMorpheControl(control);
+                if (!includeControl(resourceName, control.key)) {
+                    continue;
+                }
+                control.section = sectionFor(
+                        resourceName,
+                        control.key,
+                        control.section
+                );
+                if ("pref_general_v2".equals(resourceName)
+                        && !TextUtils.isEmpty(control.fragmentName)) {
+                    // These six routes duplicate the dedicated Morphe hubs.
+                    // Classic Boost settings remains available separately.
+                    continue;
+                }
+                if (!TextUtils.isEmpty(control.title)) {
+                    result.add(control);
+                    if (!TextUtils.isEmpty(control.key)) {
+                        controlsByKey.put(control.key, control);
+                    }
+                }
+            }
+        } catch (Exception ignored) {
+            return Collections.emptyList();
+        } finally {
+            if (parser != null) {
+                parser.close();
+            }
+        }
+        return result;
+    }
+
+    private void renderControls(
+            LinearLayout content,
+            List<Control> controls
+    ) {
+        String currentSection = null;
+        LinearLayout group = null;
+        for (Control control : controls) {
+            if (!TextUtils.equals(currentSection, control.section)) {
+                boolean repeatedPageTitle = TextUtils.equals(
+                        control.section,
+                        pageTitle
+                );
+                if (group != null) {
+                    addSpace(content, 20);
+                }
+                currentSection = control.section;
+                if (!repeatedPageTitle) {
+                    addSectionLabel(content, currentSection);
+                    addSpace(content, 6);
+                }
+                group = addGroup(content);
+            }
+            if (isToggle(control)) {
+                addToggle(group, control);
+            } else if (isChoice(control)) {
+                addChoice(group, control);
+            } else if ("SeekBarPreference".equals(control.tag)) {
+                addSeek(group, control);
+            } else {
+                addAction(group, control);
+            }
+        }
+    }
+
+    private void addToggle(LinearLayout group, Control control) {
+        boolean checked = preferences.getBoolean(
+                control.key,
+                booleanDefault(control)
+        );
+        String summaryValue = toggleSummary(control, checked);
+        LinearLayout row = baseRow(!TextUtils.isEmpty(summaryValue));
+        TextView summary = addLabels(
+                row,
+                control.title,
+                summaryValue
+        );
+
+        MorpheSettingsV14Ui.Toggle toggle =
+                new MorpheSettingsV14Ui.Toggle(
+                        requireContext(),
+                        tokens,
+                        checked
+                );
+        toggle.setOnCheckedChangeListener((button, value) -> {
+            preferences.edit().putBoolean(control.key, value).apply();
+            applySideEffects(control.key);
+            summary.setText(toggleSummary(control, value));
+            summary.setVisibility(
+                    TextUtils.isEmpty(summary.getText())
+                            ? View.GONE
+                            : View.VISIBLE
+            );
+            updateDependencies();
+        });
+        row.setOnClickListener(view -> {
+            if (row.isEnabled()) {
+                toggle.toggle();
+            }
+        });
+        row.addView(toggle, wrapParams());
+        addGroupedRow(group, row);
+        bindings.add(new Binding(control, row, summary, toggle, null));
+    }
+
+    private void addChoice(LinearLayout group, Control control) {
+        String summaryValue = selectedTitle(control);
+        LinearLayout row = baseRow(!TextUtils.isEmpty(summaryValue));
+        TextView summary = addLabels(
+                row,
+                control.title,
+                summaryValue
+        );
+        addChevron(row);
+        row.setOnClickListener(view -> {
+            if (row.isEnabled()) {
+                showChoiceDialog(control, summary);
+            }
+        });
+        addGroupedRow(group, row);
+        bindings.add(new Binding(control, row, summary, null, null));
+    }
+
+    private void addSeek(LinearLayout group, Control control) {
+        LinearLayout row = new LinearLayout(requireContext());
+        row.setOrientation(LinearLayout.VERTICAL);
+        row.setPadding(dp(16), dp(10), dp(16), dp(12));
+        row.setMinimumHeight(dp(82));
+        row.setBackground(MorpheSettingsV4Theme.interactive(
+                requireContext(),
+                0x00000000,
+                0,
+                tokens.navigationAccent().color
+        ));
+
+        LinearLayout labels = new LinearLayout(requireContext());
+        labels.setOrientation(LinearLayout.HORIZONTAL);
+        labels.setGravity(Gravity.CENTER_VERTICAL);
+        TextView title = textView(control.title, 16, tokens.textPrimary);
+        title.setTypeface(Typeface.create(
+                "sans-serif-medium",
+                Typeface.NORMAL
+        ));
+        labels.addView(title, labelsParams());
+        int value = preferences.getInt(control.key, intDefault(control));
+        TextView summary = textView(String.valueOf(value), 14, tokens.textSecondary);
+        labels.addView(summary, wrapParams());
+        row.addView(labels, matchWrapParams());
+
+        SeekBar seek = new SeekBar(requireContext());
+        seek.setMax(Math.max(0, control.max - control.min));
+        seek.setProgress(Math.max(0, value - control.min));
+        if (Build.VERSION.SDK_INT >= 21) {
+            seek.setProgressTintList(ColorStateList.valueOf(
+                    tokens.navigationAccent().color
+            ));
+            seek.setThumbTintList(ColorStateList.valueOf(
+                    tokens.navigationAccent().color
+            ));
+        }
+        seek.setOnSeekBarChangeListener(new SeekBar.OnSeekBarChangeListener() {
+            @Override
+            public void onProgressChanged(
+                    SeekBar seekBar,
+                    int progress,
+                    boolean fromUser
+            ) {
+                summary.setText(String.valueOf(control.min + progress));
+            }
+
+            @Override
+            public void onStartTrackingTouch(SeekBar seekBar) {
+            }
+
+            @Override
+            public void onStopTrackingTouch(SeekBar seekBar) {
+                int selected = control.min + seekBar.getProgress();
+                preferences.edit().putInt(control.key, selected).apply();
+                applySideEffects(control.key);
+            }
+        });
+        row.addView(seek, matchWrapParams());
+        addGroupedRow(group, row);
+        bindings.add(new Binding(control, row, summary, null, seek));
+    }
+
+    private void addAction(LinearLayout group, Control control) {
+        String summaryValue = actionSummary(control);
+        LinearLayout row = baseRow(!TextUtils.isEmpty(summaryValue));
+        TextView summary = addLabels(
+                row,
+                control.title,
+                summaryValue
+        );
+        addChevron(row);
+        row.setOnClickListener(view -> {
+            if (row.isEnabled()) {
+                performAction(control);
+            }
+        });
+        addGroupedRow(group, row);
+        bindings.add(new Binding(control, row, summary, null, null));
+    }
+
+    private void addActionRow(
+            LinearLayout group,
+            String title,
+            String summary,
+            View.OnClickListener listener
+    ) {
+        LinearLayout row = baseRow(!TextUtils.isEmpty(summary));
+        addLabels(row, title, summary);
+        addChevron(row);
+        row.setOnClickListener(listener);
+        addGroupedRow(group, row);
+    }
+
+    private void performAction(Control control) {
+        if ("FilterPreference".equals(control.tag)) {
+            showFilterEditor(control);
+            return;
+        }
+        if (control.tag.startsWith("Delete")) {
+            confirmDelete(control);
+            return;
+        }
+        if ("ColorPatternPreference".equals(control.tag)) {
+            showColorPatternEditor();
+            return;
+        }
+        String key = control.key;
+        if ("synncit_config".equals(key)) {
+            showSynccitEditor();
+        } else if ("pref_sort_per_sub".equals(key)) {
+            showSavedSortsEditor();
+        } else if ("pref_frontpage_sort".equals(key)) {
+            showSortEditor(false, frontpageSubscription(), null);
+        } else if ("pref_default_sort".equals(key)) {
+            showSortEditor(true, emptySubscription(), null);
+        } else if ("pref_saved_searches".equals(key)) {
+            showSavedSearchesEditor();
+        } else if ("pref_search_advanced_help".equals(key)) {
+            showFieldSearchHelp();
+        } else if ("pref_notifications_configure".equals(key)) {
+            openNotificationSettings();
+        } else if ("pref_edit_subscriptions".equals(key)) {
+            invokeActivityHelper("t0", Activity.class, hostActivity());
+        } else if ("pref_manage_drafts".equals(key)) {
+            invokeActivityHelper("P", Context.class, requireContext());
+        } else if ("pref_imgur_uploads".equals(key)) {
+            invokeActivityHelper("n0", Context.class, requireContext());
+        } else if ("remove_ads".equals(key)) {
+            invokeActivityHelper("y", Context.class, requireContext());
+        } else if ("buy_pro".equals(key)) {
+            invokeActivityHelper("x0", Context.class, requireContext());
+        } else if ("pref_gdpr_revoke".equals(key)) {
+            confirmGdprRevocation();
+        } else if ("pref_download_folders".equals(key)) {
+            invokeActivityHelper("S", Context.class, requireContext());
+        } else if ("pref_cache_current_size".equals(key)) {
+            clearMediaCache();
+        } else if ("reset_tips".equals(key)) {
+            resetTips();
+        } else if ("support_launch".equals(key)) {
+            invokeActivityHelper("c1", Context.class, requireContext());
+        } else if ("rate_app".equals(key)) {
+            invokeActivityHelper("u1", Context.class, requireContext());
+        } else if ("about_subreddit".equals(key)) {
+            invokeActivityHelper(
+                    "Y0",
+                    new Class<?>[]{Activity.class, String.class},
+                    new Object[]{hostActivity(), "BoostForReddit"}
+            );
+        } else if ("about_faq".equals(key)) {
+            invokeActivityHelper(
+                    "m1",
+                    new Class<?>[]{Activity.class, String.class, String.class},
+                    new Object[]{hostActivity(), "boostforreddit", "index"}
+            );
+        } else if ("licenses_preference".equals(key)) {
+            invokeActivityHelper("i0", Context.class, requireContext());
+        } else if ("privacy_policy".equals(key)) {
+            openUrl("https://www.iubenda.com/privacy-policy/7976518");
+        } else if ("about_reddit".equals(key)) {
+            invokeActivityHelper(
+                    "y0",
+                    new Class<?>[]{Context.class, String.class},
+                    new Object[]{requireContext(), "rmayayo"}
+            );
+        } else if ("about_twitter".equals(key)) {
+            openUrl("https://twitter.com/rmayayo");
+        } else if ("contact_dev_key".equals(key)) {
+            openEmail("mayayo.dev@gmail.com");
+        } else if ("about_version".equals(key)) {
+            showVersion();
+        } else {
+            showUnavailable();
+        }
+    }
+
+    private void showChoiceDialog(Control control, TextView summaryView) {
+        if (control.entries.length == 0
+                || control.entries.length != control.entryValues.length) {
+            showUnavailable();
+            return;
+        }
+        EditorPage page = openEditorPage(control.title);
+
+        String selected = preferences.getString(
+                control.key,
+                stringDefault(control)
+        );
+        LinearLayout group = addGroup(page.content);
+        for (int index = 0; index < control.entries.length; index++) {
+            final String value = control.entryValues[index];
+            boolean checked = TextUtils.equals(value, selected);
+            LinearLayout row = materialChoiceRow(
+                    control.entries[index],
+                    "",
+                    checked
+            );
+            row.setOnClickListener(view -> {
+                preferences.edit().putString(control.key, value).apply();
+                applySideEffects(control.key);
+                summaryView.setText(selectedTitle(control));
+                updateDependencies();
+                page.dismiss();
+            });
+            addGroupedRow(group, row);
+        }
+    }
+
+    private void showFilterEditor(Control control) {
+        List<String> values = loadFilters(control.key);
+        EditorPage page = openEditorPage(control.title);
+        LinearLayout content = page.content;
+        EditText input = addEditorInput(content, "Add filter", "", 4);
+
+        TextView add = actionLabel("Add", true);
+        content.addView(add, spacedMatchWrapParams(10));
+
+        LinearLayout list = new LinearLayout(materialContext());
+        list.setOrientation(LinearLayout.VERTICAL);
+        content.addView(list, spacedMatchWrapParams(14));
+
+        Runnable render = () -> renderFilterRows(
+                list,
+                values,
+                control.key
+        );
+        render.run();
+        add.setOnClickListener(view -> {
+            String value = input.getText().toString().trim();
+            if (!TextUtils.isEmpty(value) && !values.contains(value)) {
+                values.add(0, value);
+                persistFilters(control.key, values);
+                input.setText("");
+                render.run();
+            }
+        });
+
+    }
+
+    private void renderFilterRows(
+            LinearLayout list,
+            List<String> values,
+            String key
+    ) {
+        list.removeAllViews();
+        if (values.isEmpty()) {
+            TextView empty = textView(
+                    "No filters yet",
+                    14,
+                    tokens.textSecondary
+            );
+            empty.setPadding(dp(4), dp(12), dp(4), dp(12));
+            list.addView(empty);
+            return;
+        }
+        LinearLayout group = addGroup(list);
+        for (String value : new ArrayList<>(values)) {
+            LinearLayout row = new LinearLayout(requireContext());
+            row.setOrientation(LinearLayout.HORIZONTAL);
+            row.setGravity(Gravity.CENTER_VERTICAL);
+            row.setPadding(dp(4), dp(5), dp(2), dp(5));
+            TextView label = textView(value, 16, tokens.textPrimary);
+            row.addView(label, labelsParams());
+            TextView remove = actionLabel("Remove", false);
+            remove.setOnClickListener(view -> {
+                values.remove(value);
+                persistFilters(key, values);
+                renderFilterRows(list, values, key);
+            });
+            row.addView(remove, wrapParams());
+            addGroupedRow(group, row);
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private List<String> loadFilters(String key) {
+        try {
+            Object settingsObject = invokeStatic("id.b", "v0");
+            Method method = settingsObject.getClass().getMethod(
+                    "j0",
+                    String.class
+            );
+            Object value = method.invoke(settingsObject, key);
+            if (value instanceof List) {
+                return new ArrayList<>((List<String>) value);
+            }
+        } catch (Throwable ignored) {
+        }
+        return new ArrayList<>();
+    }
+
+    private void persistFilters(String key, List<String> values) {
+        try {
+            Object settingsObject = invokeStatic("id.b", "v0");
+            Method method = settingsObject.getClass().getMethod(
+                    "d6",
+                    String.class,
+                    List.class
+            );
+            method.invoke(settingsObject, key, new ArrayList<>(values));
+            applySideEffects(key);
+        } catch (Throwable throwable) {
+            showUnavailable();
+        }
+    }
+
+    private void showColorPatternEditor() {
+        Context context = requireContext();
+        EditorPage page = openEditorPage("Color patterns");
+        LinearLayout content = page.content;
+
+        String[][] palettes = new String[][]{
+                {"Standard", "standard"},
+                {"Secondary", "secondary"},
+                {"Diverging", "diverging"},
+                {"Diverging translucent", "divergingTrans"},
+                {"Pain", "pain"},
+                {"Rainbow", "Rainbow"},
+                {"Viridis", "viridis2"},
+                {"Blues", "blues"},
+                {"Yellow to red", "YlOrRd"},
+                {"Grayscale", "gradient_gray"},
+                {"Transparent", "transparent"}
+        };
+        LinearLayout group = addGroup(content);
+        int available = 0;
+        for (String[] palette : palettes) {
+            int resourceId = MorpheSettingsV4Catalog.resourceId(
+                    context,
+                    "array",
+                    palette[1]
+            );
+            if (resourceId == 0) {
+                continue;
+            }
+            int[] colors;
+            try {
+                colors = context.getResources().getIntArray(resourceId);
+            } catch (Resources.NotFoundException ignored) {
+                continue;
+            }
+            available++;
+            LinearLayout row = baseRow();
+            addLabels(row, palette[0], "");
+            LinearLayout preview = new LinearLayout(context);
+            preview.setOrientation(LinearLayout.HORIZONTAL);
+            preview.setGravity(Gravity.CENTER_VERTICAL);
+            int shown = Math.min(colors.length, 7);
+            for (int index = 0; index < shown; index++) {
+                View swatch = new View(context);
+                swatch.setBackground(MorpheSettingsV4Theme.rounded(
+                        context,
+                        colors[index],
+                        5
+                ));
+                LinearLayout.LayoutParams swatchParams =
+                        new LinearLayout.LayoutParams(dp(18), dp(30));
+                if (index > 0) {
+                    swatchParams.setMarginStart(dp(3));
+                }
+                preview.addView(swatch, swatchParams);
+            }
+            row.addView(preview, wrapParams());
+            row.setOnClickListener(view -> {
+                Object settingsObject = invokeStatic("id.b", "v0");
+                Object result = invokeInstance(
+                        settingsObject,
+                        "x6",
+                        new Class<?>[]{int[].class},
+                        new Object[]{colors}
+                );
+                if (result == InvocationFailure.INSTANCE) {
+                    showUnavailable();
+                    return;
+                }
+                setBoostStaticBoolean("j");
+                page.dismiss();
+            });
+            addGroupedRow(group, row);
+        }
+        if (available == 0) {
+            page.dismiss();
+            showUnavailable();
+            return;
+        }
+    }
+
+    private Object frontpageSubscription() {
+        return invokeStatic(
+                "com.rubenmayayo.reddit.models.reddit.SubscriptionViewModel",
+                "m"
+        );
+    }
+
+    private Object emptySubscription() {
+        return newInstance(
+                "com.rubenmayayo.reddit.models.reddit.SubscriptionViewModel",
+                new Class<?>[]{String.class},
+                new Object[]{""}
+        );
+    }
+
+    @SuppressWarnings("unchecked")
+    private void showSortEditor(
+            boolean defaultSort,
+            Object subscription,
+            Runnable afterSelection
+    ) {
+        if (subscription == InvocationFailure.INSTANCE
+                || subscription == null) {
+            showUnavailable();
+            return;
+        }
+        try {
+            Class<?> subscriptionType = Class.forName(
+                    "com.rubenmayayo.reddit.models.reddit."
+                            + "SubscriptionViewModel"
+            );
+            Object rawOptions = invokeStatic(
+                    "qc.a",
+                    "j",
+                    new Class<?>[]{subscriptionType},
+                    new Object[]{subscription}
+            );
+            if (!(rawOptions instanceof List)) {
+                showUnavailable();
+                return;
+            }
+            List<Object> options = (List<Object>) rawOptions;
+            List<Integer> optionIds = new ArrayList<>();
+            List<CharSequence> optionLabels = new ArrayList<>();
+            for (Object option : options) {
+                int id = intResult(invokeInstance(option, "q"), -1);
+                String title = menuOptionTitle(option);
+                if (TextUtils.isEmpty(title) || id < 0) {
+                    continue;
+                }
+                String supporting = stringResult(invokeInstance(option, "t"));
+                optionIds.add(id);
+                optionLabels.add(TextUtils.isEmpty(supporting)
+                        ? title
+                        : title + " — " + supporting);
+            }
+            if (optionIds.isEmpty()) {
+                showUnavailable();
+                return;
+            }
+
+            Integer selectedId = currentSortOptionId(
+                    defaultSort,
+                    subscription
+            );
+            EditorPage page = openEditorPage(
+                    defaultSort ? "Default sort" : "Sort home by"
+            );
+            if (!defaultSort && Integer.valueOf(100).equals(selectedId)) {
+                page.content.addView(MorpheSettingsV14Ui.supportingText(
+                        requireContext(),
+                        tokens,
+                        "Using the default sort"
+                ));
+                addSpace(page.content, 10);
+            }
+            LinearLayout group = addGroup(page.content);
+            boolean hasReset = false;
+            for (int index = 0; index < optionIds.size(); index++) {
+                int optionId = optionIds.get(index);
+                if (!defaultSort && optionId == 100) {
+                    hasReset = true;
+                    continue;
+                }
+                final int which = index;
+                MorpheSettingsV14Ui.ChoiceRow row = materialChoiceRow(
+                        optionLabels.get(index).toString(),
+                        "",
+                        Integer.valueOf(optionId).equals(selectedId)
+                );
+                row.setOnClickListener(view -> {
+                    int id = optionIds.get(which);
+                    boolean saved = defaultSort
+                            ? saveDefaultSort(id)
+                            : saveSubscriptionSort(subscription, id);
+                    if (!saved) {
+                        showUnavailable();
+                        return;
+                    }
+                    applySideEffects(defaultSort
+                            ? "pref_default_sort"
+                            : "pref_frontpage_sort");
+                    page.dismiss();
+                    if (afterSelection != null) {
+                        afterSelection.run();
+                    }
+                });
+                addGroupedRow(group, row);
+            }
+            if (hasReset) {
+                addSpace(page.content, 12);
+                TextView reset = actionLabel("Reset to default", false);
+                boolean resetEnabled = !Integer.valueOf(100).equals(
+                        selectedId
+                );
+                reset.setEnabled(resetEnabled);
+                reset.setAlpha(resetEnabled ? 1.0f : 0.42f);
+                reset.setOnClickListener(view -> {
+                    if (!saveSubscriptionSort(subscription, 100)) {
+                        showUnavailable();
+                        return;
+                    }
+                    applySideEffects("pref_frontpage_sort");
+                    page.dismiss();
+                    if (afterSelection != null) {
+                        afterSelection.run();
+                    }
+                });
+                page.content.addView(reset, wrapParams());
+            }
+        } catch (Throwable throwable) {
+            showUnavailable();
+        }
+    }
+
+    private int selectedSortIndex(
+            boolean defaultSort,
+            Object subscription,
+            List<Integer> optionIds
+    ) {
+        Integer selectedId = currentSortOptionId(
+                defaultSort,
+                subscription
+        );
+        return selectedId == null ? -1 : optionIds.indexOf(selectedId);
+    }
+
+    private Integer currentSortOptionId(
+            boolean defaultSort,
+            Object subscription
+    ) {
+        try {
+            Object sorting;
+            Object period;
+            if (defaultSort) {
+                Object settingsObject = invokeStatic("id.b", "v0");
+                sorting = invokeInstance(settingsObject, "Y1");
+                period = invokeInstance(settingsObject, "V1");
+            } else {
+                Class<?> subscriptionType = Class.forName(
+                        "com.rubenmayayo.reddit.models.reddit."
+                                + "SubscriptionViewModel"
+                );
+                Object manager = invokeStatic("he.c0", "e");
+                Object saved = invokeInstance(
+                        manager,
+                        "j",
+                        new Class<?>[]{subscriptionType},
+                        new Object[]{subscription}
+                );
+                if (saved == null || saved == InvocationFailure.INSTANCE) {
+                    return 100;
+                }
+                sorting = invokeInstance(saved, "a");
+                period = invokeInstance(saved, "b");
+            }
+            if (sorting == InvocationFailure.INSTANCE
+                    || sorting == null
+                    || period == InvocationFailure.INSTANCE) {
+                return null;
+            }
+            String sortingName = enumName(sorting);
+            if ("HOT".equals(sortingName)) {
+                return 0;
+            }
+            if ("NEW".equals(sortingName)) {
+                return 1;
+            }
+            if ("RISING".equals(sortingName)) {
+                return 2;
+            }
+            if ("GILDED".equals(sortingName)) {
+                return 5;
+            }
+            int periodIndex = timePeriodIndex(enumName(period));
+            if (periodIndex < 0) {
+                return null;
+            }
+            if ("TOP".equals(sortingName)) {
+                return 30 + periodIndex;
+            }
+            if ("CONTROVERSIAL".equals(sortingName)) {
+                return 40 + periodIndex;
+            }
+            return null;
+        } catch (Throwable throwable) {
+            return null;
+        }
+    }
+
+    private String enumName(Object value) {
+        return value instanceof Enum
+                ? ((Enum<?>) value).name()
+                : "";
+    }
+
+    private int timePeriodIndex(String name) {
+        String[] names = {"HOUR", "DAY", "WEEK", "MONTH", "YEAR", "ALL"};
+        for (int index = 0; index < names.length; index++) {
+            if (names[index].equals(name)) {
+                return index;
+            }
+        }
+        return -1;
+    }
+
+    private boolean saveDefaultSort(int id) {
+        String sort = null;
+        String period = null;
+        if (id == 0 || id == 1 || id == 2 || id == 5) {
+            sort = String.valueOf(id);
+        } else if (id >= 30 && id <= 35) {
+            sort = "3";
+            period = String.valueOf(id - 30);
+        } else if (id >= 40 && id <= 45) {
+            sort = "4";
+            period = String.valueOf(id - 40);
+        }
+        if (sort == null) {
+            return false;
+        }
+        Object settingsObject = invokeStatic("id.b", "v0");
+        if (invokeInstance(
+                settingsObject,
+                "B6",
+                new Class<?>[]{String.class},
+                new Object[]{sort}
+        ) == InvocationFailure.INSTANCE) {
+            return false;
+        }
+        return period == null || invokeInstance(
+                settingsObject,
+                "A6",
+                new Class<?>[]{String.class},
+                new Object[]{period}
+        ) != InvocationFailure.INSTANCE;
+    }
+
+    private boolean saveSubscriptionSort(Object subscription, int id) {
+        try {
+            Class<?> subscriptionType = Class.forName(
+                    "com.rubenmayayo.reddit.models.reddit."
+                            + "SubscriptionViewModel"
+            );
+            Object manager = invokeStatic("he.c0", "e");
+            String method = id == 100 ? "a" : "m";
+            Class<?>[] types = id == 100
+                    ? new Class<?>[]{subscriptionType}
+                    : new Class<?>[]{subscriptionType, int.class};
+            Object[] values = id == 100
+                    ? new Object[]{subscription}
+                    : new Object[]{subscription, id};
+            return invokeInstance(manager, method, types, values)
+                    != InvocationFailure.INSTANCE;
+        } catch (Throwable throwable) {
+            return false;
+        }
+    }
+
+    private String menuOptionTitle(Object option) {
+        String title = stringResult(invokeInstance(option, "v"));
+        if (!TextUtils.isEmpty(title)) {
+            return title;
+        }
+        int resourceId = intResult(invokeInstance(option, "x"), 0);
+        if (resourceId == 0) {
+            return "";
+        }
+        try {
+            return requireContext().getString(resourceId);
+        } catch (Resources.NotFoundException ignored) {
+            return "";
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private void showSavedSortsEditor() {
+        Object manager = invokeStatic("he.c0", "e");
+        if (manager == InvocationFailure.INSTANCE) {
+            showUnavailable();
+            return;
+        }
+        EditorPage page = openEditorPage("Manage saved sorts");
+        LinearLayout content = page.content;
+        LinearLayout list = new LinearLayout(materialContext());
+        list.setOrientation(LinearLayout.VERTICAL);
+        content.addView(list, matchWrapParams());
+
+        Runnable[] render = new Runnable[1];
+        render[0] = () -> {
+            list.removeAllViews();
+            Object raw = invokeInstance(manager, "k");
+            if (!(raw instanceof List) || ((List<?>) raw).isEmpty()) {
+                TextView empty = textView(
+                        "No community-specific sorts yet.",
+                        15,
+                        tokens.textSecondary
+                );
+                empty.setPadding(dp(8), dp(16), dp(8), dp(16));
+                list.addView(empty, matchWrapParams());
+                return;
+            }
+            LinearLayout group = addGroup(list);
+            for (Object subscription : (List<Object>) raw) {
+                String name = stringResult(
+                        invokeInstance(subscription, "z")
+                );
+                if (TextUtils.isEmpty(name)) {
+                    name = "Community";
+                }
+                LinearLayout row = baseRow();
+                addLabels(row, name, "Tap to change its saved sort");
+                TextView remove = actionLabel("Remove", false);
+                remove.setOnClickListener(view -> {
+                    saveSubscriptionSort(subscription, 100);
+                    render[0].run();
+                });
+                row.addView(remove, wrapParams());
+                row.setOnClickListener(view -> showSortEditor(
+                        false,
+                        subscription,
+                        render[0]
+                ));
+                addGroupedRow(group, row);
+            }
+        };
+        render[0].run();
+
+        LinearLayout actions = endAlignedActions();
+        TextView clear = actionLabel("Clear all", false);
+        clear.setOnClickListener(view -> showConfirmationPage(
+                "Clear saved sorts?",
+                "Community-specific sort choices will be removed.",
+                "Clear",
+                () -> {
+                    invokeInstance(manager, "c");
+                    render[0].run();
+                }
+        ));
+        actions.addView(clear, wrapParams());
+        content.addView(actions, matchWrapParams());
+    }
+
+    private void showSavedSearchesEditor() {
+        Object model = savedSearchesViewModel();
+        if (model == InvocationFailure.INSTANCE) {
+            showUnavailable();
+            return;
+        }
+        EditorPage page = openEditorPage("Saved searches");
+        LinearLayout content = page.content;
+
+        LinearLayout list = new LinearLayout(materialContext());
+        list.setOrientation(LinearLayout.VERTICAL);
+        content.addView(list, matchWrapParams());
+
+        SavedSearchRenderer renderer = values -> {
+            if (!page.isShowing()) {
+                return;
+            }
+            renderSavedSearches(list, model, values);
+        };
+        Object liveData = invokeInstance(model, "g");
+        Object current = invokeInstance(liveData, "e");
+        if (current instanceof List) {
+            renderer.render((List<?>) current);
+        } else {
+            renderer.render(Collections.emptyList());
+        }
+        observeSavedSearches(liveData, renderer);
+
+        LinearLayout actions = endAlignedActions();
+        TextView add = actionLabel("Add saved search", true);
+        add.setOnClickListener(view -> showSavedSearchEditor(
+                model,
+                null
+        ));
+        actions.addView(add, wrapParams());
+        content.addView(actions, matchWrapParams());
+    }
+
+    private Object savedSearchesViewModel() {
+        Activity activity = hostActivity();
+        if (activity == null) {
+            return InvocationFailure.INSTANCE;
+        }
+        try {
+            Object factory = invokeStatic(
+                    "hc.d",
+                    "e",
+                    new Class<?>[]{Context.class},
+                    new Object[]{activity}
+            );
+            if (factory == InvocationFailure.INSTANCE) {
+                return InvocationFailure.INSTANCE;
+            }
+            Class<?> ownerType = Class.forName("androidx.lifecycle.r0");
+            Class<?> factoryType = Class.forName("androidx.lifecycle.n0$b");
+            Class<?> providerType = Class.forName("androidx.lifecycle.n0");
+            Object provider = providerType
+                    .getConstructor(ownerType, factoryType)
+                    .newInstance(activity, factory);
+            Method get = providerType.getMethod("a", Class.class);
+            return get.invoke(provider, Class.forName("hc.i"));
+        } catch (Throwable throwable) {
+            return InvocationFailure.INSTANCE;
+        }
+    }
+
+    private void observeSavedSearches(
+            Object liveData,
+            SavedSearchRenderer renderer
+    ) {
+        Activity activity = hostActivity();
+        if (activity == null || liveData == InvocationFailure.INSTANCE) {
+            return;
+        }
+        try {
+            Class<?> ownerType = Class.forName("androidx.lifecycle.q");
+            Class<?> observerType = Class.forName("androidx.lifecycle.y");
+            savedSearchObserver = Proxy.newProxyInstance(
+                    observerType.getClassLoader(),
+                    new Class<?>[]{observerType},
+                    (proxy, method, arguments) -> {
+                        if ("a".equals(method.getName())
+                                && arguments != null
+                                && arguments.length == 1
+                                && arguments[0] instanceof List) {
+                            List<?> values = new ArrayList<>(
+                                    (List<?>) arguments[0]
+                            );
+                            activity.runOnUiThread(
+                                    () -> renderer.render(values)
+                            );
+                        }
+                        return null;
+                    }
+            );
+            Method observe = liveData.getClass().getMethod(
+                    "h",
+                    ownerType,
+                    observerType
+            );
+            observe.invoke(liveData, activity, savedSearchObserver);
+        } catch (Throwable ignored) {
+            savedSearchObserver = null;
+        }
+    }
+
+    private void renderSavedSearches(
+            LinearLayout list,
+            Object model,
+            List<?> values
+    ) {
+        list.removeAllViews();
+        if (values.isEmpty()) {
+            TextView empty = textView(
+                    "No saved searches yet.",
+                    15,
+                    tokens.textSecondary
+            );
+            empty.setPadding(dp(8), dp(16), dp(8), dp(16));
+            list.addView(empty, matchWrapParams());
+            return;
+        }
+        LinearLayout group = addGroup(list);
+        for (Object entity : values) {
+            String name = stringField(entity, "b");
+            String query = stringField(entity, "e");
+            if (TextUtils.isEmpty(name)) {
+                name = query;
+            }
+            String scope = stringField(entity, "c");
+            String summary = TextUtils.isEmpty(scope)
+                    ? query
+                    : query + "  ·  r/" + scope;
+            LinearLayout row = baseRow();
+            addLabels(row, name, summary);
+            TextView remove = actionLabel("Remove", false);
+            remove.setOnClickListener(view -> deleteSavedSearch(
+                    model,
+                    entity
+            ));
+            row.addView(remove, wrapParams());
+            row.setOnClickListener(view -> showSavedSearchEditor(
+                    model,
+                    entity
+            ));
+            addGroupedRow(group, row);
+        }
+    }
+
+    private void deleteSavedSearch(Object model, Object entity) {
+        try {
+            Class<?> entityType = Class.forName("hc.e");
+            if (invokeInstance(
+                    model,
+                    "f",
+                    new Class<?>[]{entityType},
+                    new Object[]{entity}
+            ) == InvocationFailure.INSTANCE) {
+                showUnavailable();
+            }
+        } catch (Throwable throwable) {
+            showUnavailable();
+        }
+    }
+
+    private void showSavedSearchEditor(Object model, Object existing) {
+        SearchDraft draft = searchDraft(existing);
+        EditorPage page = openEditorPage(
+                existing == null ? "Add saved search" : "Edit saved search"
+        );
+        LinearLayout content = page.content;
+
+        EditText name = addEditorInput(
+                content,
+                "Name (optional)",
+                draft.name,
+                4
+        );
+        EditText query = addEditorInput(
+                content,
+                "Search query",
+                draft.query,
+                12
+        );
+        EditText community = addEditorInput(
+                content,
+                "Community (optional)",
+                draft.community,
+                12
+        );
+
+        addSpace(content, 18);
+        LinearLayout choices = addGroup(content);
+        LinearLayout sortRow = baseRow();
+        TextView sortSummary = addLabels(
+                sortRow,
+                "Sort",
+                searchSortLabel(draft.sort)
+        );
+        addChevron(sortRow);
+        sortRow.setOnClickListener(view -> showValueChoice(
+                "Sort",
+                new String[]{"Relevance", "New", "Top", "Hot", "Comments"},
+                new String[]{"relevance", "new", "top", "hot", "comments"},
+                draft.sort,
+                value -> {
+                    draft.sort = value;
+                    sortSummary.setText(searchSortLabel(value));
+                }
+        ));
+        addGroupedRow(choices, sortRow);
+
+        LinearLayout periodRow = baseRow();
+        TextView periodSummary = addLabels(
+                periodRow,
+                "Time period",
+                searchPeriodLabel(draft.period)
+        );
+        addChevron(periodRow);
+        periodRow.setOnClickListener(view -> showValueChoice(
+                "Time period",
+                new String[]{"Hour", "Day", "Week", "Month", "Year", "All"},
+                new String[]{"hour", "day", "week", "month", "year", "all"},
+                draft.period,
+                value -> {
+                    draft.period = value;
+                    periodSummary.setText(searchPeriodLabel(value));
+                }
+        ));
+        addGroupedRow(choices, periodRow);
+
+        LinearLayout actions = endAlignedActions();
+        TextView cancel = actionLabel("Cancel", false);
+        cancel.setOnClickListener(view -> page.dismiss());
+        actions.addView(cancel, wrapParams());
+        TextView save = actionLabel("Save", true);
+        LinearLayout.LayoutParams saveParams = wrapParams();
+        saveParams.setMarginStart(dp(8));
+        actions.addView(save, saveParams);
+        save.setOnClickListener(view -> {
+            draft.name = name.getText().toString().trim();
+            draft.query = query.getText().toString().trim();
+            String previousCommunity = draft.community;
+            draft.community = community.getText().toString().trim();
+            if (!TextUtils.equals(previousCommunity, draft.community)) {
+                draft.scopeId = "";
+            }
+            if (TextUtils.isEmpty(draft.query)) {
+                query.setError("A search query is required");
+                return;
+            }
+            if (saveSavedSearch(model, existing, draft)) {
+                page.dismiss();
+            } else {
+                showUnavailable();
+            }
+        });
+        content.addView(actions, matchWrapParams());
+    }
+
+    private SearchDraft searchDraft(Object entity) {
+        SearchDraft draft = new SearchDraft();
+        if (entity == null) {
+            int sortIndex = integerPreference(
+                    "pref_default_search_sorting",
+                    0
+            );
+            int periodIndex = integerPreference(
+                    "pref_default_search_period",
+                    5
+            );
+            String[] sorts = new String[]{
+                    "relevance", "new", "top", "hot", "comments"
+            };
+            String[] periods = new String[]{
+                    "hour", "day", "week", "month", "year", "all"
+            };
+            draft.sort = sorts[Math.max(0, Math.min(sortIndex, 4))];
+            draft.period = periods[Math.max(0, Math.min(periodIndex, 5))];
+            return draft;
+        }
+        draft.id = intField(entity, "a", 0);
+        draft.name = stringField(entity, "b");
+        draft.community = stringField(entity, "c");
+        draft.scopeId = stringField(entity, "d");
+        draft.query = stringField(entity, "e");
+        draft.sort = stringField(entity, "f");
+        draft.period = stringField(entity, "g");
+        if (TextUtils.isEmpty(draft.sort)) {
+            draft.sort = "relevance";
+        }
+        if (TextUtils.isEmpty(draft.period)) {
+            draft.period = "all";
+        }
+        return draft;
+    }
+
+    private boolean saveSavedSearch(
+            Object model,
+            Object existing,
+            SearchDraft draft
+    ) {
+        try {
+            Class<?> entityType = Class.forName("hc.e");
+            Object entity = entityType.getConstructor().newInstance();
+            setField(entity, "a", draft.id);
+            setField(
+                    entity,
+                    "b",
+                    TextUtils.isEmpty(draft.name) ? draft.query : draft.name
+            );
+            setField(entity, "c", draft.community);
+            setField(entity, "d", draft.scopeId);
+            setField(entity, "e", draft.query);
+            setField(entity, "f", draft.sort.toLowerCase());
+            setField(entity, "g", draft.period.toLowerCase());
+            String method = existing == null ? "h" : "i";
+            return invokeInstance(
+                    model,
+                    method,
+                    new Class<?>[]{entityType},
+                    new Object[]{entity}
+            ) != InvocationFailure.INSTANCE;
+        } catch (Throwable throwable) {
+            return false;
+        }
+    }
+
+    private int integerPreference(String key, int fallback) {
+        String value = preferences.getString(key, String.valueOf(fallback));
+        try {
+            return Integer.parseInt(value);
+        } catch (NumberFormatException ignored) {
+            return fallback;
+        }
+    }
+
+    private String searchSortLabel(String value) {
+        if ("new".equals(value)) return "New";
+        if ("top".equals(value)) return "Top";
+        if ("hot".equals(value)) return "Hot";
+        if ("comments".equals(value)) return "Comments";
+        return "Relevance";
+    }
+
+    private String searchPeriodLabel(String value) {
+        if ("hour".equals(value)) return "Hour";
+        if ("day".equals(value)) return "Day";
+        if ("week".equals(value)) return "Week";
+        if ("month".equals(value)) return "Month";
+        if ("year".equals(value)) return "Year";
+        return "All";
+    }
+
+    private void showValueChoice(
+            String title,
+            String[] labels,
+            String[] values,
+            String current,
+            ValueConsumer consumer
+    ) {
+        EditorPage page = openEditorPage(title);
+        LinearLayout group = addGroup(page.content);
+        for (int index = 0; index < labels.length; index++) {
+            LinearLayout option = materialChoiceRow(
+                    labels[index],
+                    "",
+                    TextUtils.equals(values[index], current)
+            );
+            final String value = values[index];
+            option.setOnClickListener(view -> {
+                consumer.accept(value);
+                page.dismiss();
+            });
+            addGroupedRow(group, option);
+        }
+    }
+
+    private void showSynccitEditor() {
+        Context context = requireContext();
+        EditorPage page = openEditorPage("Configure Synccit");
+        LinearLayout content = page.content;
+
+        TextView explanation = textView(
+                "Synchronize read posts between supported Reddit clients. "
+                        + "Credentials are stored in Boost on this device.",
+                14,
+                tokens.textSecondary
+        );
+        explanation.setLineSpacing(0, 1.08f);
+        content.addView(explanation, spacedMatchWrapParams(4));
+
+        synccitUsernameInput = addEditorInput(
+                content,
+                "Synccit username",
+                settingsString("k4"),
+                14
+        );
+        synccitAuthInput = addEditorInput(
+                content,
+                "Device auth token",
+                settingsString("i4"),
+                12
+        );
+
+        addSpace(content, 18);
+        LinearLayout registration = addGroup(content);
+        LinearLayout account = baseRow();
+        addLabels(
+                account,
+                "Create Synccit account",
+                "Register a new account through Boost"
+        );
+        addChevron(account);
+        account.setOnClickListener(view -> startSynccitCreate(true));
+        addGroupedRow(registration, account);
+
+        LinearLayout device = baseRow();
+        addLabels(
+                device,
+                "Add this device",
+                "Generate a device auth token for the username above"
+        );
+        addChevron(device);
+        device.setOnClickListener(view -> startSynccitCreate(false));
+        addGroupedRow(registration, device);
+
+        LinearLayout actions = endAlignedActions();
+        TextView disconnect = actionLabel("Disconnect", false);
+        disconnect.setOnClickListener(view -> showConfirmationPage(
+                "Disconnect Synccit?",
+                "The saved Synccit username and token will be removed.",
+                "Disconnect",
+                () -> {
+                    saveSynccitCredentials("", "");
+                    synccitUsernameInput.setText("");
+                    synccitAuthInput.setText("");
+                }
+        ));
+        actions.addView(disconnect, wrapParams());
+
+        TextView save = actionLabel("Save", true);
+        LinearLayout.LayoutParams saveParams = wrapParams();
+        saveParams.setMarginStart(dp(8));
+        actions.addView(save, saveParams);
+        save.setOnClickListener(view -> {
+            saveSynccitCredentials(
+                    synccitUsernameInput.getText().toString().trim(),
+                    synccitAuthInput.getText().toString().trim()
+            );
+            Toast.makeText(context, "Synccit settings saved", Toast.LENGTH_SHORT)
+                    .show();
+            page.dismiss();
+        });
+        content.addView(actions, matchWrapParams());
+    }
+
+    private void startSynccitCreate(boolean accountMode) {
+        try {
+            Class<?> type = Class.forName(
+                    "com.rubenmayayo.reddit.ui.synccit."
+                            + "SynccitCreateActivity"
+            );
+            Intent intent = new Intent(requireContext(), type);
+            int requestCode;
+            if (accountMode) {
+                intent.putExtra("account_mode", true);
+                requestCode = REQUEST_SYNCCIT_ACCOUNT;
+            } else {
+                String username = synccitUsernameInput == null
+                        ? settingsString("k4")
+                        : synccitUsernameInput.getText().toString().trim();
+                intent.putExtra("username", username);
+                requestCode = REQUEST_SYNCCIT_DEVICE;
+            }
+            startActivityForResult(intent, requestCode);
+        } catch (Throwable throwable) {
+            showUnavailable();
+        }
+    }
+
+    private void saveSynccitCredentials(String username, String auth) {
+        Object settingsObject = invokeStatic("id.b", "v0");
+        invokeInstance(
+                settingsObject,
+                "y7",
+                new Class<?>[]{String.class},
+                new Object[]{username}
+        );
+        invokeInstance(
+                settingsObject,
+                "x7",
+                new Class<?>[]{String.class},
+                new Object[]{auth}
+        );
+    }
+
+    private String settingsString(String method) {
+        Object settingsObject = invokeStatic("id.b", "v0");
+        return stringResult(invokeInstance(settingsObject, method));
+    }
+
+    private void showFieldSearchHelp() {
+        EditorPage page = openEditorPage("Field search help");
+        LinearLayout content = page.content;
+        LinearLayout group = addGroup(content);
+        TextView help = textView(
+                "Use a field followed by a colon:\n\n"
+                        + "author:username\n"
+                        + "subreddit:android\n"
+                        + "title:keyword\n"
+                        + "selftext:keyword\n"
+                        + "url:example.com\n"
+                        + "site:example.com\n"
+                        + "self:yes  or  self:no\n"
+                        + "nsfw:yes  or  nsfw:no\n\n"
+                        + "Combine terms with AND, OR and NOT. "
+                        + "Use parentheses to group expressions.",
+                15,
+                tokens.textPrimary
+        );
+        help.setTextIsSelectable(true);
+        help.setLineSpacing(0, 1.12f);
+        help.setPadding(dp(18), dp(16), dp(18), dp(18));
+        group.addView(help, matchWrapParams());
+    }
+
+    private boolean notificationAccessGranted() {
+        String enabled = Settings.Secure.getString(
+                requireContext().getContentResolver(),
+                "enabled_notification_listeners"
+        );
+        if (TextUtils.isEmpty(enabled)) {
+            return false;
+        }
+        String packageName = requireContext().getPackageName();
+        for (String flat : enabled.split(":")) {
+            ComponentName component = ComponentName.unflattenFromString(flat);
+            if (component != null
+                    && packageName.equals(component.getPackageName())) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private void reconcileNotificationAccess() {
+        boolean pushEnabled = preferences.getBoolean(
+                "pref_check_messages_push",
+                false
+        );
+        boolean accessGranted = notificationAccessGranted();
+        if (pushEnabled == accessGranted) {
+            return;
+        }
+        String message = pushEnabled
+                ? "Reddit push needs Android notification access. "
+                        + "Enable access for Boost on the next screen."
+                : "Boost still has Android notification access. "
+                        + "You can revoke it on the next screen.";
+        showConfirmationPage(
+                "Reddit push",
+                message,
+                "Open settings",
+                () -> {
+                    try {
+                        startActivity(new Intent(
+                                Settings.ACTION_NOTIFICATION_LISTENER_SETTINGS
+                        ));
+                    } catch (Exception exception) {
+                        showUnavailable();
+                    }
+                }
+        );
+    }
+
+    private void confirmDelete(Control control) {
+        showConfirmationPage(
+                control.title,
+                "Delete the selected local history data?",
+                "Delete",
+                () -> {
+                    deleteForKey(control.key);
+                    Toast.makeText(
+                            requireContext(),
+                            "Deleted",
+                            Toast.LENGTH_SHORT
+                    ).show();
+                }
+        );
+    }
+
+    private void deleteForKey(String key) {
+        if ("pref_history_delete_read".equals(key)) {
+            factoryCall("he.a0", "b", "a");
+        } else if ("pref_recent_posts_delete".equals(key)) {
+            factoryCall("he.z", "e", "c");
+        } else if ("pref_history_delete".equals(key)) {
+            factoryCall("he.d0", "d", "c");
+        } else if ("pref_searches_delete".equals(key)) {
+            factoryCall("ld.c", "a", "clear");
+        } else if ("pref_all_delete".equals(key)) {
+            factoryCall("he.z", "e", "c");
+            factoryCall("he.d0", "d", "c");
+            factoryCall("ld.c", "a", "clear");
+        }
+    }
+
+    private void applySideEffects(String key) {
+        // These are Boost's existing invalidation flags. Setting a broader
+        // superset is safe and keeps changes visible without a hidden
+        // PreferenceFragment listener.
+        setBoostStaticBoolean("e");
+        setBoostStaticBoolean("f");
+        setBoostStaticBoolean("h");
+        setBoostStaticBoolean("i");
+        setBoostStaticBoolean("j");
+
+        if ("pref_subscriptions_drawer".equals(key)
+                || "pref_subscriptions_drawer_show_icon".equals(key)
+                || "pref_subscriptions_only_casual".equals(key)) {
+            invokeStatic(
+                    "he.h0",
+                    "m0",
+                    new Class<?>[]{Context.class},
+                    new Object[]{requireContext()}
+            );
+        }
+        if ("pref_check_messages".equals(key)) {
+            String method = preferences.getBoolean(key, true) ? "b" : "c";
+            invokeStatic(
+                    "pe.b",
+                    method,
+                    new Class<?>[]{Context.class},
+                    new Object[]{requireContext()}
+            );
+        } else if ("pref_check_messages_interval".equals(key)) {
+            invokeStatic(
+                    "pe.b",
+                    "b",
+                    new Class<?>[]{Context.class},
+                    new Object[]{requireContext()}
+            );
+        } else if ("pref_check_messages_push".equals(key)) {
+            reconcileNotificationAccess();
+        } else if ("pref_search_show_trending_searches".equals(key)
+                && preferences.getBoolean(key, false)) {
+            invokeStatic(
+                    "com.rubenmayayo.reddit.work.trending.TrendingWorker",
+                    "a",
+                    new Class<?>[]{Context.class, int.class},
+                    new Object[]{requireContext(), 2}
+            );
+        } else if ("pref_cache_max_size".equals(key)) {
+            invokeStatic(
+                    "qb.b",
+                    "d",
+                    new Class<?>[]{Context.class},
+                    new Object[]{requireContext()}
+            );
+        }
+    }
+
+    private void syncRows() {
+        if (preferences == null) {
+            return;
+        }
+        for (Binding binding : bindings) {
+            Control control = binding.control;
+            if (binding.toggle != null) {
+                boolean checked = preferences.getBoolean(
+                        control.key,
+                        booleanDefault(control)
+                );
+                binding.toggle.setCheckedSilently(checked);
+                binding.summary.setText(toggleSummary(control, checked));
+            } else if (isChoice(control)) {
+                binding.summary.setText(selectedTitle(control));
+            } else if (binding.seekBar != null) {
+                int value = preferences.getInt(
+                        control.key,
+                        intDefault(control)
+                );
+                binding.seekBar.setProgress(value - control.min);
+                binding.summary.setText(String.valueOf(value));
+            }
+        }
+        updateDependencies();
+    }
+
+    private void updateDependencies() {
+        for (Binding binding : bindings) {
+            Control control = binding.control;
+            boolean enabled = true;
+            if (!TextUtils.isEmpty(control.dependency)) {
+                Control parent = controlsByKey.get(control.dependency);
+                if (parent != null && isToggle(parent)) {
+                    boolean parentValue = preferences.getBoolean(
+                            parent.key,
+                            booleanDefault(parent)
+                    );
+                    enabled = parent.disableDependentsState
+                            ? !parentValue
+                            : parentValue;
+                }
+            }
+            if ("pref_video_quality_min".equals(control.key)
+                    || "pref_video_quality_max".equals(control.key)) {
+                enabled = dataVideoQualityControlEnabled(control.key);
+            }
+            setRowEnabled(binding.row, enabled);
+        }
+    }
+
+    private void setRowEnabled(View row, boolean enabled) {
+        row.setEnabled(enabled);
+        row.setAlpha(enabled ? 1.0f : 0.44f);
+        if (row instanceof ViewGroup) {
+            setChildrenEnabled((ViewGroup) row, enabled);
+        }
+    }
+
+    private void setChildrenEnabled(ViewGroup group, boolean enabled) {
+        for (int index = 0; index < group.getChildCount(); index++) {
+            View child = group.getChildAt(index);
+            child.setEnabled(enabled);
+            if (child instanceof ViewGroup) {
+                setChildrenEnabled((ViewGroup) child, enabled);
+            }
+        }
+    }
+
+    private String actionSummary(Control control) {
+        String summary = control.summary;
+        if (TextUtils.isEmpty(summary) && control.tag.startsWith("Delete")) {
+            summary = "Remove local history data";
+        }
+        if (TextUtils.isEmpty(summary)
+                && "ColorPatternPreference".equals(control.tag)) {
+            summary = "Choose comment thread colors";
+        }
+        return displayActionSummary(control.key, summary, control.tag);
+    }
+
+    private String toggleSummary(Control control, boolean checked) {
+        String summary = control.summary;
+        if (checked && !TextUtils.isEmpty(control.summaryOn)) {
+            summary = control.summaryOn;
+        } else if (!checked && !TextUtils.isEmpty(control.summaryOff)) {
+            summary = control.summaryOff;
+        }
+        return displaySummary(control.key, summary);
+    }
+
+    private String selectedTitle(Control control) {
+        String value = preferences.getString(
+                control.key,
+                stringDefault(control)
+        );
+        for (int index = 0; index < control.entryValues.length; index++) {
+            if (TextUtils.equals(value, control.entryValues[index])) {
+                return control.entries[index];
+            }
+        }
+        return value;
+    }
+
+    private boolean booleanDefault(Control control) {
+        return "true".equalsIgnoreCase(control.defaultValue);
+    }
+
+    private int intDefault(Control control) {
+        try {
+            return Integer.parseInt(control.defaultValue);
+        } catch (NumberFormatException ignored) {
+            return control.min;
+        }
+    }
+
+    private String stringDefault(Control control) {
+        return TextUtils.isEmpty(control.defaultValue)
+                ? ""
+                : control.defaultValue;
+    }
+
+    private boolean isToggle(Control control) {
+        return "CheckBoxPreference".equals(control.tag)
+                || "SwitchPreference".equals(control.tag)
+                || "SwitchPreferenceCompat".equals(control.tag);
+    }
+
+    private boolean isChoice(Control control) {
+        return "ListPreference".equals(control.tag)
+                || "PreviewSizePreference".equals(control.tag)
+                || "PreviewAlignmentPreference".equals(control.tag)
+                || "MediaTapActionPreference".equals(control.tag);
+    }
+
+    private void configureMorpheControl(Control control) {
+        if ("PreviewSizePreference".equals(control.tag)) {
+            control.entries = new String[]{"Compact", "Balanced", "Large"};
+            control.entryValues = new String[]{"compact", "balanced", "large"};
+        } else if ("PreviewAlignmentPreference".equals(control.tag)) {
+            control.entries = new String[]{"Left", "Center", "Right"};
+            control.entryValues = new String[]{"left", "center", "right"};
+        } else if ("MediaTapActionPreference".equals(control.tag)) {
+            control.entries = new String[]{
+                    "Image viewer",
+                    "Video viewer",
+                    "Browser",
+                    "Disabled"
+            };
+            control.entryValues = new String[]{
+                    "image_viewer",
+                    "video_viewer",
+                    "browser",
+                    "disabled"
+            };
+        }
+    }
+
+    private void openNotificationSettings() {
+        try {
+            Intent intent = new Intent(Settings.ACTION_APP_NOTIFICATION_SETTINGS);
+            intent.putExtra(Settings.EXTRA_APP_PACKAGE, requireContext().getPackageName());
+            startActivity(intent);
+        } catch (Exception exception) {
+            showUnavailable();
+        }
+    }
+
+    private void openUrl(String url) {
+        try {
+            startActivity(new Intent(Intent.ACTION_VIEW, Uri.parse(url)));
+        } catch (Exception exception) {
+            showUnavailable();
+        }
+    }
+
+    private void openEmail(String address) {
+        try {
+            Uri uri = Uri.parse("mailto:" + address + "?subject=Boost");
+            startActivity(new Intent(Intent.ACTION_VIEW, uri));
+        } catch (Exception exception) {
+            showUnavailable();
+        }
+    }
+
+    private void clearMediaCache() {
+        Object result = invokeStatic(
+                "qb.a",
+                "a",
+                new Class<?>[]{Context.class},
+                new Object[]{requireContext()}
+        );
+        if (result == InvocationFailure.INSTANCE) {
+            showUnavailable();
+            return;
+        }
+        Toast.makeText(
+                requireContext(),
+                "Cache cleared",
+                Toast.LENGTH_SHORT
+        ).show();
+    }
+
+    private void confirmGdprRevocation() {
+        showConfirmationPage(
+                "Revoke GDPR consent",
+                "Withdraw the stored consent choice and reopen the privacy consent flow?",
+                "Revoke",
+                this::revokeGdprConsent
+        );
+    }
+
+    private void revokeGdprConsent() {
+        Activity activity = hostActivity();
+        if (activity == null) {
+            showUnavailable();
+            return;
+        }
+        try {
+            Class<?> type = Class.forName(
+                    "com.rubenmayayo.reddit.ui.preferences.v2.custom."
+                            + "RevokeGDPRConstentPreferenceDialogFragmentCompat"
+            );
+            Object target = type.getConstructor().newInstance();
+            Method method = type.getDeclaredMethod(
+                    "checkConsent",
+                    Activity.class
+            );
+            method.setAccessible(true);
+            method.invoke(target, activity);
+        } catch (Throwable throwable) {
+            showUnavailable();
+        }
+    }
+
+    private boolean dataVideoQualityControlEnabled(String key) {
+        String mode = preferences.getString("pref_video_quality", "0");
+        boolean reduceMobile = preferences.getBoolean(
+                "pref_reduce_mobile",
+                true
+        );
+        boolean reduceWifi = preferences.getBoolean(
+                "pref_reduce_wifi",
+                false
+        );
+        if ("0".equals(mode)) {
+            return "pref_video_quality_min".equals(key);
+        }
+        if ("1".equals(mode)) {
+            return "pref_video_quality_max".equals(key);
+        }
+        if ("2".equals(mode)) {
+            if ("pref_video_quality_min".equals(key)) {
+                return reduceMobile || reduceWifi;
+            }
+            return !reduceMobile || !reduceWifi;
+        }
+        return true;
+    }
+
+    private void showVersion() {
+        String version = "Unknown";
+        try {
+            PackageInfo info = requireContext()
+                    .getPackageManager()
+                    .getPackageInfo(requireContext().getPackageName(), 0);
+            version = info.versionName;
+        } catch (Exception ignored) {
+        }
+        EditorPage page = openEditorPage("Boost version");
+        LinearLayout group = addGroup(page.content);
+        TextView value = textView(version, 18, tokens.textPrimary);
+        value.setPadding(dp(18), dp(16), dp(18), dp(18));
+        group.addView(value, matchWrapParams());
+    }
+
+    private void resetTips() {
+        factoryCall("he.f", "b", "f");
+        Toast.makeText(
+                requireContext(),
+                "Tips reset",
+                Toast.LENGTH_SHORT
+        ).show();
+    }
+
+    private void invokeActivityHelper(
+            String method,
+            Class<?> parameterType,
+            Object value
+    ) {
+        invokeActivityHelper(
+                method,
+                new Class<?>[]{parameterType},
+                new Object[]{value}
+        );
+    }
+
+    private void invokeActivityHelper(
+            String method,
+            Class<?>[] parameterTypes,
+            Object[] values
+    ) {
+        Object result = invokeStatic(
+                "com.rubenmayayo.reddit.ui.activities.i",
+                method,
+                parameterTypes,
+                values
+        );
+        if (result == InvocationFailure.INSTANCE) {
+            showUnavailable();
+        }
+    }
+
+    private void factoryCall(
+            String className,
+            String factory,
+            String method
+    ) {
+        try {
+            Object target = invokeStatic(className, factory);
+            Method action = target.getClass().getMethod(method);
+            action.invoke(target);
+        } catch (Throwable throwable) {
+            showUnavailable();
+        }
+    }
+
+    private Object invokeStatic(String className, String method) {
+        return invokeStatic(className, method, new Class<?>[0], new Object[0]);
+    }
+
+    private Object invokeStatic(
+            String className,
+            String method,
+            Class<?>[] parameterTypes,
+            Object[] values
+    ) {
+        try {
+            Class<?> type = Class.forName(className);
+            Method target = type.getMethod(method, parameterTypes);
+            return target.invoke(null, values);
+        } catch (Throwable throwable) {
+            return InvocationFailure.INSTANCE;
+        }
+    }
+
+    private Object invokeInstance(Object target, String method) {
+        return invokeInstance(
+                target,
+                method,
+                new Class<?>[0],
+                new Object[0]
+        );
+    }
+
+    private Object invokeInstance(
+            Object target,
+            String method,
+            Class<?>[] parameterTypes,
+            Object[] values
+    ) {
+        if (target == null || target == InvocationFailure.INSTANCE) {
+            return InvocationFailure.INSTANCE;
+        }
+        try {
+            Method action = target.getClass().getMethod(
+                    method,
+                    parameterTypes
+            );
+            return action.invoke(target, values);
+        } catch (Throwable throwable) {
+            return InvocationFailure.INSTANCE;
+        }
+    }
+
+    private Object newInstance(
+            String className,
+            Class<?>[] parameterTypes,
+            Object[] values
+    ) {
+        try {
+            Class<?> type = Class.forName(className);
+            return type.getConstructor(parameterTypes).newInstance(values);
+        } catch (Throwable throwable) {
+            return InvocationFailure.INSTANCE;
+        }
+    }
+
+    private String stringResult(Object value) {
+        return value instanceof String ? (String) value : "";
+    }
+
+    private int intResult(Object value, int fallback) {
+        return value instanceof Number
+                ? ((Number) value).intValue()
+                : fallback;
+    }
+
+    private String stringField(Object target, String name) {
+        Object value = fieldValue(target, name);
+        return value instanceof String ? (String) value : "";
+    }
+
+    private int intField(Object target, String name, int fallback) {
+        return intResult(fieldValue(target, name), fallback);
+    }
+
+    private Object fieldValue(Object target, String name) {
+        if (target == null) {
+            return null;
+        }
+        try {
+            Field field = target.getClass().getDeclaredField(name);
+            field.setAccessible(true);
+            return field.get(target);
+        } catch (Throwable throwable) {
+            return null;
+        }
+    }
+
+    private void setField(Object target, String name, Object value)
+            throws ReflectiveOperationException {
+        Field field = target.getClass().getDeclaredField(name);
+        field.setAccessible(true);
+        field.set(target, value);
+    }
+
+    private void setBoostStaticBoolean(String fieldName) {
+        try {
+            Class<?> settingsClass = Class.forName("id.b");
+            Field field = settingsClass.getDeclaredField(fieldName);
+            field.setAccessible(true);
+            field.setBoolean(null, true);
+        } catch (Throwable ignored) {
+        }
+    }
+
+    private void styleHost() {
+        Activity activity = hostActivity();
+        if (activity == null || tokens == null) {
+            return;
+        }
+        activity.setTitle(editorPages.isEmpty()
+                ? pageTitle
+                : editorPages.get(editorPages.size() - 1).title);
+        BoostSystemBarInsetsFix.applyMorpheSettingsV4SystemBars(
+                activity,
+                tokens.background,
+                tokens.dark
+        );
+        int toolbarId = MorpheSettingsV4Catalog.resourceId(
+                activity,
+                "id",
+                "toolbar"
+        );
+        View toolbar = activity.findViewById(toolbarId);
+        if (toolbar != null) {
+            toolbar.setBackgroundColor(tokens.background);
+            toolbar.setElevation(0);
+        }
+    }
+
+    private Activity hostActivity() {
+        Context context = getContext();
+        return context instanceof Activity ? (Activity) context : null;
+    }
+
+    private LinearLayout addGroup(LinearLayout parent) {
+        LinearLayout group = useAndroidSettingsGuidanceRows()
+                ? MorpheSettingsV14Ui.standardList(requireContext())
+                : MorpheSettingsV14Ui.group(requireContext());
+        parent.addView(group, matchWrapParams());
+        return group;
+    }
+
+    private LinearLayout baseRow() {
+        return MorpheSettingsV14Ui.baseRow(requireContext(), tokens);
+    }
+
+    private LinearLayout baseRow(boolean hasSupportingText) {
+        if (useAndroidSettingsGuidanceRows()) {
+            return MorpheSettingsV14Ui.standardListRow(
+                    requireContext(),
+                    tokens,
+                    hasSupportingText
+            );
+        }
+        return baseRow();
+    }
+
+    private MorpheSettingsV14Ui.ChoiceRow materialChoiceRow(
+            String title,
+            String summary,
+            boolean selected
+    ) {
+        return MorpheSettingsV14Ui.choiceRow(
+                requireContext(),
+                tokens,
+                title,
+                summary,
+                selected
+        );
+    }
+
+    private TextView addLabels(
+            LinearLayout row,
+            String titleValue,
+            String summaryValue
+    ) {
+        LinearLayout labels = new LinearLayout(requireContext());
+        labels.setOrientation(LinearLayout.VERTICAL);
+        TextView title = textView(titleValue, 16, tokens.textPrimary);
+        labels.addView(title);
+
+        TextView summary = textView(
+                summaryValue,
+                14,
+                tokens.textSecondary
+        );
+        summary.setLineSpacing(0, 1.04f);
+        summary.setMaxLines(
+                useAndroidSettingsGuidanceRows() ? 2 : 4
+        );
+        summary.setVisibility(
+                TextUtils.isEmpty(summaryValue) ? View.GONE : View.VISIBLE
+        );
+        LinearLayout.LayoutParams summaryParams = wrapParams();
+        summaryParams.topMargin = dp(3);
+        labels.addView(summary, summaryParams);
+        row.addView(labels, labelsParams());
+        return summary;
+    }
+
+    private void addChevron(LinearLayout row) {
+        row.addView(MorpheSettingsV14Ui.chevron(
+                requireContext(),
+                tokens
+        ));
+    }
+
+    private void addGroupedRow(LinearLayout group, View row) {
+        if (useAndroidSettingsGuidanceRows()) {
+            MorpheSettingsV14Ui.addStandardListRow(group, row, tokens);
+            return;
+        }
+        MorpheSettingsV14Ui.addSegmentedRow(group, row, tokens);
+    }
+
+    private Context materialContext() {
+        return requireContext();
+    }
+
+    private EditorPage openEditorPage(String title) {
+        if (pageHost == null) {
+            throw new IllegalStateException("Settings page is not attached");
+        }
+        if (!editorPages.isEmpty()) {
+            editorPages.get(editorPages.size() - 1).view.setVisibility(
+                    View.GONE
+            );
+        } else if (settingsPage != null) {
+            settingsPage.setVisibility(View.GONE);
+        }
+
+        ScrollView scroll = new ScrollView(materialContext());
+        scroll.setFillViewport(true);
+        scroll.setClipToPadding(false);
+        scroll.setBackgroundColor(tokens.background);
+
+        LinearLayout content = new LinearLayout(materialContext());
+        content.setOrientation(LinearLayout.VERTICAL);
+        content.setPadding(dp(16), dp(10), dp(16), dp(36));
+        scroll.addView(content, new ScrollView.LayoutParams(
+                ViewGroup.LayoutParams.MATCH_PARENT,
+                ViewGroup.LayoutParams.WRAP_CONTENT
+        ));
+
+        EditorPage page = new EditorPage(title, scroll, content);
+        editorPages.add(page);
+        pageHost.addView(scroll, new FrameLayout.LayoutParams(
+                ViewGroup.LayoutParams.MATCH_PARENT,
+                ViewGroup.LayoutParams.MATCH_PARENT
+        ));
+        try {
+            pushEditorBackStackEntry();
+        } catch (Throwable throwable) {
+            removeTopEditorView();
+            throw new IllegalStateException(
+                    "Morphe V13 editor back-stack bridge failed",
+                    throwable
+            );
+        }
+        styleHost();
+        return page;
+    }
+
+    private void closeTopEditorPage() {
+        if (editorPages.isEmpty()) {
+            return;
+        }
+        if (!popEditorBackStackEntry()) {
+            throw new IllegalStateException(
+                    "Morphe V13 editor back-stack pop failed"
+            );
+        }
+        syncEditorPagesWithBackStack();
+    }
+
+    private void removeTopEditorView() {
+        if (editorPages.isEmpty()) {
+            return;
+        }
+        EditorPage page = editorPages.remove(editorPages.size() - 1);
+        if (pageHost != null) {
+            pageHost.removeView(page.view);
+        }
+        if (editorPages.isEmpty()) {
+            if (settingsPage != null) {
+                settingsPage.setVisibility(View.VISIBLE);
+            }
+            syncRows();
+        } else {
+            editorPages.get(editorPages.size() - 1).view.setVisibility(
+                    View.VISIBLE
+            );
+        }
+        styleHost();
+    }
+
+    private void ensureEditorBackStackBridge() throws Exception {
+        if (editorFragmentManager != null
+                && editorBackStackListener != null) {
+            return;
+        }
+        editorFragmentManager = getParentFragmentManager();
+        editorBackStackBaseCount = editorBackStackCount();
+
+        Method addListener = findBackStackListenerMethod();
+        Class<?> listenerType = addListener.getParameterTypes()[0];
+        if (!listenerType.isInterface()) {
+            throw new NoSuchMethodException(
+                    "Boost FragmentManager listener ABI unavailable"
+            );
+        }
+        editorBackStackListener = Proxy.newProxyInstance(
+                listenerType.getClassLoader(),
+                new Class<?>[]{listenerType},
+                (proxy, method, args) -> {
+                    if (method.getDeclaringClass() == Object.class) {
+                        if ("hashCode".equals(method.getName())) {
+                            return System.identityHashCode(proxy);
+                        }
+                        if ("equals".equals(method.getName())) {
+                            return proxy == args[0];
+                        }
+                        if ("toString".equals(method.getName())) {
+                            return EDITOR_BACK_STACK_MARKER;
+                        }
+                    }
+                    if ("onBackStackChanged".equals(method.getName())) {
+                        syncEditorPagesWithBackStack();
+                    }
+                    return null;
+                }
+        );
+        addListener.invoke(editorFragmentManager, editorBackStackListener);
+    }
+
+    private Method findBackStackListenerMethod()
+            throws NoSuchMethodException {
+        for (Method method
+                : editorFragmentManager.getClass().getMethods()) {
+            if (("addOnBackStackChangedListener".equals(method.getName())
+                    || "i".equals(method.getName()))
+                    && method.getParameterTypes().length == 1
+                    && method.getParameterTypes()[0].isInterface()) {
+                for (Method callback
+                        : method.getParameterTypes()[0].getMethods()) {
+                    if ("onBackStackChanged".equals(callback.getName())
+                            && callback.getParameterTypes().length == 0) {
+                        method.setAccessible(true);
+                        return method;
+                    }
+                }
+            }
+        }
+        throw new NoSuchMethodException(
+                "Boost FragmentManager back-stack listener unavailable"
+        );
+    }
+
+    private void pushEditorBackStackEntry() throws Exception {
+        ensureEditorBackStackBridge();
+        Object transaction = invokeRuntimeMethod(
+                editorFragmentManager,
+                "beginTransaction",
+                "n",
+                new Class<?>[0],
+                new Object[0]
+        );
+        String name = "morphe-v13-editor-" + (++editorBackStackSequence);
+        invokeRuntimeMethod(
+                transaction,
+                "addToBackStack",
+                "g",
+                new Class<?>[]{String.class},
+                new Object[]{name}
+        );
+        invokeRuntimeMethod(
+                transaction,
+                "commit",
+                "i",
+                new Class<?>[0],
+                new Object[0]
+        );
+    }
+
+    private boolean popEditorBackStackEntry() {
+        if (editorFragmentManager == null) {
+            return false;
+        }
+        try {
+            Object result = invokeRuntimeMethod(
+                    editorFragmentManager,
+                    "popBackStackImmediate",
+                    "Z0",
+                    new Class<?>[0],
+                    new Object[0]
+            );
+            return Boolean.TRUE.equals(result);
+        } catch (Throwable throwable) {
+            return false;
+        }
+    }
+
+    private void syncEditorPagesWithBackStack() {
+        if (editorFragmentManager == null
+                || editorBackStackBaseCount < 0) {
+            return;
+        }
+        try {
+            int depth = Math.max(
+                    0,
+                    editorBackStackCount() - editorBackStackBaseCount
+            );
+            while (editorPages.size() > depth) {
+                removeTopEditorView();
+            }
+        } catch (Throwable ignored) {
+        }
+    }
+
+    private int editorBackStackCount() throws Exception {
+        Object value = invokeRuntimeMethod(
+                editorFragmentManager,
+                "getBackStackEntryCount",
+                "n0",
+                new Class<?>[0],
+                new Object[0]
+        );
+        if (!(value instanceof Number)) {
+            throw new IllegalStateException(
+                    "Boost FragmentManager back-stack count unavailable"
+            );
+        }
+        return ((Number) value).intValue();
+    }
+
+    private Object invokeRuntimeMethod(
+            Object target,
+            String canonicalName,
+            String boostName,
+            Class<?>[] parameterTypes,
+            Object[] values
+    ) throws Exception {
+        Method method = findRuntimeMethod(
+                target,
+                canonicalName,
+                boostName,
+                parameterTypes.length,
+                parameterTypes
+        );
+        return method.invoke(target, values);
+    }
+
+    private Method findRuntimeMethod(
+            Object target,
+            String canonicalName,
+            String boostName,
+            int parameterCount,
+            Class<?>[] parameterTypes
+    ) throws NoSuchMethodException {
+        for (Method method : target.getClass().getMethods()) {
+            if ((!canonicalName.equals(method.getName())
+                    && !boostName.equals(method.getName()))
+                    || method.getParameterTypes().length != parameterCount) {
+                continue;
+            }
+            if (parameterTypes != null) {
+                Class<?>[] actual = method.getParameterTypes();
+                boolean matches = true;
+                for (int index = 0; index < actual.length; index++) {
+                    if (actual[index] != parameterTypes[index]) {
+                        matches = false;
+                        break;
+                    }
+                }
+                if (!matches) {
+                    continue;
+                }
+            }
+            method.setAccessible(true);
+            return method;
+        }
+        throw new NoSuchMethodException(
+                target.getClass().getName()
+                        + "." + canonicalName
+                        + "/" + boostName
+        );
+    }
+
+    private EditText addEditorInput(
+            LinearLayout parent,
+            String hint,
+            String value,
+            int topMarginDp
+    ) {
+        MorpheSettingsV14Ui.Field field = MorpheSettingsV14Ui.outlinedField(
+                materialContext(),
+                tokens,
+                hint,
+                value
+        );
+        EditText input = field.input;
+        input.setInputType(InputType.TYPE_CLASS_TEXT);
+
+        LinearLayout.LayoutParams params = matchWrapParams();
+        params.topMargin = dp(topMarginDp);
+        parent.addView(field.root, params);
+        return input;
+    }
+
+    private TextView actionLabel(String value, boolean filled) {
+        return MorpheSettingsV14Ui.action(
+                materialContext(),
+                tokens,
+                value,
+                filled
+        );
+    }
+
+    private LinearLayout endAlignedActions() {
+        LinearLayout actions = new LinearLayout(requireContext());
+        actions.setOrientation(LinearLayout.HORIZONTAL);
+        actions.setGravity(Gravity.END | Gravity.CENTER_VERTICAL);
+        actions.setPadding(0, dp(14), 0, 0);
+        return actions;
+    }
+
+    private LinearLayout.LayoutParams spacedMatchWrapParams(int topDp) {
+        LinearLayout.LayoutParams params = matchWrapParams();
+        params.topMargin = dp(topDp);
+        return params;
+    }
+
+    private void showConfirmationPage(
+            String title,
+            String message,
+            String confirmLabel,
+            Runnable confirmation
+    ) {
+        EditorPage page = openEditorPage(title);
+        TextView body = textView(message, 16, tokens.textPrimary);
+        body.setLineSpacing(0, 1.12f);
+        body.setPadding(dp(4), dp(12), dp(4), dp(12));
+        page.content.addView(body, matchWrapParams());
+
+        LinearLayout actions = endAlignedActions();
+        TextView cancel = actionLabel("Cancel", false);
+        cancel.setOnClickListener(view -> page.dismiss());
+        actions.addView(cancel, wrapParams());
+        TextView confirm = actionLabel(confirmLabel, true);
+        LinearLayout.LayoutParams confirmParams = wrapParams();
+        confirmParams.setMarginStart(dp(8));
+        actions.addView(confirm, confirmParams);
+        confirm.setOnClickListener(view -> {
+            confirmation.run();
+            page.dismiss();
+        });
+        page.content.addView(actions, matchWrapParams());
+    }
+
+    private final class EditorPage {
+        final String title;
+        final View view;
+        final LinearLayout content;
+
+        EditorPage(String title, View view, LinearLayout content) {
+            this.title = title;
+            this.view = view;
+            this.content = content;
+        }
+
+        boolean isShowing() {
+            return pageHost != null && view.getParent() == pageHost;
+        }
+
+        void dismiss() {
+            if (!editorPages.isEmpty()
+                    && editorPages.get(editorPages.size() - 1) == this) {
+                closeTopEditorPage();
+            }
+        }
+    }
+
+    private void hideMenuItem(Menu menu, String resourceName) {
+        int id = MorpheSettingsV4Catalog.resourceId(
+                requireContext(),
+                "id",
+                resourceName
+        );
+        if (id != 0) {
+            MenuItem item = menu.findItem(id);
+            if (item != null) {
+                item.setVisible(false);
+            }
+        }
+    }
+
+    private void showUnavailable() {
+        Toast.makeText(
+                requireContext(),
+                "This Boost setting is currently unavailable.",
+                Toast.LENGTH_SHORT
+        ).show();
+    }
+
+    private void addSectionLabel(LinearLayout parent, String value) {
+        parent.addView(MorpheSettingsV14Ui.sectionLabel(
+                requireContext(),
+                tokens,
+                value
+        ));
+    }
+
+    private TextView textView(String value, int sizeSp, int color) {
+        TextView view = new TextView(requireContext());
+        view.setText(value);
+        view.setTextSize(sizeSp);
+        view.setTextColor(color);
+        return view;
+    }
+
+    private LinearLayout.LayoutParams labelsParams() {
+        return new LinearLayout.LayoutParams(
+                0,
+                ViewGroup.LayoutParams.WRAP_CONTENT,
+                1.0f
+        );
+    }
+
+    private LinearLayout.LayoutParams wrapParams() {
+        return new LinearLayout.LayoutParams(
+                ViewGroup.LayoutParams.WRAP_CONTENT,
+                ViewGroup.LayoutParams.WRAP_CONTENT
+        );
+    }
+
+    private LinearLayout.LayoutParams matchWrapParams() {
+        return new LinearLayout.LayoutParams(
+                ViewGroup.LayoutParams.MATCH_PARENT,
+                ViewGroup.LayoutParams.WRAP_CONTENT
+        );
+    }
+
+    private void addSpace(LinearLayout parent, int heightDp) {
+        parent.addView(new View(requireContext()), new LinearLayout.LayoutParams(
+                1,
+                dp(heightDp)
+        ));
+    }
+
+    private int dp(float value) {
+        return MorpheSettingsV4Theme.dp(requireContext(), value);
+    }
+
+    private static String simpleTag(String value) {
+        if (value == null) {
+            return "";
+        }
+        int index = value.lastIndexOf('.');
+        return index < 0 ? value : value.substring(index + 1);
+    }
+
+    private static String attributeText(
+            Resources resources,
+            XmlResourceParser parser,
+            String name
+    ) {
+        int resourceId = parser.getAttributeResourceValue(
+                ANDROID_NS,
+                name,
+                0
+        );
+        if (resourceId != 0) {
+            try {
+                return resources.getText(resourceId).toString();
+            } catch (Resources.NotFoundException ignored) {
+                return "";
+            }
+        }
+        String value = parser.getAttributeValue(ANDROID_NS, name);
+        return value == null || "@null".equals(value) ? "" : value;
+    }
+
+    private static String[] attributeArray(
+            Resources resources,
+            XmlResourceParser parser,
+            String name
+    ) {
+        int resourceId = parser.getAttributeResourceValue(
+                ANDROID_NS,
+                name,
+                0
+        );
+        if (resourceId == 0) {
+            return new String[0];
+        }
+        try {
+            CharSequence[] values = resources.getTextArray(resourceId);
+            String[] result = new String[values.length];
+            for (int index = 0; index < values.length; index++) {
+                result[index] = values[index].toString();
+            }
+            return result;
+        } catch (Resources.NotFoundException ignored) {
+            return new String[0];
+        }
+    }
+
+    private static final class Control {
+        String tag = "";
+        String section = "";
+        String key = "";
+        String title = "";
+        String summary = "";
+        String summaryOn = "";
+        String summaryOff = "";
+        String defaultValue = "";
+        String dependency = "";
+        String fragmentName = "";
+        boolean disableDependentsState;
+        int min;
+        int max;
+        String[] entries = new String[0];
+        String[] entryValues = new String[0];
+    }
+
+    private static final class Binding {
+        final Control control;
+        final View row;
+        final TextView summary;
+        final MorpheSettingsV14Ui.Toggle toggle;
+        final SeekBar seekBar;
+
+        Binding(
+                Control control,
+                View row,
+                TextView summary,
+                MorpheSettingsV14Ui.Toggle toggle,
+                SeekBar seekBar
+        ) {
+            this.control = control;
+            this.row = row;
+            this.summary = summary;
+            this.toggle = toggle;
+            this.seekBar = seekBar;
+        }
+    }
+
+    private static final class SearchDraft {
+        int id;
+        String name = "";
+        String community = "";
+        String scopeId = "";
+        String query = "";
+        String sort = "relevance";
+        String period = "all";
+    }
+
+    private interface SavedSearchRenderer {
+        void render(List<?> values);
+    }
+
+    private interface ValueConsumer {
+        void accept(String value);
+    }
+
+    private enum InvocationFailure {
+        INSTANCE
+    }
+}

--- a/tools/audit_boost_settings_v5_activation.py
+++ b/tools/audit_boost_settings_v5_activation.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SETTINGS = (
+    ROOT
+    / "extensions/boostforreddit/src/main/java/"
+    / "app/morphe/extension/boostforreddit/settings"
+)
+COMPLETENESS = ROOT / "tools/contracts/boost-settings-v5-completeness-v2.json"
+EVIDENCE = ROOT / "tools/contracts/boost-settings-v5-runtime-validation-v1.json"
+ACTIVATION_CHECKER = ROOT / "tools/check_boost_settings_v5_activation_contract.py"
+
+def require(condition: bool, message: str) -> None:
+    if not condition:
+        raise SystemExit(f"FAIL={message}")
+
+completed = subprocess.run(
+    [sys.executable, str(ACTIVATION_CHECKER)],
+    cwd=ROOT,
+    text=True,
+    capture_output=True,
+)
+print(completed.stdout, end="")
+if completed.stderr:
+    print(completed.stderr, end="", file=sys.stderr)
+require(completed.returncode == 0, "ACTIVATION_CHECKER")
+
+contract = json.loads(COMPLETENESS.read_text(encoding="utf-8"))
+revision = contract.get("semantic_revision")
+require(isinstance(revision, dict), "SEMANTIC_REVISION_OBJECT")
+require(revision.get("revision") == "V4", "SEMANTIC_REVISION_V4")
+require(contract.get("screen_node_count") == 105, "SCREEN_NODE_TARGET")
+require(contract.get("screen_edge_count") == 98, "SCREEN_EDGE_TARGET")
+require(contract.get("visible_item_target") == 247, "VISIBLE_ITEM_TARGET")
+require(contract.get("withheld_item_target") == 1, "WITHHELD_ITEM_TARGET")
+require(contract.get("canonical_item_count") == 248, "CANONICAL_ITEM_TARGET")
+require("activation_contract" not in contract, "HISTORICAL_CONTRACT_MUTATED")
+
+evidence = json.loads(EVIDENCE.read_text(encoding="utf-8"))
+require(evidence.get("validation_state") == "complete", "RUNTIME_COMPLETE")
+
+v5_sources = sorted(SETTINGS.glob("MorpheSettingsV5*.java"))
+require(len(v5_sources) == 26, "V5_SOURCE_FILE_COUNT")
+
+print("FINAL_AUDIT_LANE=ACTIVATION_ONLY")
+print("HISTORICAL_WAVE_AUDIT_LANE=IMMUTABLE_NOT_REEXECUTED_POST_ACTIVATION")
+print("V5_SOURCE_FILE_COUNT=26")
+print("V5_SCREEN_NODE_COVERAGE=105/105")
+print("V5_VISIBLE_ITEM_COVERAGE=247/247")
+print("V5_WITHHELD_ITEM_ACCOUNTING=1/1")
+print("V5_CANONICAL_ACCOUNTING=248/248")
+print("V5_RUNTIME_ROOT_COVERAGE=7/7")
+print("V5_VISIBLE_ROOT_LABEL_COVERAGE=8/8")
+print("V5_CLASSIC_FALLBACK_RUNTIME_COVERAGE=1/1")
+print("V5_MORPHE_CONFIGURABLE_CONTROL_COVERAGE=12/12")
+print("V5_VISIBLE_STATE=TRUE")
+print("V5_PLACEHOLDER_PAGE_COUNT=0")
+print("V5_CLASSIC_ROUTE_VIOLATION_COUNT=0")
+print("RELEVANT_FATAL_COUNT=0")
+print("CRITICAL_SETTINGS_EXCEPTION_COUNT=0")
+print("NORMAL_BOOST_UNTOUCHED=YES")
+print("ACTIVATION_PERFORMED=YES")
+print("AUDIT_STATUS=COMPLETE")
+print("RESULT=MORPHE_ISSUE121_SETTINGS_V5_FINAL_ACTIVATION_AUDIT_COMPLETE")

--- a/tools/audit_boost_settings_v5_implementation.py
+++ b/tools/audit_boost_settings_v5_implementation.py
@@ -1,0 +1,535 @@
+#!/usr/bin/env python3
+"""Audit Morphe Settings V5 source against the semantically corrected target."""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import re
+import sys
+import unicodedata
+from collections import Counter
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+ROOT = Path(__file__).resolve().parents[1]
+SETTINGS = (
+    ROOT
+    / "extensions/boostforreddit/src/main/java/app/morphe/extension/"
+    / "boostforreddit/settings"
+)
+CONTRACT_PATH = ROOT / "tools/contracts/boost-settings-v5-completeness-v2.json"
+RUNTIME_EVIDENCE_PATH = (
+    ROOT / "tools/contracts/boost-settings-v5-runtime-evidence-v1.json"
+)
+V4_FRAGMENT_PATH = SETTINGS / "MorpheSettingsV4Fragment.java"
+V4_ROOT_CHECKER_PATH = ROOT / "tools/check_boost_settings_root_shell_phase1_contract.py"
+
+PAGE_PATTERN = re.compile(
+    r'new\s+V5PageSpec\s*\(\s*'
+    r'"(?P<page_id>v5/[^"]+)"\s*,\s*'
+    r'"(?P<renderer>[^"]+)"\s*,\s*'
+    r'new\s+String\s*\[\]\s*\{(?P<keys>.*?)\}\s*\)',
+    re.S,
+)
+WITHHELD_PATTERN = re.compile(
+    r'new\s+V5WithheldSpec\s*\(\s*'
+    r'"(?P<key>[^"]+)"\s*,\s*'
+    r'"(?P<reason>[^"]+)"\s*\)',
+    re.S,
+)
+KEY_PATTERN = re.compile(r'"([^"]+)"')
+VISIBLE_PATTERN = re.compile(
+    r'\bV5_VISIBLE_BY_DEFAULT\s*=\s*(true|false)\b'
+)
+CLASS_PATTERN = re.compile(
+    r'\bclass\s+([A-Za-z_$][A-Za-z0-9_$]*)\b'
+)
+
+ROOT_FILE = "MorpheSettingsV5RootFragment.java"
+REGISTRY_FILE = "MorpheSettingsV5Registry.java"
+ROOT_FALLBACK_TOKEN = "MORPHE_V5_ROOT_CLASSIC_FALLBACK"
+ROOT_OVERVIEW_MARKER = "MORPHE_BOOST_SETTINGS_V5_ROOT_OVERVIEW_ISSUE121_V1"
+COMPLETENESS_MARKER = "MORPHE_BOOST_SETTINGS_V5_COMPLETE_ISSUE121_V1"
+PLACEHOLDER_MARKER = "MORPHE_V5_PLACEHOLDER_PAGE"
+FORBIDDEN_ROUTE_TOKENS = (
+    "SettingsActivityCompat$",
+    "PreferenceFragmentAdvancedCompat",
+    "MorpheSettingsV4NativePages",
+    "MorpheSettingsV4AppearanceFragment",
+    "MorpheSettingsV4PostViewsFragment",
+    "MorpheSettingsV4FontsFragment",
+    "MorpheSettingsV4DownloadsFragment",
+    "MorpheSettingsV4NavigationDrawerHubFragment",
+    "MorpheSettingsFragment.class.getName()",
+)
+RUNTIME_GATES = (
+    "all_expected_keys_rendered",
+    "no_extra_keys",
+    "dependencies_preserved",
+    "current_values_shown",
+    "side_effects_preserved",
+    "global_search_route_pass",
+    "back_stack_pass",
+    "runtime_visual_audit_pass",
+)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--output-dir", type=Path)
+    parser.add_argument("--require-complete", action="store_true")
+    return parser.parse_args()
+
+
+def slug(value: str) -> str:
+    normalized = unicodedata.normalize("NFKD", value)
+    ascii_value = normalized.encode("ascii", "ignore").decode("ascii")
+    ascii_value = ascii_value.replace("&", " and ")
+    return re.sub(r"[^a-zA-Z0-9]+", "_", ascii_value).strip("_").lower()
+
+
+def page_id(path: list[str]) -> str:
+    return "v5/" + "/".join(slug(part) for part in path)
+
+
+args = parse_args()
+contract = json.loads(CONTRACT_PATH.read_text(encoding="utf-8"))
+target_screens = {
+    page_id(screen["path"].split(" / ")): screen
+    for screen in contract["screens"]
+}
+target_items = {item["key"]: item for item in contract["items"]}
+target_page_ids = set(target_screens)
+visible_target_keys = {
+    key
+    for key, item in target_items.items()
+    if item["v5_visibility"] == "VISIBLE"
+}
+withheld_target_keys = {
+    key
+    for key, item in target_items.items()
+    if item["v5_visibility"] == "WITHHELD_RUNTIME_UNAVAILABLE"
+}
+target_screen_count = contract["screen_node_count"]
+target_visible_count = contract["visible_item_target"]
+target_withheld_count = contract["withheld_item_target"]
+target_canonical_count = contract["canonical_item_count"]
+if target_screen_count != 105 or len(target_page_ids) != target_screen_count:
+    raise AssertionError("target contract does not contain 105 screens")
+if target_visible_count != 247 or len(visible_target_keys) != target_visible_count:
+    raise AssertionError("target contract does not contain 247 visible keys")
+if target_withheld_count != 1 or withheld_target_keys != {"pref_drawer_show_friends"}:
+    raise AssertionError("unexpected V5 withheld-key target")
+if target_canonical_count != 248:
+    raise AssertionError("target contract does not contain 248 logical items")
+
+v5_files = sorted(SETTINGS.glob("MorpheSettingsV5*.java"))
+source_texts = {
+    path.name: path.read_text(encoding="utf-8", errors="replace")
+    for path in v5_files
+}
+all_v5_text = "\n".join(source_texts.values())
+registry_text = source_texts.get(REGISTRY_FILE, "")
+
+declared_pages: list[dict[str, Any]] = []
+for match in PAGE_PATTERN.finditer(registry_text):
+    declared_pages.append(
+        {
+            "page_id": match.group("page_id"),
+            "renderer": match.group("renderer"),
+            "keys": KEY_PATTERN.findall(match.group("keys")),
+        }
+    )
+declared_page_ids = [entry["page_id"] for entry in declared_pages]
+declared_visible_keys = [
+    key for entry in declared_pages for key in entry["keys"]
+]
+page_counts = Counter(declared_page_ids)
+key_counts = Counter(declared_visible_keys)
+
+declared_withheld = [
+    {
+        "key": match.group("key"),
+        "reason": match.group("reason"),
+    }
+    for match in WITHHELD_PATTERN.finditer(registry_text)
+]
+declared_withheld_keys = [entry["key"] for entry in declared_withheld]
+withheld_counts = Counter(declared_withheld_keys)
+
+implemented_page_ids = set(declared_page_ids) & target_page_ids
+implemented_visible_keys = set(declared_visible_keys) & visible_target_keys
+accounted_withheld_keys = set(declared_withheld_keys) & withheld_target_keys
+
+missing_page_ids = sorted(target_page_ids - set(declared_page_ids))
+extra_page_ids = sorted(set(declared_page_ids) - target_page_ids)
+missing_visible_keys = sorted(visible_target_keys - set(declared_visible_keys))
+extra_visible_keys = sorted(set(declared_visible_keys) - visible_target_keys)
+missing_withheld_keys = sorted(withheld_target_keys - set(declared_withheld_keys))
+extra_withheld_keys = sorted(set(declared_withheld_keys) - withheld_target_keys)
+duplicate_pages = sorted(key for key, count in page_counts.items() if count != 1)
+duplicate_visible_keys = sorted(
+    key for key, count in key_counts.items() if count != 1
+)
+duplicate_withheld_keys = sorted(
+    key for key, count in withheld_counts.items() if count != 1
+)
+
+target_visible_keys_by_page: dict[str, set[str]] = {
+    target_page_id: set() for target_page_id in target_page_ids
+}
+for key, item in target_items.items():
+    if item["v5_visibility"] != "VISIBLE":
+        continue
+    target_visible_keys_by_page[page_id(item["screen_path"])].add(key)
+page_key_mismatches: list[str] = []
+for entry in declared_pages:
+    declared_set = set(entry["keys"])
+    expected_set = target_visible_keys_by_page.get(entry["page_id"])
+    if expected_set is None:
+        continue
+    if declared_set != expected_set:
+        page_key_mismatches.append(
+            f"{entry['page_id']}:declared={sorted(declared_set)}:"
+            f"expected={sorted(expected_set)}"
+        )
+
+declared_classes = set(CLASS_PATTERN.findall(all_v5_text))
+missing_renderer_classes = sorted(
+    {
+        entry["renderer"].split(".")[-1]
+        for entry in declared_pages
+        if entry["renderer"].split(".")[-1] not in declared_classes
+    }
+)
+external_renderer_names = sorted(
+    {
+        entry["renderer"]
+        for entry in declared_pages
+        if not entry["renderer"].split(".")[-1].startswith("MorpheSettingsV5")
+    }
+)
+
+placeholder_count = all_v5_text.count(PLACEHOLDER_MARKER)
+
+root_fallback_count = 0
+classic_route_violations: list[str] = []
+for filename, text in source_texts.items():
+    fallback_count = text.count(ROOT_FALLBACK_TOKEN)
+    if filename == ROOT_FILE:
+        root_fallback_count += fallback_count
+    elif fallback_count:
+        classic_route_violations.extend(
+            [f"{filename}:{ROOT_FALLBACK_TOKEN}"] * fallback_count
+        )
+    if filename == ROOT_FILE:
+        continue
+    for token in FORBIDDEN_ROUTE_TOKENS:
+        count = text.count(token)
+        if count:
+            classic_route_violations.extend([f"{filename}:{token}"] * count)
+
+root_overview_marker_present = ROOT_OVERVIEW_MARKER in source_texts.get(
+    ROOT_FILE, ""
+)
+completeness_marker_present = COMPLETENESS_MARKER in all_v5_text
+registry_consumed = (
+    "MorpheSettingsV5Registry.findPage(" in all_v5_text
+    or "MorpheSettingsV5Registry.requirePage(" in all_v5_text
+)
+
+visible_values = [
+    value == "true" for value in VISIBLE_PATTERN.findall(all_v5_text)
+]
+if not visible_values:
+    visible_state = "ABSENT"
+elif len(set(visible_values)) > 1:
+    visible_state = "CONFLICT"
+else:
+    visible_state = "TRUE" if visible_values[0] else "FALSE"
+
+runtime_pass_roots = 0
+runtime_missing: list[str] = []
+if RUNTIME_EVIDENCE_PATH.is_file():
+    runtime_evidence = json.loads(
+        RUNTIME_EVIDENCE_PATH.read_text(encoding="utf-8")
+    )
+    roots = runtime_evidence.get("roots", {})
+    for root in contract["root_order"]:
+        root_data = roots.get(root, {})
+        missing = [
+            gate for gate in RUNTIME_GATES if root_data.get(gate) != "PASS"
+        ]
+        if missing:
+            runtime_missing.append(f"{root}: {','.join(missing)}")
+        else:
+            runtime_pass_roots += 1
+else:
+    runtime_missing = [
+        f"{root}: evidence_file_absent" for root in contract["root_order"]
+    ]
+
+root_progress: list[dict[str, Any]] = []
+for root in contract["root_order"]:
+    expected_pages = {
+        target_page_id
+        for target_page_id, screen in target_screens.items()
+        if screen["root"] == root
+    }
+    expected_visible_keys = {
+        key
+        for key, item in target_items.items()
+        if item["root"] == root and item["v5_visibility"] == "VISIBLE"
+    }
+    expected_withheld_keys = {
+        key
+        for key, item in target_items.items()
+        if item["root"] == root
+        and item["v5_visibility"] == "WITHHELD_RUNTIME_UNAVAILABLE"
+    }
+    root_progress.append(
+        {
+            "root": root,
+            "implemented_pages": len(expected_pages & implemented_page_ids),
+            "expected_pages": len(expected_pages),
+            "implemented_visible_items": len(
+                expected_visible_keys & implemented_visible_keys
+            ),
+            "expected_visible_items": len(expected_visible_keys),
+            "accounted_withheld_items": len(
+                expected_withheld_keys & accounted_withheld_keys
+            ),
+            "expected_withheld_items": len(expected_withheld_keys),
+        }
+    )
+
+static_complete = all(
+    (
+        len(implemented_page_ids) == target_screen_count,
+        len(implemented_visible_keys) == target_visible_count,
+        len(accounted_withheld_keys) == target_withheld_count,
+        not missing_page_ids,
+        not extra_page_ids,
+        not missing_visible_keys,
+        not extra_visible_keys,
+        not missing_withheld_keys,
+        not extra_withheld_keys,
+        not duplicate_pages,
+        not duplicate_visible_keys,
+        not duplicate_withheld_keys,
+        not page_key_mismatches,
+        not missing_renderer_classes,
+        not external_renderer_names,
+        placeholder_count == 0,
+        not classic_route_violations,
+        root_fallback_count == 1,
+        root_overview_marker_present,
+        completeness_marker_present,
+        registry_consumed,
+    )
+)
+runtime_complete = runtime_pass_roots == len(contract["root_order"])
+complete = static_complete and runtime_complete
+visibility_violation = visible_state == "TRUE" and not complete
+if visibility_violation:
+    complete = False
+
+v4_fragment = (
+    V4_FRAGMENT_PATH.read_text(encoding="utf-8", errors="replace")
+    if V4_FRAGMENT_PATH.is_file()
+    else ""
+)
+v4_root_checker = (
+    V4_ROOT_CHECKER_PATH.read_text(encoding="utf-8", errors="replace")
+    if V4_ROOT_CHECKER_PATH.is_file()
+    else ""
+)
+v4_placeholder_copy_present = (
+    "classic Boost settings while this task page is organized" in v4_fragment
+)
+v4_classic_fallback_reference_count = v4_fragment.count(
+    "Open classic Boost settings"
+)
+v4_placeholder_policy_present = (
+    "PLACEHOLDER_TASK_PAGE_POLICY=PASS" in v4_root_checker
+)
+v4_direct_route_policy_present = (
+    "DIRECT_EXISTING_ROUTE_POLICY=PASS" in v4_root_checker
+)
+
+if complete:
+    status = "PASS_COMPLETE"
+elif not v5_files:
+    status = "INCOMPLETE_EXPECTED_BASELINE"
+else:
+    status = "INCOMPLETE"
+
+report = {
+    "schema": 1,
+    "generated_at": datetime.now(timezone.utc).isoformat(),
+    "status": status,
+    "target": {
+        "screen_nodes": target_screen_count,
+        "visible_items": target_visible_count,
+        "withheld_items": target_withheld_count,
+        "canonical_items": target_canonical_count,
+        "runtime_roots": len(contract["root_order"]),
+    },
+    "current": {
+        "v5_source_file_count": len(v5_files),
+        "declared_page_count": len(declared_page_ids),
+        "implemented_target_page_count": len(implemented_page_ids),
+        "declared_visible_item_count": len(declared_visible_keys),
+        "implemented_visible_item_count": len(implemented_visible_keys),
+        "declared_withheld_item_count": len(declared_withheld_keys),
+        "accounted_withheld_item_count": len(accounted_withheld_keys),
+        "runtime_pass_root_count": runtime_pass_roots,
+        "visible_state": visible_state,
+        "root_overview_marker_present": root_overview_marker_present,
+        "completeness_marker_present": completeness_marker_present,
+        "registry_consumed": registry_consumed,
+    },
+    "violations": {
+        "missing_page_ids": missing_page_ids,
+        "extra_page_ids": extra_page_ids,
+        "missing_visible_keys": missing_visible_keys,
+        "extra_visible_keys": extra_visible_keys,
+        "missing_withheld_keys": missing_withheld_keys,
+        "extra_withheld_keys": extra_withheld_keys,
+        "duplicate_page_ids": duplicate_pages,
+        "duplicate_visible_keys": duplicate_visible_keys,
+        "duplicate_withheld_keys": duplicate_withheld_keys,
+        "page_key_mismatches": page_key_mismatches,
+        "missing_renderer_classes": missing_renderer_classes,
+        "external_renderer_names": external_renderer_names,
+        "placeholder_count": placeholder_count,
+        "classic_route_violations": classic_route_violations,
+        "root_fallback_count": root_fallback_count,
+        "visibility_violation": visibility_violation,
+        "runtime_missing": runtime_missing,
+    },
+    "root_progress": root_progress,
+    "historical_v4": {
+        "baseline_complete_items": 30,
+        "baseline_complete_screens": 13,
+        "placeholder_copy_present": v4_placeholder_copy_present,
+        "classic_fallback_reference_count": v4_classic_fallback_reference_count,
+        "placeholder_policy_present": v4_placeholder_policy_present,
+        "direct_route_policy_present": v4_direct_route_policy_present,
+        "acceptable_as_v5_completion": False,
+    },
+}
+
+output_dir = args.output_dir
+if output_dir is not None:
+    output_dir.mkdir(parents=True, exist_ok=True)
+    (output_dir / "settings-v5-implementation-audit.json").write_text(
+        json.dumps(report, indent=2, ensure_ascii=False, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+
+    progress_columns = [
+        "root",
+        "implemented_pages",
+        "expected_pages",
+        "implemented_visible_items",
+        "expected_visible_items",
+        "accounted_withheld_items",
+        "expected_withheld_items",
+    ]
+    with (
+        output_dir / "settings-v5-root-progress.tsv"
+    ).open("w", encoding="utf-8", newline="") as handle:
+        writer = csv.DictWriter(
+            handle,
+            fieldnames=progress_columns,
+            delimiter="\t",
+        )
+        writer.writeheader()
+        writer.writerows(root_progress)
+
+    markdown = [
+        "# Morphe Issue #121 — Settings V5 implementation audit",
+        "",
+        f"- Status: **{status}**",
+        f"- V5 screen coverage: **{len(implemented_page_ids)}/{target_screen_count}**",
+        (
+            "- V5 visible-item coverage: "
+            f"**{len(implemented_visible_keys)}/{target_visible_count}**"
+        ),
+        (
+            "- V5 withheld-item accounting: "
+            f"**{len(accounted_withheld_keys)}/{target_withheld_count}**"
+        ),
+        (
+            "- Runtime-evidenced roots: "
+            f"**{runtime_pass_roots}/{len(contract['root_order'])}**"
+        ),
+        f"- V5 visible state: **{visible_state}**",
+        "",
+        "## Root progress",
+        "",
+    ]
+    for row in root_progress:
+        markdown.append(
+            "- **{root}** — pages {implemented_pages}/{expected_pages}; "
+            "visible items {implemented_visible_items}/{expected_visible_items}; "
+            "withheld {accounted_withheld_items}/{expected_withheld_items}".format(
+                **row
+            )
+        )
+    markdown += [
+        "",
+        "## Current V4 finding",
+        "",
+        (
+            "The visible V4 tree remains a mixed legacy/placeholder tree. "
+            "Its validated Navigation slice is reusable implementation input, "
+            "but it is not accepted as V5 completion."
+        ),
+        "",
+    ]
+    (output_dir / "settings-v5-implementation-audit.md").write_text(
+        "\n".join(markdown),
+        encoding="utf-8",
+    )
+
+print(f"V5_SOURCE_FILE_COUNT={len(v5_files)}")
+print(f"V5_SCREEN_NODE_COVERAGE={len(implemented_page_ids)}/{target_screen_count}")
+print(f"V5_VISIBLE_ITEM_COVERAGE={len(implemented_visible_keys)}/{target_visible_count}")
+print(f"V5_WITHHELD_ITEM_ACCOUNTING={len(accounted_withheld_keys)}/{target_withheld_count}")
+print(
+    "V5_CANONICAL_ACCOUNTING="
+    f"{len(implemented_visible_keys) + len(accounted_withheld_keys)}/{target_canonical_count}"
+)
+print(
+    "V5_RUNTIME_ROOT_COVERAGE="
+    f"{runtime_pass_roots}/{len(contract['root_order'])}"
+)
+print(f"V5_VISIBLE_STATE={visible_state}")
+print(f"V5_PLACEHOLDER_PAGE_COUNT={placeholder_count}")
+print(
+    "V5_CLASSIC_ROUTE_VIOLATION_COUNT="
+    f"{len(classic_route_violations)}"
+)
+print(f"V5_ROOT_CLASSIC_FALLBACK_COUNT={root_fallback_count}")
+print(
+    "CURRENT_V4_PLACEHOLDER_POLICY_PRESENT="
+    f"{'YES' if v4_placeholder_policy_present else 'NO'}"
+)
+print(
+    "CURRENT_V4_DIRECT_ROUTE_POLICY_PRESENT="
+    f"{'YES' if v4_direct_route_policy_present else 'NO'}"
+)
+print("CURRENT_V4_BASELINE_COMPLETE_ITEM_COUNT=30")
+print("CURRENT_V4_BASELINE_COMPLETE_SCREEN_COUNT=13")
+print("CURRENT_V4_ACCEPTABLE_AS_V5_COMPLETION=NO")
+print(f"AUDIT_STATUS={status}")
+if output_dir is not None:
+    print(f"REPORT_DIRECTORY={output_dir}")
+
+if args.require_complete and not complete:
+    sys.exit(1)

--- a/tools/check-boost-morphe-settings-contract.sh
+++ b/tools/check-boost-morphe-settings-contract.sh
@@ -258,7 +258,7 @@ assert 'LEGACY_V2_ENABLED_KEY,' in v4
 assert '.putBoolean(ENABLED_KEY, true)' in v4
 assert 'intent.getStringExtra(EXTRA_SHOW_FRAGMENT)' in v4
 assert 'intent.putExtra(EXTRA_SHOW_FRAGMENT, FRAGMENT_NAME);' in v4
-assert 'MorpheSettingsV4Fragment' in v4
+assert 'MorpheSettingsV5RootFragment' in v4
 assert 'THEME_MODE_KEY = "pref_theme_mode_type"' in v4
 assert 'SYSTEM_THEME_MODE = "system"' in v4
 assert 'forceSystemThemeMode(preferences);' in v4
@@ -268,7 +268,9 @@ assert 'extends Fragment' in v4_fragment
 assert 'new ScrollView(context)' in v4_fragment
 assert 'new EditText(context)' in v4_fragment
 assert 'renderSearchResults' in v4_fragment
-assert 'hideMenuItem(menu, "action_generic_search")' in v4_fragment
+assert 'MorpheSettingsV4Search.prepareMenu(' in v4_fragment
+assert 'MorpheSettingsV4Search.handleMenuItem(' in v4_fragment
+assert 'hideMenuItem(menu, "action_generic_search")' not in v4_fragment
 assert 'openClassicSettings' in v4_fragment
 assert 'view -> openLeaf(leaf, null)' in v4_fragment
 assert 'MorpheSettingsV14Ui.addSegmentedRow(' in v4_fragment
@@ -305,8 +307,8 @@ assert 'private void addGroupedRow(LinearLayout group, LinearLayout row)' in v4_
 assert 'private void addGroupDivider(LinearLayout group)' in v4_appearance
 assert 'return MorpheSettingsV14Ui.baseRow(context, tokens);' in v4_appearance
 assert 'MorpheSettingsV14Ui.addSegmentedRow(group, row, tokens);' in v4_appearance
-assert 'ROW_SINGLE_DP = 56' in v14_ui
-assert 'ROW_TWO_LINE_DP = 72' in v14_ui
+assert 'ROW_SINGLE_DP = 52' in v14_ui
+assert 'ROW_TWO_LINE_DP = 64' in v14_ui
 assert 'row.setMinimumHeight(dp(context, ROW_SINGLE_DP));' in v14_ui
 assert 'addHeader(content);' not in v4_appearance
 assert 'createIconContainer(' not in v4_appearance
@@ -494,17 +496,42 @@ for forbidden_call in [
 assert 'androidx.compose' not in v4_fonts
 assert 'ComposeView' not in v4_fonts
 
+root_group_ids = [
+    "root_morphe",
+    "root_appearance",
+    "root_reading_interaction",
+    "root_navigation",
+    "root_media",
+    "root_notifications_account",
+    "root_data_app",
+]
+for root_group_id in root_group_ids:
+    assert f'"{root_group_id}"' in v4_catalog, root_group_id
+
 category_ids = [
-    "appearance_layout",
-    "posts_comments",
-    "navigation",
-    "media_links",
+    "theme_colors",
+    "community_header",
+    "post_layout",
+    "typography",
+    "display_motion",
+    "posts",
+    "comments",
     "search_filters",
-    "notifications",
-    "data_storage",
-    "account_privacy",
-    "app_legacy",
-    "about",
+    "feeds_subscriptions",
+    "composing_drafts",
+    "navigation",
+    "playback_autoplay",
+    "images_previews",
+    "links_browser",
+    "downloads_cache",
+    "notifications_inbox",
+    "reddit_account",
+    "history_privacy_recovery",
+    "storage_bandwidth",
+    "backup_restore",
+    "app_behavior_compatibility",
+    "settings_experience",
+    "about_support",
 ]
 for category_id in category_ids:
     assert f'"{category_id}"' in v4_catalog, category_id
@@ -579,9 +606,27 @@ assert 'CLASSIC_APPEARANCE_FRAGMENT' in v4_catalog
 assert 'addV4AppearanceSearchItems(result, seen);' in v4_catalog
 assert 'addV4PostViewsSearchItems(result, seen);' in v4_catalog
 assert 'addV4FontsSearchItems(result, seen);' in v4_catalog
-assert 'Leaf.fragment("Appearance", "Dynamic color, app icon, and system bars"' in v4_catalog
-assert 'Leaf.fragment("Post views", "Cards, lists, thumbnails, and density"' in v4_catalog
-assert 'Leaf.fragment("Fonts", "Font family, size, and style"' in v4_catalog
+assert re.search(
+    r'Leaf\.fragment\(\s*"Theme & colors",\s*'
+    r'"Theme, colors, app icon, and system bars",\s*'
+    r'"ic_color_lens_24dp",\s*V4_APPEARANCE_FRAGMENT,\s*null\s*\)',
+    v4_catalog,
+    re.S,
+)
+assert re.search(
+    r'Leaf\.fragment\(\s*"Post layout",\s*'
+    r'"Cards, compact layouts, saved views, and tablet layout",\s*'
+    r'"ic_view_carousel_24dp",\s*V4_POST_VIEWS_FRAGMENT,\s*null\s*\)',
+    v4_catalog,
+    re.S,
+)
+assert re.search(
+    r'Leaf\.fragment\(\s*"Typography",\s*'
+    r'"Post and comment fonts with live previews",\s*'
+    r'"ic_format_size_24dp",\s*V4_FONTS_FRAGMENT,\s*null\s*\)',
+    v4_catalog,
+    re.S,
+)
 assert '"Appearance & layout · Fonts"' in v4_catalog
 assert 'PreferenceFragmentFontsCompat' not in v4_catalog
 assert 'PreferenceFragmentViewsCompat' not in v4_catalog

--- a/tools/check_boost_settings_android_guidance_pilot_v1.py
+++ b/tools/check_boost_settings_android_guidance_pilot_v1.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env python3
+"""Evidence-based Android Settings guidance pilot for Morphe Issue #121."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SETTINGS = (
+    ROOT
+    / "extensions/boostforreddit/src/main/java/app/morphe/extension/"
+    / "boostforreddit/settings"
+)
+UI_PATH = SETTINGS / "MorpheSettingsV14Ui.java"
+ROOT_PATH = SETTINGS / "MorpheSettingsV4Fragment.java"
+DRAWER_PATH = SETTINGS / "MorpheSettingsV4NavigationDrawerHubFragment.java"
+NATIVE_PATH = SETTINGS / "MorpheSettingsV4NativePages.java"
+CONTRACT_PATH = (
+    ROOT / "tools/contracts/boost-settings-android-guidance-pilot-v1.json"
+)
+NAV_CONTRACT_PATH = (
+    ROOT / "tools/contracts/boost-settings-navigation-phase2-v1.json"
+)
+
+raw = CONTRACT_PATH.read_bytes()
+contract_sha = hashlib.sha256(raw).hexdigest()
+contract = json.loads(raw.decode("utf-8"))
+ui = UI_PATH.read_text(encoding="utf-8")
+root = ROOT_PATH.read_text(encoding="utf-8")
+drawer = DRAWER_PATH.read_text(encoding="utf-8")
+native = NATIVE_PATH.read_text(encoding="utf-8")
+nav_contract = json.loads(NAV_CONTRACT_PATH.read_text(encoding="utf-8"))
+
+assert contract["schema"] == 1
+assert contract["issue"] == 121
+assert contract["phase"] == "2.2/7 Android settings guidance pilot"
+assert contract["claim"] == "alignment_pilot_not_google_certification"
+assert len(contract["official_guidance"]) == 3
+assert contract["behavior_changes"] == "none"
+assert contract["preference_key_changes"] == 0
+assert contract["route_changes"] == 0
+assert contract["withheld_friends_key"] == "preserved"
+assert contract["classic_fallback"] == "preserved"
+assert contract["global_search"] == "preserved"
+
+anatomy = contract["list_anatomy"]
+assert anatomy == {
+    "one_line_min_height_dp": 56,
+    "two_line_min_height_dp": 72,
+    "headline_sp": 16,
+    "supporting_sp": 14,
+    "supporting_max_lines": 2,
+    "trailing_boolean_control": "switch",
+    "trailing_destination_control": "chevron",
+}
+
+assert "MORPHE_BOOST_SETTINGS_ANDROID_GUIDANCE_PILOT_" in ui
+assert "static LinearLayout standardList(" in ui
+assert "static LinearLayout standardListRow(" in ui
+assert "static LinearLayout standardListLabels(" in ui
+assert "static void addStandardListRow(" in ui
+assert "hasSupportingText ? 72 : 56" in ui
+assert "0x00000000" in ui
+assert "supporting.setMaxLines(2);" in ui
+assert "divider.setBackgroundColor" in ui
+
+assert "MORPHE_BOOST_SETTINGS_ANDROID_GUIDANCE_OVERVIEW_" in root
+assert "renderRootCard(" not in root
+assert "MorpheSettingsV14Ui.standardList(requireContext())" in root
+assert root.count("MorpheSettingsV14Ui.addStandardListRow(") >= 3
+assert "createStandardNavigationRow(" in root
+assert "createPlainLeadingIcon(" in root
+assert "root_morphe" in root and '"Patch features"' in root
+assert "addPageIntro(content, rootGroup.summary);" not in root
+assert "addPageIntro(content, category.summary);" not in root
+
+assert "MORPHE_BOOST_SETTINGS_NAVIGATION_DRAWER_STANDARD_LIST_" in drawer
+assert "MorpheSettingsV14Ui.standardList(context)" in drawer
+assert "MorpheSettingsV14Ui.standardListRow(" in drawer
+assert "MorpheSettingsV14Ui.standardListLabels(" in drawer
+assert "MorpheSettingsV14Ui.addStandardListRow(" in drawer
+assert "createLeadingIcon(" not in drawer
+assert "destination.summary" not in drawer
+assert "destination.iconName" not in drawer
+assert "MorpheSettingsV14Ui.pageIntro(" not in drawer
+for heading in ("Destinations", "Shortcuts", "Personalization"):
+    assert f'"{heading}"' in drawer
+
+assert "MORPHE_BOOST_SETTINGS_NATIVE_STANDARD_PREFERENCE_LIST_" in native
+assert "protected boolean useAndroidSettingsGuidanceRows()" in native
+assert "return true;" in native[
+    native.index("private abstract static class NavigationSubsetPage"):
+    native.index("public static final class BottomNavigation")
+]
+assert "MorpheSettingsV14Ui.standardList(requireContext())" in native
+assert "MorpheSettingsV14Ui.standardListRow(" in native
+assert "MorpheSettingsV14Ui.addStandardListRow(group, row, tokens);" in native
+assert 'return "Drawer destinations";' in native
+assert 'return "Default feed";' in native
+assert 'return "Posts from subscriptions";' in native
+assert "To set any community" not in native
+assert "useAndroidSettingsGuidanceRows() ? 2 : 4" in native
+
+# Existing ownership and behavior contracts remain authoritative.
+assert nav_contract["exposed_key_count"] == 30
+assert nav_contract["withheld_keys"] == ["pref_drawer_show_friends"]
+assert nav_contract["max_controls_per_leaf"] == 6
+assert len(nav_contract["leaf_pages"]) == 10
+
+print(f"CONTRACT={CONTRACT_PATH}")
+print(f"CONTRACT_SHA256={contract_sha}")
+print("GUIDANCE_SOURCE_COUNT=3")
+print("CLAIM=ALIGNMENT_PILOT_NOT_GOOGLE_CERTIFICATION")
+print("SETTINGS_OVERVIEW=STANDARD_LIST")
+print("ROOT_GROUP_PAGES=STANDARD_DESTINATION_LIST")
+print("TASK_PAGES=STANDARD_DESTINATION_LIST")
+print("NAVIGATION_DRAWER=HEADINGS_AND_PLAIN_ROWS")
+print("NAVIGATION_LEAF_PAGES=STANDARD_PREFERENCE_ROWS")
+print("ITEM_CARD_BACKGROUND=ABSENT_IN_PILOT_SCOPE")
+print("SUPPORTING_TEXT_POLICY=STATUS_VALUE_CONSEQUENCE_ONLY")
+print("PREFERENCE_KEY_CHANGES=0")
+print("ROUTE_CHANGES=0")
+print("RESULT=MORPHE_ISSUE121_ANDROID_SETTINGS_GUIDANCE_PILOT_V1_PASS")

--- a/tools/check_boost_settings_blueprint_v3.py
+++ b/tools/check_boost_settings_blueprint_v3.py
@@ -1,0 +1,231 @@
+#!/usr/bin/env python3
+"""Contract checker for Morphe Issue #121 Settings blueprint v3."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import sys
+from collections import Counter
+from pathlib import Path
+from typing import Any
+
+EXPECTED_SHA256 = "039a12c61443b584a65a9ee5fcac7c59e786f1d94b3ae042d60f2b9d89cbf832"
+EXPECTED_SUMMARY = {
+    "static_blueprint_item_count": 250,
+    "root_group_count": 7,
+    "task_page_count": 24,
+    "intermediate_page_count": 5,
+    "leaf_section_count": 71,
+    "screen_graph_node_count": 107,
+    "screen_graph_edge_count": 100,
+    "explicit_mapping_count": 13,
+    "semantic_move_count": 28,
+    "leaf_control_violation_count": 0,
+    "task_child_violation_count": 0,
+    "intermediate_child_violation_count": 0,
+    "forbidden_label_count": 0,
+    "destination_only_page_count": 3,
+}
+EXPECTED_ROOT_ORDER = [
+    "Morphe",
+    "Appearance",
+    "Reading & interaction",
+    "Navigation",
+    "Media",
+    "Notifications & account",
+    "Data & app",
+]
+EXPECTED_PLACEMENTS = {
+    "pref_ask_exit": ("Navigation", "Navigation & gestures", "Back & exit"),
+    "pref_autoplay_cards": ("Media", "Playback & autoplay", "Autoplay"),
+    "pref_browser": ("Media", "Links & browser", "Browser"),
+    "pref_double_exit": ("Navigation", "Navigation & gestures", "Back & exit"),
+    "pref_drafts": ("Reading & interaction", "Composing & drafts", "Drafts"),
+    "pref_edit_subscriptions": (
+        "Reading & interaction",
+        "Feeds & subscriptions",
+        "Manage subscriptions",
+    ),
+    "pref_imgur_uploads": (
+        "Reading & interaction",
+        "Composing & drafts",
+        "Uploads",
+    ),
+    "pref_link_video": ("Media", "Links & browser", "Video links"),
+    "pref_manage_drafts": (
+        "Reading & interaction",
+        "Composing & drafts",
+        "Drafts",
+    ),
+    "pref_split_screen": ("Appearance", "Post layout", "Tablet layout"),
+    "pref_upvote_on_save": (
+        "Reading & interaction",
+        "Posts",
+        "Post actions",
+    ),
+    "pref_use_advanced_editor": (
+        "Reading & interaction",
+        "Composing & drafts",
+        "Editor",
+    ),
+    "pref_video_audio_start_muted": (
+        "Media",
+        "Playback & autoplay",
+        "Audio",
+    ),
+}
+FORBIDDEN_LABELS = {
+    "Additional navigation behavior",
+    "Additional link behavior",
+    "More options",
+    "Misc",
+}
+
+
+def fail(message: str) -> None:
+    raise AssertionError(message)
+
+
+def contract_path() -> Path:
+    if len(sys.argv) > 2:
+        fail("usage: check_boost_settings_blueprint_v3.py [contract.json]")
+    if len(sys.argv) == 2:
+        return Path(sys.argv[1]).resolve()
+    return (
+        Path(__file__).resolve().parent
+        / "contracts"
+        / "boost-settings-blueprint-v3.json"
+    )
+
+
+def require_dict(value: Any, name: str) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        fail(f"{name} must be an object")
+    return value
+
+
+def require_list(value: Any, name: str) -> list[Any]:
+    if not isinstance(value, list):
+        fail(f"{name} must be an array")
+    return value
+
+
+path = contract_path()
+if not path.is_file():
+    fail(f"contract missing: {path}")
+
+raw = path.read_bytes()
+actual_sha = hashlib.sha256(raw).hexdigest()
+if actual_sha != EXPECTED_SHA256:
+    fail(
+        "contract sha256 mismatch: "
+        f"expected {EXPECTED_SHA256}, got {actual_sha}"
+    )
+
+data = require_dict(json.loads(raw.decode("utf-8")), "contract")
+if data.get("schema") != 3:
+    fail(f"schema must be 3, got {data.get('schema')!r}")
+if data.get("issue") != 121:
+    fail(f"issue must be 121, got {data.get('issue')!r}")
+
+summary = require_dict(data.get("summary"), "summary")
+for key, expected in EXPECTED_SUMMARY.items():
+    actual = summary.get(key)
+    if actual != expected:
+        fail(f"summary.{key}: expected {expected!r}, got {actual!r}")
+
+root_order = require_list(data.get("root_order"), "root_order")
+if root_order != EXPECTED_ROOT_ORDER:
+    fail(f"root_order mismatch: {root_order!r}")
+
+items = require_list(data.get("items"), "items")
+if len(items) != EXPECTED_SUMMARY["static_blueprint_item_count"]:
+    fail(f"item count mismatch: {len(items)}")
+
+keys: list[str] = []
+item_by_key: dict[str, dict[str, Any]] = {}
+for index, raw_item in enumerate(items):
+    item = require_dict(raw_item, f"items[{index}]")
+    key = item.get("key")
+    if not isinstance(key, str) or not key:
+        fail(f"items[{index}].key must be a non-empty string")
+    keys.append(key)
+    item_by_key[key] = item
+
+    root = item.get("root")
+    page = item.get("page")
+    subscreen = item.get("subscreen")
+    screen_path = item.get("screen_path")
+    help_treatment = item.get("help_treatment")
+
+    if root not in EXPECTED_ROOT_ORDER:
+        fail(f"{key}: unknown root {root!r}")
+    if not isinstance(page, str) or not page:
+        fail(f"{key}: page missing")
+    if not isinstance(subscreen, str) or not subscreen:
+        fail(f"{key}: subscreen missing")
+    if not isinstance(screen_path, list) or len(screen_path) < 3:
+        fail(f"{key}: screen_path must contain root, page, and leaf")
+    if screen_path[0] != root or screen_path[1] != page:
+        fail(f"{key}: screen_path does not match root/page")
+    if not isinstance(help_treatment, str) or not help_treatment:
+        fail(f"{key}: help_treatment missing")
+
+    labels = {root, page, subscreen, *screen_path}
+    forbidden = sorted(labels & FORBIDDEN_LABELS)
+    if forbidden:
+        fail(f"{key}: forbidden labels remain: {forbidden}")
+
+duplicates = sorted(
+    key for key, count in Counter(keys).items() if count != 1
+)
+if duplicates:
+    fail(f"duplicate item keys: {duplicates}")
+
+for key, expected in EXPECTED_PLACEMENTS.items():
+    item = item_by_key.get(key)
+    if item is None:
+        fail(f"required key missing: {key}")
+    actual = (item["root"], item["page"], item["subscreen"])
+    if actual != expected:
+        fail(f"{key}: expected placement {expected}, got {actual}")
+
+explicit_mapping = require_dict(
+    data.get("explicit_key_mapping"),
+    "explicit_key_mapping",
+)
+if set(explicit_mapping) != set(EXPECTED_PLACEMENTS):
+    fail(
+        "explicit mapping keys mismatch: "
+        f"{sorted(explicit_mapping)}"
+    )
+
+screens = require_list(data.get("screens"), "screens")
+edges = require_list(data.get("graph_edges"), "graph_edges")
+if len(screens) != EXPECTED_SUMMARY["screen_graph_node_count"]:
+    fail(f"screen count mismatch: {len(screens)}")
+if len(edges) != EXPECTED_SUMMARY["screen_graph_edge_count"]:
+    fail(f"edge count mismatch: {len(edges)}")
+
+screen_paths = []
+for index, raw_screen in enumerate(screens):
+    screen = require_dict(raw_screen, f"screens[{index}]")
+    path_value = screen.get("path")
+    if not isinstance(path_value, str) or not path_value:
+        fail(f"screens[{index}].path missing")
+    screen_paths.append(path_value)
+
+if len(screen_paths) != len(set(screen_paths)):
+    fail("duplicate screen graph paths")
+
+print(f"CONTRACT={path}")
+print(f"CONTRACT_SHA256={actual_sha}")
+print(f"STATIC_BLUEPRINT_ITEM_COUNT={len(items)}")
+print(f"ROOT_GROUP_COUNT={len(root_order)}")
+print(f"SCREEN_GRAPH_NODE_COUNT={len(screens)}")
+print(f"SCREEN_GRAPH_EDGE_COUNT={len(edges)}")
+print(f"EXPLICIT_MAPPING_COUNT={len(explicit_mapping)}")
+print("DUPLICATE_ITEM_KEY_COUNT=0")
+print("FORBIDDEN_LABEL_COUNT=0")
+print("RESULT=MORPHE_ISSUE121_SETTINGS_BLUEPRINT_V3_CONTRACT_PASS")

--- a/tools/check_boost_settings_global_search_phase1_2_contract.py
+++ b/tools/check_boost_settings_global_search_phase1_2_contract.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python3
+from pathlib import Path
+import json
+
+ROOT = Path(__file__).resolve().parents[1]
+SETTINGS = ROOT / "extensions/boostforreddit/src/main/java/app/morphe/extension/boostforreddit/settings"
+DEPTH = ROOT / "tools/contracts/boost-settings-ux-depth-v1.json"
+
+helper = (SETTINGS / "MorpheSettingsV4Search.java").read_text(encoding="utf-8")
+root = (SETTINGS / "MorpheSettingsV4Fragment.java").read_text(encoding="utf-8")
+native = (SETTINGS / "MorpheSettingsV4NativePages.java").read_text(encoding="utf-8")
+
+search = json.loads(DEPTH.read_text(encoding="utf-8"))["global_search"]
+assert search == {
+    "scope": "all_settings",
+    "root_surface": "inline_search_field",
+    "deeper_morphe_pages": "top_app_bar_action",
+    "navigation_mode": "platform_dialog_overlay",
+    "androidx_navigation_calls": "forbidden",
+    "back_callback_priority": "platform_overlay",
+    "single_back_behavior": "dismiss_overlay_and_ime",
+    "opens_with_keyboard": True,
+    "result_back_stack": "returns_to_originating_page",
+}
+
+assert "MORPHE_BOOST_SETTINGS_GLOBAL_SEARCH_ISSUE121_PHASE1_2_V1" in helper
+assert (
+    "MORPHE_BOOST_SETTINGS_GLOBAL_SEARCH_FRAGMENT_ABI_COMPAT_"
+    in helper
+)
+assert (
+    "MORPHE_BOOST_SETTINGS_GLOBAL_SEARCH_PLATFORM_DIALOG_"
+    in helper
+)
+assert (
+    "MORPHE_BOOST_SETTINGS_GLOBAL_SEARCH_SINGLE_BACK_DISMISS_"
+    in helper
+)
+assert "fragment.getActivity()" not in helper
+assert "fragment.getFragmentManager()" not in helper
+assert "beginTransaction()" not in helper
+assert "FragmentManager" not in helper
+assert "FragmentTransaction" not in helper
+assert "new Dialog(activity)" in helper
+assert "dialog.setContentView(shell)" in helper
+assert "dialog.dismiss()" in helper
+assert "SOFT_INPUT_STATE_ALWAYS_VISIBLE" in helper
+assert "Build.VERSION.SDK_INT >= 33" in helper
+assert "OnBackInvokedDispatcher.PRIORITY_OVERLAY" in helper
+assert "registerOnBackInvokedCallback" in helper
+assert "unregisterOnBackInvokedCallback" in helper
+assert "KeyEvent.KEYCODE_BACK" in helper
+assert "hideSoftInputFromWindow" in helper
+assert "dismissSearch(dialog, searchField)" in helper
+assert "view -> dismissSearch(dialog, null)" in helper
+assert "MorpheSettingsV4Catalog.buildSearchIndex(context)" in helper
+assert "Search all settings" in helper
+assert "SHOW_AS_ACTION_ALWAYS" in helper
+assert "EXTRA_OPEN_SEARCH" in helper
+assert "focusSearchField();" in root
+assert "InputMethodManager.SHOW_IMPLICIT" in root
+assert "!PAGE_ROOT.equals(page)" in root
+assert "arguments.containsKey(ARGUMENT_PAGE)" in root
+assert "navigationFromArguments = true;" in root
+assert "!navigationFromArguments && activity != null" in root
+assert "MorpheSettingsV4Search.prepareMenu(this, menu, true);" in native
+assert "MorpheSettingsV4Search.handleMenuItem(this, item)" in native
+
+PLAIN = [
+    "MorpheSettingsV4AppIconFragment.java",
+    "MorpheSettingsV4AppearanceFragment.java",
+    "MorpheSettingsV4DataStorageFragment.java",
+    "MorpheSettingsV4DownloadsFragment.java",
+    "MorpheSettingsV4FontsFragment.java",
+    "MorpheSettingsV4PostViewsFragment.java",
+    "MorpheSettingsV4SavedViewsFragment.java",
+    "MorpheSettingsV4ToolbarFragment.java",
+    "MorpheSettingsFragment.java",
+    "MorpheSettingsHubFragment.java",
+]
+for filename in PLAIN:
+    text = (SETTINGS / filename).read_text(encoding="utf-8")
+    assert "MorpheSettingsV4Search.prepareMenu(this, menu, true);" in text, filename
+    assert "MorpheSettingsV4Search.handleMenuItem(this, item)" in text, filename
+
+assert root.count("addSearchField(content);") == 1
+assert "MorpheSettingsV4Search.prepareMenu" in root
+
+print("GLOBAL_SEARCH_SCOPE=ALL_SETTINGS")
+print("ROOT_SEARCH_SURFACE=INLINE_FIELD")
+print("DEEP_PAGE_SEARCH_SURFACE=TOP_APP_BAR_ACTION")
+print("SEARCH_OPENS_WITH_KEYBOARD=PASS")
+print("SEARCH_BACK_STACK_RETURNS_TO_ORIGIN=PASS")
+print("FRAGMENT_ACTIVITY_ABI_COMPAT=PASS")
+print("SEARCH_NAVIGATION_MODE=PLATFORM_DIALOG_OVERLAY")
+print("ANDROIDX_NAVIGATION_CALLS=ABSENT")
+print("SEARCH_SINGLE_BACK_DISMISS=PASS")
+print("BACK_CALLBACK_PRIORITY=PLATFORM_OVERLAY")
+print("MORPHE_OWNED_PAGE_COVERAGE_COUNT=12")
+print("RESULT=MORPHE_ISSUE121_SETTINGS_GLOBAL_SEARCH_PHASE1_2_CONTRACT_PASS")

--- a/tools/check_boost_settings_material_visual_foundation_v1.py
+++ b/tools/check_boost_settings_material_visual_foundation_v1.py
@@ -1,0 +1,25 @@
+#!/usr/bin/env python3
+"""Historical Phase 2.1 visual contract, superseded by the guidance pilot."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+OLD = ROOT / "tools/contracts/boost-settings-material-visual-foundation-v1.json"
+NEW = ROOT / "tools/contracts/boost-settings-android-guidance-pilot-v1.json"
+
+old = json.loads(OLD.read_text(encoding="utf-8"))
+new = json.loads(NEW.read_text(encoding="utf-8"))
+assert old["status"] == "superseded"
+assert old["superseded_by"] == NEW.name
+assert old["compliance_claim"] == "none"
+assert new["claim"] == "alignment_pilot_not_google_certification"
+assert new["preference_key_changes"] == 0
+assert new["route_changes"] == 0
+
+print("LEGACY_VISUAL_CONTRACT=SUPERSEDED")
+print("SUPERSEDED_BY=ANDROID_SETTINGS_GUIDANCE_PILOT_V1")
+print("COMPLIANCE_CLAIM=NONE")
+print("RESULT=MORPHE_ISSUE121_MATERIAL_VISUAL_FOUNDATION_V1_SUPERSEDED_PASS")

--- a/tools/check_boost_settings_navigation_ia_contract.py
+++ b/tools/check_boost_settings_navigation_ia_contract.py
@@ -1,0 +1,113 @@
+#!/usr/bin/env python3
+"""Phase 2 Navigation contract for Morphe Issue #121."""
+from __future__ import annotations
+import hashlib, json, re
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SETTINGS = ROOT / "extensions/boostforreddit/src/main/java/app/morphe/extension/boostforreddit/settings"
+NATIVE_PATH = SETTINGS / "MorpheSettingsV4NativePages.java"
+CATALOG_PATH = SETTINGS / "MorpheSettingsV4Catalog.java"
+HUB_PATH = SETTINGS / "MorpheSettingsV4NavigationDrawerHubFragment.java"
+CONTRACT_PATH = ROOT / "tools/contracts/boost-settings-navigation-phase2-v1.json"
+EXPECTED_CONTRACT_SHA256 = "0a1be51e15f3e914d78ebe04fd832895f5d0fe8f326b78048c8474fce282e624"
+
+def class_block(text: str, declaration: str) -> str:
+    start=text.find(declaration)
+    if start<0: raise AssertionError(f"missing declaration: {declaration}")
+    brace=text.find("{",start); depth=0
+    for index in range(brace,len(text)):
+        if text[index]=="{": depth+=1
+        elif text[index]=="}":
+            depth-=1
+            if depth==0: return text[start:index+1]
+    raise AssertionError(f"unclosed declaration: {declaration}")
+
+def switch_case_map(method: str) -> dict[str,str]:
+    result={}
+    pattern=re.compile(r'((?:\s*case "(pref_[a-z0-9_]+)":)+)\s*return ([A-Z0-9_]+);',re.S)
+    for m in pattern.finditer(method):
+        for key in re.findall(r'case "(pref_[a-z0-9_]+)":',m.group(1)):
+            result[key]=m.group(3)
+    return result
+
+raw=CONTRACT_PATH.read_bytes()
+actual_sha=hashlib.sha256(raw).hexdigest()
+assert actual_sha==EXPECTED_CONTRACT_SHA256,actual_sha
+contract=json.loads(raw.decode())
+native=NATIVE_PATH.read_text()
+catalog=CATALOG_PATH.read_text()
+hub=HUB_PATH.read_text()
+
+assert contract["task_page"]["children"]==['Toolbar', 'Bottom navigation', 'Navigation drawer', 'Back & exit']
+assert contract["drawer_hub"]["children"]==['Feeds & library', 'Account & tools', 'Go-to shortcuts', 'Quick toggles', 'Subscriptions', 'Account switcher', 'Drawer behavior']
+assert contract["exposed_key_count"]==30
+assert contract["withheld_keys"]==["pref_drawer_show_friends"]
+assert contract["max_controls_per_leaf"]==6
+assert len(contract["leaf_pages"])==10
+
+expected_keys=set(); expected_fragments={}
+for page in contract["leaf_pages"]:
+    keys=page["keys"]; assert 1<=len(keys)<=6
+    expected_keys.update(keys)
+    for key in keys: expected_fragments[key]=page["fragment_constant"]
+    declaration="public static final class "+page["fragment_class"]+"\n            extends NavigationSubsetPage"
+    block=class_block(native,declaration)
+    literals=set(re.findall(r'"(pref_[a-z0-9_]+)"',block))
+    literals.discard(page["resource"])
+    assert literals==set(keys),(page["id"],sorted(literals),sorted(keys))
+    assert f'"{page["title"]}"' in block
+    assert f'"{page["resource"]}"' in block
+
+assert len(expected_keys)==30
+assert "pref_drawer_show_friends" not in expected_keys
+assert "MORPHE_BOOST_SETTINGS_NAVIGATION_PHASE2_LEAF_SPLIT_ISSUE121_V1" in native
+assert "private abstract static class NavigationSubsetPage" in native
+assert "protected String pageIntro()" in native
+
+nstart=catalog.index('new Category(\n                    "navigation"')
+nend=catalog.index("new Category(",nstart+1)
+ncat=catalog[nstart:nend]
+for title in contract["task_page"]["children"]: assert f'"{title}"' in ncat
+for constant in ("V4_NAVIGATION_TOOLBAR_FRAGMENT","V4_NAVIGATION_BOTTOM_FRAGMENT",
+                 "V4_NAVIGATION_DRAWER_HUB_FRAGMENT","V4_NAVIGATION_BACK_EXIT_FRAGMENT"):
+    assert constant in ncat
+assert "V4_NAVIGATION_FRAGMENT" not in catalog
+assert '"Navigation controls"' not in ncat
+assert '"navigation".equals(category.id)' not in catalog
+
+frag_method=class_block(catalog,"private static String navigationFragmentForKey(String key)")
+assert switch_case_map(frag_method)==expected_fragments
+exposed=class_block(catalog,"private static boolean isNavigationExposedKey(String key)")
+assert set(re.findall(r'case "(pref_[a-z0-9_]+)":',exposed))==expected_keys
+assert "pref_drawer_show_friends" not in exposed
+
+general=class_block(native,"public static final class General extends NativePage")
+assert '"pref_ask_exit".equals(key)' in general and '"pref_double_exit".equals(key)' in general
+
+assert "MORPHE_BOOST_SETTINGS_NAVIGATION_DRAWER_HUB_ISSUE121_V1" in hub
+astart=hub.index("private static final Destination[] DESTINATIONS")
+aend=hub.index("\n    };",astart)+len("\n    };")
+arr=hub[astart:aend]
+assert arr.count("new Destination(")==7
+for page in contract["leaf_pages"]:
+    if page["parent"]=="Navigation drawer":
+        assert f'"{page["title"]}"' in arr
+        assert "MorpheSettingsV4Catalog."+page["fragment_constant"] in arr
+assert "MorpheSettingsV4Search.prepareMenu(this, menu, true);" in hub
+assert "MorpheSettingsV4Search.handleMenuItem(this, item)" in hub
+assert "public static final class BottomNavigation extends NativePage" in native
+assert "public static final class Drawer extends NativePage" in native
+
+print(f"CONTRACT={CONTRACT_PATH}")
+print(f"CONTRACT_SHA256={actual_sha}")
+print("NAVIGATION_TASK_CHILD_COUNT=4")
+print("NAVIGATION_DRAWER_CHILD_COUNT=7")
+print("NAVIGATION_LEAF_PAGE_COUNT=10")
+print("NAVIGATION_EXPOSED_KEY_COUNT=30")
+print("NAVIGATION_MAX_CONTROLS_PER_LEAF=6")
+print("WITHHELD_FRIENDS_KEY=PASS")
+print("SEARCH_ROUTE_CONTRACT=PASS")
+print("GLOBAL_SEARCH_COVERAGE=PASS")
+print("CLASSIC_FALLBACK_PRESERVED=PASS")
+print("RESULT=MORPHE_ISSUE121_NAVIGATION_PHASE2_CONTRACT_PASS")

--- a/tools/check_boost_settings_root_shell_phase1_contract.py
+++ b/tools/check_boost_settings_root_shell_phase1_contract.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python3
+"""Static task-page contract for Morphe Issue #121 Settings Phase 1."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SETTINGS = ROOT / "extensions/boostforreddit/src/main/java/app/morphe/extension/boostforreddit/settings"
+CATALOG_PATH = SETTINGS / "MorpheSettingsV4Catalog.java"
+FRAGMENT_PATH = SETTINGS / "MorpheSettingsV4Fragment.java"
+NATIVE_PATH = SETTINGS / "MorpheSettingsV4NativePages.java"
+
+catalog = CATALOG_PATH.read_text(encoding="utf-8")
+fragment = FRAGMENT_PATH.read_text(encoding="utf-8")
+native = NATIVE_PATH.read_text(encoding="utf-8")
+
+EXPECTED_CATEGORIES = [
+    ("theme_colors", "Theme & colors"),
+    ("community_header", "Community header"),
+    ("post_layout", "Post layout"),
+    ("typography", "Typography"),
+    ("display_motion", "Display & motion"),
+    ("posts", "Posts"),
+    ("comments", "Comments"),
+    ("search_filters", "Search & filters"),
+    ("feeds_subscriptions", "Feeds & subscriptions"),
+    ("composing_drafts", "Composing & drafts"),
+    ("navigation", "Navigation & gestures"),
+    ("playback_autoplay", "Playback & autoplay"),
+    ("images_previews", "Images, GIFs & previews"),
+    ("links_browser", "Links & browser"),
+    ("downloads_cache", "Downloads & cache"),
+    ("notifications_inbox", "Notifications & inbox"),
+    ("reddit_account", "Reddit account"),
+    ("history_privacy_recovery", "History, privacy & recovery"),
+    ("storage_bandwidth", "Storage & bandwidth"),
+    ("backup_restore", "Backup & restore"),
+    ("app_behavior_compatibility", "App behavior & compatibility"),
+    ("settings_experience", "Settings experience"),
+    ("about_support", "About & support"),
+]
+
+category_pattern = re.compile(
+    r'new\s+Category\(\s*"([^"]+)"\s*,\s*"([^"]+)"\s*,',
+    re.S,
+)
+actual_categories = category_pattern.findall(catalog)
+assert actual_categories == EXPECTED_CATEGORIES, actual_categories
+assert len(EXPECTED_CATEGORIES) + 1 == 24
+
+assert "MORPHE_BOOST_SETTINGS_ROOT_SHELL_ISSUE121_PHASE1_V1" in fragment
+assert "if (!opensDirectly(category))" in catalog
+assert "addTaskPageSearchItem(result, seen, category);" in catalog
+assert "static boolean opensDirectly(Category category)" in catalog
+assert "final String pageId;" in catalog
+assert "openCategory(category);" in fragment
+assert "intent.putExtra(ARGUMENT_PAGE, categoryId);" in fragment
+assert "MorpheSettingsV4Catalog.opensDirectly(category)" in fragment
+assert "category.leaves.length == 1" in catalog
+assert '"navigation".equals(category.id)' not in catalog
+navigation_start = catalog.index(
+    'new Category(\n                    "navigation"'
+)
+navigation_end = catalog.index("new Category(", navigation_start + 1)
+navigation_category = catalog[navigation_start:navigation_end]
+assert navigation_category.count("Leaf.fragment(") == 4
+for title in (
+    "Toolbar",
+    "Bottom navigation",
+    "Navigation drawer",
+    "Back & exit",
+):
+    assert f'"{title}"' in navigation_category
+assert "category.leaves.length == 0" in fragment
+assert "classic Boost settings while this task page is organized" in fragment
+assert "public static final class Headers extends NativePage" in native
+assert 'super("Community header", "pref_headers_v2");' in native
+
+print("TASK_PAGE_COUNT=24")
+print("TASK_PAGE_SEARCH_ROUTING=PASS")
+print("DIRECT_EXISTING_ROUTE_POLICY=PASS")
+print("PLACEHOLDER_TASK_PAGE_POLICY=PASS")
+print("CLASSIC_FALLBACK_PRESERVED=PASS")
+print("RESULT=MORPHE_ISSUE121_SETTINGS_ROOT_SHELL_PHASE1_CONTRACT_PASS")

--- a/tools/check_boost_settings_seven_card_root_phase1_1_contract.py
+++ b/tools/check_boost_settings_seven_card_root_phase1_1_contract.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python3
+"""Seven-category root depth contract for Morphe Issue #121."""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SETTINGS = ROOT / "extensions/boostforreddit/src/main/java/app/morphe/extension/boostforreddit/settings"
+CATALOG = (SETTINGS / "MorpheSettingsV4Catalog.java").read_text(encoding="utf-8")
+FRAGMENT = (SETTINGS / "MorpheSettingsV4Fragment.java").read_text(encoding="utf-8")
+DEPTH_PATH = ROOT / "tools/contracts/boost-settings-ux-depth-v1.json"
+DEPTH = json.loads(DEPTH_PATH.read_text(encoding="utf-8"))
+
+EXPECTED_ROOT_GROUPS = [
+    ("root_morphe", "Morphe", []),
+    ("root_appearance", "Appearance", [
+        "theme_colors", "community_header", "post_layout", "typography", "display_motion"
+    ]),
+    ("root_reading_interaction", "Reading & interaction", [
+        "posts", "comments", "search_filters", "feeds_subscriptions", "composing_drafts"
+    ]),
+    ("root_navigation", "Navigation", ["navigation"]),
+    ("root_media", "Media", [
+        "playback_autoplay", "images_previews", "links_browser", "downloads_cache"
+    ]),
+    ("root_notifications_account", "Notifications & account", [
+        "notifications_inbox", "reddit_account", "history_privacy_recovery"
+    ]),
+    ("root_data_app", "Data & app", [
+        "storage_bandwidth", "backup_restore", "app_behavior_compatibility",
+        "settings_experience", "about_support"
+    ]),
+]
+
+array_start = CATALOG.index("private static final RootGroup[] ROOT_GROUPS")
+array_end = CATALOG.index("\n\n    private MorpheSettingsV4Catalog()", array_start)
+array = CATALOG[array_start:array_end]
+blocks = re.findall(r"new RootGroup\((.*?)\n            \)", array, re.S)
+actual = []
+for block in blocks:
+    strings = re.findall(r'"([^"]+)"', block)
+    assert len(strings) >= 4, strings
+    actual.append((strings[0], strings[1], strings[4:]))
+assert actual == EXPECTED_ROOT_GROUPS, actual
+
+render_start = FRAGMENT.index("    private void renderCategories() {")
+render_end = FRAGMENT.index("\n\n    private void renderSearchResults(", render_start)
+render = FRAGMENT[render_start:render_end]
+assert "MorpheSettingsV4Catalog.rootGroups()" in render
+assert "MorpheSettingsV14Ui.standardList(requireContext())" in render
+assert "MorpheSettingsV14Ui.addStandardListRow(" in render
+assert "renderRootCard(" not in FRAGMENT
+assert "renderHomeSection(" not in render
+for _, task_title in re.findall(
+    r'new\s+Category\(\s*"([^"]+)"\s*,\s*"([^"]+)"', CATALOG, re.S
+):
+    assert f'addSectionLabel(dynamicContent, "{task_title}")' not in render
+
+assert "private void buildRootGroup(" in FRAGMENT
+assert "rootGroup.includesMorphe" in FRAGMENT
+assert "for (String categoryId : rootGroup.categoryIds)" in FRAGMENT
+assert "view -> openRootGroup(rootGroup)" in FRAGMENT
+assert "MORPHE_BOOST_SETTINGS_SEVEN_CARD_ROOT_ISSUE121_PHASE1_1_V1" in FRAGMENT
+assert "MorpheSettingsV4Catalog.findRootGroup(page)" in FRAGMENT
+
+assert DEPTH["schema"] == 1
+assert DEPTH["issue"] == 121
+assert DEPTH["root_screen"] == "seven_category_list_rows"
+assert DEPTH["root_group_count"] == 7
+assert DEPTH["task_pages"] == "one_level_below_root"
+assert DEPTH["task_pages_must_not_be_xml_dumps"] is True
+assert DEPTH["intermediate_pages_required_when_domains_mix"] is True
+assert DEPTH["leaf_target_controls"] == {"min": 4, "max": 9}
+assert DEPTH["leaf_hard_max_controls"] == 12
+assert DEPTH["section_headers_do_not_replace_navigation"] is True
+assert DEPTH["comments_topology"]["child_pages"] == [
+    "Sorting & loading", "Appearance", "Collapse behavior", "Navigation & controls"
+]
+
+print("ROOT_CATEGORY_ROW_COUNT=7")
+print("ROOT_LAYOUT=STANDARD_LIST")
+print("TASK_PAGES_ON_ROOT=0")
+print("TASK_PAGES_ONE_LEVEL_DOWN=PASS")
+print("LEAF_TARGET_RANGE=4_TO_9")
+print("LEAF_HARD_MAX=12")
+print("COMMENTS_DEPTH_CONTRACT=PASS")
+print("CLASSIC_FALLBACK_PRESERVED=PASS")
+print("RESULT=MORPHE_ISSUE121_SETTINGS_SEVEN_CATEGORY_ROOT_CONTRACT_PASS")

--- a/tools/check_boost_settings_v5_activation_contract.py
+++ b/tools/check_boost_settings_v5_activation_contract.py
@@ -1,0 +1,158 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+COMPLETENESS = ROOT / "tools/contracts/boost-settings-v5-completeness-v2.json"
+ROOT_WAVE_CONTRACT = (
+    ROOT / "tools/contracts/boost-settings-v5-root-overview-wave-v1.json"
+)
+HISTORICAL_AUDIT = ROOT / "tools/audit_boost_settings_v5_implementation.py"
+ROOT_WAVE_CHECKER = (
+    ROOT / "tools/check_boost_settings_v5_root_overview_wave_v1.py"
+)
+EVIDENCE = ROOT / "tools/contracts/boost-settings-v5-runtime-validation-v1.json"
+MPP = ROOT / "patches/build/libs/patches-1.4.94.mpp"
+
+SETTINGS = (
+    ROOT
+    / "extensions/boostforreddit/src/main/java/"
+    / "app/morphe/extension/boostforreddit/settings"
+)
+V4 = SETTINGS / "MorpheSettingsV4.java"
+REGISTRY = SETTINGS / "MorpheSettingsV5Registry.java"
+ROOT_FRAGMENT = SETTINGS / "MorpheSettingsV5RootFragment.java"
+
+EXPECTED_HISTORICAL = {
+    COMPLETENESS: "f1d6a9ac6c27f71eec61b300e5f36d0785d831fde14cb982450e21b3ae238682",
+    ROOT_WAVE_CONTRACT: "68712a6fd73aebda4e5a24a013517191e4abbecc1eb8b7b46d6280546b93d5b7",
+    HISTORICAL_AUDIT: "3472dfaea9972d47d49267f28f2bc7f390b95a5fc055ea3be2d4849c8a093845",
+    ROOT_WAVE_CHECKER: "19e673a0fd415117c87ebd49557a21d328800273d6d1de4e395c3a53b4fb075d",
+}
+EXPECTED_EVIDENCE_SHA = (
+    "d6b2c47b59202aa035e4e339cc89b3095087715dfb60feaad7a5478c1100dcf3"
+)
+EXPECTED_MPP_SHA = (
+    "0c52634ea6519c720896624e3f13706efa29c15d2c36d2d8f6fa88df0b1cc7cb"
+)
+
+def require(condition: bool, message: str) -> None:
+    if not condition:
+        raise SystemExit(f"FAIL={message}")
+
+def sha(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+def load(path: Path) -> dict:
+    value = json.loads(path.read_text(encoding="utf-8"))
+    require(isinstance(value, dict), f"JSON_OBJECT_REQUIRED_{path.name}")
+    return value
+
+for path, expected in EXPECTED_HISTORICAL.items():
+    require(path.is_file(), f"HISTORICAL_FILE_MISSING_{path.name}")
+    require(sha(path) == expected, f"HISTORICAL_SHA_{path.name}")
+
+require(sha(EVIDENCE) == EXPECTED_EVIDENCE_SHA, "RUNTIME_EVIDENCE_SHA")
+require(sha(MPP) == EXPECTED_MPP_SHA, "ACTIVATED_MPP_SHA")
+
+completeness = load(COMPLETENESS)
+revision = completeness.get("semantic_revision")
+require(isinstance(revision, dict), "SEMANTIC_REVISION_OBJECT")
+require(revision.get("revision") == "V4", "SEMANTIC_REVISION_V4")
+require("activation_contract" not in completeness, "HISTORICAL_COMPLETENESS_MUTATED")
+
+evidence = load(EVIDENCE)
+require(evidence.get("schema_version") == 1, "EVIDENCE_SCHEMA")
+require(evidence.get("issue") == 121, "EVIDENCE_ISSUE")
+require(evidence.get("semantic_revision") == "V4", "EVIDENCE_REVISION")
+require(evidence.get("validation_state") == "complete", "EVIDENCE_COMPLETE")
+
+activation = evidence["activation"]
+require(activation["v5_visible_by_default"] is True, "VISIBLE_DEFAULT")
+require(activation["material_settings_true_route"] == "v5", "TRUE_ROUTE")
+require(activation["material_settings_false_route"] == "classic", "FALSE_ROUTE")
+require(
+    activation["normal_settings_launch_fragment_override"] is False,
+    "NORMAL_LAUNCH_OVERRIDE",
+)
+
+expected_coverage = {
+    "classic_fallback_runtime": 1,
+    "root_destinations_click": 7,
+    "root_destinations_render": 7,
+    "root_destinations_back": 7,
+    "visible_root_labels": 8,
+    "morphe_configurable_controls": 12,
+}
+for key, target in expected_coverage.items():
+    require(
+        evidence["coverage"][key] == {"covered": target, "target": target},
+        f"COVERAGE_{key}",
+    )
+
+safety = evidence["safety"]
+require(safety["relevant_fatal_count"] == 0, "RELEVANT_FATALS")
+require(
+    safety["critical_settings_exception_count"] == 0,
+    "CRITICAL_SETTINGS_EXCEPTIONS",
+)
+require(safety["normal_boost_untouched"] is True, "NORMAL_BOOST_UNTOUCHED")
+require(
+    safety["setting_value_mutations_by_harness"] is False,
+    "SETTING_MUTATIONS",
+)
+
+v4_text = V4.read_text(encoding="utf-8")
+registry_text = REGISTRY.read_text(encoding="utf-8")
+root_text = ROOT_FRAGMENT.read_text(encoding="utf-8")
+
+require('"MorpheSettingsV5RootFragment"' in v4_text, "V5_ENTRY_ROUTE")
+require(
+    re.search(r"V5_VISIBLE_BY_DEFAULT\s*=\s*true", registry_text)
+    is not None,
+    "V5_VISIBLE_SOURCE",
+)
+require("Open classic Boost settings" in root_text, "CLASSIC_FALLBACK_SOURCE")
+
+root_children_match = re.search(
+    r'case\s+"v5/root"\s*:\s*'
+    r'return\s+new\s+String\[\]\s*\{([^}]*)\}',
+    registry_text,
+    re.S,
+)
+require(root_children_match is not None, "ROOT_CHILDREN_SOURCE")
+require(
+    len(re.findall(r'"v5/[^"]+"', root_children_match.group(1))) == 7,
+    "ROOT_CHILD_COUNT",
+)
+
+artifact_roles = {item["role"] for item in evidence["artifacts"]}
+require(len(artifact_roles) == 10, "RUNTIME_ARTIFACT_ROLE_COUNT")
+for item in evidence["artifacts"]:
+    require(
+        re.fullmatch(r"[0-9a-f]{64}", item["sha256"]) is not None,
+        f"ARTIFACT_SHA_{item['role']}",
+    )
+
+print("CONTRACT_ARCHITECTURE=IMMUTABLE_HISTORICAL_WAVES_PLUS_FINAL_ACTIVATION_EVIDENCE")
+print(f"EVIDENCE={EVIDENCE}")
+print(f"EVIDENCE_SHA256={sha(EVIDENCE)}")
+print("SEMANTIC_REVISION=V4")
+print("HISTORICAL_COMPLETENESS_IMMUTABLE=YES")
+print("HISTORICAL_ROOT_WAVE_IMMUTABLE=YES")
+print("HISTORICAL_IMPLEMENTATION_AUDIT_IMMUTABLE=YES")
+print("V5_RUNTIME_ROOT_COVERAGE=7/7")
+print("V5_VISIBLE_ROOT_LABEL_COVERAGE=8/8")
+print("V5_CLASSIC_FALLBACK_RUNTIME_COVERAGE=1/1")
+print("V5_MORPHE_CONFIGURABLE_CONTROL_COVERAGE=12/12")
+print("V5_VISIBLE_STATE=TRUE")
+print("ACTIVATION_PERFORMED=YES")
+print("RELEVANT_FATAL_COUNT=0")
+print("CRITICAL_SETTINGS_EXCEPTION_COUNT=0")
+print("NORMAL_BOOST_UNTOUCHED=YES")
+print("RESULT=MORPHE_ISSUE121_SETTINGS_V5_FINAL_ACTIVATION_CONTRACT_PASS")

--- a/tools/check_boost_settings_v5_appearance_wave_v1.py
+++ b/tools/check_boost_settings_v5_appearance_wave_v1.py
@@ -1,0 +1,232 @@
+#!/usr/bin/env python3
+"""Static contract for the hidden, complete Settings V5 Appearance wave."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+import subprocess
+import tempfile
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SETTINGS = (
+    ROOT
+    / "extensions/boostforreddit/src/main/java/app/morphe/extension/"
+    / "boostforreddit/settings"
+)
+WAVE_CONTRACT = ROOT / "tools/contracts/boost-settings-v5-appearance-wave-v1.json"
+V5_CONTRACT = ROOT / "tools/contracts/boost-settings-v5-completeness-v2.json"
+AUDIT = ROOT / "tools/audit_boost_settings_v5_implementation.py"
+
+EXPECTED_WAVE_SHA = "987fec53ecef1bd96dd22839a0fd67a6c25722d1504cc77e472ca5aa1b20fe10"
+EXPECTED_CAPTURE_V5_SHA = "4c8e081069d7444938c3ff5ad0e451bb3b16183592114a6b8adf77cd1208d3f7"
+EXPECTED_V5_SHA = "f1d6a9ac6c27f71eec61b300e5f36d0785d831fde14cb982450e21b3ae238682"
+EXPECTED_ARCHIVE_SHA = "1953af26eb18a1f00a9adeb02252696551d394867892afa0b62ac65ad0b53ae3"
+EXPECTED_BASE_APK_SHA = "a68c22d632a5dd1f446c3759a171c7dbb9edab2afc3c2f87e39323f198606742"
+EXPECTED_SOURCE_MPP_SHA = "c238c79d16f17877a46483e6f467f36a0086f50fe8c4172b64663e4ab30016f7"
+
+PAGE_PATTERN = re.compile(
+    r'new\s+V5PageSpec\s*\(\s*'
+    r'"(?P<page_id>v5/[^"]+)"\s*,\s*'
+    r'"(?P<renderer>[^"]+)"\s*,\s*'
+    r'new\s+String\s*\[\]\s*\{(?P<keys>.*?)\}\s*\)',
+    re.S,
+)
+KEY_PATTERN = re.compile(r'"([^"]+)"')
+FORBIDDEN = (
+    "SettingsActivityCompat$",
+    "PreferenceFragmentAdvancedCompat",
+    "MorpheSettingsV4NativePages",
+    "MorpheSettingsV4AppearanceFragment",
+    "MorpheSettingsV4PostViewsFragment",
+    "MorpheSettingsV4FontsFragment",
+    "MorpheSettingsV4DownloadsFragment",
+    "MorpheSettingsV4NavigationDrawerHubFragment",
+    "MorpheSettingsFragment.class.getName()",
+    "MORPHE_V5_PLACEHOLDER_PAGE",
+)
+
+
+def bound_json(path: Path, expected_sha: str) -> dict:
+    raw = path.read_bytes()
+    actual = hashlib.sha256(raw).hexdigest()
+    assert actual == expected_sha, (path, actual, expected_sha)
+    return json.loads(raw.decode("utf-8"))
+
+
+wave = bound_json(WAVE_CONTRACT, EXPECTED_WAVE_SHA)
+v5 = bound_json(V5_CONTRACT, EXPECTED_V5_SHA)
+assert wave["schema"] == 1
+assert wave["issue"] == 121
+assert wave["wave"] == "Appearance"
+assert wave["binding_capture"] == {
+    "archive_sha256": EXPECTED_ARCHIVE_SHA,
+    "base_apk_sha256": EXPECTED_BASE_APK_SHA,
+    "source_mpp_sha256": EXPECTED_SOURCE_MPP_SHA,
+    "v5_contract_sha256": EXPECTED_CAPTURE_V5_SHA,
+}
+assert wave["target"] == {
+    "legacy_routes": 0,
+    "max_controls_per_leaf": 8,
+    "placeholder_pages": 0,
+    "screen_nodes": 22,
+    "visible_by_default": False,
+    "visible_items": 39,
+    "withheld_items": 0,
+}
+
+appearance_screens = [screen for screen in v5["screens"] if screen["root"] == "Appearance"]
+appearance_items = [item for item in v5["items"] if item["root"] == "Appearance"]
+assert len(appearance_screens) == 22
+assert len(appearance_items) == 39
+assert all(item["v5_visibility"] == "VISIBLE" for item in appearance_items)
+
+expected_pages = {entry["page_id"]: entry for entry in wave["screens"]}
+expected_keys_by_page = {page_id: set() for page_id in expected_pages}
+for item in wave["items"]:
+    expected_keys_by_page[item["page_id"]].add(item["key"])
+assert len(expected_pages) == 22
+assert sum(len(keys) for keys in expected_keys_by_page.values()) == 39
+assert max(len(keys) for keys in expected_keys_by_page.values()) == 8
+
+source_paths = [SETTINGS / name for name in wave["source_files"]]
+assert all(path.is_file() for path in source_paths)
+source = {path.name: path.read_text(encoding="utf-8") for path in source_paths}
+all_text = "\n".join(source.values())
+registry = source["MorpheSettingsV5Registry.java"]
+fragment = source["MorpheSettingsV5AppearanceFragment.java"]
+bindings = source["MorpheSettingsV5AppearanceBindings.java"]
+search = source["MorpheSettingsV5Search.java"]
+
+for token in FORBIDDEN:
+    assert token not in all_text, token
+
+assert "V5_VISIBLE_BY_DEFAULT = false" in registry
+assert "V5_VISIBLE_BY_DEFAULT = true" not in registry
+assert "MORPHE_BOOST_SETTINGS_V5_APPEARANCE_WAVE_ISSUE121_V1" in registry
+assert "MORPHE_BOOST_SETTINGS_V5_APPEARANCE_FRAGMENT_ISSUE121_V1" in fragment
+assert "MORPHE_BOOST_SETTINGS_V5_APPEARANCE_BINDINGS_ISSUE121_V1" in bindings
+assert "MORPHE_BOOST_SETTINGS_V5_SEARCH_ISSUE121_V1" in search
+
+actual_pages: dict[str, dict] = {}
+for match in PAGE_PATTERN.finditer(registry):
+    page_id = match.group("page_id")
+    assert page_id not in actual_pages
+    actual_pages[page_id] = {
+        "renderer": match.group("renderer"),
+        "keys": set(KEY_PATTERN.findall(match.group("keys"))),
+    }
+appearance_actual_pages = {
+    page_id: value
+    for page_id, value in actual_pages.items()
+    if page_id.startswith("v5/appearance")
+}
+assert set(appearance_actual_pages) == set(expected_pages)
+for page_id, page in appearance_actual_pages.items():
+    assert page["renderer"] == "MorpheSettingsV5AppearanceFragment"
+    assert page["keys"] == expected_keys_by_page[page_id], (
+        page_id,
+        sorted(page["keys"]),
+        sorted(expected_keys_by_page[page_id]),
+    )
+
+assert "MorpheSettingsV5Registry.requirePage(" in fragment
+assert "MorpheSettingsV5Registry.childrenFor(" in fragment
+assert "MorpheSettingsV5AppearanceBindings.renderPage(" in fragment
+assert "MorpheSettingsV5Search.prepareMenu(this, menu)" in fragment
+assert "MorpheSettingsV5Search.handleMenuItem(this, item)" in fragment
+navigation = (SETTINGS / "MorpheSettingsV5Navigation.java").read_text(
+    encoding="utf-8"
+)
+assert "MorpheSettingsV5Navigation.openPage(this, targetPageId)" in fragment
+assert "activity.startActivity(intent)" in navigation
+
+assert "PreferenceManager.getDefaultSharedPreferences" in bindings
+assert '"com.rubenmayayo.reddit.VIEW_PER_SUBSCRIPTION"' in bindings
+assert "pref_theme_values_night" in bindings
+assert "pref_theme_values" in bindings
+assert 'Class.forName("he.f0")' in bindings
+assert 'invokeStaticNoArgs("kb.a", "d")' in bindings
+assert 'Class.forName("id.b")' in bindings
+assert "TimePickerDialog" in bindings
+assert "PackageManager.COMPONENT_ENABLED_STATE_ENABLED" in bindings
+assert "pref_cards_preview_self_lines" in bindings
+assert "setBoostStaticString(" in bindings
+assert "showAddSavedViewDialog" in bindings
+assert "renderSavedEntries" in bindings
+assert "confirmResetTypography" in bindings
+assert "hideSoftInputFromWindow" in search
+assert "OnBackInvokedDispatcher.PRIORITY_OVERLAY" in search
+assert "new Dialog(activity)" in search
+assert "MorpheSettingsV5Navigation.openPage(host, entry.pageId)" in search
+
+for key, dependency in wave["dependencies"].items():
+    assert f'"{key}"' in bindings
+    if dependency.startswith("not:"):
+        assert f'"{dependency[4:]}"' in bindings
+        assert "inverseDependency" in bindings
+    else:
+        assert f'"{dependency}"' in bindings
+
+for category, keys in wave["special_handlers"].items():
+    assert keys, category
+    for key in keys:
+        assert f'"{key}"' in bindings, (category, key)
+
+with tempfile.TemporaryDirectory(prefix="morphe-v5-appearance-audit-") as temp:
+    output_dir = Path(temp)
+    completed = subprocess.run(
+        ["python3", str(AUDIT), "--output-dir", str(output_dir)],
+        cwd=ROOT,
+        text=True,
+        capture_output=True,
+        check=True,
+    )
+    report = json.loads(
+        (output_dir / "settings-v5-implementation-audit.json").read_text(
+            encoding="utf-8"
+        )
+    )
+    assert report["status"] == "INCOMPLETE"
+    assert report["current"]["v5_source_file_count"] >= 4
+    assert report["current"]["implemented_target_page_count"] >= 22
+    assert report["current"]["implemented_visible_item_count"] >= 39
+    assert report["current"]["visible_state"] == "FALSE"
+    violations = report["violations"]
+    assert violations["placeholder_count"] == 0
+    assert violations["classic_route_violations"] == []
+    assert violations["duplicate_page_ids"] == []
+    assert violations["duplicate_visible_keys"] == []
+    assert violations["page_key_mismatches"] == []
+    assert violations["missing_renderer_classes"] == []
+    appearance = next(
+        row for row in report["root_progress"] if row["root"] == "Appearance"
+    )
+    assert appearance == {
+        "root": "Appearance",
+        "implemented_pages": 22,
+        "expected_pages": 22,
+        "implemented_visible_items": 39,
+        "expected_visible_items": 39,
+        "accounted_withheld_items": 0,
+        "expected_withheld_items": 0,
+    }
+    assert "V5_SCREEN_NODE_COVERAGE=" in completed.stdout
+    assert "V5_VISIBLE_ITEM_COVERAGE=" in completed.stdout
+    assert "V5_VISIBLE_STATE=FALSE" in completed.stdout
+
+print(f"CONTRACT={WAVE_CONTRACT}")
+print(f"CONTRACT_SHA256={EXPECTED_WAVE_SHA}")
+print("V5_APPEARANCE_SCREEN_COVERAGE=22/22")
+print("V5_APPEARANCE_VISIBLE_ITEM_COVERAGE=39/39")
+print("V5_GLOBAL_SCREEN_COVERAGE=22/105")
+print("V5_GLOBAL_VISIBLE_ITEM_COVERAGE=39/247")
+print("V5_VISIBLE_STATE=FALSE")
+print("PLACEHOLDER_PAGE_COUNT=0")
+print("LEGACY_ROUTE_COUNT=0")
+print("SPECIAL_HANDLER_ACCOUNTING=PASS")
+print("DEPENDENCY_ACCOUNTING=PASS")
+print("GLOBAL_SEARCH_ROUTE=PASS")
+print("RESULT=MORPHE_ISSUE121_SETTINGS_V5_APPEARANCE_WAVE_V1_CONTRACT_PASS")

--- a/tools/check_boost_settings_v5_completeness_contract.py
+++ b/tools/check_boost_settings_v5_completeness_contract.py
@@ -1,0 +1,594 @@
+#!/usr/bin/env python3
+"""Integrity checker for the semantically corrected Morphe Settings V5 target."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+from collections import Counter, defaultdict
+from pathlib import Path
+from typing import Any
+
+EXPECTED_BLUEPRINT_SHA256 = "039a12c61443b584a65a9ee5fcac7c59e786f1d94b3ae042d60f2b9d89cbf832"
+EXPECTED_NAVIGATION_SHA256 = "0a1be51e15f3e914d78ebe04fd832895f5d0fe8f326b78048c8474fce282e624"
+EXPECTED_PREVIOUS_CONTRACT_SHA256 = (
+    "30745994dd0aec9f8c5d9b118dfaaee26d4522c5ca6d55a01da27a97961896f7"
+)
+EXPECTED_CONTRACT_SHA256 = (
+    "f1d6a9ac6c27f71eec61b300e5f36d0785d831fde14cb982450e21b3ae238682"
+)
+
+EXPECTED_ROOT_ORDER = [
+    "Morphe",
+    "Appearance",
+    "Reading & interaction",
+    "Navigation",
+    "Media",
+    "Notifications & account",
+    "Data & app",
+]
+EXPECTED_ROLE_COUNTS = Counter({
+    "root_group": 7,
+    "task_page": 22,
+    "intermediate_page": 5,
+    "leaf_section": 71,
+})
+EXPECTED_ACTIVATION_GATE = {
+    "activation_policy": "parallel_hidden_until_complete",
+    "allowed_classic_fallbacks": 1,
+    "allowed_external_action_destinations": 1,
+    "allowed_legacy_fragments": 0,
+    "allowed_legacy_xml_routes": 0,
+    "allowed_placeholder_pages": 0,
+    "allowed_title_route_mismatches": 0,
+    "allowed_unmapped_keys": 0,
+    "canonical_item_accounting": 248,
+    "classic_fallback_location": "root_only",
+    "external_action_destination_allowlist": ["BackupActivity"],
+    "partial_completion_must_not_replace_current_visible_tree": True,
+    "required_complete_screen_nodes": 105,
+    "required_complete_visible_items": 247,
+    "root_overview_shell_count": 1,
+    "root_overview_shell_must_be_complete": True,
+    "target_screen_edge_count": 98,
+    "target_screen_node_count": 105,
+    "visible_item_target": 247,
+    "withheld_controls_must_have_evidence": True,
+    "withheld_item_target": 1,
+}
+
+EXPECTED_CORRECTIONS = {
+    "buy_pro": (
+        "Appearance / Community header / Community header",
+        "Data & app / About & support / About Boost",
+    ),
+    "remove_ads": (
+        "Appearance / Community header / Community header",
+        "Data & app / About & support / About Boost",
+    ),
+    "pref_app_icon": (
+        "Appearance / Theme & colors / Theme",
+        "Appearance / Theme & colors / Personalization",
+    ),
+    "pref_load_readability": (
+        "Appearance / Post layout / Swipe",
+        "Media / Links & browser / Link handling",
+    ),
+    "pref_lock_sidebar": (
+        "Appearance / Post layout / Swipe",
+        "Navigation / Navigation drawer / Drawer behavior",
+    ),
+}
+EXPECTED_ALIAS_REMOVALS = {
+    "action:appearance:app_icon": "pref_app_icon",
+    "action:post_layout:manage_saved_views": "pref_view_per_sub",
+}
+REMOVED_SCREEN_PATHS = {
+    "Appearance / Post layout / Swipe",
+    "Morphe / Patch features",
+}
+STABLE_ITEM_FIELDS = (
+    "title",
+    "source_type",
+    "logical_kind",
+    "storage_type",
+    "default_value",
+    "dependency",
+    "help_treatment",
+    "proposed_summary",
+)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--root",
+        type=Path,
+        help="Repository root. Defaults to the parent of tools/.",
+    )
+    parser.add_argument(
+        "--contract",
+        type=Path,
+        help="Corrected V5 contract path. Defaults to the installed v2 contract.",
+    )
+    parser.add_argument(
+        "--previous-contract",
+        type=Path,
+        help="Superseded V5 v1 contract path.",
+    )
+    return parser.parse_args()
+
+
+def fail(message: str) -> None:
+    raise AssertionError(message)
+
+
+def load_bound(
+    path: Path,
+    expected_sha: str,
+    label: str,
+) -> tuple[dict[str, Any], str]:
+    if not path.is_file():
+        fail(f"{label} missing: {path}")
+    raw = path.read_bytes()
+    actual = hashlib.sha256(raw).hexdigest()
+    if actual != expected_sha:
+        fail(f"{label} sha mismatch: expected {expected_sha}, got {actual}")
+    data = json.loads(raw.decode("utf-8"))
+    if not isinstance(data, dict):
+        fail(f"{label} must be an object")
+    return data, actual
+
+
+def screen_path_for_navigation_page(page: dict[str, Any]) -> list[str]:
+    parent = page.get("parent")
+    title = page.get("title")
+    if parent == "Navigation & gestures":
+        return ["Navigation", title]
+    if parent == "Navigation drawer":
+        return [
+            "Navigation",
+            "Navigation drawer",
+            title,
+        ]
+    fail(f"unexpected Navigation parent: {parent!r}")
+
+
+args = parse_args()
+script_root = Path(__file__).resolve().parents[1]
+root = (args.root or script_root).resolve()
+blueprint_path = root / "tools/contracts/boost-settings-blueprint-v3.json"
+navigation_path = root / "tools/contracts/boost-settings-navigation-phase2-v1.json"
+previous_contract_path = (
+    args.previous_contract
+    or root / "tools/contracts/boost-settings-v5-completeness-v1.json"
+).resolve()
+contract_path = (
+    args.contract
+    or root / "tools/contracts/boost-settings-v5-completeness-v2.json"
+).resolve()
+
+blueprint, blueprint_sha = load_bound(
+    blueprint_path,
+    EXPECTED_BLUEPRINT_SHA256,
+    "blueprint",
+)
+navigation, navigation_sha = load_bound(
+    navigation_path,
+    EXPECTED_NAVIGATION_SHA256,
+    "navigation contract",
+)
+previous_contract, previous_sha = load_bound(
+    previous_contract_path,
+    EXPECTED_PREVIOUS_CONTRACT_SHA256,
+    "superseded V5 v1 contract",
+)
+contract, contract_sha = load_bound(
+    contract_path,
+    EXPECTED_CONTRACT_SHA256,
+    "corrected V5 v2 contract",
+)
+
+if blueprint.get("schema") != 3 or blueprint.get("issue") != 121:
+    fail("unexpected blueprint identity")
+if navigation.get("schema") != 1 or navigation.get("issue") != 121:
+    fail("unexpected Navigation contract identity")
+if previous_contract.get("schema") != 1 or previous_contract.get("issue") != 121:
+    fail("unexpected superseded V5 v1 contract identity")
+
+if contract.get("schema") != 1 or contract.get("issue") != 121:
+    fail("unexpected corrected V5 contract identity")
+if contract.get("target") != (
+    "Morphe Settings V5 semantically corrected complete tree"
+):
+    fail("unexpected corrected V5 target name")
+if contract.get("root_order") != EXPECTED_ROOT_ORDER:
+    fail("V5 root order mismatch")
+if contract.get("canonical_item_count") != 248:
+    fail("canonical logical-item target is not 248")
+if contract.get("visible_item_target") != 247:
+    fail("visible item target is not 247")
+if contract.get("withheld_item_target") != 1:
+    fail("withheld item target is not 1")
+if contract.get("screen_node_count") != 105:
+    fail("screen node target is not 105")
+if contract.get("screen_edge_count") != 98:
+    fail("screen edge target is not 98")
+if contract.get("morphe_configurable_feature_reference_count") != 12:
+    fail("Morphe configurable-feature reference count is not 12")
+if contract.get("root_overview_shell") != {
+    "classic_fallback_location": "root_only",
+    "count": 1,
+    "status_required": "COMPLETE",
+}:
+    fail("root overview shell policy mismatch")
+if contract.get("activation_gate") != EXPECTED_ACTIVATION_GATE:
+    fail("activation gate differs from the semantically corrected target")
+
+revision = contract.get("semantic_revision")
+if not isinstance(revision, dict) or revision.get("schema") != 2:
+    fail("semantic revision metadata missing")
+if revision.get("revision") != "V4":
+    fail("semantic revision identifier is not V4")
+if revision.get("supersedes_contract_sha256") != ("627f8850c2d8051fe03b3a07accb512f5392d6d54b1c708bf25e328e0112cac3"):
+    fail("semantic V4 does not supersede the locked semantic V3 contract")
+if revision.get("original_v1_contract_sha256") != previous_sha:
+    fail("semantic V4 does not preserve the original V1 lineage")
+if revision.get("principles") != [
+    "task-based placement",
+    "one visible control per user action",
+    "route aliases are graph metadata rather than duplicate controls",
+    "empty leaf screens are removed",
+    "single-task root wrappers are flattened into their root page",
+]:
+    fail("semantic revision principles mismatch")
+
+flattening = revision.get("hierarchy_flattening")
+if flattening != [
+    {
+        "action": "REMOVE_REDUNDANT_SINGLE_TASK_WRAPPER",
+        "from_path": "Navigation / Navigation & gestures",
+        "reason": (
+            "The Navigation root contained only one task destination, adding a "
+            "click without adding information."
+        ),
+        "result": (
+            "The Navigation root renders the Navigation & gestures destinations "
+            "directly."
+        ),
+    },
+    {
+        "action": "REMOVE_REDUNDANT_SINGLE_TASK_WRAPPER",
+        "from_path": "Morphe / Patch features",
+        "reason": (
+            "The Morphe root contained only one task destination, adding a click "
+            "without adding information and implying an incomplete patch catalog."
+        ),
+        "result": (
+            "The Morphe root renders the 12 configurable Morphe feature "
+            "references directly."
+        ),
+    },
+]:
+    fail("semantic V4 hierarchy-flattening metadata mismatch")
+
+corrections = revision.get("classification_corrections")
+if not isinstance(corrections, list) or len(corrections) != 5:
+    fail("semantic revision must contain five placement corrections")
+correction_map: dict[str, tuple[str, str]] = {}
+for correction in corrections:
+    if correction.get("action") != "MOVE":
+        fail("semantic correction action must be MOVE")
+    key = correction.get("key")
+    pair = (correction.get("from_path"), correction.get("to_path"))
+    if not isinstance(key, str) or not all(isinstance(value, str) for value in pair):
+        fail("malformed semantic correction")
+    correction_map[key] = pair
+    if not correction.get("reason") or not correction.get("title"):
+        fail(f"{key}: semantic correction lacks reason/title")
+if correction_map != EXPECTED_CORRECTIONS:
+    fail("semantic placement corrections differ from the audited proposal")
+
+alias_removals = revision.get("route_alias_removals")
+if not isinstance(alias_removals, list) or len(alias_removals) != 2:
+    fail("semantic revision must contain two route-alias removals")
+alias_map: dict[str, str] = {}
+for removal in alias_removals:
+    key = removal.get("key")
+    replacement = removal.get("replacement_key")
+    if not isinstance(key, str) or not isinstance(replacement, str):
+        fail("malformed route-alias removal")
+    if not removal.get("reason") or not removal.get("title"):
+        fail(f"{key}: route-alias removal lacks reason/title")
+    alias_map[key] = replacement
+if alias_map != EXPECTED_ALIAS_REMOVALS:
+    fail("route-alias removal set differs from the audited proposal")
+
+withheld = contract.get("withheld_controls")
+if not isinstance(withheld, list) or len(withheld) != 1:
+    fail("exactly one withheld control is required")
+if withheld[0].get("key") != "pref_drawer_show_friends":
+    fail("unexpected withheld key")
+if withheld[0].get("target_path") != (
+    "Navigation / Navigation drawer / Account & tools"
+):
+    fail("withheld Friends target path mismatch")
+if not withheld[0].get("reason") or not withheld[0].get("required_resolution"):
+    fail("withheld Friends evidence policy is incomplete")
+
+screens = contract.get("screens")
+edges = contract.get("graph_edges")
+items = contract.get("items")
+if not isinstance(screens, list) or len(screens) != 105:
+    fail("V5 screen list must contain 105 entries")
+if not isinstance(edges, list) or len(edges) != 98:
+    fail("V5 edge list must contain 98 entries")
+if not isinstance(items, list) or len(items) != 248:
+    fail("V5 item list must contain 248 entries")
+
+screen_by_path: dict[str, dict[str, Any]] = {}
+for index, screen in enumerate(screens):
+    if not isinstance(screen, dict):
+        fail(f"screens[{index}] must be an object")
+    path = screen.get("path")
+    if not isinstance(path, str) or not path:
+        fail(f"screens[{index}].path missing")
+    if path in screen_by_path:
+        fail(f"duplicate screen path: {path}")
+    parts = path.split(" / ")
+    if screen.get("root") != parts[0]:
+        fail(f"screen root mismatch: {path}")
+    if screen.get("title") != parts[-1]:
+        fail(f"screen title mismatch: {path}")
+    if screen.get("depth") != len(parts) - 1:
+        fail(f"screen depth mismatch: {path}")
+    if screen.get("root") == "Navigation" and len(parts) > 1:
+        expected_task = "Navigation & gestures"
+    else:
+        expected_task = parts[1] if len(parts) > 1 else ""
+    if screen.get("task_page") != expected_task:
+        fail(f"screen task-page mismatch: {path}")
+    screen_by_path[path] = screen
+
+if Counter(screen["role"] for screen in screens) != EXPECTED_ROLE_COUNTS:
+    fail("V5 screen role counts differ from the corrected target")
+if set(screen["root"] for screen in screens) != set(EXPECTED_ROOT_ORDER):
+    fail("V5 screen roots differ from the locked root set")
+for removed_path in REMOVED_SCREEN_PATHS:
+    if removed_path in screen_by_path:
+        fail(f"semantically empty screen remains: {removed_path}")
+
+edge_pairs: set[tuple[str, str]] = set()
+children_by_parent: dict[str, set[str]] = defaultdict(set)
+for index, edge in enumerate(edges):
+    if not isinstance(edge, dict):
+        fail(f"graph_edges[{index}] must be an object")
+    parent = edge.get("parent_path")
+    child = edge.get("child_path")
+    title = edge.get("child_title")
+    if parent not in screen_by_path or child not in screen_by_path:
+        fail(f"edge references missing screen: {parent!r} -> {child!r}")
+    child_parts = child.split(" / ")
+    if parent != " / ".join(child_parts[:-1]):
+        fail(f"edge is not an immediate parent relation: {parent} -> {child}")
+    if title != child_parts[-1]:
+        fail(f"edge child title mismatch: {parent} -> {child}")
+    pair = (parent, child)
+    if pair in edge_pairs:
+        fail(f"duplicate edge: {pair}")
+    edge_pairs.add(pair)
+    children_by_parent[parent].add(child)
+
+expected_edges = {
+    (" / ".join(path.split(" / ")[:-1]), path)
+    for path in screen_by_path
+    if " / " in path
+}
+if edge_pairs != expected_edges:
+    fail("V5 edge set differs from the path-derived graph")
+
+item_by_key: dict[str, dict[str, Any]] = {}
+items_by_path: dict[str, list[str]] = defaultdict(list)
+visibility_counts: Counter[str] = Counter()
+for index, item in enumerate(items):
+    if not isinstance(item, dict):
+        fail(f"items[{index}] must be an object")
+    key = item.get("key")
+    if not isinstance(key, str) or not key:
+        fail(f"items[{index}].key missing")
+    if key in item_by_key:
+        fail(f"duplicate item key: {key}")
+    path_value = item.get("screen_path")
+    if not isinstance(path_value, list) or len(path_value) < 2:
+        fail(f"{key}: invalid screen_path")
+    path = " / ".join(path_value)
+    if path not in screen_by_path:
+        fail(f"{key}: target screen is absent: {path}")
+    if item.get("root") != path_value[0]:
+        fail(f"{key}: root does not match screen_path")
+    expected_page = (
+        "Navigation & gestures"
+        if path_value[0] == "Navigation"
+        else path_value[1]
+    )
+    if item.get("page") != expected_page:
+        fail(f"{key}: page does not match screen_path")
+    if item.get("leaf_section") != path_value[-1]:
+        fail(f"{key}: leaf_section does not match screen_path")
+    if item.get("screen_depth") != len(path_value) - 1:
+        fail(f"{key}: screen_depth does not match screen_path")
+    visibility = item.get("v5_visibility")
+    if visibility not in {"VISIBLE", "WITHHELD_RUNTIME_UNAVAILABLE"}:
+        fail(f"{key}: invalid V5 visibility")
+    if visibility == "WITHHELD_RUNTIME_UNAVAILABLE":
+        if key != "pref_drawer_show_friends":
+            fail(f"unexpected withheld item: {key}")
+        if not item.get("v5_visibility_reason"):
+            fail("withheld Friends item lacks a reason")
+    elif item.get("v5_visibility_reason"):
+        fail(f"{key}: visible item unexpectedly has a withholding reason")
+    visibility_counts[visibility] += 1
+    item_by_key[key] = item
+    items_by_path[path].append(key)
+
+if visibility_counts != Counter({
+    "VISIBLE": 247,
+    "WITHHELD_RUNTIME_UNAVAILABLE": 1,
+}):
+    fail(f"V5 visibility accounting mismatch: {visibility_counts}")
+
+for removed_alias in EXPECTED_ALIAS_REMOVALS:
+    if removed_alias in item_by_key:
+        fail(f"route alias still renders as a control: {removed_alias}")
+for replacement in EXPECTED_ALIAS_REMOVALS.values():
+    if replacement not in item_by_key:
+        fail(f"route-alias replacement control missing: {replacement}")
+
+for path, screen in screen_by_path.items():
+    expected_control_count = len(items_by_path.get(path, []))
+    if screen.get("control_count") != expected_control_count:
+        fail(
+            f"screen control count mismatch for {path}: "
+            f"{screen.get('control_count')} != {expected_control_count}"
+        )
+    expected_child_count = len(children_by_parent.get(path, set()))
+    if screen.get("child_count") != expected_child_count:
+        fail(
+            f"screen child count mismatch for {path}: "
+            f"{screen.get('child_count')} != {expected_child_count}"
+        )
+
+blueprint_items = {item["key"]: item for item in blueprint.get("items", [])}
+if len(blueprint_items) != 250:
+    fail("blueprint v3 does not contain 250 source items")
+expected_key_set = set(blueprint_items) - set(EXPECTED_ALIAS_REMOVALS)
+if set(item_by_key) != expected_key_set:
+    fail("corrected V5 logical key set differs from blueprint minus route aliases")
+
+navigation_paths: dict[str, list[str]] = {}
+for page in navigation.get("leaf_pages", []):
+    path = screen_path_for_navigation_page(page)
+    for key in page.get("keys", []):
+        if key in navigation_paths:
+            fail(f"duplicate key in Navigation contract: {key}")
+        navigation_paths[key] = path
+navigation_paths["pref_drawer_show_friends"] = [
+    "Navigation",
+    "Navigation drawer",
+    "Account & tools",
+]
+if len(navigation_paths) != 31:
+    fail("Navigation Phase 2 accounting is not 31")
+navigation_paths["pref_lock_sidebar"] = [
+    "Navigation",
+    "Navigation drawer",
+    "Drawer behavior",
+]
+
+explicit_target_paths = {
+    key: to_path.split(" / ")
+    for key, (_, to_path) in EXPECTED_CORRECTIONS.items()
+}
+
+for key, target in item_by_key.items():
+    source = blueprint_items[key]
+    if key in explicit_target_paths:
+        expected_path = explicit_target_paths[key]
+    elif key in navigation_paths:
+        expected_path = navigation_paths[key]
+    else:
+        expected_path = source.get("screen_path")
+
+    if target.get("screen_path") != expected_path:
+        fail(f"{key}: corrected target path mismatch")
+    if target.get("root") != expected_path[0]:
+        fail(f"{key}: corrected root mismatch")
+    expected_page = (
+        "Navigation & gestures"
+        if target.get("root") == "Navigation"
+        else expected_path[1]
+    )
+    if target.get("page") != expected_page:
+        fail(f"{key}: corrected page mismatch")
+    expected_subscreen = (
+        expected_path[-1]
+        if key in explicit_target_paths or key in navigation_paths
+        else source.get("subscreen")
+    )
+    if target.get("subscreen") != expected_subscreen:
+        fail(f"{key}: corrected subscreen mismatch")
+    if target.get("leaf_section") != expected_path[-1]:
+        fail(f"{key}: corrected leaf_section mismatch")
+
+    for field in STABLE_ITEM_FIELDS:
+        if target.get(field) != source.get(field):
+            fail(f"{key}: stable field {field} differs from blueprint")
+
+# Validate the corrected screen topology:
+# - preserve every non-Navigation blueprint screen except the empty Swipe leaf;
+# - replace Navigation with the validated Phase 2 topology.
+blueprint_non_navigation_paths = {
+    screen["path"]
+    for screen in blueprint.get("screens", [])
+    if screen.get("root") != "Navigation"
+} - REMOVED_SCREEN_PATHS
+
+expected_navigation_paths = {
+    "Navigation",
+    "Navigation / Toolbar",
+    "Navigation / Bottom navigation",
+    "Navigation / Back & exit",
+    "Navigation / Navigation drawer",
+}
+for page in navigation.get("leaf_pages", []):
+    if page.get("parent") == "Navigation drawer":
+        expected_navigation_paths.add(
+            "Navigation / Navigation drawer / " + page["title"]
+        )
+
+expected_screen_paths = (
+    blueprint_non_navigation_paths | expected_navigation_paths
+)
+if set(screen_by_path) != expected_screen_paths:
+    missing = sorted(expected_screen_paths - set(screen_by_path))
+    extra = sorted(set(screen_by_path) - expected_screen_paths)
+    fail(f"corrected V5 screen topology mismatch: missing={missing}, extra={extra}")
+
+print(f"BLUEPRINT={blueprint_path}")
+print(f"BLUEPRINT_SHA256={blueprint_sha}")
+print(f"NAVIGATION_CONTRACT={navigation_path}")
+print(f"NAVIGATION_CONTRACT_SHA256={navigation_sha}")
+print(f"SUPERSEDED_V5_CONTRACT={previous_contract_path}")
+print(f"SUPERSEDED_V5_CONTRACT_SHA256={previous_sha}")
+print(f"V5_CONTRACT={contract_path}")
+print(f"V5_CONTRACT_SHA256={contract_sha}")
+print("SEMANTIC_REVISION=V4")
+print("CLASSIFICATION_CORRECTION_COUNT=5")
+print("ROUTE_ALIAS_REMOVAL_COUNT=2")
+print("EMPTY_SCREEN_REMOVAL_COUNT=1")
+print("REDUNDANT_NAVIGATION_WRAPPER_REMOVAL_COUNT=1")
+print("REDUNDANT_MORPHE_WRAPPER_REMOVAL_COUNT=1")
+print("CANONICAL_LOGICAL_ITEM_TARGET=248")
+print("VISIBLE_ITEM_TARGET=247")
+print("WITHHELD_ITEM_TARGET=1")
+print("SCREEN_NODE_TARGET=105")
+print("SCREEN_EDGE_TARGET=98")
+print("ROOT_OVERVIEW_SHELL_TARGET=1")
+print("ROOT_GROUP_TARGET=7")
+print("TASK_PAGE_TARGET=22")
+print("INTERMEDIATE_PAGE_TARGET=5")
+print("LEAF_PAGE_TARGET=71")
+print("PLACEHOLDER_PAGE_TARGET=0")
+print("LEGACY_FRAGMENT_ROUTE_TARGET=0")
+print("LEGACY_XML_ROUTE_TARGET=0")
+print("ROOT_CLASSIC_FALLBACK_TARGET=1")
+print("V5_VISIBLE_BEFORE_COMPLETE=NO")
+print("WITHHELD_FRIENDS_ACCOUNTING=PASS")
+print("NAVIGATION_OVERRIDE_ACCOUNTING=PASS")
+print("SEMANTIC_PLACEMENT_ACCOUNTING=PASS")
+print("ROUTE_ALIAS_DEDUPLICATION=PASS")
+print("EMPTY_SWIPE_SCREEN_REMOVAL=PASS")
+print("NAVIGATION_ROOT_FLATTENING=PASS")
+print("MORPHE_ROOT_FLATTENING=PASS")
+print("RESULT=MORPHE_ISSUE121_SETTINGS_V5_SEMANTIC_COMPLETENESS_TARGET_V4_PASS")

--- a/tools/check_boost_settings_v5_data_app_wave_v1.py
+++ b/tools/check_boost_settings_v5_data_app_wave_v1.py
@@ -1,0 +1,318 @@
+#!/usr/bin/env python3
+"""Static contract for the hidden Settings V5 Data & app wave."""
+
+from __future__ import annotations
+
+import collections
+import hashlib
+import json
+import re
+import subprocess
+import tempfile
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SETTINGS = (
+    ROOT
+    / "extensions/boostforreddit/src/main/java/app/morphe/extension/"
+    / "boostforreddit/settings"
+)
+WAVE_CONTRACT = ROOT / "tools/contracts/boost-settings-v5-data-app-wave-v1.json"
+V5_CONTRACT = ROOT / "tools/contracts/boost-settings-v5-completeness-v2.json"
+AUDIT = ROOT / "tools/audit_boost_settings_v5_implementation.py"
+
+EXPECTED_WAVE_SHA = "045d0982e7b81d320049ff3a067c3cebda1bd1825047f6253259976ba56d095a"
+EXPECTED_V5_SHA = "f1d6a9ac6c27f71eec61b300e5f36d0785d831fde14cb982450e21b3ae238682"
+EXPECTED_BINDING_ARCHIVE_SHA = "3b5f170322d956db8c0898943d0532aab871f7546cf041c9611ea749b42f5a3d"
+EXPECTED_SPECIAL_ARCHIVE_SHA = "d2fe10c466530ef6168af9108728f8d3fcf4cdbe81d68f855dd730cb7bac41d7"
+EXPECTED_BASE_APK_SHA = "a68c22d632a5dd1f446c3759a171c7dbb9edab2afc3c2f87e39323f198606742"
+EXPECTED_SOURCE_MPP_SHA = "600904a3d9639e198adcf9bab6d17ab6cbb3fd07e3a53694fc756b85d1be9934"
+
+PAGE_PATTERN = re.compile(
+    r'new\s+V5PageSpec\s*\(\s*'
+    r'"(?P<page_id>v5/[^"]+)"\s*,\s*'
+    r'"(?P<renderer>[^"]+)"\s*,\s*'
+    r'new\s+String\s*\[\]\s*\{(?P<keys>.*?)\}\s*\)',
+    re.S,
+)
+KEY_PATTERN = re.compile(r'"([^"]+)"')
+FORBIDDEN = (
+    "SettingsActivityCompat$",
+    "PreferenceFragmentAdvancedCompat",
+    "MorpheSettingsV4NativePages",
+    "MorpheSettingsV4AppearanceFragment",
+    "MorpheSettingsV4PostViewsFragment",
+    "MorpheSettingsV4FontsFragment",
+    "MorpheSettingsV4DownloadsFragment",
+    "MorpheSettingsV4NavigationDrawerHubFragment",
+    "MorpheSettingsFragment.class.getName()",
+    "MORPHE_V5_PLACEHOLDER_PAGE",
+)
+
+
+def bound_json(path: Path, expected_sha: str) -> dict:
+    raw = path.read_bytes()
+    actual = hashlib.sha256(raw).hexdigest()
+    assert actual == expected_sha, (path, actual, expected_sha)
+    return json.loads(raw.decode("utf-8"))
+
+
+wave = bound_json(WAVE_CONTRACT, EXPECTED_WAVE_SHA)
+v5 = bound_json(V5_CONTRACT, EXPECTED_V5_SHA)
+
+assert wave["schema"] == 1
+assert wave["issue"] == 121
+assert wave["root"] == "Data & app"
+assert wave["binding_capture"] == {
+    "archive_sha256": EXPECTED_BINDING_ARCHIVE_SHA,
+    "base_apk_sha256": EXPECTED_BASE_APK_SHA,
+    "source_mpp_sha256": EXPECTED_SOURCE_MPP_SHA,
+    "special_handler_archive_sha256": EXPECTED_SPECIAL_ARCHIVE_SHA,
+    "v5_contract_sha256": EXPECTED_V5_SHA,
+}
+assert wave["targets"] == {
+    "action_count": 15,
+    "dependency_count": 0,
+    "screen_count": 18,
+    "special_preference_count": 1,
+    "stored_setting_count": 22,
+    "visible_item_count": 38,
+    "zero_control_route_count": 1,
+}
+
+screens = [screen for screen in v5["screens"] if screen["root"] == "Data & app"]
+items = [item for item in v5["items"] if item["root"] == "Data & app"]
+assert len(screens) == 18
+assert len(items) == 38
+assert all(item["v5_visibility"] == "VISIBLE" for item in items)
+assert collections.Counter(item["logical_kind"] for item in items) == {
+    "stored_setting": 22,
+    "action": 15,
+    "special_preference": 1,
+}
+assert collections.Counter(item["page"] for item in items) == {
+    "About & support": 14,
+    "App behavior & compatibility": 14,
+    "Settings experience": 1,
+    "Storage & bandwidth": 9,
+}
+assert not [item for item in items if item.get("dependency")]
+
+expected_pages = {entry["page_id"]: entry for entry in wave["screens"]}
+expected_keys_by_page = {page_id: set() for page_id in expected_pages}
+for item in wave["items"]:
+    expected_keys_by_page[item["page_id"]].add(item["key"])
+assert len(expected_pages) == 18
+assert sum(len(keys) for keys in expected_keys_by_page.values()) == 38
+assert expected_pages["v5/data_and_app/backup_and_restore"] == {
+    "child_count": 0,
+    "control_count": 0,
+    "page_id": "v5/data_and_app/backup_and_restore",
+    "path": "Data & app / Backup & restore",
+    "renderer": "MorpheSettingsV5BackupRestoreFragment",
+    "role": "task_page",
+    "title": "Backup & restore",
+}
+
+source_files = (
+    "MorpheSettingsV5Registry.java",
+    "MorpheSettingsV5Search.java",
+    "MorpheSettingsV5XmlPreferenceFragment.java",
+    "MorpheSettingsV5DataAppFragment.java",
+    "MorpheSettingsV5DataAppLeafFragment.java",
+    "MorpheSettingsV5DataAppMetadata.java",
+    "MorpheSettingsV5BackupRestoreFragment.java",
+)
+source_paths = [SETTINGS / name for name in source_files]
+assert all(path.is_file() for path in source_paths)
+source = {path.name: path.read_text(encoding="utf-8") for path in source_paths}
+all_text = "\n".join(source.values())
+
+registry = source["MorpheSettingsV5Registry.java"]
+search = source["MorpheSettingsV5Search.java"]
+engine = source["MorpheSettingsV5XmlPreferenceFragment.java"]
+hub = source["MorpheSettingsV5DataAppFragment.java"]
+leaf = source["MorpheSettingsV5DataAppLeafFragment.java"]
+metadata = source["MorpheSettingsV5DataAppMetadata.java"]
+backup = source["MorpheSettingsV5BackupRestoreFragment.java"]
+
+for token in FORBIDDEN:
+    assert token not in all_text, token
+
+markers = (
+    "MORPHE_BOOST_SETTINGS_V5_DATA_APP_WAVE_ISSUE121_V1",
+    "MORPHE_BOOST_SETTINGS_V5_SEARCH_DATA_APP_WAVE_ISSUE121_V1",
+    "MORPHE_BOOST_SETTINGS_V5_DATA_APP_SPECIAL_HANDLERS_ISSUE121_V1",
+    "MORPHE_BOOST_SETTINGS_V5_DATA_APP_FRAGMENT_ISSUE121_V1",
+    "MORPHE_BOOST_SETTINGS_V5_DATA_APP_HIDDEN_WAVE_ISSUE121_V1",
+    "MORPHE_BOOST_SETTINGS_V5_DATA_APP_LEAF_ISSUE121_V1",
+    "MORPHE_BOOST_SETTINGS_V5_DATA_APP_BINDINGS_ISSUE121_V1",
+    "MORPHE_BOOST_SETTINGS_V5_DATA_APP_HANDLER_BINDINGS_ISSUE121_V1",
+    "MORPHE_BOOST_SETTINGS_V5_DATA_APP_METADATA_ISSUE121_V1",
+    "MORPHE_BOOST_SETTINGS_V5_BACKUP_RESTORE_ROUTE_ISSUE121_V1",
+    "MORPHE_BOOST_SETTINGS_V5_BACKUP_RESTORE_ZERO_CONTROLS_ISSUE121_V1",
+)
+for marker in markers:
+    assert marker in all_text, marker
+
+actual_pages = {}
+for match in PAGE_PATTERN.finditer(registry):
+    page_id = match.group("page_id")
+    assert page_id not in actual_pages
+    actual_pages[page_id] = {
+        "renderer": match.group("renderer"),
+        "keys": set(KEY_PATTERN.findall(match.group("keys"))),
+    }
+data_actual = {
+    page_id: value
+    for page_id, value in actual_pages.items()
+    if page_id.startswith("v5/data_and_app")
+}
+assert set(data_actual) == set(expected_pages)
+for page_id, page in data_actual.items():
+    assert page["renderer"] == expected_pages[page_id]["renderer"]
+    assert page["keys"] == expected_keys_by_page[page_id], (
+        page_id,
+        sorted(page["keys"]),
+        sorted(expected_keys_by_page[page_id]),
+    )
+
+assert 'case "v5/data_and_app":' in registry
+for child in (
+    "v5/data_and_app/about_and_support",
+    "v5/data_and_app/app_behavior_and_compatibility",
+    "v5/data_and_app/backup_and_restore",
+    "v5/data_and_app/settings_experience",
+    "v5/data_and_app/storage_and_bandwidth",
+):
+    assert f'"{child}"' in registry
+assert "MorpheSettingsV5Registry.requirePage(pageId)" in hub
+assert "MorpheSettingsV5Registry.childrenFor(pageId)" in hub
+assert "MorpheSettingsV5Navigation.openPage(this, targetPageId)" in hub
+assert "MorpheSettingsV5Search.prepareMenu(this, menu)" in hub
+
+assert "MorpheSettingsV5Registry.requirePage(pageId)" in leaf
+assert "page.containsKey(key)" in leaf
+assert "includeHiddenControl" in leaf
+for resource in (
+    "pref_headers_v2",
+    "pref_about_v2",
+    "pref_misc_v2",
+    "pref_data_v2",
+    "morphe_boost_settings_skeleton",
+):
+    assert f'"{resource}"' in leaf
+
+for item in wave["items"]:
+    assert f'case "{item["key"]}":' in metadata, item["key"]
+assert "MorpheSettingsV5DataAppMetadata.titleFor(" in search
+assert "MorpheSettingsV5DataAppMetadata.searchSummaryFor(" in search
+assert "MorpheSettingsV5Navigation.openPage(host, entry.pageId)" in search
+
+assert re.search(
+    r'"remove_ads"\.equals\(key\).*?invokeActivityHelper\("y",\s*Context\.class,\s*requireContext\(\)\)',
+    engine,
+    re.S,
+)
+assert re.search(
+    r'"buy_pro"\.equals\(key\).*?invokeActivityHelper\("x0",\s*Context\.class,\s*requireContext\(\)\)',
+    engine,
+    re.S,
+)
+assert re.search(
+    r'"pref_download_folders"\.equals\(key\).*?invokeActivityHelper\("S",\s*Context\.class,\s*requireContext\(\)\)',
+    engine,
+    re.S,
+)
+assert '"qb.a"' in engine and '"a"' in engine and "clearMediaCache()" in engine
+assert '"qb.b"' in engine and '"d"' in engine and '"pref_cache_max_size"' in engine
+assert '"pref_gdpr_revoke".equals(key)' in engine
+assert "confirmGdprRevocation()" in engine
+assert "RevokeGDPRConstentPreferenceDialogFragmentCompat" in engine
+assert 'getDeclaredMethod(\n                    "checkConsent"' in engine
+assert "method.setAccessible(true)" in engine
+assert "dataVideoQualityControlEnabled" in engine
+for key in (
+    "pref_video_quality",
+    "pref_video_quality_min",
+    "pref_video_quality_max",
+    "pref_reduce_mobile",
+    "pref_reduce_wifi",
+):
+    assert f'"{key}"' in engine
+assert "Intent.ACTION_VIEW" in engine and 'Uri.parse("mailto:" + address' in engine
+
+assert "com.rubenmayayo.reddit.BackupActivity" in backup
+assert "startActivity(intent)" in backup
+assert "page.keys.length != 0" in backup
+assert "MorpheSettingsV5Search.prepareMenu(this, menu)" in backup
+
+for category, values in wave["special_handlers"].items():
+    assert values, category
+    for value in values:
+        assert value in all_text, (category, value)
+
+with tempfile.TemporaryDirectory(prefix="morphe-v5-data-app-audit-") as temp:
+    output_dir = Path(temp)
+    completed = subprocess.run(
+        ["python3", str(AUDIT), "--output-dir", str(output_dir)],
+        cwd=ROOT,
+        text=True,
+        capture_output=True,
+        check=True,
+    )
+    report = json.loads(
+        (output_dir / "settings-v5-implementation-audit.json").read_text(
+            encoding="utf-8"
+        )
+    )
+    assert report["status"] == "INCOMPLETE"
+    assert report["current"]["v5_source_file_count"] >= 24
+    assert report["current"]["implemented_target_page_count"] >= 104
+    assert report["current"]["implemented_visible_item_count"] == 247
+    assert report["current"]["accounted_withheld_item_count"] == 1
+    assert report["current"]["visible_state"] == "FALSE"
+    root = next(
+        entry for entry in report["root_progress"]
+        if entry["root"] == "Data & app"
+    )
+    assert root == {
+        "accounted_withheld_items": 0,
+        "expected_pages": 18,
+        "expected_visible_items": 38,
+        "expected_withheld_items": 0,
+        "implemented_pages": 18,
+        "implemented_visible_items": 38,
+        "root": "Data & app",
+    }
+    for expected in (
+        "V5_SOURCE_FILE_COUNT=",
+        "V5_SCREEN_NODE_COVERAGE=",
+        "V5_VISIBLE_ITEM_COVERAGE=247/247",
+        "V5_WITHHELD_ITEM_ACCOUNTING=1/1",
+        "V5_CANONICAL_ACCOUNTING=248/248",
+        "V5_VISIBLE_STATE=FALSE",
+        "V5_PLACEHOLDER_PAGE_COUNT=0",
+        "V5_CLASSIC_ROUTE_VIOLATION_COUNT=0",
+        "AUDIT_STATUS=INCOMPLETE",
+    ):
+        assert expected in completed.stdout, expected
+
+print(f"CONTRACT={WAVE_CONTRACT}")
+print(f"CONTRACT_SHA256={EXPECTED_WAVE_SHA}")
+print("V5_DATA_APP_SCREEN_COVERAGE=18/18")
+print("V5_DATA_APP_VISIBLE_ITEM_COVERAGE=38/38")
+print("V5_GLOBAL_SCREEN_COVERAGE=104/105")
+print("V5_GLOBAL_VISIBLE_ITEM_COVERAGE=247/247")
+print("V5_WITHHELD_ITEM_ACCOUNTING=1/1")
+print("V5_CANONICAL_ACCOUNTING=248/248")
+print("V5_VISIBLE_STATE=FALSE")
+print("PLACEHOLDER_PAGE_COUNT=0")
+print("LEGACY_ROUTE_COUNT=0")
+print("BACKUP_RESTORE_ZERO_CONTROL_ROUTE=PASS")
+print("PURCHASE_ADS_HANDLER_ACCOUNTING=PASS")
+print("GDPR_HANDLER_ACCOUNTING=PASS")
+print("STORAGE_HANDLER_ACCOUNTING=PASS")
+print("VIDEO_QUALITY_STATE_ACCOUNTING=PASS")
+print("GLOBAL_SEARCH_ROUTE=PASS")
+print("RESULT=MORPHE_ISSUE121_SETTINGS_V5_DATA_APP_WAVE_V1_CONTRACT_PASS")

--- a/tools/check_boost_settings_v5_font_preview_v1.py
+++ b/tools/check_boost_settings_v5_font_preview_v1.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python3
+"""V5 font-preview contract for Morphe Issue #121."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SOURCE = ROOT / "extensions/boostforreddit/src/main/java/app/morphe/extension/boostforreddit/settings/MorpheSettingsV5AppearanceBindings.java"
+CONTRACT = ROOT / "tools/contracts/boost-settings-v5-font-preview-v1.json"
+EXPECTED_CONTRACT_SHA256 = "794eccd7afb4fef711ed7498465eb8cd0a821cd6dcecf7c7da48a792eac8aa3f"
+
+raw = CONTRACT.read_bytes()
+actual_sha = hashlib.sha256(raw).hexdigest()
+assert actual_sha == EXPECTED_CONTRACT_SHA256, actual_sha
+contract = json.loads(raw.decode("utf-8"))
+source = SOURCE.read_text(encoding="utf-8")
+
+assert contract["schema"] == 1
+assert contract["issue"] == 121
+assert contract["canonical_keys"] == ["pref_title_font", "pref_comments_font"]
+assert contract["font_option_count"] == 13
+assert contract["requirements"]["route_changes"] == 0
+assert contract["requirements"]["preference_key_changes"] == 0
+
+assert "MORPHE_BOOST_SETTINGS_V5_FONT_PREVIEW_ISSUE121_V1" in source
+assert "MORPHE_BOOST_SETTINGS_V5_FONT_RESOLVER_ISSUE121_V1" in source
+assert "private void showFontChoiceDialog(" in source
+assert "row.setTitleTypeface(resolveFontTypeface(value));" in source
+assert "binding.summary.setTypeface(resolveFontTypeface(" in source
+assert 'Class.forName("id.b")' in source
+assert 'getDeclaredMethod("v0")' in source
+assert '"p4",' in source
+assert "Context.class" in source
+assert "String.class" in source
+assert "Typeface.createFromAsset" in source
+assert 'stringArray("font_options", FONT_TITLES)' in source
+assert 'stringArray("font_values", FONT_VALUES)' in source
+assert source.count('case "pref_comments_font":') == 1
+assert source.count('case "pref_title_font":') == 1
+assert source.count('"Roboto Slab"') == 1
+assert source.count('"RobotoSlab-Regular.ttf"') == 1
+
+font_dialog_start = source.index("private void showFontDialog(String key)")
+font_dialog_end = source.index("private void showAppIconDialog()", font_dialog_start)
+font_dialog = source[font_dialog_start:font_dialog_end]
+assert "showFontChoiceDialog(" in font_dialog
+assert "showChoiceDialog(" not in font_dialog
+
+print(f"CONTRACT={CONTRACT}")
+print(f"CONTRACT_SHA256={actual_sha}")
+print("CANONICAL_FONT_KEY_COUNT=2")
+print("FONT_OPTION_COUNT=13")
+print("FONT_PICKER_ROW_TYPEFACE_PREVIEW=PASS")
+print("FONT_CURRENT_VALUE_TYPEFACE_PREVIEW=PASS")
+print("BOOST_CANONICAL_TYPEFACE_RESOLVER=PASS")
+print("PREFERENCE_KEY_CHANGES=0")
+print("ROUTE_CHANGES=0")
+print("RESULT=MORPHE_ISSUE121_SETTINGS_V5_FONT_PREVIEW_V1_CONTRACT_PASS")

--- a/tools/check_boost_settings_v5_media_wave_v1.py
+++ b/tools/check_boost_settings_v5_media_wave_v1.py
@@ -1,0 +1,261 @@
+#!/usr/bin/env python3
+"""Static contract for the complete hidden Settings V5 Media wave."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+import subprocess
+import tempfile
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SETTINGS = (
+    ROOT
+    / "extensions/boostforreddit/src/main/java/app/morphe/extension/"
+    / "boostforreddit/settings"
+)
+WAVE_CONTRACT = ROOT / "tools/contracts/boost-settings-v5-media-wave-v1.json"
+V5_CONTRACT = ROOT / "tools/contracts/boost-settings-v5-completeness-v2.json"
+AUDIT = ROOT / "tools/audit_boost_settings_v5_implementation.py"
+
+EXPECTED_WAVE_SHA = "48b2bda96c2b2b9917f326c89848dee3c1448f3a5fc02efe8b1549155448a3b9"
+EXPECTED_CAPTURE_V5_SHA = "4c8e081069d7444938c3ff5ad0e451bb3b16183592114a6b8adf77cd1208d3f7"
+EXPECTED_V5_SHA = "f1d6a9ac6c27f71eec61b300e5f36d0785d831fde14cb982450e21b3ae238682"
+EXPECTED_ARCHIVE_SHA = "12e3a8ac2604dec833bbb3d223316e1afc8eddd1aebd40e9518bd6f42c0618ca"
+EXPECTED_BASE_APK_SHA = "a68c22d632a5dd1f446c3759a171c7dbb9edab2afc3c2f87e39323f198606742"
+EXPECTED_SOURCE_MPP_SHA = "765bfd3c15487e5021f9e7979cd1aabee600363217beda9a381ff29545fb6280"
+
+PAGE_PATTERN = re.compile(
+    r'new\s+V5PageSpec\s*\(\s*'
+    r'"(?P<page_id>v5/[^"]+)"\s*,\s*'
+    r'"(?P<renderer>[^"]+)"\s*,\s*'
+    r'new\s+String\s*\[\]\s*\{(?P<keys>.*?)\}\s*\)',
+    re.S,
+)
+KEY_PATTERN = re.compile(r'"([^"]+)"')
+FORBIDDEN = (
+    "SettingsActivityCompat$",
+    "PreferenceFragmentAdvancedCompat",
+    "MorpheSettingsV4NativePages",
+    "MorpheSettingsV4AppearanceFragment",
+    "MorpheSettingsV4PostViewsFragment",
+    "MorpheSettingsV4FontsFragment",
+    "MorpheSettingsV4DownloadsFragment",
+    "MorpheSettingsV4NavigationDrawerHubFragment",
+    "MorpheSettingsFragment.class.getName()",
+    "MORPHE_V5_PLACEHOLDER_PAGE",
+)
+
+
+def bound_json(path: Path, expected_sha: str) -> dict:
+    raw = path.read_bytes()
+    actual = hashlib.sha256(raw).hexdigest()
+    assert actual == expected_sha, (path, actual, expected_sha)
+    return json.loads(raw.decode("utf-8"))
+
+
+wave = bound_json(WAVE_CONTRACT, EXPECTED_WAVE_SHA)
+v5 = bound_json(V5_CONTRACT, EXPECTED_V5_SHA)
+
+assert wave["schema"] == 1
+assert wave["issue"] == 121
+assert wave["wave"] == "Media"
+assert wave["binding_capture"] == {
+    "archive_sha256": EXPECTED_ARCHIVE_SHA,
+    "base_apk_sha256": EXPECTED_BASE_APK_SHA,
+    "source_mpp_sha256": EXPECTED_SOURCE_MPP_SHA,
+    "v5_contract_sha256": EXPECTED_CAPTURE_V5_SHA,
+}
+assert wave["target"] == {
+    "legacy_routes": 0,
+    "max_controls_per_leaf": 8,
+    "placeholder_pages": 0,
+    "screen_nodes": 18,
+    "visible_by_default": False,
+    "visible_items": 36,
+    "withheld_items": 0,
+}
+
+media_screens = [screen for screen in v5["screens"] if screen["root"] == "Media"]
+media_items = [item for item in v5["items"] if item["root"] == "Media"]
+assert len(media_screens) == 18
+assert len(media_items) == 36
+assert all(item["v5_visibility"] == "VISIBLE" for item in media_items)
+
+expected_pages = {entry["page_id"]: entry for entry in wave["screens"]}
+expected_keys_by_page = {page_id: set() for page_id in expected_pages}
+for item in wave["items"]:
+    expected_keys_by_page[item["page_id"]].add(item["key"])
+assert len(expected_pages) == 18
+assert sum(len(keys) for keys in expected_keys_by_page.values()) == 36
+assert max(len(keys) for keys in expected_keys_by_page.values()) == 8
+
+source_paths = [SETTINGS / name for name in wave["source_files"]]
+assert all(path.is_file() for path in source_paths)
+source = {path.name: path.read_text(encoding="utf-8") for path in source_paths}
+all_text = "\n".join(source.values())
+
+registry = source["MorpheSettingsV5Registry.java"]
+navigation = source["MorpheSettingsV5Navigation.java"]
+hub = source["MorpheSettingsV5MediaFragment.java"]
+leaf = source["MorpheSettingsV5MediaLeafFragment.java"]
+metadata = source["MorpheSettingsV5MediaMetadata.java"]
+downloads = source["MorpheSettingsV5MediaDownloadFoldersFragment.java"]
+engine = source["MorpheSettingsV5XmlPreferenceFragment.java"]
+search = source["MorpheSettingsV5Search.java"]
+
+for token in FORBIDDEN:
+    assert token not in all_text, token
+
+assert "V5_VISIBLE_BY_DEFAULT = false" in registry
+assert "V5_VISIBLE_BY_DEFAULT = true" not in registry
+assert "MORPHE_BOOST_SETTINGS_V5_MEDIA_WAVE_ISSUE121_V1" in registry
+assert "MORPHE_BOOST_SETTINGS_V5_NAVIGATION_ISSUE121_V1" in navigation
+assert "MORPHE_BOOST_SETTINGS_V5_MEDIA_FRAGMENT_ISSUE121_V1" in hub
+assert "MORPHE_BOOST_SETTINGS_V5_MEDIA_LEAF_ISSUE121_V1" in leaf
+assert "MORPHE_BOOST_SETTINGS_V5_MEDIA_METADATA_ISSUE121_V1" in metadata
+assert "MORPHE_BOOST_SETTINGS_V5_MEDIA_DOWNLOAD_FOLDERS_ISSUE121_V1" in downloads
+assert "MORPHE_BOOST_SETTINGS_V5_MEDIA_DOWNLOAD_BINDINGS_ISSUE121_V1" in downloads
+assert "MORPHE_BOOST_SETTINGS_V5_XML_PREFERENCE_ENGINE_ISSUE121_V1" in engine
+assert "MORPHE_BOOST_SETTINGS_V5_SEARCH_MEDIA_WAVE_ISSUE121_V1" in search
+
+actual_pages = {}
+for match in PAGE_PATTERN.finditer(registry):
+    page_id = match.group("page_id")
+    assert page_id not in actual_pages
+    actual_pages[page_id] = {
+        "renderer": match.group("renderer"),
+        "keys": set(KEY_PATTERN.findall(match.group("keys"))),
+    }
+
+media_actual = {
+    page_id: value
+    for page_id, value in actual_pages.items()
+    if page_id.startswith("v5/media")
+}
+assert set(media_actual) == set(expected_pages)
+for page_id, page in media_actual.items():
+    assert page["renderer"] == expected_pages[page_id]["renderer"]
+    assert page["keys"] == expected_keys_by_page[page_id], (
+        page_id,
+        sorted(page["keys"]),
+        sorted(expected_keys_by_page[page_id]),
+    )
+
+assert "MorpheSettingsV5Registry.requirePage(" in hub
+assert "MorpheSettingsV5Registry.childrenFor(" in hub
+assert "MorpheSettingsV5Navigation.openPage(this, targetPageId)" in hub
+assert "MorpheSettingsV5Search.prepareMenu(this, menu)" in hub
+assert "MorpheSettingsV5Registry.requirePage(pageId)" in leaf
+assert "page.containsKey(key)" in leaf
+for resource in (
+    "pref_views_v2",
+    "pref_media_v2",
+    "pref_general_v2",
+    "pref_links_v2",
+    "pref_data_v2",
+    "morphe_boost_settings_skeleton",
+):
+    assert f'"{resource}"' in leaf
+
+assert "PreferenceManager.getDefaultSharedPreferences" in engine
+assert "XmlResourceParser" in engine
+assert "seenKeys.add(control.key)" in engine
+assert "showFilterEditor(control)" in engine
+assert '"FilterPreference".equals(control.tag)' in engine
+assert '"PreviewSizePreference".equals(control.tag)' in engine
+assert '"PreviewAlignmentPreference".equals(control.tag)' in engine
+assert '"MediaTapActionPreference".equals(control.tag)' in engine
+
+assert "Intent.ACTION_OPEN_DOCUMENT_TREE" in downloads
+assert "takePersistableUriPermission" in downloads
+assert '"pref_download_folder_default"' in downloads
+assert '"pref_download_folder_img"' in downloads
+assert '"pref_download_folder_mp4"' in downloads
+assert '"pref_download_folder_gif"' in downloads
+assert '"pref_download_folder_per_subreddit"' in downloads
+for method in ('"D6"', '"d0"', '"O"', '"E6"', '"l2"'):
+    assert method in downloads
+assert '"sb.a"' in downloads
+assert '"f"' in downloads
+assert '"g"' in downloads
+assert "MorpheSettingsV5Search.prepareMenu(this, menu)" in downloads
+assert "MorpheSettingsV5Search.handleMenuItem(this, item)" in downloads
+
+assert "MorpheSettingsV5MediaMetadata.titleFor(" in search
+assert "MorpheSettingsV5MediaMetadata.searchSummaryFor(" in search
+assert "MorpheSettingsV5Navigation.openPage(host, entry.pageId)" in search
+assert "activity.startActivity(intent)" in navigation
+
+for key, dependency in wave["dependencies"].items():
+    assert f'"{key}"' in registry
+    assert f'"{dependency}"' in registry
+
+for category, keys in wave["special_handlers"].items():
+    assert keys, category
+    for key in keys:
+        assert f'"{key}"' in all_text, (category, key)
+
+with tempfile.TemporaryDirectory(prefix="morphe-v5-media-audit-") as temp:
+    output_dir = Path(temp)
+    completed = subprocess.run(
+        ["python3", str(AUDIT), "--output-dir", str(output_dir)],
+        cwd=ROOT,
+        text=True,
+        capture_output=True,
+        check=True,
+    )
+    report = json.loads(
+        (output_dir / "settings-v5-implementation-audit.json").read_text(
+            encoding="utf-8"
+        )
+    )
+    assert report["status"] == "INCOMPLETE"
+    assert report["current"]["v5_source_file_count"] >= 13
+    assert report["current"]["implemented_target_page_count"] >= 66
+    assert report["current"]["implemented_visible_item_count"] >= 162
+    assert report["current"]["visible_state"] == "FALSE"
+
+    violations = report["violations"]
+    assert violations["placeholder_count"] == 0
+    assert violations["classic_route_violations"] == []
+    assert violations["duplicate_page_ids"] == []
+    assert violations["duplicate_visible_keys"] == []
+    assert violations["page_key_mismatches"] == []
+    assert violations["missing_renderer_classes"] == []
+
+    media = next(
+        row for row in report["root_progress"]
+        if row["root"] == "Media"
+    )
+    assert media == {
+        "root": "Media",
+        "implemented_pages": 18,
+        "expected_pages": 18,
+        "implemented_visible_items": 36,
+        "expected_visible_items": 36,
+        "accounted_withheld_items": 0,
+        "expected_withheld_items": 0,
+    }
+
+    assert "V5_SCREEN_NODE_COVERAGE=" in completed.stdout
+    assert "V5_VISIBLE_ITEM_COVERAGE=" in completed.stdout
+    assert "V5_CANONICAL_ACCOUNTING=" in completed.stdout
+    assert "V5_VISIBLE_STATE=FALSE" in completed.stdout
+
+print(f"CONTRACT={WAVE_CONTRACT}")
+print(f"CONTRACT_SHA256={EXPECTED_WAVE_SHA}")
+print("V5_MEDIA_SCREEN_COVERAGE=18/18")
+print("V5_MEDIA_VISIBLE_ITEM_COVERAGE=36/36")
+print("V5_GLOBAL_SCREEN_COVERAGE=66/105")
+print("V5_GLOBAL_VISIBLE_ITEM_COVERAGE=162/247")
+print("V5_CANONICAL_ACCOUNTING=162/248")
+print("V5_VISIBLE_STATE=FALSE")
+print("PLACEHOLDER_PAGE_COUNT=0")
+print("LEGACY_ROUTE_COUNT=0")
+print("SPECIAL_HANDLER_ACCOUNTING=PASS")
+print("DEPENDENCY_ACCOUNTING=PASS")
+print("GLOBAL_SEARCH_ROUTE=PASS")
+print("RESULT=MORPHE_ISSUE121_SETTINGS_V5_MEDIA_WAVE_V1_CONTRACT_PASS")

--- a/tools/check_boost_settings_v5_navigation_wave_v1.py
+++ b/tools/check_boost_settings_v5_navigation_wave_v1.py
@@ -1,0 +1,305 @@
+#!/usr/bin/env python3
+"""Static contract for the hidden Settings V5 Navigation wave."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+import subprocess
+import tempfile
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SETTINGS = (
+    ROOT
+    / "extensions/boostforreddit/src/main/java/app/morphe/extension/"
+    / "boostforreddit/settings"
+)
+WAVE_CONTRACT = ROOT / "tools/contracts/boost-settings-v5-navigation-wave-v1.json"
+V5_CONTRACT = ROOT / "tools/contracts/boost-settings-v5-completeness-v2.json"
+AUDIT = ROOT / "tools/audit_boost_settings_v5_implementation.py"
+
+EXPECTED_WAVE_SHA = "0962172c47e5991e2b3372936c02293efa614ab761b7989742f0a666f0e4ca41"
+EXPECTED_CAPTURE_V5_SHA = "4c8e081069d7444938c3ff5ad0e451bb3b16183592114a6b8adf77cd1208d3f7"
+EXPECTED_V5_SHA = "f1d6a9ac6c27f71eec61b300e5f36d0785d831fde14cb982450e21b3ae238682"
+EXPECTED_ARCHIVE_SHA = "38d6836a42121090affca2016b95da80383e20898195e61abae8f6ffe4ea96b1"
+EXPECTED_BASE_APK_SHA = "a68c22d632a5dd1f446c3759a171c7dbb9edab2afc3c2f87e39323f198606742"
+EXPECTED_SOURCE_MPP_SHA = "1121fe81f01f6bd7701948ac825f49d4e9873baee4bd0f229ab14307d7abc4f3"
+
+PAGE_PATTERN = re.compile(
+    r'new\s+V5PageSpec\s*\(\s*'
+    r'"(?P<page_id>v5/[^"]+)"\s*,\s*'
+    r'"(?P<renderer>[^"]+)"\s*,\s*'
+    r'new\s+String\s*\[\]\s*\{(?P<keys>.*?)\}\s*\)',
+    re.S,
+)
+WITHHELD_PATTERN = re.compile(
+    r'new\s+V5WithheldSpec\s*\(\s*'
+    r'"(?P<key>[^"]+)"\s*,\s*'
+    r'"(?P<reason>[^"]+)"\s*\)',
+    re.S,
+)
+KEY_PATTERN = re.compile(r'"([^"]+)"')
+FORBIDDEN = (
+    "SettingsActivityCompat$",
+    "PreferenceFragmentAdvancedCompat",
+    "MorpheSettingsV4NativePages",
+    "MorpheSettingsV4AppearanceFragment",
+    "MorpheSettingsV4PostViewsFragment",
+    "MorpheSettingsV4FontsFragment",
+    "MorpheSettingsV4DownloadsFragment",
+    "MorpheSettingsV4NavigationDrawerHubFragment",
+    "MorpheSettingsFragment.class.getName()",
+    "MORPHE_V5_PLACEHOLDER_PAGE",
+)
+
+
+def bound_json(path: Path, expected_sha: str) -> dict:
+    raw = path.read_bytes()
+    actual = hashlib.sha256(raw).hexdigest()
+    assert actual == expected_sha, (path, actual, expected_sha)
+    return json.loads(raw.decode("utf-8"))
+
+
+wave = bound_json(WAVE_CONTRACT, EXPECTED_WAVE_SHA)
+v5 = bound_json(V5_CONTRACT, EXPECTED_V5_SHA)
+
+assert wave["schema"] == 1
+assert wave["issue"] == 121
+assert wave["wave"] == "Navigation"
+assert wave["binding_capture"] == {
+    "archive_sha256": EXPECTED_ARCHIVE_SHA,
+    "base_apk_sha256": EXPECTED_BASE_APK_SHA,
+    "source_mpp_sha256": EXPECTED_SOURCE_MPP_SHA,
+    "v5_contract_sha256": EXPECTED_CAPTURE_V5_SHA,
+}
+assert wave["target"] == {
+    "legacy_routes": 0,
+    "max_controls_per_leaf": 6,
+    "placeholder_pages": 0,
+    "screen_nodes": 12,
+    "visible_by_default": False,
+    "visible_items": 31,
+    "withheld_items": 1,
+}
+
+navigation_screens = [
+    screen for screen in v5["screens"] if screen["root"] == "Navigation"
+]
+navigation_items = [
+    item for item in v5["items"] if item["root"] == "Navigation"
+]
+visible_items = [
+    item for item in navigation_items if item["v5_visibility"] == "VISIBLE"
+]
+withheld_items = [
+    item
+    for item in navigation_items
+    if item["v5_visibility"] == "WITHHELD_RUNTIME_UNAVAILABLE"
+]
+assert len(navigation_screens) == 12
+assert len(navigation_items) == 32
+assert len(visible_items) == 31
+assert len(withheld_items) == 1
+assert withheld_items[0]["key"] == "pref_drawer_show_friends"
+assert withheld_items[0]["v5_visibility_reason"] == (
+    "Static implementation exists, but the Friends destination was not "
+    "proven to return functional Reddit data at runtime."
+)
+
+expected_pages = {entry["page_id"]: entry for entry in wave["screens"]}
+expected_keys_by_page = {page_id: set() for page_id in expected_pages}
+for item in wave["items"]:
+    if item["v5_visibility"] == "VISIBLE":
+        expected_keys_by_page[item["page_id"]].add(item["key"])
+expected_withheld = {
+    item["key"]: item["v5_visibility_reason"]
+    for item in wave["items"]
+    if item["v5_visibility"] != "VISIBLE"
+}
+assert len(expected_pages) == 12
+assert sum(len(keys) for keys in expected_keys_by_page.values()) == 31
+assert max(len(keys) for keys in expected_keys_by_page.values()) == 6
+assert expected_withheld == {
+    "pref_drawer_show_friends": (
+        "Static implementation exists, but the Friends destination was not "
+        "proven to return functional Reddit data at runtime."
+    )
+}
+
+source_paths = [SETTINGS / name for name in wave["source_files"]]
+assert all(path.is_file() for path in source_paths)
+source = {path.name: path.read_text(encoding="utf-8") for path in source_paths}
+all_text = "\n".join(source.values())
+
+registry = source["MorpheSettingsV5Registry.java"]
+navigation = source["MorpheSettingsV5Navigation.java"]
+hub = source["MorpheSettingsV5NavigationFragment.java"]
+leaf = source["MorpheSettingsV5NavigationLeafFragment.java"]
+metadata = source["MorpheSettingsV5NavigationMetadata.java"]
+engine = source["MorpheSettingsV5XmlPreferenceFragment.java"]
+search = source["MorpheSettingsV5Search.java"]
+
+for token in FORBIDDEN:
+    assert token not in all_text, token
+
+assert "V5_VISIBLE_BY_DEFAULT = false" in registry
+assert "V5_VISIBLE_BY_DEFAULT = true" not in registry
+assert "MORPHE_BOOST_SETTINGS_V5_NAVIGATION_WAVE_ISSUE121_V1" in registry
+assert "MORPHE_BOOST_SETTINGS_V5_NAVIGATION_ROOT_FLATTEN_ISSUE121_V1" in registry
+assert "MORPHE_BOOST_SETTINGS_V5_WITHHELD_FRIENDS_ISSUE121_V1" in registry
+assert "MORPHE_BOOST_SETTINGS_V5_NAVIGATION_ISSUE121_V1" in navigation
+assert "MORPHE_BOOST_SETTINGS_V5_NAVIGATION_FRAGMENT_ISSUE121_V1" in hub
+assert "MORPHE_BOOST_SETTINGS_V5_NAVIGATION_HIDDEN_WAVE_ISSUE121_V1" in hub
+assert "MORPHE_BOOST_SETTINGS_V5_NAVIGATION_LEAF_ISSUE121_V1" in leaf
+assert "MORPHE_BOOST_SETTINGS_V5_NAVIGATION_BINDINGS_ISSUE121_V1" in leaf
+assert "MORPHE_BOOST_SETTINGS_V5_NAVIGATION_WITHHELD_FRIENDS_ISSUE121_V1" in leaf
+assert "MORPHE_BOOST_SETTINGS_V5_NAVIGATION_METADATA_ISSUE121_V1" in metadata
+assert "MORPHE_BOOST_SETTINGS_V5_XML_PREFERENCE_ENGINE_ISSUE121_V1" in engine
+assert "MORPHE_BOOST_SETTINGS_V5_SEARCH_NAVIGATION_WAVE_ISSUE121_V1" in search
+
+actual_pages = {}
+for match in PAGE_PATTERN.finditer(registry):
+    page_id = match.group("page_id")
+    assert page_id not in actual_pages
+    actual_pages[page_id] = {
+        "renderer": match.group("renderer"),
+        "keys": set(KEY_PATTERN.findall(match.group("keys"))),
+    }
+
+navigation_actual = {
+    page_id: value
+    for page_id, value in actual_pages.items()
+    if page_id.startswith("v5/navigation")
+}
+assert set(navigation_actual) == set(expected_pages)
+for page_id, page in navigation_actual.items():
+    assert page["renderer"] == expected_pages[page_id]["renderer"]
+    assert page["keys"] == expected_keys_by_page[page_id], (
+        page_id,
+        sorted(page["keys"]),
+        sorted(expected_keys_by_page[page_id]),
+    )
+
+actual_withheld = {
+    match.group("key"): match.group("reason")
+    for match in WITHHELD_PATTERN.finditer(registry)
+}
+assert actual_withheld == expected_withheld
+assert "static V5WithheldSpec[] allWithheld()" in registry
+assert "return WITHHELD.clone();" in registry
+
+assert "MorpheSettingsV5Registry.requirePage(" in hub
+assert "MorpheSettingsV5Registry.childrenFor(" in hub
+assert 'case "v5/navigation":' in registry
+assert 'return "Navigation & gestures";' in registry
+assert '"v5/navigation/back_and_exit"' in registry
+assert '"v5/navigation/bottom_navigation"' in registry
+assert '"v5/navigation/navigation_drawer"' in registry
+assert '"v5/navigation/toolbar"' in registry
+assert 'v5/navigation/navigation_and_gestures' not in registry
+assert "MorpheSettingsV5Navigation.openPage(this, targetPageId)" in hub
+assert "MorpheSettingsV5Search.prepareMenu(this, menu)" in hub
+assert "MorpheSettingsV5Registry.requirePage(pageId)" in leaf
+assert "page.containsKey(key)" in leaf
+assert '"pref_drawer_show_friends"' not in expected_keys_by_page[
+    "v5/navigation/navigation_drawer/account_and_tools"
+]
+for resource in (
+    "pref_views_v2",
+    "pref_general_v2",
+    "pref_bottom_navigation_v2",
+    "pref_drawer_v2",
+    "pref_toolbar_v2",
+):
+    assert f'"{resource}"' in leaf
+
+assert "PreferenceManager.getDefaultSharedPreferences" in engine
+assert "XmlResourceParser" in engine
+assert "seenKeys.add(control.key)" in engine
+assert "updateDependencies()" in engine
+assert "control.dependency" in engine
+assert '"pref_toolbar_main_action"' in metadata
+assert '"pref_bottom_navigation"' in metadata
+assert '"pref_drawer_sticky_settings"' in metadata
+assert "MorpheSettingsV5NavigationMetadata.titleFor(" in search
+assert "MorpheSettingsV5NavigationMetadata.searchSummaryFor(" in search
+assert "MorpheSettingsV5Navigation.openPage(host, entry.pageId)" in search
+assert "activity.startActivity(intent)" in navigation
+
+for key, dependency in wave["dependencies"].items():
+    assert f'"{key}"' in registry
+    assert f'"{dependency}"' in registry
+
+for category, keys in wave["special_handlers"].items():
+    assert keys, category
+    for key in keys:
+        assert f'"{key}"' in all_text, (category, key)
+
+with tempfile.TemporaryDirectory(prefix="morphe-v5-navigation-audit-") as temp:
+    output_dir = Path(temp)
+    completed = subprocess.run(
+        ["python3", str(AUDIT), "--output-dir", str(output_dir)],
+        cwd=ROOT,
+        text=True,
+        capture_output=True,
+        check=True,
+    )
+    report = json.loads(
+        (output_dir / "settings-v5-implementation-audit.json").read_text(
+            encoding="utf-8"
+        )
+    )
+    assert report["status"] == "INCOMPLETE"
+    assert report["current"]["v5_source_file_count"] >= 20
+    assert report["current"]["implemented_target_page_count"] >= 86
+    assert report["current"]["implemented_visible_item_count"] >= 209
+    assert report["current"]["accounted_withheld_item_count"] == 1
+    assert report["current"]["visible_state"] == "FALSE"
+
+    violations = report["violations"]
+    assert violations["placeholder_count"] == 0
+    assert violations["classic_route_violations"] == []
+    assert violations["duplicate_page_ids"] == []
+    assert violations["duplicate_visible_keys"] == []
+    assert violations["duplicate_withheld_keys"] == []
+    assert violations["page_key_mismatches"] == []
+    assert violations["missing_renderer_classes"] == []
+    assert violations["missing_withheld_keys"] == []
+    assert violations["extra_withheld_keys"] == []
+
+    progress = next(
+        row for row in report["root_progress"] if row["root"] == "Navigation"
+    )
+    assert progress == {
+        "root": "Navigation",
+        "implemented_pages": 12,
+        "expected_pages": 12,
+        "implemented_visible_items": 31,
+        "expected_visible_items": 31,
+        "accounted_withheld_items": 1,
+        "expected_withheld_items": 1,
+    }
+
+    assert "V5_SCREEN_NODE_COVERAGE=" in completed.stdout
+    assert "V5_VISIBLE_ITEM_COVERAGE=" in completed.stdout
+    assert "V5_WITHHELD_ITEM_ACCOUNTING=1/1" in completed.stdout
+    assert "V5_CANONICAL_ACCOUNTING=" in completed.stdout
+    assert "V5_VISIBLE_STATE=FALSE" in completed.stdout
+
+print(f"CONTRACT={WAVE_CONTRACT}")
+print(f"CONTRACT_SHA256={EXPECTED_WAVE_SHA}")
+print("V5_NAVIGATION_SCREEN_COVERAGE=12/12")
+print("V5_NAVIGATION_VISIBLE_ITEM_COVERAGE=31/31")
+print("V5_NAVIGATION_WITHHELD_ITEM_ACCOUNTING=1/1")
+print("V5_GLOBAL_SCREEN_COVERAGE=86/105")
+print("V5_GLOBAL_VISIBLE_ITEM_COVERAGE=209/247")
+print("V5_CANONICAL_ACCOUNTING=210/248")
+print("V5_VISIBLE_STATE=FALSE")
+print("PLACEHOLDER_PAGE_COUNT=0")
+print("LEGACY_ROUTE_COUNT=0")
+print("WITHHELD_FRIENDS_ACCOUNTING=PASS")
+print("DEPENDENCY_ACCOUNTING=PASS")
+print("GLOBAL_SEARCH_ROUTE=PASS")
+print("RESULT=MORPHE_ISSUE121_SETTINGS_V5_NAVIGATION_WAVE_V1_CONTRACT_PASS")

--- a/tools/check_boost_settings_v5_notifications_account_wave_v1.py
+++ b/tools/check_boost_settings_v5_notifications_account_wave_v1.py
@@ -1,0 +1,300 @@
+#!/usr/bin/env python3
+"""Static contract for hidden Settings V5 Notifications & account wave."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+import subprocess
+import tempfile
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SETTINGS = (
+    ROOT
+    / "extensions/boostforreddit/src/main/java/app/morphe/extension/"
+    / "boostforreddit/settings"
+)
+WAVE_CONTRACT = (
+    ROOT
+    / "tools/contracts/boost-settings-v5-notifications-account-wave-v1.json"
+)
+V5_CONTRACT = ROOT / "tools/contracts/boost-settings-v5-completeness-v2.json"
+AUDIT = ROOT / "tools/audit_boost_settings_v5_implementation.py"
+
+EXPECTED_WAVE_SHA = "c0ad548fd5ec6bc1feb484c3e8562c98c82e39afae0fcc8ae2241580a85846d6"
+EXPECTED_CAPTURE_V5_SHA = "4c8e081069d7444938c3ff5ad0e451bb3b16183592114a6b8adf77cd1208d3f7"
+EXPECTED_V5_SHA = "f1d6a9ac6c27f71eec61b300e5f36d0785d831fde14cb982450e21b3ae238682"
+EXPECTED_ARCHIVE_SHA = "38fe3cb8f3a276cbc15dcc4aa3d564c357c09060765a778ff3c773cf251a0c3b"
+EXPECTED_BASE_APK_SHA = "a68c22d632a5dd1f446c3759a171c7dbb9edab2afc3c2f87e39323f198606742"
+EXPECTED_SOURCE_MPP_SHA = "f5912189364f1c672c25a18fdda04fda99fdcd61edb6aebbadf2cedb0e086158"
+
+PAGE_PATTERN = re.compile(
+    r'new\s+V5PageSpec\s*\(\s*'
+    r'"(?P<page_id>v5/[^"]+)"\s*,\s*'
+    r'"(?P<renderer>[^"]+)"\s*,\s*'
+    r'new\s+String\s*\[\]\s*\{(?P<keys>.*?)\}\s*\)',
+    re.S,
+)
+KEY_PATTERN = re.compile(r'"([^"]+)"')
+FORBIDDEN = (
+    "SettingsActivityCompat$",
+    "PreferenceFragmentAdvancedCompat",
+    "PreferenceFragmentAccountCompat",
+    "MorpheSettingsV4NativePages",
+    "MorpheSettingsV4AppearanceFragment",
+    "MorpheSettingsV4PostViewsFragment",
+    "MorpheSettingsV4FontsFragment",
+    "MorpheSettingsV4DownloadsFragment",
+    "MorpheSettingsV4NavigationDrawerHubFragment",
+    "MorpheSettingsFragment.class.getName()",
+    "MORPHE_V5_PLACEHOLDER_PAGE",
+)
+
+
+def bound_json(path: Path, expected_sha: str) -> dict:
+    raw = path.read_bytes()
+    actual = hashlib.sha256(raw).hexdigest()
+    assert actual == expected_sha, (path, actual, expected_sha)
+    return json.loads(raw.decode("utf-8"))
+
+
+wave = bound_json(WAVE_CONTRACT, EXPECTED_WAVE_SHA)
+v5 = bound_json(V5_CONTRACT, EXPECTED_V5_SHA)
+
+assert wave["schema"] == 1
+assert wave["issue"] == 121
+assert wave["wave"] == "Notifications & account"
+assert wave["binding_capture"] == {
+    "archive_sha256": EXPECTED_ARCHIVE_SHA,
+    "base_apk_sha256": EXPECTED_BASE_APK_SHA,
+    "source_mpp_sha256": EXPECTED_SOURCE_MPP_SHA,
+    "v5_contract_sha256": EXPECTED_CAPTURE_V5_SHA,
+}
+assert wave["target"] == {
+    "legacy_routes": 0,
+    "max_controls_per_leaf": 8,
+    "placeholder_pages": 0,
+    "screen_nodes": 8,
+    "visible_by_default": False,
+    "visible_items": 16,
+    "withheld_items": 0,
+}
+
+root_name = "Notifications & account"
+target_screens = [screen for screen in v5["screens"] if screen["root"] == root_name]
+target_items = [item for item in v5["items"] if item["root"] == root_name]
+assert len(target_screens) == 8
+assert len(target_items) == 16
+assert all(item["v5_visibility"] == "VISIBLE" for item in target_items)
+
+expected_pages = {entry["page_id"]: entry for entry in wave["screens"]}
+expected_keys_by_page = {page_id: set() for page_id in expected_pages}
+for item in wave["items"]:
+    expected_keys_by_page[item["page_id"]].add(item["key"])
+assert len(expected_pages) == 8
+assert sum(len(keys) for keys in expected_keys_by_page.values()) == 16
+assert max(len(keys) for keys in expected_keys_by_page.values()) == 8
+
+account_page = expected_pages["v5/notifications_and_account/reddit_account"]
+assert account_page == {
+    "child_count": 0,
+    "control_count": 0,
+    "page_id": "v5/notifications_and_account/reddit_account",
+    "renderer": "MorpheSettingsV5RedditAccountFragment",
+    "role": "task_page",
+    "title": "Reddit account",
+}
+
+source_paths = [SETTINGS / name for name in wave["source_files"]]
+assert all(path.is_file() for path in source_paths)
+source = {path.name: path.read_text(encoding="utf-8") for path in source_paths}
+all_text = "\n".join(source.values())
+
+registry = source["MorpheSettingsV5Registry.java"]
+navigation = source["MorpheSettingsV5Navigation.java"]
+hub = source["MorpheSettingsV5NotificationsAccountFragment.java"]
+leaf = source["MorpheSettingsV5NotificationsAccountLeafFragment.java"]
+metadata = source["MorpheSettingsV5NotificationsAccountMetadata.java"]
+account = source["MorpheSettingsV5RedditAccountFragment.java"]
+engine = source["MorpheSettingsV5XmlPreferenceFragment.java"]
+search = source["MorpheSettingsV5Search.java"]
+
+for token in FORBIDDEN:
+    assert token not in all_text, token
+
+assert "V5_VISIBLE_BY_DEFAULT = false" in registry
+assert "V5_VISIBLE_BY_DEFAULT = true" not in registry
+assert "MORPHE_BOOST_SETTINGS_V5_NOTIFICATIONS_ACCOUNT_WAVE_ISSUE121_V1" in registry
+assert "MORPHE_BOOST_SETTINGS_V5_NAVIGATION_ISSUE121_V1" in navigation
+assert "MORPHE_BOOST_SETTINGS_V5_NOTIFICATIONS_ACCOUNT_FRAGMENT_ISSUE121_V1" in hub
+assert "MORPHE_BOOST_SETTINGS_V5_NOTIFICATIONS_ACCOUNT_HIDDEN_WAVE_ISSUE121_V1" in hub
+assert "MORPHE_BOOST_SETTINGS_V5_NOTIFICATIONS_ACCOUNT_LEAF_ISSUE121_V1" in leaf
+assert "MORPHE_BOOST_SETTINGS_V5_NOTIFICATIONS_ACCOUNT_BINDINGS_ISSUE121_V1" in leaf
+assert "MORPHE_BOOST_SETTINGS_V5_NOTIFICATIONS_ACCOUNT_HIDDEN_HISTORY_ISSUE121_V1" in leaf
+assert "MORPHE_BOOST_SETTINGS_V5_NOTIFICATIONS_ACCOUNT_METADATA_ISSUE121_V1" in metadata
+assert "MORPHE_BOOST_SETTINGS_V5_REDDIT_ACCOUNT_ISSUE121_V1" in account
+assert "MORPHE_BOOST_SETTINGS_V5_REDDIT_ACCOUNT_ZERO_CANONICAL_CONTROLS_ISSUE121_V1" in account
+assert "MORPHE_BOOST_SETTINGS_V5_HIDDEN_CANONICAL_OVERRIDE_ISSUE121_V1" in engine
+assert "MORPHE_BOOST_SETTINGS_V5_SEARCH_NOTIFICATIONS_ACCOUNT_WAVE_ISSUE121_V1" in search
+
+actual_pages: dict[str, dict[str, object]] = {}
+for match in PAGE_PATTERN.finditer(registry):
+    page_id = match.group("page_id")
+    assert page_id not in actual_pages
+    actual_pages[page_id] = {
+        "renderer": match.group("renderer"),
+        "keys": set(KEY_PATTERN.findall(match.group("keys"))),
+    }
+
+actual_wave_pages = {
+    page_id: value
+    for page_id, value in actual_pages.items()
+    if page_id.startswith("v5/notifications_and_account")
+}
+assert set(actual_wave_pages) == set(expected_pages)
+for page_id, page in actual_wave_pages.items():
+    assert page["renderer"] == expected_pages[page_id]["renderer"]
+    assert page["keys"] == expected_keys_by_page[page_id], (
+        page_id,
+        sorted(page["keys"]),
+        sorted(expected_keys_by_page[page_id]),
+    )
+
+assert "MorpheSettingsV5Registry.requirePage(" in hub
+assert "MorpheSettingsV5Registry.childrenFor(" in hub
+assert "MorpheSettingsV5Navigation.openPage(this, targetPageId)" in hub
+assert "MorpheSettingsV5Search.prepareMenu(this, menu)" in hub
+assert "MorpheSettingsV5Search.handleMenuItem(this, item)" in hub
+
+assert "MorpheSettingsV5Registry.requirePage(pageId)" in leaf
+assert "page.containsKey(key)" in leaf
+for resource in (
+    "pref_privacy_v2",
+    "pref_messages_v2",
+    "morphe_boost_settings_skeleton",
+):
+    assert f'"{resource}"' in leaf
+
+hidden_keys = set(wave["special_handlers"]["hidden_canonical_controls"])
+assert hidden_keys == {"pref_search_history_save", "pref_searches_delete"}
+assert "protected boolean includeHiddenControl(" in leaf
+for key in hidden_keys:
+    assert f'"{key}"' in leaf
+assert '"pref_privacy_v2".equals(resourceName)' in leaf
+assert "page.containsKey(key)" in leaf
+assert "protected boolean includeHiddenControl(" in engine
+assert "String rawKey = attributeText(resources, parser, \"key\")" in engine
+assert "boolean forcedVisible = !visible" in engine
+assert "&& includeHiddenControl(resourceName, rawKey)" in engine
+assert "if (!visible && !forcedVisible)" in engine
+
+for key in wave["special_handlers"]["history_delete_actions"]:
+    assert f'"{key}"' in engine
+assert "confirmDelete(control)" in engine
+assert "deleteForKey(control.key)" in engine
+assert 'factoryCall("he.z", "e", "c")' in engine
+assert 'factoryCall("he.d0", "d", "c")' in engine
+assert 'factoryCall("ld.c", "a", "clear")' in engine
+
+assert '"pref_notifications_configure".equals(key)' in engine
+assert "openNotificationSettings()" in engine
+assert "Settings.ACTION_APP_NOTIFICATION_SETTINGS" in engine
+assert "Settings.EXTRA_APP_PACKAGE" in engine
+
+for key in wave["special_handlers"]["notification_side_effects"]:
+    assert f'"{key}"' in engine
+assert 'invokeStatic(\n                    "pe.b"' in engine
+assert "reconcileNotificationAccess()" in engine
+assert "Settings.ACTION_NOTIFICATION_LISTENER_SETTINGS" in engine
+
+assert "PreferenceManager.getDefaultSharedPreferences" in engine
+assert "XmlResourceParser" in engine
+assert "seenKeys.add(control.key)" in engine
+
+assert "MorpheSettingsV5NotificationsAccountMetadata.titleFor(" in search
+assert "MorpheSettingsV5NotificationsAccountMetadata.searchSummaryFor(" in search
+assert "MorpheSettingsV5Navigation.openPage(host, entry.pageId)" in search
+assert "activity.startActivity(intent)" in navigation
+
+assert '"v5/notifications_and_account/reddit_account"' in account
+assert "page.keys.length != 0" in account
+assert "!page.isLeaf()" in account
+assert "Boost has no app-local controls in this category" in account
+assert "Reddit-hosted preferences" in account
+assert "MorpheSettingsV5Search.prepareMenu(this, menu)" in account
+assert "MorpheSettingsV5Search.handleMenuItem(this, item)" in account
+
+for item in wave["items"]:
+    key = item["key"]
+    assert f'case "{key}":' in metadata, key
+    assert f'"{key}"' in registry, key
+
+for key, dependency in wave["dependencies"].items():
+    assert f'"{key}"' in registry
+    assert f'"{dependency}"' in registry
+
+with tempfile.TemporaryDirectory(prefix="morphe-v5-notifications-account-audit-") as temp:
+    output_dir = Path(temp)
+    completed = subprocess.run(
+        ["python3", str(AUDIT), "--output-dir", str(output_dir)],
+        cwd=ROOT,
+        text=True,
+        capture_output=True,
+        check=True,
+    )
+    report = json.loads(
+        (output_dir / "settings-v5-implementation-audit.json").read_text(
+            encoding="utf-8"
+        )
+    )
+    assert report["status"] == "INCOMPLETE"
+    assert report["current"]["v5_source_file_count"] >= 17
+    assert report["current"]["implemented_target_page_count"] >= 74
+    assert report["current"]["implemented_visible_item_count"] >= 178
+    assert report["current"]["visible_state"] == "FALSE"
+
+    violations = report["violations"]
+    assert violations["placeholder_count"] == 0
+    assert violations["classic_route_violations"] == []
+    assert violations["duplicate_page_ids"] == []
+    assert violations["duplicate_visible_keys"] == []
+    assert violations["page_key_mismatches"] == []
+    assert violations["missing_renderer_classes"] == []
+
+    progress = next(
+        row for row in report["root_progress"]
+        if row["root"] == root_name
+    )
+    assert progress == {
+        "root": root_name,
+        "implemented_pages": 8,
+        "expected_pages": 8,
+        "implemented_visible_items": 16,
+        "expected_visible_items": 16,
+        "accounted_withheld_items": 0,
+        "expected_withheld_items": 0,
+    }
+
+    assert "V5_SCREEN_NODE_COVERAGE=" in completed.stdout
+    assert "V5_VISIBLE_ITEM_COVERAGE=" in completed.stdout
+    assert "V5_CANONICAL_ACCOUNTING=" in completed.stdout
+    assert "V5_VISIBLE_STATE=FALSE" in completed.stdout
+
+print(f"CONTRACT={WAVE_CONTRACT}")
+print(f"CONTRACT_SHA256={EXPECTED_WAVE_SHA}")
+print("V5_NOTIFICATIONS_ACCOUNT_SCREEN_COVERAGE=8/8")
+print("V5_NOTIFICATIONS_ACCOUNT_VISIBLE_ITEM_COVERAGE=16/16")
+print("V5_GLOBAL_SCREEN_COVERAGE=74/105")
+print("V5_GLOBAL_VISIBLE_ITEM_COVERAGE=178/247")
+print("V5_CANONICAL_ACCOUNTING=178/248")
+print("V5_VISIBLE_STATE=FALSE")
+print("PLACEHOLDER_PAGE_COUNT=0")
+print("LEGACY_ROUTE_COUNT=0")
+print("HIDDEN_CANONICAL_CONTROL_ACCOUNTING=PASS")
+print("REDDIT_ACCOUNT_ZERO_CONTROL_ACCOUNTING=PASS")
+print("SPECIAL_HANDLER_ACCOUNTING=PASS")
+print("DEPENDENCY_ACCOUNTING=PASS")
+print("GLOBAL_SEARCH_ROUTE=PASS")
+print("RESULT=MORPHE_ISSUE121_SETTINGS_V5_NOTIFICATIONS_ACCOUNT_WAVE_V1_CONTRACT_PASS")

--- a/tools/check_boost_settings_v5_reading_wave_v1.py
+++ b/tools/check_boost_settings_v5_reading_wave_v1.py
@@ -1,0 +1,234 @@
+#!/usr/bin/env python3
+"""Static contract for the complete hidden Settings V5 Reading wave."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+import subprocess
+import tempfile
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SETTINGS = ROOT / "extensions/boostforreddit/src/main/java/app/morphe/extension/boostforreddit/settings"
+WAVE_CONTRACT = ROOT / "tools/contracts/boost-settings-v5-reading-wave-v1.json"
+V5_CONTRACT = ROOT / "tools/contracts/boost-settings-v5-completeness-v2.json"
+AUDIT = ROOT / "tools/audit_boost_settings_v5_implementation.py"
+
+EXPECTED_WAVE_SHA = "de76707761088cfbe7e72503e3c2152c97a8685128651dce4a27cf70ee19322a"
+EXPECTED_CAPTURE_V5_SHA = "4c8e081069d7444938c3ff5ad0e451bb3b16183592114a6b8adf77cd1208d3f7"
+EXPECTED_V5_SHA = "f1d6a9ac6c27f71eec61b300e5f36d0785d831fde14cb982450e21b3ae238682"
+EXPECTED_ARCHIVE_SHA = "3a6fd1ae8faef9ba369e9162926e6b4a054c81a3e194bcd502150d04ed50e594"
+EXPECTED_BASE_APK_SHA = "a68c22d632a5dd1f446c3759a171c7dbb9edab2afc3c2f87e39323f198606742"
+EXPECTED_SOURCE_MPP_SHA = "a860dc7e6845b23fe557d4c8aeb06c02486b91f49b5d75d8dd852f2e18123a0f"
+
+PAGE_PATTERN = re.compile(
+    r'new\s+V5PageSpec\s*\(\s*'
+    r'"(?P<page_id>v5/[^"]+)"\s*,\s*'
+    r'"(?P<renderer>[^"]+)"\s*,\s*'
+    r'new\s+String\s*\[\]\s*\{(?P<keys>.*?)\}\s*\)',
+    re.S,
+)
+KEY_PATTERN = re.compile(r'"([^"]+)"')
+FORBIDDEN = (
+    "SettingsActivityCompat$",
+    "PreferenceFragmentAdvancedCompat",
+    "MorpheSettingsV4NativePages",
+    "MorpheSettingsV4AppearanceFragment",
+    "MorpheSettingsV4PostViewsFragment",
+    "MorpheSettingsV4FontsFragment",
+    "MorpheSettingsV4DownloadsFragment",
+    "MorpheSettingsV4NavigationDrawerHubFragment",
+    "MorpheSettingsFragment.class.getName()",
+    "MORPHE_V5_PLACEHOLDER_PAGE",
+)
+
+
+def bound_json(path: Path, expected_sha: str) -> dict:
+    raw = path.read_bytes()
+    actual = hashlib.sha256(raw).hexdigest()
+    assert actual == expected_sha, (path, actual, expected_sha)
+    return json.loads(raw.decode("utf-8"))
+
+
+wave = bound_json(WAVE_CONTRACT, EXPECTED_WAVE_SHA)
+v5 = bound_json(V5_CONTRACT, EXPECTED_V5_SHA)
+assert wave["schema"] == 1
+assert wave["issue"] == 121
+assert wave["wave"] == "Reading & interaction"
+assert wave["binding_capture"] == {
+    "archive_sha256": EXPECTED_ARCHIVE_SHA,
+    "base_apk_sha256": EXPECTED_BASE_APK_SHA,
+    "source_mpp_sha256": EXPECTED_SOURCE_MPP_SHA,
+    "v5_contract_sha256": EXPECTED_CAPTURE_V5_SHA,
+}
+assert wave["target"] == {
+    "legacy_routes": 0,
+    "max_controls_per_leaf": 12,
+    "placeholder_pages": 0,
+    "screen_nodes": 26,
+    "visible_by_default": False,
+    "visible_items": 87,
+    "withheld_items": 0,
+}
+
+reading_screens = [s for s in v5["screens"] if s["root"] == "Reading & interaction"]
+reading_items = [i for i in v5["items"] if i["root"] == "Reading & interaction"]
+assert len(reading_screens) == 26
+assert len(reading_items) == 87
+assert all(item["v5_visibility"] == "VISIBLE" for item in reading_items)
+
+expected_pages = {entry["page_id"]: entry for entry in wave["screens"]}
+expected_keys_by_page = {page_id: set() for page_id in expected_pages}
+for item in wave["items"]:
+    expected_keys_by_page[item["page_id"]].add(item["key"])
+assert len(expected_pages) == 26
+assert sum(len(keys) for keys in expected_keys_by_page.values()) == 87
+assert max(len(keys) for keys in expected_keys_by_page.values()) == 12
+
+source_paths = [SETTINGS / name for name in wave["source_files"]]
+assert all(path.is_file() for path in source_paths)
+source = {path.name: path.read_text(encoding="utf-8") for path in source_paths}
+all_text = "\n".join(source.values())
+registry = source["MorpheSettingsV5Registry.java"]
+navigation = source["MorpheSettingsV5Navigation.java"]
+hub = source["MorpheSettingsV5ReadingFragment.java"]
+leaf = source["MorpheSettingsV5ReadingLeafFragment.java"]
+metadata = source["MorpheSettingsV5ReadingMetadata.java"]
+engine = source["MorpheSettingsV5XmlPreferenceFragment.java"]
+search = source["MorpheSettingsV5Search.java"]
+
+for token in FORBIDDEN:
+    assert token not in all_text, token
+
+assert "V5_VISIBLE_BY_DEFAULT = false" in registry
+assert "V5_VISIBLE_BY_DEFAULT = true" not in registry
+assert "MORPHE_BOOST_SETTINGS_V5_READING_WAVE_ISSUE121_V1" in registry
+assert "MORPHE_BOOST_SETTINGS_V5_NAVIGATION_ISSUE121_V1" in navigation
+assert "MORPHE_BOOST_SETTINGS_V5_READING_FRAGMENT_ISSUE121_V1" in hub
+assert "MORPHE_BOOST_SETTINGS_V5_READING_LEAF_ISSUE121_V1" in leaf
+assert "MORPHE_BOOST_SETTINGS_V5_READING_METADATA_ISSUE121_V1" in metadata
+assert "MORPHE_BOOST_SETTINGS_V5_XML_PREFERENCE_ENGINE_ISSUE121_V1" in engine
+assert "MORPHE_BOOST_SETTINGS_V5_SEARCH_MULTI_WAVE_ISSUE121_V1" in search
+
+actual_pages = {}
+for match in PAGE_PATTERN.finditer(registry):
+    page_id = match.group("page_id")
+    assert page_id not in actual_pages
+    actual_pages[page_id] = {
+        "renderer": match.group("renderer"),
+        "keys": set(KEY_PATTERN.findall(match.group("keys"))),
+    }
+reading_actual = {
+    pid: value for pid, value in actual_pages.items()
+    if pid.startswith("v5/reading_and_interaction")
+}
+assert set(reading_actual) == set(expected_pages)
+for page_id, page in reading_actual.items():
+    expected_renderer = (
+        "MorpheSettingsV5ReadingLeafFragment"
+        if expected_pages[page_id]["role"] == "leaf_section"
+        else "MorpheSettingsV5ReadingFragment"
+    )
+    assert page["renderer"] == expected_renderer
+    assert page["keys"] == expected_keys_by_page[page_id], (
+        page_id,
+        sorted(page["keys"]),
+        sorted(expected_keys_by_page[page_id]),
+    )
+
+assert "MorpheSettingsV5Registry.requirePage(" in hub
+assert "MorpheSettingsV5Registry.childrenFor(" in hub
+assert "MorpheSettingsV5Navigation.openPage(this, targetPageId)" in hub
+assert "MorpheSettingsV5Search.prepareMenu(this, menu)" in hub
+assert "MorpheSettingsV5Registry.requirePage(pageId)" in leaf
+assert "page.containsKey(key)" in leaf
+assert '"pref_comments_v2"' in leaf
+assert '"morphe_boost_settings_skeleton"' in leaf
+assert "PreferenceManager.getDefaultSharedPreferences" in engine
+assert "XmlResourceParser" in engine
+assert "seenKeys.add(control.key)" in engine
+assert "MorpheSettingsV14Ui.standardListRow" in engine
+assert "MorpheSettingsV5Search.prepareMenu(this, menu)" in engine
+assert "showFilterEditor(control)" in engine
+assert "showColorPatternEditor()" in engine
+assert "confirmDelete(control)" in engine
+assert "showSynccitEditor()" in engine
+assert "showSavedSortsEditor()" in engine
+assert "showSavedSearchesEditor()" in engine
+assert "showFieldSearchHelp()" in engine
+assert 'invokeActivityHelper("t0"' in engine
+assert 'invokeActivityHelper("P"' in engine
+assert 'invokeActivityHelper("n0"' in engine
+assert "MorpheSettingsV5ReadingMetadata.titleFor(" in search
+assert "MorpheSettingsV5Navigation.openPage(host, entry.pageId)" in search
+assert "activity.startActivity(intent)" in navigation
+
+for key, dependency in wave["dependencies"].items():
+    assert f'"{key}"' in registry
+    assert f'"{dependency}"' in registry
+
+for category, keys in wave["special_handlers"].items():
+    assert keys, category
+    for key in keys:
+        assert f'"{key}"' in all_text, (category, key)
+
+with tempfile.TemporaryDirectory(prefix="morphe-v5-reading-audit-") as temp:
+    output_dir = Path(temp)
+    completed = subprocess.run(
+        ["python3", str(AUDIT), "--output-dir", str(output_dir)],
+        cwd=ROOT,
+        text=True,
+        capture_output=True,
+        check=True,
+    )
+    report = json.loads(
+        (output_dir / "settings-v5-implementation-audit.json").read_text(
+            encoding="utf-8"
+        )
+    )
+    assert report["status"] == "INCOMPLETE"
+    assert report["current"]["v5_source_file_count"] >= 9
+    assert report["current"]["implemented_target_page_count"] >= 48
+    assert report["current"]["implemented_visible_item_count"] >= 126
+    assert report["current"]["visible_state"] == "FALSE"
+    violations = report["violations"]
+    assert violations["placeholder_count"] == 0
+    assert violations["classic_route_violations"] == []
+    assert violations["duplicate_page_ids"] == []
+    assert violations["duplicate_visible_keys"] == []
+    assert violations["page_key_mismatches"] == []
+    assert violations["missing_renderer_classes"] == []
+    reading = next(
+        row for row in report["root_progress"]
+        if row["root"] == "Reading & interaction"
+    )
+    assert reading == {
+        "root": "Reading & interaction",
+        "implemented_pages": 26,
+        "expected_pages": 26,
+        "implemented_visible_items": 87,
+        "expected_visible_items": 87,
+        "accounted_withheld_items": 0,
+        "expected_withheld_items": 0,
+    }
+    assert "V5_SCREEN_NODE_COVERAGE=" in completed.stdout
+    assert "V5_VISIBLE_ITEM_COVERAGE=" in completed.stdout
+    assert "V5_CANONICAL_ACCOUNTING=" in completed.stdout
+    assert "V5_VISIBLE_STATE=FALSE" in completed.stdout
+
+print(f"CONTRACT={WAVE_CONTRACT}")
+print(f"CONTRACT_SHA256={EXPECTED_WAVE_SHA}")
+print("V5_READING_SCREEN_COVERAGE=26/26")
+print("V5_READING_VISIBLE_ITEM_COVERAGE=87/87")
+print("V5_GLOBAL_SCREEN_COVERAGE=48/105")
+print("V5_GLOBAL_VISIBLE_ITEM_COVERAGE=126/247")
+print("V5_CANONICAL_ACCOUNTING=126/248")
+print("V5_VISIBLE_STATE=FALSE")
+print("PLACEHOLDER_PAGE_COUNT=0")
+print("LEGACY_ROUTE_COUNT=0")
+print("SPECIAL_HANDLER_ACCOUNTING=PASS")
+print("DEPENDENCY_ACCOUNTING=PASS")
+print("GLOBAL_SEARCH_ROUTE=PASS")
+print("RESULT=MORPHE_ISSUE121_SETTINGS_V5_READING_WAVE_V1_CONTRACT_PASS")

--- a/tools/check_boost_settings_v5_root_overview_wave_v1.py
+++ b/tools/check_boost_settings_v5_root_overview_wave_v1.py
@@ -1,0 +1,277 @@
+#!/usr/bin/env python3
+"""Static contract for Settings V5 root overview semantic V4."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+import subprocess
+import tempfile
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SETTINGS = (
+    ROOT
+    / "extensions/boostforreddit/src/main/java/app/morphe/extension/"
+    / "boostforreddit/settings"
+)
+PATCH_SOURCE = (
+    ROOT
+    / "patches/src/main/kotlin/app/morphe/patches/reddit/customclients/"
+    / "boostforreddit/misc/settings/BoostMorpheSettingsSkeletonPatch.kt"
+)
+WAVE_CONTRACT = (
+    ROOT / "tools/contracts/boost-settings-v5-root-overview-wave-v1.json"
+)
+V5_CONTRACT = ROOT / "tools/contracts/boost-settings-v5-completeness-v2.json"
+AUDIT = ROOT / "tools/audit_boost_settings_v5_implementation.py"
+
+EXPECTED_WAVE_SHA = "68712a6fd73aebda4e5a24a013517191e4abbecc1eb8b7b46d6280546b93d5b7"
+EXPECTED_V5_SHA = "f1d6a9ac6c27f71eec61b300e5f36d0785d831fde14cb982450e21b3ae238682"
+
+PAGE_PATTERN = re.compile(
+    r'new\s+V5PageSpec\s*\(\s*'
+    r'"(?P<page_id>v5/[^"]+)"\s*,\s*'
+    r'"(?P<renderer>[^"]+)"\s*,\s*'
+    r'new\s+String\s*\[\]\s*\{(?P<keys>.*?)\}\s*\)',
+    re.S,
+)
+KEY_PATTERN = re.compile(r'"([^"]+)"')
+
+
+def bound_json(path: Path, expected_sha: str) -> dict:
+    raw = path.read_bytes()
+    actual = hashlib.sha256(raw).hexdigest()
+    assert actual == expected_sha, (path, actual, expected_sha)
+    return json.loads(raw.decode("utf-8"))
+
+
+wave = bound_json(WAVE_CONTRACT, EXPECTED_WAVE_SHA)
+v5 = bound_json(V5_CONTRACT, EXPECTED_V5_SHA)
+
+assert wave["schema"] == 1
+assert wave["issue"] == 121
+assert wave["wave"] == "root_overview_morphe_flatten_and_classic_fallback"
+assert wave["root"] == "Morphe"
+assert wave["semantic_revision"] == {
+    "revision": "V4",
+    "removed_page_id": "v5/morphe/patch_features",
+    "removed_path": "Morphe / Patch features",
+    "result": "Morphe renders its 12 configurable feature references directly",
+}
+assert wave["v5_contract"] == {
+    "path": "tools/contracts/boost-settings-v5-completeness-v2.json",
+    "sha256": EXPECTED_V5_SHA,
+}
+assert wave["targets"] == {
+    "classic_fallback_count": 1,
+    "configurable_feature_reference_count": 12,
+    "root_destination_count": 7,
+    "root_group_count": 1,
+    "root_overview_shell_count": 1,
+    "screen_count": 1,
+    "task_page_count": 0,
+    "visible_item_count": 0,
+    "withheld_item_count": 0,
+}
+assert wave["activation_state"] == {
+    "activation_performed": False,
+    "root_classic_fallback_location": "root_only",
+    "v5_visible_by_default": False,
+}
+
+assert [screen for screen in v5["screens"] if screen["root"] == "Morphe"] == [{
+    "child_count": 0,
+    "control_count": 0,
+    "depth": 0,
+    "max_children_contract": "",
+    "path": "Morphe",
+    "role": "root_group",
+    "root": "Morphe",
+    "task_page": "",
+    "title": "Morphe",
+}]
+assert not [item for item in v5["items"] if item["root"] == "Morphe"]
+assert v5["morphe_configurable_feature_reference_count"] == 12
+assert v5["screen_node_count"] == 105
+assert v5["screen_edge_count"] == 98
+
+root_fragment_path = SETTINGS / "MorpheSettingsV5RootFragment.java"
+morphe_fragment_path = SETTINGS / "MorpheSettingsV5MorpheFragment.java"
+retired_fragment_path = SETTINGS / "MorpheSettingsV5PatchFeaturesFragment.java"
+registry_path = SETTINGS / "MorpheSettingsV5Registry.java"
+search_path = SETTINGS / "MorpheSettingsV5Search.java"
+v4_entry_path = SETTINGS / "MorpheSettingsV4.java"
+
+for path in (
+    root_fragment_path,
+    morphe_fragment_path,
+    registry_path,
+    search_path,
+    v4_entry_path,
+    PATCH_SOURCE,
+):
+    assert path.is_file(), path
+assert not retired_fragment_path.exists(), retired_fragment_path
+
+root_fragment = root_fragment_path.read_text(encoding="utf-8")
+morphe_fragment = morphe_fragment_path.read_text(encoding="utf-8")
+registry = registry_path.read_text(encoding="utf-8")
+search = search_path.read_text(encoding="utf-8")
+v4_entry = v4_entry_path.read_text(encoding="utf-8")
+patch_source = PATCH_SOURCE.read_text(encoding="utf-8")
+
+for marker in (
+    "MORPHE_BOOST_SETTINGS_V5_ROOT_OVERVIEW_ISSUE121_V1",
+    "MORPHE_BOOST_SETTINGS_V5_COMPLETE_ISSUE121_V1",
+    "MORPHE_BOOST_SETTINGS_V5_ROOT_HIDDEN_WAVE_ISSUE121_V1",
+):
+    assert marker in root_fragment, marker
+assert root_fragment.count("MORPHE_V5_ROOT_CLASSIC_FALLBACK") == 1
+assert root_fragment.count("Open classic Boost settings") >= 2
+assert "SettingsActivityCompat$HeaderFragment" in root_fragment
+assert "MorpheSettingsV5Search.openGlobalSearch(this)" in root_fragment
+assert "MorpheSettingsV5Registry.childrenFor(PAGE_ROOT)" in root_fragment
+assert "PAGE_MORPHE" not in root_fragment
+assert "buildMorpheGroup" not in root_fragment
+assert "v5/morphe/patch_features" not in root_fragment
+
+for marker in (
+    "MORPHE_BOOST_SETTINGS_V5_MORPHE_CONTROLS_ISSUE121_V1",
+    "MORPHE_BOOST_SETTINGS_V5_MORPHE_CONFIGURABLE_REFERENCE_COUNT_12_ISSUE121_V1",
+    "MORPHE_BOOST_SETTINGS_V5_MORPHE_ROOT_FLATTEN_ISSUE121_V1",
+):
+    assert marker in morphe_fragment, marker
+assert '"morphe_boost_settings_skeleton"' in morphe_fragment
+assert "setPreferencesFromResource(resourceId, rootKey)" in morphe_fragment
+assert 'activity.setTitle("Morphe")' in morphe_fragment
+assert "MorpheSettingsV5Search.prepareMenu(this, menu)" in morphe_fragment
+
+assert "static void openGlobalSearch(Fragment host)" in search
+assert "private static void openGlobalSearch(Fragment host)" not in search
+
+actual_pages = {}
+for match in PAGE_PATTERN.finditer(registry):
+    actual_pages[match.group("page_id")] = {
+        "renderer": match.group("renderer"),
+        "keys": KEY_PATTERN.findall(match.group("keys")),
+    }
+assert actual_pages["v5/morphe"] == {
+    "renderer": "MorpheSettingsV5MorpheFragment",
+    "keys": [],
+}
+assert "v5/morphe/patch_features" not in actual_pages
+assert "MorpheSettingsV5PatchFeaturesFragment" not in registry
+assert "MORPHE_BOOST_SETTINGS_V5_MORPHE_ROOT_FLATTEN_ISSUE121_V1" in registry
+
+expected_root_destinations = [
+    "v5/morphe",
+    "v5/appearance",
+    "v5/reading_and_interaction",
+    "v5/navigation",
+    "v5/media",
+    "v5/notifications_and_account",
+    "v5/data_and_app",
+]
+assert [entry["page_id"] for entry in wave["root_destinations"]] == (
+    expected_root_destinations
+)
+root_children_match = re.search(
+    r'case "v5/root":\s*return new String\[\]\{(?P<children>.*?)\};',
+    registry,
+    re.S,
+)
+assert root_children_match
+assert KEY_PATTERN.findall(root_children_match.group("children")) == (
+    expected_root_destinations
+)
+assert 'return new String[]{"v5/morphe/patch_features"};' not in registry
+assert re.search(r'V5_VISIBLE_BY_DEFAULT\s*=\s*false', registry)
+
+# Normal Settings remains on V4 until the separate activation gate.
+assert '"MorpheSettingsV4Fragment"' in v4_entry
+assert "MorpheSettingsV5RootFragment" not in v4_entry
+
+reference_keys = wave["configurable_feature_reference_keys"]
+assert len(reference_keys) == 12
+assert len(set(reference_keys)) == 12
+for key in reference_keys:
+    assert f'android:key="{key}"' in patch_source, key
+
+with tempfile.TemporaryDirectory(
+    prefix="morphe-v5-root-overview-v4-audit-"
+) as temp:
+    output_dir = Path(temp)
+    completed = subprocess.run(
+        ["python3", str(AUDIT), "--output-dir", str(output_dir)],
+        cwd=ROOT,
+        text=True,
+        capture_output=True,
+        check=True,
+    )
+    report = json.loads(
+        (output_dir / "settings-v5-implementation-audit.json").read_text(
+            encoding="utf-8"
+        )
+    )
+    assert report["status"] == "INCOMPLETE"
+    assert report["current"]["v5_source_file_count"] == 26
+    assert report["current"]["implemented_target_page_count"] == 105
+    assert report["current"]["implemented_visible_item_count"] == 247
+    assert report["current"]["accounted_withheld_item_count"] == 1
+    assert report["current"]["visible_state"] == "FALSE"
+    assert report["current"]["root_overview_marker_present"] is True
+    assert report["current"]["completeness_marker_present"] is True
+    assert report["violations"]["root_fallback_count"] == 1
+    assert report["violations"]["classic_route_violations"] == []
+    assert report["violations"]["missing_page_ids"] == []
+    assert report["violations"]["extra_page_ids"] == []
+    morphe = next(
+        entry for entry in report["root_progress"]
+        if entry["root"] == "Morphe"
+    )
+    assert morphe == {
+        "accounted_withheld_items": 0,
+        "expected_pages": 1,
+        "expected_visible_items": 0,
+        "expected_withheld_items": 0,
+        "implemented_pages": 1,
+        "implemented_visible_items": 0,
+        "root": "Morphe",
+    }
+    for expected in (
+        "V5_SOURCE_FILE_COUNT=26",
+        "V5_SCREEN_NODE_COVERAGE=105/105",
+        "V5_VISIBLE_ITEM_COVERAGE=247/247",
+        "V5_WITHHELD_ITEM_ACCOUNTING=1/1",
+        "V5_CANONICAL_ACCOUNTING=248/248",
+        "V5_RUNTIME_ROOT_COVERAGE=0/7",
+        "V5_VISIBLE_STATE=FALSE",
+        "V5_PLACEHOLDER_PAGE_COUNT=0",
+        "V5_CLASSIC_ROUTE_VIOLATION_COUNT=0",
+        "V5_ROOT_CLASSIC_FALLBACK_COUNT=1",
+        "AUDIT_STATUS=INCOMPLETE",
+    ):
+        assert expected in completed.stdout, expected
+
+print(f"CONTRACT={WAVE_CONTRACT}")
+print(f"CONTRACT_SHA256={EXPECTED_WAVE_SHA}")
+print("SEMANTIC_REVISION=V4")
+print("V5_ROOT_OVERVIEW_SHELL_COVERAGE=1/1")
+print("V5_MORPHE_SCREEN_COVERAGE=1/1")
+print("V5_MORPHE_WRAPPER_REMOVAL_COUNT=1")
+print("V5_ROOT_DESTINATION_COVERAGE=7/7")
+print("V5_MORPHE_CONFIGURABLE_REFERENCE_COUNT=12/12")
+print("V5_ROOT_CLASSIC_FALLBACK_COUNT=1/1")
+print("V5_GLOBAL_SCREEN_COVERAGE=105/105")
+print("V5_GLOBAL_VISIBLE_ITEM_COVERAGE=247/247")
+print("V5_WITHHELD_ITEM_ACCOUNTING=1/1")
+print("V5_CANONICAL_ACCOUNTING=248/248")
+print("V5_VISIBLE_STATE=FALSE")
+print("PLACEHOLDER_PAGE_COUNT=0")
+print("LEGACY_ROUTE_COUNT=0")
+print("GLOBAL_SEARCH_LAUNCHER=PASS")
+print("ROOT_CLASSIC_FALLBACK_LOCATION=PASS")
+print("ACTIVATION_PERFORMED=NO")
+print("RESULT=MORPHE_ISSUE121_SETTINGS_V5_ROOT_OVERVIEW_SEMANTIC_V4_CONTRACT_PASS")

--- a/tools/contracts/boost-settings-android-guidance-pilot-v1.json
+++ b/tools/contracts/boost-settings-android-guidance-pilot-v1.json
@@ -1,0 +1,86 @@
+{
+  "schema": 1,
+  "issue": 121,
+  "phase": "2.2/7 Android settings guidance pilot",
+  "claim": "alignment_pilot_not_google_certification",
+  "official_guidance": [
+    {
+      "source": "https://developer.android.com/design/ui/mobile/guides/patterns/settings",
+      "retrieved": "2026-07-24",
+      "applied_rules": [
+        "settings_use_list_or_list_detail_layout",
+        "group_with_headings_and_intrinsic_or_visual_containment",
+        "supporting_text_is_optional_and_explains_status_or_consequence",
+        "icons_clarify_meaning_or_status",
+        "boolean_settings_use_trailing_switches",
+        "subscreen_label_matches_subscreen_title"
+      ]
+    },
+    {
+      "source": "https://developer.android.com/reference/kotlin/androidx/compose/material3/ListItem.composable",
+      "retrieved": "2026-07-24",
+      "applied_rules": [
+        "continuous_vertical_list",
+        "headline_supporting_leading_and_trailing_anatomy",
+        "one_line_and_two_line_templates"
+      ]
+    },
+    {
+      "source": "https://developer.android.com/develop/ui/views/components/settings/customize-your-settings",
+      "retrieved": "2026-07-24",
+      "applied_rules": [
+        "persisted_choice_shows_current_value_in_summary"
+      ]
+    }
+  ],
+  "scope": {
+    "settings_overview": "standard_list_with_meaningful_leading_icons",
+    "root_group_pages": "standard_destination_list_without_redundant_summaries",
+    "task_pages": "standard_destination_list_without_redundant_summaries",
+    "navigation_drawer_hub": "section_headings_and_plain_destination_rows",
+    "navigation_leaf_pages": "standard_preference_rows",
+    "feeds_library": "pilot_summary_cleanup"
+  },
+  "list_anatomy": {
+    "one_line_min_height_dp": 56,
+    "two_line_min_height_dp": 72,
+    "headline_sp": 16,
+    "supporting_sp": 14,
+    "supporting_max_lines": 2,
+    "trailing_boolean_control": "switch",
+    "trailing_destination_control": "chevron"
+  },
+  "containment": {
+    "item_card_background": "forbidden_in_pilot_scope",
+    "rounded_group_container": "forbidden_in_pilot_scope",
+    "grouping": "headings_and_dividers"
+  },
+  "supporting_text": {
+    "allowed_roles": [
+      "current_value",
+      "current_status",
+      "consequence",
+      "dependency_explanation",
+      "clarify_unfamiliar_label"
+    ],
+    "forbidden_roles": [
+      "repeat_title",
+      "generic_category_description",
+      "long_procedural_instruction"
+    ],
+    "feeds_library_visible_summaries": {
+      "pref_drawer_show_home": "Default feed",
+      "pref_drawer_show_frontpage": "Posts from subscriptions"
+    }
+  },
+  "icons": {
+    "settings_overview": "allowed_when_meaningful",
+    "below_overview": "omitted_in_pilot_scope"
+  },
+  "behavior_changes": "none",
+  "preference_key_changes": 0,
+  "route_changes": 0,
+  "withheld_friends_key": "preserved",
+  "classic_fallback": "preserved",
+  "global_search": "preserved"
+}

--- a/tools/contracts/boost-settings-blueprint-v3.json
+++ b/tools/contracts/boost-settings-blueprint-v3.json
@@ -1,0 +1,10577 @@
+{
+  "design_contract": {
+    "canonical_keys_and_defaults": "unchanged",
+    "classic_settings_fallback": "preserved",
+    "default_summary_length": "one_short_sentence",
+    "explicit_key_mapping_required_for_cross_domain_moves": true,
+    "flat_subscreen_model": "replaced_by_screen_graph",
+    "help_model": "section_intro_plus_contextual_summaries",
+    "max_controls_per_subscreen": 12,
+    "max_intermediate_page_children": 6,
+    "max_leaf_controls": 12,
+    "max_task_page_children": 5,
+    "progressive_disclosure": "required_for_complex_topics",
+    "self_explanatory_controls": "summary_may_be_omitted",
+    "structure": "task_based_with_subscreens",
+    "vague_bucket_labels_forbidden": [
+      "Additional link behavior",
+      "Additional navigation behavior",
+      "Misc",
+      "More options"
+    ]
+  },
+  "destination_only_pages": [
+    {
+      "kind": "aggregate_compatibility_page",
+      "page": "Patch features",
+      "page_intro": "Configure features added by Morphe patches.",
+      "referenced_item_count": 12,
+      "root": "Morphe",
+      "route": "MorpheSettingsFragment"
+    },
+    {
+      "kind": "activity_destination",
+      "page": "Backup & restore",
+      "page_intro": "Export or restore supported Boost and Morphe preferences.",
+      "referenced_item_count": 0,
+      "root": "Data & app",
+      "route": "BackupActivity"
+    },
+    {
+      "kind": "native_destination",
+      "page": "Reddit account",
+      "page_intro": "Open account and Reddit-specific preferences.",
+      "referenced_item_count": 0,
+      "root": "Notifications & account",
+      "route": "PreferenceFragmentAdvancedCompat"
+    }
+  ],
+  "explicit_key_mapping": {
+    "pref_ask_exit": {
+      "page": "Navigation & gestures",
+      "root": "Navigation",
+      "subscreen": "Back & exit"
+    },
+    "pref_autoplay_cards": {
+      "page": "Playback & autoplay",
+      "root": "Media",
+      "subscreen": "Autoplay"
+    },
+    "pref_browser": {
+      "page": "Links & browser",
+      "root": "Media",
+      "subscreen": "Browser"
+    },
+    "pref_double_exit": {
+      "page": "Navigation & gestures",
+      "root": "Navigation",
+      "subscreen": "Back & exit"
+    },
+    "pref_drafts": {
+      "page": "Composing & drafts",
+      "root": "Reading & interaction",
+      "subscreen": "Drafts"
+    },
+    "pref_edit_subscriptions": {
+      "page": "Feeds & subscriptions",
+      "root": "Reading & interaction",
+      "subscreen": "Manage subscriptions"
+    },
+    "pref_imgur_uploads": {
+      "page": "Composing & drafts",
+      "root": "Reading & interaction",
+      "subscreen": "Uploads"
+    },
+    "pref_link_video": {
+      "page": "Links & browser",
+      "root": "Media",
+      "subscreen": "Video links"
+    },
+    "pref_manage_drafts": {
+      "page": "Composing & drafts",
+      "root": "Reading & interaction",
+      "subscreen": "Drafts"
+    },
+    "pref_split_screen": {
+      "page": "Post layout",
+      "root": "Appearance",
+      "subscreen": "Tablet layout"
+    },
+    "pref_upvote_on_save": {
+      "page": "Posts",
+      "root": "Reading & interaction",
+      "subscreen": "Post actions"
+    },
+    "pref_use_advanced_editor": {
+      "page": "Composing & drafts",
+      "root": "Reading & interaction",
+      "subscreen": "Editor"
+    },
+    "pref_video_audio_start_muted": {
+      "page": "Playback & autoplay",
+      "root": "Media",
+      "subscreen": "Audio"
+    }
+  },
+  "generated_at": "2026-07-24T02:35:23.425595+00:00",
+  "graph_edges": [
+    {
+      "child_path": "Appearance / Community header",
+      "child_title": "Community header",
+      "parent_path": "Appearance"
+    },
+    {
+      "child_path": "Appearance / Display & motion",
+      "child_title": "Display & motion",
+      "parent_path": "Appearance"
+    },
+    {
+      "child_path": "Appearance / Post layout",
+      "child_title": "Post layout",
+      "parent_path": "Appearance"
+    },
+    {
+      "child_path": "Appearance / Theme & colors",
+      "child_title": "Theme & colors",
+      "parent_path": "Appearance"
+    },
+    {
+      "child_path": "Appearance / Typography",
+      "child_title": "Typography",
+      "parent_path": "Appearance"
+    },
+    {
+      "child_path": "Appearance / Community header / Community header",
+      "child_title": "Community header",
+      "parent_path": "Appearance / Community header"
+    },
+    {
+      "child_path": "Appearance / Display & motion / Display performance",
+      "child_title": "Display performance",
+      "parent_path": "Appearance / Display & motion"
+    },
+    {
+      "child_path": "Appearance / Post layout / Cards",
+      "child_title": "Cards",
+      "parent_path": "Appearance / Post layout"
+    },
+    {
+      "child_path": "Appearance / Post layout / Compact layouts",
+      "child_title": "Compact layouts",
+      "parent_path": "Appearance / Post layout"
+    },
+    {
+      "child_path": "Appearance / Post layout / Layout & saved views",
+      "child_title": "Layout & saved views",
+      "parent_path": "Appearance / Post layout"
+    },
+    {
+      "child_path": "Appearance / Post layout / Swipe",
+      "child_title": "Swipe",
+      "parent_path": "Appearance / Post layout"
+    },
+    {
+      "child_path": "Appearance / Post layout / Tablet layout",
+      "child_title": "Tablet layout",
+      "parent_path": "Appearance / Post layout"
+    },
+    {
+      "child_path": "Appearance / Post layout / Compact layouts / Dense",
+      "child_title": "Dense",
+      "parent_path": "Appearance / Post layout / Compact layouts"
+    },
+    {
+      "child_path": "Appearance / Post layout / Compact layouts / Small cards",
+      "child_title": "Small cards",
+      "parent_path": "Appearance / Post layout / Compact layouts"
+    },
+    {
+      "child_path": "Appearance / Post layout / Layout & saved views / Post layout",
+      "child_title": "Post layout",
+      "parent_path": "Appearance / Post layout / Layout & saved views"
+    },
+    {
+      "child_path": "Appearance / Post layout / Layout & saved views / Saved community views",
+      "child_title": "Saved community views",
+      "parent_path": "Appearance / Post layout / Layout & saved views"
+    },
+    {
+      "child_path": "Appearance / Theme & colors / Advanced appearance",
+      "child_title": "Advanced appearance",
+      "parent_path": "Appearance / Theme & colors"
+    },
+    {
+      "child_path": "Appearance / Theme & colors / Personalization",
+      "child_title": "Personalization",
+      "parent_path": "Appearance / Theme & colors"
+    },
+    {
+      "child_path": "Appearance / Theme & colors / Theme",
+      "child_title": "Theme",
+      "parent_path": "Appearance / Theme & colors"
+    },
+    {
+      "child_path": "Appearance / Typography / Comments",
+      "child_title": "Comments",
+      "parent_path": "Appearance / Typography"
+    },
+    {
+      "child_path": "Appearance / Typography / Posts",
+      "child_title": "Posts",
+      "parent_path": "Appearance / Typography"
+    },
+    {
+      "child_path": "Appearance / Typography / Reset",
+      "child_title": "Reset",
+      "parent_path": "Appearance / Typography"
+    },
+    {
+      "child_path": "Data & app / About & support",
+      "child_title": "About & support",
+      "parent_path": "Data & app"
+    },
+    {
+      "child_path": "Data & app / App behavior & compatibility",
+      "child_title": "App behavior & compatibility",
+      "parent_path": "Data & app"
+    },
+    {
+      "child_path": "Data & app / Backup & restore",
+      "child_title": "Backup & restore",
+      "parent_path": "Data & app"
+    },
+    {
+      "child_path": "Data & app / Settings experience",
+      "child_title": "Settings experience",
+      "parent_path": "Data & app"
+    },
+    {
+      "child_path": "Data & app / Storage & bandwidth",
+      "child_title": "Storage & bandwidth",
+      "parent_path": "Data & app"
+    },
+    {
+      "child_path": "Data & app / About & support / About Boost",
+      "child_title": "About Boost",
+      "parent_path": "Data & app / About & support"
+    },
+    {
+      "child_path": "Data & app / About & support / Author",
+      "child_title": "Author",
+      "parent_path": "Data & app / About & support"
+    },
+    {
+      "child_path": "Data & app / About & support / Privacy",
+      "child_title": "Privacy",
+      "parent_path": "Data & app / About & support"
+    },
+    {
+      "child_path": "Data & app / App behavior & compatibility / Community shortcuts",
+      "child_title": "Community shortcuts",
+      "parent_path": "Data & app / App behavior & compatibility"
+    },
+    {
+      "child_path": "Data & app / App behavior & compatibility / Compatibility & legacy",
+      "child_title": "Compatibility & legacy",
+      "parent_path": "Data & app / App behavior & compatibility"
+    },
+    {
+      "child_path": "Data & app / App behavior & compatibility / Other app behavior",
+      "child_title": "Other app behavior",
+      "parent_path": "Data & app / App behavior & compatibility"
+    },
+    {
+      "child_path": "Data & app / Settings experience / Settings presentation",
+      "child_title": "Settings presentation",
+      "parent_path": "Data & app / Settings experience"
+    },
+    {
+      "child_path": "Data & app / Storage & bandwidth / Cache",
+      "child_title": "Cache",
+      "parent_path": "Data & app / Storage & bandwidth"
+    },
+    {
+      "child_path": "Data & app / Storage & bandwidth / Data saver",
+      "child_title": "Data saver",
+      "parent_path": "Data & app / Storage & bandwidth"
+    },
+    {
+      "child_path": "Data & app / Storage & bandwidth / Data usage",
+      "child_title": "Data usage",
+      "parent_path": "Data & app / Storage & bandwidth"
+    },
+    {
+      "child_path": "Data & app / Storage & bandwidth / Images",
+      "child_title": "Images",
+      "parent_path": "Data & app / Storage & bandwidth"
+    },
+    {
+      "child_path": "Data & app / Storage & bandwidth / Videos",
+      "child_title": "Videos",
+      "parent_path": "Data & app / Storage & bandwidth"
+    },
+    {
+      "child_path": "Media / Downloads & cache",
+      "child_title": "Downloads & cache",
+      "parent_path": "Media"
+    },
+    {
+      "child_path": "Media / Images, GIFs & previews",
+      "child_title": "Images, GIFs & previews",
+      "parent_path": "Media"
+    },
+    {
+      "child_path": "Media / Links & browser",
+      "child_title": "Links & browser",
+      "parent_path": "Media"
+    },
+    {
+      "child_path": "Media / Playback & autoplay",
+      "child_title": "Playback & autoplay",
+      "parent_path": "Media"
+    },
+    {
+      "child_path": "Media / Downloads & cache / Download folders",
+      "child_title": "Download folders",
+      "parent_path": "Media / Downloads & cache"
+    },
+    {
+      "child_path": "Media / Images, GIFs & previews / Native image behavior",
+      "child_title": "Native image behavior",
+      "parent_path": "Media / Images, GIFs & previews"
+    },
+    {
+      "child_path": "Media / Images, GIFs & previews / Open behavior",
+      "child_title": "Open behavior",
+      "parent_path": "Media / Images, GIFs & previews"
+    },
+    {
+      "child_path": "Media / Images, GIFs & previews / Preview behavior",
+      "child_title": "Preview behavior",
+      "parent_path": "Media / Images, GIFs & previews"
+    },
+    {
+      "child_path": "Media / Images, GIFs & previews / Preview layout",
+      "child_title": "Preview layout",
+      "parent_path": "Media / Images, GIFs & previews"
+    },
+    {
+      "child_path": "Media / Links & browser / Browser",
+      "child_title": "Browser",
+      "parent_path": "Media / Links & browser"
+    },
+    {
+      "child_path": "Media / Links & browser / Link handling",
+      "child_title": "Link handling",
+      "parent_path": "Media / Links & browser"
+    },
+    {
+      "child_path": "Media / Links & browser / Links to open in app",
+      "child_title": "Links to open in app",
+      "parent_path": "Media / Links & browser"
+    },
+    {
+      "child_path": "Media / Links & browser / Video links",
+      "child_title": "Video links",
+      "parent_path": "Media / Links & browser"
+    },
+    {
+      "child_path": "Media / Playback & autoplay / Audio",
+      "child_title": "Audio",
+      "parent_path": "Media / Playback & autoplay"
+    },
+    {
+      "child_path": "Media / Playback & autoplay / Autoplay",
+      "child_title": "Autoplay",
+      "parent_path": "Media / Playback & autoplay"
+    },
+    {
+      "child_path": "Media / Playback & autoplay / Media behavior",
+      "child_title": "Media behavior",
+      "parent_path": "Media / Playback & autoplay"
+    },
+    {
+      "child_path": "Media / Playback & autoplay / Playback & autoplay",
+      "child_title": "Playback & autoplay",
+      "parent_path": "Media / Playback & autoplay"
+    },
+    {
+      "child_path": "Morphe / Patch features",
+      "child_title": "Patch features",
+      "parent_path": "Morphe"
+    },
+    {
+      "child_path": "Navigation / Navigation & gestures",
+      "child_title": "Navigation & gestures",
+      "parent_path": "Navigation"
+    },
+    {
+      "child_path": "Navigation / Navigation & gestures / Back & exit",
+      "child_title": "Back & exit",
+      "parent_path": "Navigation / Navigation & gestures"
+    },
+    {
+      "child_path": "Navigation / Navigation & gestures / Bottom navigation",
+      "child_title": "Bottom navigation",
+      "parent_path": "Navigation / Navigation & gestures"
+    },
+    {
+      "child_path": "Navigation / Navigation & gestures / Navigation drawer",
+      "child_title": "Navigation drawer",
+      "parent_path": "Navigation / Navigation & gestures"
+    },
+    {
+      "child_path": "Navigation / Navigation & gestures / Toolbar",
+      "child_title": "Toolbar",
+      "parent_path": "Navigation / Navigation & gestures"
+    },
+    {
+      "child_path": "Navigation / Navigation & gestures / Navigation drawer / Account switcher",
+      "child_title": "Account switcher",
+      "parent_path": "Navigation / Navigation & gestures / Navigation drawer"
+    },
+    {
+      "child_path": "Navigation / Navigation & gestures / Navigation drawer / Destinations",
+      "child_title": "Destinations",
+      "parent_path": "Navigation / Navigation & gestures / Navigation drawer"
+    },
+    {
+      "child_path": "Navigation / Navigation & gestures / Navigation drawer / Drawer behavior",
+      "child_title": "Drawer behavior",
+      "parent_path": "Navigation / Navigation & gestures / Navigation drawer"
+    },
+    {
+      "child_path": "Navigation / Navigation & gestures / Navigation drawer / Go-to shortcuts",
+      "child_title": "Go-to shortcuts",
+      "parent_path": "Navigation / Navigation & gestures / Navigation drawer"
+    },
+    {
+      "child_path": "Navigation / Navigation & gestures / Navigation drawer / Quick toggles",
+      "child_title": "Quick toggles",
+      "parent_path": "Navigation / Navigation & gestures / Navigation drawer"
+    },
+    {
+      "child_path": "Navigation / Navigation & gestures / Navigation drawer / Subscriptions",
+      "child_title": "Subscriptions",
+      "parent_path": "Navigation / Navigation & gestures / Navigation drawer"
+    },
+    {
+      "child_path": "Notifications & account / History, privacy & recovery",
+      "child_title": "History, privacy & recovery",
+      "parent_path": "Notifications & account"
+    },
+    {
+      "child_path": "Notifications & account / Notifications & inbox",
+      "child_title": "Notifications & inbox",
+      "parent_path": "Notifications & account"
+    },
+    {
+      "child_path": "Notifications & account / Reddit account",
+      "child_title": "Reddit account",
+      "parent_path": "Notifications & account"
+    },
+    {
+      "child_path": "Notifications & account / History, privacy & recovery / History",
+      "child_title": "History",
+      "parent_path": "Notifications & account / History, privacy & recovery"
+    },
+    {
+      "child_path": "Notifications & account / History, privacy & recovery / Recovery & archives",
+      "child_title": "Recovery & archives",
+      "parent_path": "Notifications & account / History, privacy & recovery"
+    },
+    {
+      "child_path": "Notifications & account / Notifications & inbox / Advanced",
+      "child_title": "Advanced",
+      "parent_path": "Notifications & account / Notifications & inbox"
+    },
+    {
+      "child_path": "Notifications & account / Notifications & inbox / Notifications",
+      "child_title": "Notifications",
+      "parent_path": "Notifications & account / Notifications & inbox"
+    },
+    {
+      "child_path": "Reading & interaction / Comments",
+      "child_title": "Comments",
+      "parent_path": "Reading & interaction"
+    },
+    {
+      "child_path": "Reading & interaction / Composing & drafts",
+      "child_title": "Composing & drafts",
+      "parent_path": "Reading & interaction"
+    },
+    {
+      "child_path": "Reading & interaction / Feeds & subscriptions",
+      "child_title": "Feeds & subscriptions",
+      "parent_path": "Reading & interaction"
+    },
+    {
+      "child_path": "Reading & interaction / Posts",
+      "child_title": "Posts",
+      "parent_path": "Reading & interaction"
+    },
+    {
+      "child_path": "Reading & interaction / Search & filters",
+      "child_title": "Search & filters",
+      "parent_path": "Reading & interaction"
+    },
+    {
+      "child_path": "Reading & interaction / Comments / Comment actions",
+      "child_title": "Comment actions",
+      "parent_path": "Reading & interaction / Comments"
+    },
+    {
+      "child_path": "Reading & interaction / Comments / Comment appearance",
+      "child_title": "Comment appearance",
+      "parent_path": "Reading & interaction / Comments"
+    },
+    {
+      "child_path": "Reading & interaction / Comments / Comment behavior",
+      "child_title": "Comment behavior",
+      "parent_path": "Reading & interaction / Comments"
+    },
+    {
+      "child_path": "Reading & interaction / Comments / Thread navigation",
+      "child_title": "Thread navigation",
+      "parent_path": "Reading & interaction / Comments"
+    },
+    {
+      "child_path": "Reading & interaction / Composing & drafts / Drafts",
+      "child_title": "Drafts",
+      "parent_path": "Reading & interaction / Composing & drafts"
+    },
+    {
+      "child_path": "Reading & interaction / Composing & drafts / Editor",
+      "child_title": "Editor",
+      "parent_path": "Reading & interaction / Composing & drafts"
+    },
+    {
+      "child_path": "Reading & interaction / Composing & drafts / Uploads",
+      "child_title": "Uploads",
+      "parent_path": "Reading & interaction / Composing & drafts"
+    },
+    {
+      "child_path": "Reading & interaction / Feeds & subscriptions / Manage subscriptions",
+      "child_title": "Manage subscriptions",
+      "parent_path": "Reading & interaction / Feeds & subscriptions"
+    },
+    {
+      "child_path": "Reading & interaction / Posts / Feed behavior",
+      "child_title": "Feed behavior",
+      "parent_path": "Reading & interaction / Posts"
+    },
+    {
+      "child_path": "Reading & interaction / Posts / Post actions",
+      "child_title": "Post actions",
+      "parent_path": "Reading & interaction / Posts"
+    },
+    {
+      "child_path": "Reading & interaction / Posts / Post behavior",
+      "child_title": "Post behavior",
+      "parent_path": "Reading & interaction / Posts"
+    },
+    {
+      "child_path": "Reading & interaction / Posts / Reading state",
+      "child_title": "Reading state",
+      "parent_path": "Reading & interaction / Posts"
+    },
+    {
+      "child_path": "Reading & interaction / Search & filters / Content filters",
+      "child_title": "Content filters",
+      "parent_path": "Reading & interaction / Search & filters"
+    },
+    {
+      "child_path": "Reading & interaction / Search & filters / Search",
+      "child_title": "Search",
+      "parent_path": "Reading & interaction / Search & filters"
+    },
+    {
+      "child_path": "Reading & interaction / Search & filters / Content filters / Filter behavior",
+      "child_title": "Filter behavior",
+      "parent_path": "Reading & interaction / Search & filters / Content filters"
+    },
+    {
+      "child_path": "Reading & interaction / Search & filters / Content filters / Muted content",
+      "child_title": "Muted content",
+      "parent_path": "Reading & interaction / Search & filters / Content filters"
+    },
+    {
+      "child_path": "Reading & interaction / Search & filters / Content filters / Post matching",
+      "child_title": "Post matching",
+      "parent_path": "Reading & interaction / Search & filters / Content filters"
+    },
+    {
+      "child_path": "Reading & interaction / Search & filters / Search / Advanced search",
+      "child_title": "Advanced search",
+      "parent_path": "Reading & interaction / Search & filters / Search"
+    },
+    {
+      "child_path": "Reading & interaction / Search & filters / Search / Search behavior",
+      "child_title": "Search behavior",
+      "parent_path": "Reading & interaction / Search & filters / Search"
+    },
+    {
+      "child_path": "Reading & interaction / Search & filters / Search / Suggestions",
+      "child_title": "Suggestions",
+      "parent_path": "Reading & interaction / Search & filters / Search"
+    }
+  ],
+  "issue": 121,
+  "items": [
+    {
+      "default_value": "",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "OMIT_OR_ONE_LINE_ACTION_HINT",
+      "key": "buy_pro",
+      "leaf_section": "Community header",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": null,
+          "key": "buy_pro",
+          "logical_kind": "action",
+          "resource": "pref_headers_v2",
+          "root_referenced": false
+        }
+      ],
+      "logical_kind": "action",
+      "page": "Community header",
+      "page_intro": "Control the title, description, and header shown for communities.",
+      "proposed_summary": "",
+      "root": "Appearance",
+      "screen_depth": 2,
+      "screen_path": [
+        "Appearance",
+        "Community header",
+        "Community header"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "none_or_custom",
+      "subscreen": "Community header",
+      "title": "Boost PRO"
+    },
+    {
+      "default_value": "center",
+      "dependency": "pref_show_subreddit_header",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE",
+      "key": "pref_toolbar_header_type",
+      "leaf_section": "Community header",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": null,
+          "key": "pref_toolbar_header_type",
+          "logical_kind": "stored_setting",
+          "resource": "pref_toolbar_v2",
+          "root_referenced": false
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Community header",
+      "page_intro": "Control the title, description, and header shown for communities.",
+      "proposed_summary": "",
+      "root": "Appearance",
+      "screen_depth": 2,
+      "screen_path": [
+        "Appearance",
+        "Community header",
+        "Community header"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "string",
+      "subscreen": "Community header",
+      "title": "Community info alignment"
+    },
+    {
+      "default_value": "",
+      "dependency": "",
+      "existing_summary": "Support Boost",
+      "help_treatment": "REVIEW_EXISTING_SUMMARY",
+      "key": "remove_ads",
+      "leaf_section": "Community header",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": null,
+          "key": "remove_ads",
+          "logical_kind": "action",
+          "resource": "pref_headers_v2",
+          "root_referenced": false
+        }
+      ],
+      "logical_kind": "action",
+      "page": "Community header",
+      "page_intro": "Control the title, description, and header shown for communities.",
+      "proposed_summary": "Support Boost",
+      "root": "Appearance",
+      "screen_depth": 2,
+      "screen_path": [
+        "Appearance",
+        "Community header",
+        "Community header"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "none_or_custom",
+      "subscreen": "Community header",
+      "title": "Remove ads"
+    },
+    {
+      "default_value": "true",
+      "dependency": "pref_show_subreddit_header",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE",
+      "key": "pref_header_show_description",
+      "leaf_section": "Community header",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": null,
+          "key": "pref_header_show_description",
+          "logical_kind": "stored_setting",
+          "resource": "pref_toolbar_v2",
+          "root_referenced": false
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Community header",
+      "page_intro": "Control the title, description, and header shown for communities.",
+      "proposed_summary": "",
+      "root": "Appearance",
+      "screen_depth": 2,
+      "screen_path": [
+        "Appearance",
+        "Community header",
+        "Community header"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Community header",
+      "title": "Show community description"
+    },
+    {
+      "default_value": "false",
+      "dependency": "",
+      "existing_summary": "Show banner and icon in communities",
+      "help_treatment": "REVIEW_EXISTING_SUMMARY",
+      "key": "pref_show_subreddit_header",
+      "leaf_section": "Community header",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": null,
+          "key": "pref_show_subreddit_header",
+          "logical_kind": "stored_setting",
+          "resource": "pref_toolbar_v2",
+          "root_referenced": false
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Community header",
+      "page_intro": "Control the title, description, and header shown for communities.",
+      "proposed_summary": "Show banner and icon in communities",
+      "root": "Appearance",
+      "screen_depth": 2,
+      "screen_path": [
+        "Appearance",
+        "Community header",
+        "Community header"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Community header",
+      "title": "Show community header"
+    },
+    {
+      "default_value": "true",
+      "dependency": "",
+      "existing_summary": "Ask Android to use a high refresh rate for Boost windows on adaptive-refresh displays.",
+      "help_treatment": "REVIEW_EXISTING_SUMMARY+PROGRESSIVE_DISCLOSURE",
+      "key": "morphe_boost_prefer_high_refresh_rate",
+      "leaf_section": "Display performance",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Display & performance",
+          "key": "morphe_boost_prefer_high_refresh_rate",
+          "logical_kind": "morphe_user_setting",
+          "resource": "morphe_boost_settings_skeleton",
+          "root_referenced": false
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Display & motion",
+      "page_intro": "Adjust display behavior, animation, and refresh-rate preferences.",
+      "proposed_summary": "Ask Android to use a high refresh rate for Boost windows on adaptive-refresh displays.",
+      "root": "Appearance",
+      "screen_depth": 2,
+      "screen_path": [
+        "Appearance",
+        "Display & motion",
+        "Display performance"
+      ],
+      "source_type": "morphe_embedded_xml",
+      "storage_type": "boolean",
+      "subscreen": "Display performance",
+      "title": "Prefer high refresh rate"
+    },
+    {
+      "default_value": "true",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE",
+      "key": "pref_cards_gallery_carousel",
+      "leaf_section": "Cards",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Cards",
+          "key": "pref_cards_gallery_carousel",
+          "logical_kind": "stored_setting",
+          "resource": "pref_views_v2",
+          "root_referenced": false
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Post layout",
+      "page_intro": "Control how posts and feed cards are arranged.",
+      "proposed_summary": "",
+      "root": "Appearance",
+      "screen_depth": 2,
+      "screen_path": [
+        "Appearance",
+        "Post layout",
+        "Cards"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Cards",
+      "title": "Carousel for multiple images"
+    },
+    {
+      "default_value": "true",
+      "dependency": "",
+      "existing_summary": "Remove horizontal margins",
+      "help_treatment": "REVIEW_EXISTING_SUMMARY",
+      "key": "pref_cards_full",
+      "leaf_section": "Cards",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Cards",
+          "key": "pref_cards_full",
+          "logical_kind": "stored_setting",
+          "resource": "pref_views_v2",
+          "root_referenced": false
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Post layout",
+      "page_intro": "Control how posts and feed cards are arranged.",
+      "proposed_summary": "Remove horizontal margins",
+      "root": "Appearance",
+      "screen_depth": 2,
+      "screen_path": [
+        "Appearance",
+        "Post layout",
+        "Cards"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Cards",
+      "title": "Fill the screen width"
+    },
+    {
+      "default_value": "false",
+      "dependency": "",
+      "existing_summary": "Disable for fixed height images",
+      "help_treatment": "REVIEW_EXISTING_SUMMARY",
+      "key": "pref_cards_full_preview",
+      "leaf_section": "Cards",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Cards",
+          "key": "pref_cards_full_preview",
+          "logical_kind": "stored_setting",
+          "resource": "pref_views_v2",
+          "root_referenced": false
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Post layout",
+      "page_intro": "Control how posts and feed cards are arranged.",
+      "proposed_summary": "Disable for fixed height images",
+      "root": "Appearance",
+      "screen_depth": 2,
+      "screen_path": [
+        "Appearance",
+        "Post layout",
+        "Cards"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Cards",
+      "title": "Full height images"
+    },
+    {
+      "default_value": "5",
+      "dependency": "pref_cards_preview_self",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE",
+      "key": "pref_cards_preview_self_lines",
+      "leaf_section": "Cards",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Cards",
+          "key": "pref_cards_preview_self_lines",
+          "logical_kind": "stored_setting",
+          "resource": "pref_views_v2",
+          "root_referenced": false
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Post layout",
+      "page_intro": "Control how posts and feed cards are arranged.",
+      "proposed_summary": "",
+      "root": "Appearance",
+      "screen_depth": 2,
+      "screen_path": [
+        "Appearance",
+        "Post layout",
+        "Cards"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "integer",
+      "subscreen": "Cards",
+      "title": "Lines to preview"
+    },
+    {
+      "default_value": "true",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE",
+      "key": "pref_cards_preview_self",
+      "leaf_section": "Cards",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Cards",
+          "key": "pref_cards_preview_self",
+          "logical_kind": "stored_setting",
+          "resource": "pref_views_v2",
+          "root_referenced": false
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Post layout",
+      "page_intro": "Control how posts and feed cards are arranged.",
+      "proposed_summary": "",
+      "root": "Appearance",
+      "screen_depth": 2,
+      "screen_path": [
+        "Appearance",
+        "Post layout",
+        "Cards"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Cards",
+      "title": "Preview text from posts"
+    },
+    {
+      "default_value": "false",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE",
+      "key": "pref_cards_rounded_corners",
+      "leaf_section": "Cards",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Cards",
+          "key": "pref_cards_rounded_corners",
+          "logical_kind": "stored_setting",
+          "resource": "pref_views_v2",
+          "root_referenced": false
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Post layout",
+      "page_intro": "Control how posts and feed cards are arranged.",
+      "proposed_summary": "",
+      "root": "Appearance",
+      "screen_depth": 2,
+      "screen_path": [
+        "Appearance",
+        "Post layout",
+        "Cards"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Cards",
+      "title": "Rounded corners"
+    },
+    {
+      "default_value": "true",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE",
+      "key": "pref_cards_subreddit_icon",
+      "leaf_section": "Cards",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Cards",
+          "key": "pref_cards_subreddit_icon",
+          "logical_kind": "stored_setting",
+          "resource": "pref_views_v2",
+          "root_referenced": false
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Post layout",
+      "page_intro": "Control how posts and feed cards are arranged.",
+      "proposed_summary": "",
+      "root": "Appearance",
+      "screen_depth": 2,
+      "screen_path": [
+        "Appearance",
+        "Post layout",
+        "Cards"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Cards",
+      "title": "Show community icon"
+    },
+    {
+      "default_value": "true",
+      "dependency": "",
+      "existing_summary": "Disable to use large image previews",
+      "help_treatment": "REVIEW_EXISTING_SUMMARY",
+      "key": "pref_cards_links_as_thumbnails",
+      "leaf_section": "Cards",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Cards",
+          "key": "pref_cards_links_as_thumbnails",
+          "logical_kind": "stored_setting",
+          "resource": "pref_views_v2",
+          "root_referenced": false
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Post layout",
+      "page_intro": "Control how posts and feed cards are arranged.",
+      "proposed_summary": "Disable to use large image previews",
+      "root": "Appearance",
+      "screen_depth": 2,
+      "screen_path": [
+        "Appearance",
+        "Post layout",
+        "Cards"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Cards",
+      "title": "Show thumbnails for link posts"
+    },
+    {
+      "default_value": "false",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE",
+      "key": "pref_dense_buttons_visible",
+      "leaf_section": "Dense",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Dense",
+          "key": "pref_dense_buttons_visible",
+          "logical_kind": "stored_setting",
+          "resource": "pref_views_v2",
+          "root_referenced": false
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Post layout",
+      "page_intro": "Control how posts and feed cards are arranged.",
+      "proposed_summary": "",
+      "root": "Appearance",
+      "screen_depth": 3,
+      "screen_path": [
+        "Appearance",
+        "Post layout",
+        "Compact layouts",
+        "Dense"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Dense",
+      "title": "Buttons always visible"
+    },
+    {
+      "default_value": "false",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE",
+      "key": "pref_mini_cards_buttons_visible",
+      "leaf_section": "Small cards",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Small cards",
+          "key": "pref_mini_cards_buttons_visible",
+          "logical_kind": "stored_setting",
+          "resource": "pref_views_v2",
+          "root_referenced": false
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Post layout",
+      "page_intro": "Control how posts and feed cards are arranged.",
+      "proposed_summary": "",
+      "root": "Appearance",
+      "screen_depth": 3,
+      "screen_path": [
+        "Appearance",
+        "Post layout",
+        "Compact layouts",
+        "Small cards"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Small cards",
+      "title": "Buttons always visible"
+    },
+    {
+      "default_value": "false",
+      "dependency": "",
+      "existing_summary": "Remove horizontal margins",
+      "help_treatment": "REVIEW_EXISTING_SUMMARY",
+      "key": "pref_mini_cards_full",
+      "leaf_section": "Small cards",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Small cards",
+          "key": "pref_mini_cards_full",
+          "logical_kind": "stored_setting",
+          "resource": "pref_views_v2",
+          "root_referenced": false
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Post layout",
+      "page_intro": "Control how posts and feed cards are arranged.",
+      "proposed_summary": "Remove horizontal margins",
+      "root": "Appearance",
+      "screen_depth": 3,
+      "screen_path": [
+        "Appearance",
+        "Post layout",
+        "Compact layouts",
+        "Small cards"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Small cards",
+      "title": "Fill the screen width"
+    },
+    {
+      "default_value": "true",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE",
+      "key": "pref_mini_cards_rounded_corners",
+      "leaf_section": "Small cards",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Small cards",
+          "key": "pref_mini_cards_rounded_corners",
+          "logical_kind": "stored_setting",
+          "resource": "pref_views_v2",
+          "root_referenced": false
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Post layout",
+      "page_intro": "Control how posts and feed cards are arranged.",
+      "proposed_summary": "",
+      "root": "Appearance",
+      "screen_depth": 3,
+      "screen_path": [
+        "Appearance",
+        "Post layout",
+        "Compact layouts",
+        "Small cards"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Small cards",
+      "title": "Rounded corners"
+    },
+    {
+      "default_value": "true",
+      "dependency": "",
+      "existing_summary": "Limit title to 2 lines",
+      "help_treatment": "REVIEW_EXISTING_SUMMARY",
+      "key": "pref_mini_cards_truncate_title",
+      "leaf_section": "Small cards",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Small cards",
+          "key": "pref_mini_cards_truncate_title",
+          "logical_kind": "stored_setting",
+          "resource": "pref_views_v2",
+          "root_referenced": false
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Post layout",
+      "page_intro": "Control how posts and feed cards are arranged.",
+      "proposed_summary": "Limit title to 2 lines",
+      "root": "Appearance",
+      "screen_depth": 3,
+      "screen_path": [
+        "Appearance",
+        "Post layout",
+        "Compact layouts",
+        "Small cards"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Small cards",
+      "title": "Truncate title"
+    },
+    {
+      "default_value": "false",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE",
+      "key": "pref_show_subreddit_prefix",
+      "leaf_section": "Post layout",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": null,
+          "key": "pref_show_subreddit_prefix",
+          "logical_kind": "stored_setting",
+          "resource": "pref_views_v2",
+          "root_referenced": false
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Post layout",
+      "page_intro": "Control how posts and feed cards are arranged.",
+      "proposed_summary": "",
+      "root": "Appearance",
+      "screen_depth": 3,
+      "screen_path": [
+        "Appearance",
+        "Post layout",
+        "Layout & saved views",
+        "Post layout"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Post layout",
+      "title": "Communities start with r/"
+    },
+    {
+      "default_value": "0",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE",
+      "key": "pref_view",
+      "leaf_section": "Post layout",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": null,
+          "key": "pref_view",
+          "logical_kind": "stored_setting",
+          "resource": "pref_views_v2",
+          "root_referenced": false
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Post layout",
+      "page_intro": "Control how posts and feed cards are arranged.",
+      "proposed_summary": "",
+      "root": "Appearance",
+      "screen_depth": 3,
+      "screen_path": [
+        "Appearance",
+        "Post layout",
+        "Layout & saved views",
+        "Post layout"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "string",
+      "subscreen": "Post layout",
+      "title": "Default view"
+    },
+    {
+      "default_value": "",
+      "dependency": "pref_view_per_subscription",
+      "existing_summary": "",
+      "help_treatment": "OMIT_OR_ONE_LINE_ACTION_HINT",
+      "key": "pref_view_per_sub",
+      "leaf_section": "Post layout",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": null,
+          "key": "pref_view_per_sub",
+          "logical_kind": "action",
+          "resource": "pref_views_v2",
+          "root_referenced": false
+        }
+      ],
+      "logical_kind": "action",
+      "page": "Post layout",
+      "page_intro": "Control how posts and feed cards are arranged.",
+      "proposed_summary": "",
+      "root": "Appearance",
+      "screen_depth": 3,
+      "screen_path": [
+        "Appearance",
+        "Post layout",
+        "Layout & saved views",
+        "Post layout"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "none_or_custom",
+      "subscreen": "Post layout",
+      "title": "Manage saved views"
+    },
+    {
+      "default_value": "false",
+      "dependency": "",
+      "existing_summary": "Each community will remember the last view you selected for that community",
+      "help_treatment": "REVIEW_EXISTING_SUMMARY",
+      "key": "pref_view_per_subscription",
+      "leaf_section": "Post layout",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": null,
+          "key": "pref_view_per_subscription",
+          "logical_kind": "stored_setting",
+          "resource": "pref_views_v2",
+          "root_referenced": false
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Post layout",
+      "page_intro": "Control how posts and feed cards are arranged.",
+      "proposed_summary": "Each community will remember the last view you selected for that community",
+      "root": "Appearance",
+      "screen_depth": 3,
+      "screen_path": [
+        "Appearance",
+        "Post layout",
+        "Layout & saved views",
+        "Post layout"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Post layout",
+      "title": "Remember per community"
+    },
+    {
+      "default_value": "false",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE",
+      "key": "pref_left_handed",
+      "leaf_section": "Post layout",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": null,
+          "key": "pref_left_handed",
+          "logical_kind": "stored_setting",
+          "resource": "pref_views_v2",
+          "root_referenced": false
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Post layout",
+      "page_intro": "Control how posts and feed cards are arranged.",
+      "proposed_summary": "",
+      "root": "Appearance",
+      "screen_depth": 3,
+      "screen_path": [
+        "Appearance",
+        "Post layout",
+        "Layout & saved views",
+        "Post layout"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Post layout",
+      "title": "Thumbnails on left"
+    },
+    {
+      "default_value": "",
+      "dependency": "pref_view_per_subscription",
+      "existing_summary": "Choose a community or custom feed and its view.",
+      "help_treatment": "DIRECT_CONTROL_SUMMARY",
+      "key": "action:saved_views:add",
+      "leaf_section": "Saved community views",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Community views",
+          "logical_kind": "direct_action",
+          "resource": "MorpheSettingsV4SavedViewsFragment",
+          "root_referenced": false
+        }
+      ],
+      "logical_kind": "action",
+      "page": "Post layout",
+      "page_intro": "Control how posts and feed cards are arranged.",
+      "proposed_summary": "Choose a community or custom feed and its view.",
+      "root": "Appearance",
+      "screen_depth": 3,
+      "screen_path": [
+        "Appearance",
+        "Post layout",
+        "Layout & saved views",
+        "Saved community views"
+      ],
+      "source_type": "morphe_direct_ui",
+      "storage_type": "private_preferences",
+      "subscreen": "Saved community views",
+      "title": "Add saved view"
+    },
+    {
+      "default_value": "",
+      "dependency": "saved_views_not_empty",
+      "existing_summary": "Remove the saved view for every community.",
+      "help_treatment": "DIRECT_CONTROL_SUMMARY+CONFIRMATION_REQUIRED",
+      "key": "action:saved_views:clear_all",
+      "leaf_section": "Saved community views",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Community views",
+          "logical_kind": "direct_action",
+          "resource": "MorpheSettingsV4SavedViewsFragment",
+          "root_referenced": false
+        }
+      ],
+      "logical_kind": "destructive_action",
+      "page": "Post layout",
+      "page_intro": "Control how posts and feed cards are arranged.",
+      "proposed_summary": "Remove the saved view for every community.",
+      "root": "Appearance",
+      "screen_depth": 3,
+      "screen_path": [
+        "Appearance",
+        "Post layout",
+        "Layout & saved views",
+        "Saved community views"
+      ],
+      "source_type": "morphe_direct_ui",
+      "storage_type": "private_preferences",
+      "subscreen": "Saved community views",
+      "title": "Clear all saved views"
+    },
+    {
+      "default_value": "",
+      "dependency": "pref_view_per_subscription",
+      "existing_summary": "Review or clear community-specific views.",
+      "help_treatment": "DIRECT_CONTROL_SUMMARY",
+      "key": "action:post_layout:manage_saved_views",
+      "leaf_section": "Saved community views",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Layout",
+          "logical_kind": "direct_destination",
+          "resource": "MorpheSettingsV4PostViewsFragment",
+          "root_referenced": false
+        }
+      ],
+      "logical_kind": "destination",
+      "page": "Post layout",
+      "page_intro": "Control how posts and feed cards are arranged.",
+      "proposed_summary": "Review or clear community-specific views.",
+      "root": "Appearance",
+      "screen_depth": 3,
+      "screen_path": [
+        "Appearance",
+        "Post layout",
+        "Layout & saved views",
+        "Saved community views"
+      ],
+      "source_type": "morphe_direct_ui",
+      "storage_type": "none",
+      "subscreen": "Saved community views",
+      "title": "Manage saved views"
+    },
+    {
+      "default_value": "false",
+      "dependency": "",
+      "existing_summary": "Disables opening the sidebar with a swipe",
+      "help_treatment": "REVIEW_EXISTING_SUMMARY",
+      "key": "pref_lock_sidebar",
+      "leaf_section": "Swipe",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Swipe",
+          "key": "pref_lock_sidebar",
+          "logical_kind": "stored_setting",
+          "resource": "pref_views_v2",
+          "root_referenced": false
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Post layout",
+      "page_intro": "Control how posts and feed cards are arranged.",
+      "proposed_summary": "Disables opening the sidebar with a swipe",
+      "root": "Appearance",
+      "screen_depth": 2,
+      "screen_path": [
+        "Appearance",
+        "Post layout",
+        "Swipe"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Swipe",
+      "title": "Lock sidebar"
+    },
+    {
+      "default_value": "false",
+      "dependency": "",
+      "existing_summary": "Automatically load text preview for external links",
+      "help_treatment": "REVIEW_EXISTING_SUMMARY",
+      "key": "pref_load_readability",
+      "leaf_section": "Swipe",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Swipe",
+          "key": "pref_load_readability",
+          "logical_kind": "stored_setting",
+          "resource": "pref_views_v2",
+          "root_referenced": false
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Post layout",
+      "page_intro": "Control how posts and feed cards are arranged.",
+      "proposed_summary": "Automatically load text preview for external links",
+      "root": "Appearance",
+      "screen_depth": 2,
+      "screen_path": [
+        "Appearance",
+        "Post layout",
+        "Swipe"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Swipe",
+      "title": "Preview external links"
+    },
+    {
+      "default_value": "true",
+      "dependency": "",
+      "existing_summary": "Show posts and comments in landscape",
+      "help_treatment": "REVIEW_EXISTING_SUMMARY",
+      "key": "pref_split_screen",
+      "leaf_section": "Tablet layout",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Navigation",
+          "key": "pref_split_screen",
+          "logical_kind": "stored_setting",
+          "resource": "pref_general_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Post layout",
+      "page_intro": "Control how posts and feed cards are arranged.",
+      "proposed_summary": "Show posts and comments in landscape",
+      "root": "Appearance",
+      "screen_depth": 2,
+      "screen_path": [
+        "Appearance",
+        "Post layout",
+        "Tablet layout"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Tablet layout",
+      "title": "Tablet split screen mode"
+    },
+    {
+      "default_value": "false",
+      "dependency": "",
+      "existing_summary": "Same color as toolbar",
+      "help_treatment": "REVIEW_EXISTING_SUMMARY",
+      "key": "pref_colored_nav_bar",
+      "leaf_section": "Advanced appearance",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": null,
+          "key": "pref_colored_nav_bar",
+          "logical_kind": "stored_setting",
+          "resource": "pref_appearance_advanced_v2",
+          "root_referenced": false
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Theme & colors",
+      "page_intro": "Choose the app theme, color behavior, and night-mode presentation.",
+      "proposed_summary": "Same color as toolbar",
+      "root": "Appearance",
+      "screen_depth": 2,
+      "screen_path": [
+        "Appearance",
+        "Theme & colors",
+        "Advanced appearance"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Advanced appearance",
+      "title": "Colored navigation bar"
+    },
+    {
+      "default_value": "true",
+      "dependency": "",
+      "existing_summary": "Same color as toolbar",
+      "help_treatment": "REVIEW_EXISTING_SUMMARY",
+      "key": "pref_colored_status_bar",
+      "leaf_section": "Advanced appearance",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": null,
+          "key": "pref_colored_status_bar",
+          "logical_kind": "stored_setting",
+          "resource": "pref_appearance_advanced_v2",
+          "root_referenced": false
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Theme & colors",
+      "page_intro": "Choose the app theme, color behavior, and night-mode presentation.",
+      "proposed_summary": "Same color as toolbar",
+      "root": "Appearance",
+      "screen_depth": 2,
+      "screen_path": [
+        "Appearance",
+        "Theme & colors",
+        "Advanced appearance"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Advanced appearance",
+      "title": "Colored status bar"
+    },
+    {
+      "default_value": "Default",
+      "dependency": "",
+      "existing_summary": "Choose the icon shown by your launcher.",
+      "help_treatment": "DIRECT_CONTROL_SUMMARY",
+      "key": "action:appearance:app_icon",
+      "leaf_section": "Personalization",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Personalization",
+          "logical_kind": "direct_destination",
+          "resource": "MorpheSettingsV4AppearanceFragment",
+          "root_referenced": false
+        }
+      ],
+      "logical_kind": "choice_destination",
+      "page": "Theme & colors",
+      "page_intro": "Choose the app theme, color behavior, and night-mode presentation.",
+      "proposed_summary": "Choose the icon shown by your launcher.",
+      "root": "Appearance",
+      "screen_depth": 2,
+      "screen_path": [
+        "Appearance",
+        "Theme & colors",
+        "Personalization"
+      ],
+      "source_type": "morphe_direct_ui",
+      "storage_type": "component_alias",
+      "subscreen": "Personalization",
+      "title": "App icon"
+    },
+    {
+      "default_value": "",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "OMIT_OR_ONE_LINE_ACTION_HINT",
+      "key": "pref_app_icon",
+      "leaf_section": "Theme",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": null,
+          "key": "pref_app_icon",
+          "logical_kind": "action",
+          "resource": "pref_appearance_v2",
+          "root_referenced": false
+        }
+      ],
+      "logical_kind": "action",
+      "page": "Theme & colors",
+      "page_intro": "Choose the app theme, color behavior, and night-mode presentation.",
+      "proposed_summary": "",
+      "root": "Appearance",
+      "screen_depth": 2,
+      "screen_path": [
+        "Appearance",
+        "Theme & colors",
+        "Theme"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "none_or_custom",
+      "subscreen": "Theme",
+      "title": "App icon"
+    },
+    {
+      "default_value": "0",
+      "dependency": "pref_dynamic_colors",
+      "existing_summary": "",
+      "help_treatment": "OMIT_OR_ONE_LINE_ACTION_HINT",
+      "key": "pref_theme",
+      "leaf_section": "Theme",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": null,
+          "key": "pref_theme",
+          "logical_kind": "action",
+          "resource": "pref_appearance_v2",
+          "root_referenced": false
+        }
+      ],
+      "logical_kind": "action",
+      "page": "Theme & colors",
+      "page_intro": "Choose the app theme, color behavior, and night-mode presentation.",
+      "proposed_summary": "",
+      "root": "Appearance",
+      "screen_depth": 2,
+      "screen_path": [
+        "Appearance",
+        "Theme & colors",
+        "Theme"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "none_or_custom",
+      "subscreen": "Theme",
+      "title": "Customize colors"
+    },
+    {
+      "default_value": "1140",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE",
+      "key": "pref_theme_night_start_minutes",
+      "leaf_section": "Theme",
+      "legacy_route_count": 2,
+      "legacy_routes": [
+        {
+          "category": null,
+          "key": "pref_theme_night_start_minutes",
+          "logical_kind": "special_preference",
+          "resource": "pref_appearance_v2",
+          "root_referenced": false
+        },
+        {
+          "category": null,
+          "key": "pref_theme_night_start_minutes",
+          "logical_kind": "special_preference",
+          "resource": "pref_night_mode_v2",
+          "root_referenced": false
+        }
+      ],
+      "logical_kind": "special_preference",
+      "page": "Theme & colors",
+      "page_intro": "Choose the app theme, color behavior, and night-mode presentation.",
+      "proposed_summary": "",
+      "root": "Appearance",
+      "screen_depth": 2,
+      "screen_path": [
+        "Appearance",
+        "Theme & colors",
+        "Theme"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "none_or_custom",
+      "subscreen": "Theme",
+      "title": "Dark start time"
+    },
+    {
+      "default_value": "8",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE",
+      "key": "pref_theme_night",
+      "leaf_section": "Theme",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": null,
+          "key": "pref_theme_night",
+          "logical_kind": "special_preference",
+          "resource": "pref_appearance_v2",
+          "root_referenced": false
+        }
+      ],
+      "logical_kind": "special_preference",
+      "page": "Theme & colors",
+      "page_intro": "Choose the app theme, color behavior, and night-mode presentation.",
+      "proposed_summary": "",
+      "root": "Appearance",
+      "screen_depth": 2,
+      "screen_path": [
+        "Appearance",
+        "Theme & colors",
+        "Theme"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "none_or_custom",
+      "subscreen": "Theme",
+      "title": "Dark theme"
+    },
+    {
+      "default_value": "false",
+      "dependency": "",
+      "existing_summary": "Apply color palette from your system",
+      "help_treatment": "REVIEW_EXISTING_SUMMARY",
+      "key": "pref_dynamic_colors",
+      "leaf_section": "Theme",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": null,
+          "key": "pref_dynamic_colors",
+          "logical_kind": "stored_setting",
+          "resource": "pref_appearance_v2",
+          "root_referenced": false
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Theme & colors",
+      "page_intro": "Choose the app theme, color behavior, and night-mode presentation.",
+      "proposed_summary": "Apply color palette from your system",
+      "root": "Appearance",
+      "screen_depth": 2,
+      "screen_path": [
+        "Appearance",
+        "Theme & colors",
+        "Theme"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Theme",
+      "title": "Dynamic color"
+    },
+    {
+      "default_value": "420",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE",
+      "key": "pref_theme_night_end_minutes",
+      "leaf_section": "Theme",
+      "legacy_route_count": 2,
+      "legacy_routes": [
+        {
+          "category": null,
+          "key": "pref_theme_night_end_minutes",
+          "logical_kind": "special_preference",
+          "resource": "pref_appearance_v2",
+          "root_referenced": false
+        },
+        {
+          "category": null,
+          "key": "pref_theme_night_end_minutes",
+          "logical_kind": "special_preference",
+          "resource": "pref_night_mode_v2",
+          "root_referenced": false
+        }
+      ],
+      "logical_kind": "special_preference",
+      "page": "Theme & colors",
+      "page_intro": "Choose the app theme, color behavior, and night-mode presentation.",
+      "proposed_summary": "",
+      "root": "Appearance",
+      "screen_depth": 2,
+      "screen_path": [
+        "Appearance",
+        "Theme & colors",
+        "Theme"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "none_or_custom",
+      "subscreen": "Theme",
+      "title": "Light start time"
+    },
+    {
+      "default_value": "system",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE",
+      "key": "pref_theme_mode_type",
+      "leaf_section": "Theme",
+      "legacy_route_count": 2,
+      "legacy_routes": [
+        {
+          "category": null,
+          "key": "pref_theme_mode_type",
+          "logical_kind": "stored_setting",
+          "resource": "pref_appearance_v2",
+          "root_referenced": false
+        },
+        {
+          "category": null,
+          "key": "pref_theme_mode_type",
+          "logical_kind": "stored_setting",
+          "resource": "pref_night_mode_v2",
+          "root_referenced": false
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Theme & colors",
+      "page_intro": "Choose the app theme, color behavior, and night-mode presentation.",
+      "proposed_summary": "",
+      "root": "Appearance",
+      "screen_depth": 2,
+      "screen_path": [
+        "Appearance",
+        "Theme & colors",
+        "Theme"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "string",
+      "subscreen": "Theme",
+      "title": "Theme"
+    },
+    {
+      "default_value": "",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE",
+      "key": "pref_comments_font",
+      "leaf_section": "Comments",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Comments",
+          "key": "pref_comments_font",
+          "logical_kind": "special_preference",
+          "resource": "pref_fonts_v2",
+          "root_referenced": false
+        }
+      ],
+      "logical_kind": "special_preference",
+      "page": "Typography",
+      "page_intro": "Adjust text size and font presentation throughout Boost.",
+      "proposed_summary": "",
+      "root": "Appearance",
+      "screen_depth": 2,
+      "screen_path": [
+        "Appearance",
+        "Typography",
+        "Comments"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "none_or_custom",
+      "subscreen": "Comments",
+      "title": "Comments font"
+    },
+    {
+      "default_value": "Medium",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE",
+      "key": "pref_font_size",
+      "leaf_section": "Comments",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Comments",
+          "key": "pref_font_size",
+          "logical_kind": "stored_setting",
+          "resource": "pref_fonts_v2",
+          "root_referenced": false
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Typography",
+      "page_intro": "Adjust text size and font presentation throughout Boost.",
+      "proposed_summary": "",
+      "root": "Appearance",
+      "screen_depth": 2,
+      "screen_path": [
+        "Appearance",
+        "Typography",
+        "Comments"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "string",
+      "subscreen": "Comments",
+      "title": "Comments text size"
+    },
+    {
+      "default_value": "",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE",
+      "key": "pref_title_font",
+      "leaf_section": "Posts",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Posts",
+          "key": "pref_title_font",
+          "logical_kind": "special_preference",
+          "resource": "pref_fonts_v2",
+          "root_referenced": false
+        }
+      ],
+      "logical_kind": "special_preference",
+      "page": "Typography",
+      "page_intro": "Adjust text size and font presentation throughout Boost.",
+      "proposed_summary": "",
+      "root": "Appearance",
+      "screen_depth": 2,
+      "screen_path": [
+        "Appearance",
+        "Typography",
+        "Posts"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "none_or_custom",
+      "subscreen": "Posts",
+      "title": "Title font"
+    },
+    {
+      "default_value": "Medium",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE",
+      "key": "pref_font_size_title",
+      "leaf_section": "Posts",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Posts",
+          "key": "pref_font_size_title",
+          "logical_kind": "stored_setting",
+          "resource": "pref_fonts_v2",
+          "root_referenced": false
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Typography",
+      "page_intro": "Adjust text size and font presentation throughout Boost.",
+      "proposed_summary": "",
+      "root": "Appearance",
+      "screen_depth": 2,
+      "screen_path": [
+        "Appearance",
+        "Typography",
+        "Posts"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "string",
+      "subscreen": "Posts",
+      "title": "Title text size"
+    },
+    {
+      "default_value": "",
+      "dependency": "",
+      "existing_summary": "Reset post and comment fonts to their default values.",
+      "help_treatment": "DIRECT_CONTROL_SUMMARY",
+      "key": "action:typography:restore_defaults",
+      "leaf_section": "Reset",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Reset",
+          "logical_kind": "direct_action",
+          "resource": "MorpheSettingsV4FontsFragment",
+          "root_referenced": false
+        }
+      ],
+      "logical_kind": "destructive_action",
+      "page": "Typography",
+      "page_intro": "Adjust text size and font presentation throughout Boost.",
+      "proposed_summary": "Reset post and comment fonts to their default values.",
+      "root": "Appearance",
+      "screen_depth": 2,
+      "screen_path": [
+        "Appearance",
+        "Typography",
+        "Reset"
+      ],
+      "source_type": "morphe_direct_ui",
+      "storage_type": "none",
+      "subscreen": "Reset",
+      "title": "Restore font defaults"
+    },
+    {
+      "default_value": "false",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE",
+      "key": "pref_comments_buttons",
+      "leaf_section": "Comment actions",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Appearance",
+          "key": "pref_comments_buttons",
+          "logical_kind": "stored_setting",
+          "resource": "pref_comments_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Comments",
+      "page_intro": "Control comment display, actions, navigation, and thread behavior.",
+      "proposed_summary": "",
+      "root": "Reading & interaction",
+      "screen_depth": 2,
+      "screen_path": [
+        "Reading & interaction",
+        "Comments",
+        "Comment actions"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Comment actions",
+      "title": "Buttons always visible"
+    },
+    {
+      "default_value": "35",
+      "dependency": "pref_swipe_back",
+      "existing_summary": "Dragging distance from edge as percentage of screen width to close and go back",
+      "help_treatment": "REVIEW_EXISTING_SUMMARY",
+      "key": "pref_swipe_threshold_percentage",
+      "leaf_section": "Comment actions",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Gestures",
+          "key": "pref_swipe_threshold_percentage",
+          "logical_kind": "stored_setting",
+          "resource": "pref_comments_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Comments",
+      "page_intro": "Control comment display, actions, navigation, and thread behavior.",
+      "proposed_summary": "Dragging distance from edge as percentage of screen width to close and go back",
+      "root": "Reading & interaction",
+      "screen_depth": 2,
+      "screen_path": [
+        "Reading & interaction",
+        "Comments",
+        "Comment actions"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "integer",
+      "subscreen": "Comment actions",
+      "title": "Distance threshold"
+    },
+    {
+      "default_value": "false",
+      "dependency": "pref_comments_buttons",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE",
+      "key": "pref_comments_buttons_collapse_after_action",
+      "leaf_section": "Comment actions",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Appearance",
+          "key": "pref_comments_buttons_collapse_after_action",
+          "logical_kind": "stored_setting",
+          "resource": "pref_comments_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Comments",
+      "page_intro": "Control comment display, actions, navigation, and thread behavior.",
+      "proposed_summary": "",
+      "root": "Reading & interaction",
+      "screen_depth": 2,
+      "screen_path": [
+        "Reading & interaction",
+        "Comments",
+        "Comment actions"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Comment actions",
+      "title": "Hide buttons after voting/saving"
+    },
+    {
+      "default_value": "true",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE",
+      "key": "pref_comments_button_save",
+      "leaf_section": "Comment actions",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Visible buttons",
+          "key": "pref_comments_button_save",
+          "logical_kind": "stored_setting",
+          "resource": "pref_comments_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Comments",
+      "page_intro": "Control comment display, actions, navigation, and thread behavior.",
+      "proposed_summary": "",
+      "root": "Reading & interaction",
+      "screen_depth": 2,
+      "screen_path": [
+        "Reading & interaction",
+        "Comments",
+        "Comment actions"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Comment actions",
+      "title": "Save"
+    },
+    {
+      "default_value": "true",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE",
+      "key": "pref_comments_floating_button",
+      "leaf_section": "Comment actions",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Appearance",
+          "key": "pref_comments_floating_button",
+          "logical_kind": "stored_setting",
+          "resource": "pref_comments_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Comments",
+      "page_intro": "Control comment display, actions, navigation, and thread behavior.",
+      "proposed_summary": "",
+      "root": "Reading & interaction",
+      "screen_depth": 2,
+      "screen_path": [
+        "Reading & interaction",
+        "Comments",
+        "Comment actions"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Comment actions",
+      "title": "Show floating button"
+    },
+    {
+      "default_value": "false",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE",
+      "key": "pref_info_post_upvote_percentage",
+      "leaf_section": "Comment actions",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Appearance",
+          "key": "pref_info_post_upvote_percentage",
+          "logical_kind": "stored_setting",
+          "resource": "pref_comments_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Comments",
+      "page_intro": "Control comment display, actions, navigation, and thread behavior.",
+      "proposed_summary": "",
+      "root": "Reading & interaction",
+      "screen_depth": 2,
+      "screen_path": [
+        "Reading & interaction",
+        "Comments",
+        "Comment actions"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Comment actions",
+      "title": "Show post upvote percentage"
+    },
+    {
+      "default_value": "80",
+      "dependency": "pref_swipe_back",
+      "existing_summary": "Touch sensitivity to start the dragging. Higher means easier.",
+      "help_treatment": "REVIEW_EXISTING_SUMMARY",
+      "key": "pref_swipe_sensitivity_percentage",
+      "leaf_section": "Comment actions",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Gestures",
+          "key": "pref_swipe_sensitivity_percentage",
+          "logical_kind": "stored_setting",
+          "resource": "pref_comments_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Comments",
+      "page_intro": "Control comment display, actions, navigation, and thread behavior.",
+      "proposed_summary": "Touch sensitivity to start the dragging. Higher means easier.",
+      "root": "Reading & interaction",
+      "screen_depth": 2,
+      "screen_path": [
+        "Reading & interaction",
+        "Comments",
+        "Comment actions"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "integer",
+      "subscreen": "Comment actions",
+      "title": "Swipe sensitivity"
+    },
+    {
+      "default_value": "true",
+      "dependency": "",
+      "existing_summary": "Swipe right to go back",
+      "help_treatment": "REVIEW_EXISTING_SUMMARY",
+      "key": "pref_swipe_back",
+      "leaf_section": "Comment actions",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Gestures",
+          "key": "pref_swipe_back",
+          "logical_kind": "stored_setting",
+          "resource": "pref_comments_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Comments",
+      "page_intro": "Control comment display, actions, navigation, and thread behavior.",
+      "proposed_summary": "Swipe right to go back",
+      "root": "Reading & interaction",
+      "screen_depth": 2,
+      "screen_path": [
+        "Reading & interaction",
+        "Comments",
+        "Comment actions"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Comment actions",
+      "title": "Swipe to close"
+    },
+    {
+      "default_value": "1",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE",
+      "key": "pref_comments_button_parent",
+      "leaf_section": "Comment actions",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Visible buttons",
+          "key": "pref_comments_button_parent",
+          "logical_kind": "stored_setting",
+          "resource": "pref_comments_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Comments",
+      "page_intro": "Control comment display, actions, navigation, and thread behavior.",
+      "proposed_summary": "",
+      "root": "Reading & interaction",
+      "screen_depth": 2,
+      "screen_path": [
+        "Reading & interaction",
+        "Comments",
+        "Comment actions"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "string",
+      "subscreen": "Comment actions",
+      "title": "Up button"
+    },
+    {
+      "default_value": "true",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE",
+      "key": "pref_comments_color_pattern",
+      "leaf_section": "Comment appearance",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Appearance",
+          "key": "pref_comments_color_pattern",
+          "logical_kind": "special_preference",
+          "resource": "pref_comments_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "special_preference",
+      "page": "Comments",
+      "page_intro": "Control comment display, actions, navigation, and thread behavior.",
+      "proposed_summary": "",
+      "root": "Reading & interaction",
+      "screen_depth": 2,
+      "screen_path": [
+        "Reading & interaction",
+        "Comments",
+        "Comment appearance"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "none_or_custom",
+      "subscreen": "Comment appearance",
+      "title": "Color pattern"
+    },
+    {
+      "default_value": "true",
+      "dependency": "pref_comments_user_flair",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE",
+      "key": "pref_user_flair_emojis",
+      "leaf_section": "Comment appearance",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Flairs",
+          "key": "pref_user_flair_emojis",
+          "logical_kind": "stored_setting",
+          "resource": "pref_comments_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Comments",
+      "page_intro": "Control comment display, actions, navigation, and thread behavior.",
+      "proposed_summary": "",
+      "root": "Reading & interaction",
+      "screen_depth": 2,
+      "screen_path": [
+        "Reading & interaction",
+        "Comments",
+        "Comment appearance"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Comment appearance",
+      "title": "Show emojis"
+    },
+    {
+      "default_value": "false",
+      "dependency": "pref_comments_user_flair",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE",
+      "key": "pref_user_flair_colors",
+      "leaf_section": "Comment appearance",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Flairs",
+          "key": "pref_user_flair_colors",
+          "logical_kind": "stored_setting",
+          "resource": "pref_comments_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Comments",
+      "page_intro": "Control comment display, actions, navigation, and thread behavior.",
+      "proposed_summary": "",
+      "root": "Reading & interaction",
+      "screen_depth": 2,
+      "screen_path": [
+        "Reading & interaction",
+        "Comments",
+        "Comment appearance"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Comment appearance",
+      "title": "Show flair colors"
+    },
+    {
+      "default_value": "false",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE",
+      "key": "pref_comments_show_avatar",
+      "leaf_section": "Comment appearance",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Appearance",
+          "key": "pref_comments_show_avatar",
+          "logical_kind": "stored_setting",
+          "resource": "pref_comments_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Comments",
+      "page_intro": "Control comment display, actions, navigation, and thread behavior.",
+      "proposed_summary": "",
+      "root": "Reading & interaction",
+      "screen_depth": 2,
+      "screen_path": [
+        "Reading & interaction",
+        "Comments",
+        "Comment appearance"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Comment appearance",
+      "title": "Show user avatar"
+    },
+    {
+      "default_value": "true",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE",
+      "key": "pref_comments_user_flair",
+      "leaf_section": "Comment appearance",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Flairs",
+          "key": "pref_comments_user_flair",
+          "logical_kind": "stored_setting",
+          "resource": "pref_comments_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Comments",
+      "page_intro": "Control comment display, actions, navigation, and thread behavior.",
+      "proposed_summary": "",
+      "root": "Reading & interaction",
+      "screen_depth": 2,
+      "screen_path": [
+        "Reading & interaction",
+        "Comments",
+        "Comment appearance"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Comment appearance",
+      "title": "Show user flair"
+    },
+    {
+      "default_value": "true",
+      "dependency": "pref_show_awards_comments",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE",
+      "key": "pref_clickable_awards_comments",
+      "leaf_section": "Comment behavior",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Awards",
+          "key": "pref_clickable_awards_comments",
+          "logical_kind": "stored_setting",
+          "resource": "pref_comments_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Comments",
+      "page_intro": "Control comment display, actions, navigation, and thread behavior.",
+      "proposed_summary": "",
+      "root": "Reading & interaction",
+      "screen_depth": 2,
+      "screen_path": [
+        "Reading & interaction",
+        "Comments",
+        "Comment behavior"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Comment behavior",
+      "title": "Clickable awards"
+    },
+    {
+      "default_value": "0",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE",
+      "key": "pref_default_comment_sorting",
+      "leaf_section": "Comment behavior",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": null,
+          "key": "pref_default_comment_sorting",
+          "logical_kind": "stored_setting",
+          "resource": "pref_comments_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Comments",
+      "page_intro": "Control comment display, actions, navigation, and thread behavior.",
+      "proposed_summary": "",
+      "root": "Reading & interaction",
+      "screen_depth": 2,
+      "screen_path": [
+        "Reading & interaction",
+        "Comments",
+        "Comment behavior"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "string",
+      "subscreen": "Comment behavior",
+      "title": "Default sort"
+    },
+    {
+      "default_value": "true",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE",
+      "key": "pref_comments_highlight_mine",
+      "leaf_section": "Comment behavior",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Appearance",
+          "key": "pref_comments_highlight_mine",
+          "logical_kind": "stored_setting",
+          "resource": "pref_comments_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Comments",
+      "page_intro": "Control comment display, actions, navigation, and thread behavior.",
+      "proposed_summary": "",
+      "root": "Reading & interaction",
+      "screen_depth": 2,
+      "screen_path": [
+        "Reading & interaction",
+        "Comments",
+        "Comment behavior"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Comment behavior",
+      "title": "Highlight my username"
+    },
+    {
+      "default_value": "1",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE",
+      "key": "pref_comments_image",
+      "leaf_section": "Comment behavior",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Appearance",
+          "key": "pref_comments_image",
+          "logical_kind": "stored_setting",
+          "resource": "pref_comments_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Comments",
+      "page_intro": "Control comment display, actions, navigation, and thread behavior.",
+      "proposed_summary": "",
+      "root": "Reading & interaction",
+      "screen_depth": 2,
+      "screen_path": [
+        "Reading & interaction",
+        "Comments",
+        "Comment behavior"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "string",
+      "subscreen": "Comment behavior",
+      "title": "Post media preview size"
+    },
+    {
+      "default_value": "true",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE",
+      "key": "pref_show_awards_comments",
+      "leaf_section": "Comment behavior",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Awards",
+          "key": "pref_show_awards_comments",
+          "logical_kind": "stored_setting",
+          "resource": "pref_comments_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Comments",
+      "page_intro": "Control comment display, actions, navigation, and thread behavior.",
+      "proposed_summary": "",
+      "root": "Reading & interaction",
+      "screen_depth": 2,
+      "screen_path": [
+        "Reading & interaction",
+        "Comments",
+        "Comment behavior"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Comment behavior",
+      "title": "Show awards"
+    },
+    {
+      "default_value": "true",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE",
+      "key": "pref_comments_clickable_username",
+      "leaf_section": "Comment behavior",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Behavior",
+          "key": "pref_comments_clickable_username",
+          "logical_kind": "stored_setting",
+          "resource": "pref_comments_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Comments",
+      "page_intro": "Control comment display, actions, navigation, and thread behavior.",
+      "proposed_summary": "",
+      "root": "Reading & interaction",
+      "screen_depth": 2,
+      "screen_path": [
+        "Reading & interaction",
+        "Comments",
+        "Comment behavior"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Comment behavior",
+      "title": "Tap username to view profile"
+    },
+    {
+      "default_value": "true",
+      "dependency": "",
+      "existing_summary": "Use comment sort suggested by community or post",
+      "help_treatment": "REVIEW_EXISTING_SUMMARY",
+      "key": "pref_suggested_comment_sorting",
+      "leaf_section": "Comment behavior",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": null,
+          "key": "pref_suggested_comment_sorting",
+          "logical_kind": "stored_setting",
+          "resource": "pref_comments_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Comments",
+      "page_intro": "Control comment display, actions, navigation, and thread behavior.",
+      "proposed_summary": "Use comment sort suggested by community or post",
+      "root": "Reading & interaction",
+      "screen_depth": 2,
+      "screen_path": [
+        "Reading & interaction",
+        "Comments",
+        "Comment behavior"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Comment behavior",
+      "title": "Use suggested sort"
+    },
+    {
+      "default_value": "false",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE",
+      "key": "pref_comments_scroll_animation",
+      "leaf_section": "Thread navigation",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Navigation",
+          "key": "pref_comments_scroll_animation",
+          "logical_kind": "stored_setting",
+          "resource": "pref_comments_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Comments",
+      "page_intro": "Control comment display, actions, navigation, and thread behavior.",
+      "proposed_summary": "",
+      "root": "Reading & interaction",
+      "screen_depth": 2,
+      "screen_path": [
+        "Reading & interaction",
+        "Comments",
+        "Thread navigation"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Thread navigation",
+      "title": "Animate navigation"
+    },
+    {
+      "default_value": "false",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE",
+      "key": "pref_comments_click",
+      "leaf_section": "Thread navigation",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Behavior",
+          "key": "pref_comments_click",
+          "logical_kind": "stored_setting",
+          "resource": "pref_comments_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Comments",
+      "page_intro": "Control comment display, actions, navigation, and thread behavior.",
+      "proposed_summary": "",
+      "root": "Reading & interaction",
+      "screen_depth": 2,
+      "screen_path": [
+        "Reading & interaction",
+        "Comments",
+        "Thread navigation"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Thread navigation",
+      "title": "Click to collapse comment"
+    },
+    {
+      "default_value": "false",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE",
+      "key": "pref_comments_collapse_automoderator",
+      "leaf_section": "Thread navigation",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Appearance",
+          "key": "pref_comments_collapse_automoderator",
+          "logical_kind": "stored_setting",
+          "resource": "pref_comments_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Comments",
+      "page_intro": "Control comment display, actions, navigation, and thread behavior.",
+      "proposed_summary": "",
+      "root": "Reading & interaction",
+      "screen_depth": 2,
+      "screen_path": [
+        "Reading & interaction",
+        "Comments",
+        "Thread navigation"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Thread navigation",
+      "title": "Collapse AutoModerator"
+    },
+    {
+      "default_value": "false",
+      "dependency": "",
+      "existing_summary": "Crowd control, downvoted, deleted…",
+      "help_treatment": "REVIEW_EXISTING_SUMMARY",
+      "key": "pref_comments_collapse_collapsed",
+      "leaf_section": "Thread navigation",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Appearance",
+          "key": "pref_comments_collapse_collapsed",
+          "logical_kind": "stored_setting",
+          "resource": "pref_comments_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Comments",
+      "page_intro": "Control comment display, actions, navigation, and thread behavior.",
+      "proposed_summary": "Crowd control, downvoted, deleted…",
+      "root": "Reading & interaction",
+      "screen_depth": 2,
+      "screen_path": [
+        "Reading & interaction",
+        "Comments",
+        "Thread navigation"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Thread navigation",
+      "title": "Collapse disruptive comments"
+    },
+    {
+      "default_value": "0",
+      "dependency": "pref_comments_highlight_new_comments",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE",
+      "key": "pref_comments_default_navigation",
+      "leaf_section": "Thread navigation",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Navigation",
+          "key": "pref_comments_default_navigation",
+          "logical_kind": "stored_setting",
+          "resource": "pref_comments_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Comments",
+      "page_intro": "Control comment display, actions, navigation, and thread behavior.",
+      "proposed_summary": "",
+      "root": "Reading & interaction",
+      "screen_depth": 2,
+      "screen_path": [
+        "Reading & interaction",
+        "Comments",
+        "Thread navigation"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "string",
+      "subscreen": "Thread navigation",
+      "title": "Default navigation mode"
+    },
+    {
+      "default_value": "true",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE",
+      "key": "pref_comments_animation",
+      "leaf_section": "Thread navigation",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Behavior",
+          "key": "pref_comments_animation",
+          "logical_kind": "stored_setting",
+          "resource": "pref_comments_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Comments",
+      "page_intro": "Control comment display, actions, navigation, and thread behavior.",
+      "proposed_summary": "",
+      "root": "Reading & interaction",
+      "screen_depth": 2,
+      "screen_path": [
+        "Reading & interaction",
+        "Comments",
+        "Thread navigation"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Thread navigation",
+      "title": "Expand/collapse animation"
+    },
+    {
+      "default_value": "false",
+      "dependency": "",
+      "existing_summary": "Show only comment header when collapsed",
+      "help_treatment": "REVIEW_EXISTING_SUMMARY",
+      "key": "pref_comments_full_collapse",
+      "leaf_section": "Thread navigation",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Behavior",
+          "key": "pref_comments_full_collapse",
+          "logical_kind": "stored_setting",
+          "resource": "pref_comments_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Comments",
+      "page_intro": "Control comment display, actions, navigation, and thread behavior.",
+      "proposed_summary": "Show only comment header when collapsed",
+      "root": "Reading & interaction",
+      "screen_depth": 2,
+      "screen_path": [
+        "Reading & interaction",
+        "Comments",
+        "Thread navigation"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Thread navigation",
+      "title": "Hide text of collapsed comments"
+    },
+    {
+      "default_value": "true",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE",
+      "key": "pref_comments_highlight_new_comments",
+      "leaf_section": "Thread navigation",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Navigation",
+          "key": "pref_comments_highlight_new_comments",
+          "logical_kind": "stored_setting",
+          "resource": "pref_comments_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Comments",
+      "page_intro": "Control comment display, actions, navigation, and thread behavior.",
+      "proposed_summary": "",
+      "root": "Reading & interaction",
+      "screen_depth": 2,
+      "screen_path": [
+        "Reading & interaction",
+        "Comments",
+        "Thread navigation"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Thread navigation",
+      "title": "Highlight new comments"
+    },
+    {
+      "default_value": "false",
+      "dependency": "",
+      "existing_summary": "Load top level comments with its replies collapsed",
+      "help_treatment": "REVIEW_EXISTING_SUMMARY",
+      "key": "pref_comments_load_collapsed",
+      "leaf_section": "Thread navigation",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Behavior",
+          "key": "pref_comments_load_collapsed",
+          "logical_kind": "stored_setting",
+          "resource": "pref_comments_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Comments",
+      "page_intro": "Control comment display, actions, navigation, and thread behavior.",
+      "proposed_summary": "Load top level comments with its replies collapsed",
+      "root": "Reading & interaction",
+      "screen_depth": 2,
+      "screen_path": [
+        "Reading & interaction",
+        "Comments",
+        "Thread navigation"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Thread navigation",
+      "title": "Load collapsed by default"
+    },
+    {
+      "default_value": "false",
+      "dependency": "",
+      "existing_summary": "Jump between comments",
+      "help_treatment": "REVIEW_EXISTING_SUMMARY",
+      "key": "pref_comments_navigation_bar",
+      "leaf_section": "Thread navigation",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Appearance",
+          "key": "pref_comments_navigation_bar",
+          "logical_kind": "stored_setting",
+          "resource": "pref_comments_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Comments",
+      "page_intro": "Control comment display, actions, navigation, and thread behavior.",
+      "proposed_summary": "Jump between comments",
+      "root": "Reading & interaction",
+      "screen_depth": 2,
+      "screen_path": [
+        "Reading & interaction",
+        "Comments",
+        "Thread navigation"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Thread navigation",
+      "title": "Show navigation bar"
+    },
+    {
+      "default_value": "0",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE",
+      "key": "pref_indent_style",
+      "leaf_section": "Thread navigation",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Appearance",
+          "key": "pref_indent_style",
+          "logical_kind": "stored_setting",
+          "resource": "pref_comments_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Comments",
+      "page_intro": "Control comment display, actions, navigation, and thread behavior.",
+      "proposed_summary": "",
+      "root": "Reading & interaction",
+      "screen_depth": 2,
+      "screen_path": [
+        "Reading & interaction",
+        "Comments",
+        "Thread navigation"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "string",
+      "subscreen": "Thread navigation",
+      "title": "Thread level indicator"
+    },
+    {
+      "default_value": "false",
+      "dependency": "",
+      "existing_summary": "Use volume keys to go to next and previous comment",
+      "help_treatment": "REVIEW_EXISTING_SUMMARY",
+      "key": "pref_comments_volume_scroll",
+      "leaf_section": "Thread navigation",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Navigation",
+          "key": "pref_comments_volume_scroll",
+          "logical_kind": "stored_setting",
+          "resource": "pref_comments_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Comments",
+      "page_intro": "Control comment display, actions, navigation, and thread behavior.",
+      "proposed_summary": "Use volume keys to go to next and previous comment",
+      "root": "Reading & interaction",
+      "screen_depth": 2,
+      "screen_path": [
+        "Reading & interaction",
+        "Comments",
+        "Thread navigation"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Thread navigation",
+      "title": "Volume key navigation"
+    },
+    {
+      "default_value": "",
+      "dependency": "",
+      "existing_summary": "View or delete drafts saved on reddit",
+      "help_treatment": "REVIEW_EXISTING_SUMMARY",
+      "key": "pref_manage_drafts",
+      "leaf_section": "Drafts",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Composing",
+          "key": "pref_manage_drafts",
+          "logical_kind": "action",
+          "resource": "pref_general_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "action",
+      "page": "Composing & drafts",
+      "page_intro": "Configure editors, draft storage, and uploaded composing media.",
+      "proposed_summary": "View or delete drafts saved on reddit",
+      "root": "Reading & interaction",
+      "screen_depth": 2,
+      "screen_path": [
+        "Reading & interaction",
+        "Composing & drafts",
+        "Drafts"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "none_or_custom",
+      "subscreen": "Drafts",
+      "title": "Post drafts"
+    },
+    {
+      "default_value": "true",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE",
+      "key": "pref_drafts",
+      "leaf_section": "Drafts",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Composing",
+          "key": "pref_drafts",
+          "logical_kind": "stored_setting",
+          "resource": "pref_general_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Composing & drafts",
+      "page_intro": "Configure editors, draft storage, and uploaded composing media.",
+      "proposed_summary": "",
+      "root": "Reading & interaction",
+      "screen_depth": 2,
+      "screen_path": [
+        "Reading & interaction",
+        "Composing & drafts",
+        "Drafts"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Drafts",
+      "title": "Save drafts"
+    },
+    {
+      "default_value": "false",
+      "dependency": "",
+      "existing_summary": "Disable to use quick reply dialog",
+      "help_treatment": "REVIEW_EXISTING_SUMMARY",
+      "key": "pref_use_advanced_editor",
+      "leaf_section": "Editor",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Composing",
+          "key": "pref_use_advanced_editor",
+          "logical_kind": "stored_setting",
+          "resource": "pref_general_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Composing & drafts",
+      "page_intro": "Configure editors, draft storage, and uploaded composing media.",
+      "proposed_summary": "Disable to use quick reply dialog",
+      "root": "Reading & interaction",
+      "screen_depth": 2,
+      "screen_path": [
+        "Reading & interaction",
+        "Composing & drafts",
+        "Editor"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Editor",
+      "title": "Advanced fullscreen editor"
+    },
+    {
+      "default_value": "",
+      "dependency": "",
+      "existing_summary": "\"View or delete images you've uploaded to Imgur\"",
+      "help_treatment": "REVIEW_EXISTING_SUMMARY",
+      "key": "pref_imgur_uploads",
+      "leaf_section": "Uploads",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Composing",
+          "key": "pref_imgur_uploads",
+          "logical_kind": "action",
+          "resource": "pref_general_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "action",
+      "page": "Composing & drafts",
+      "page_intro": "Configure editors, draft storage, and uploaded composing media.",
+      "proposed_summary": "\"View or delete images you've uploaded to Imgur\"",
+      "root": "Reading & interaction",
+      "screen_depth": 2,
+      "screen_path": [
+        "Reading & interaction",
+        "Composing & drafts",
+        "Uploads"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "none_or_custom",
+      "subscreen": "Uploads",
+      "title": "Uploaded images"
+    },
+    {
+      "default_value": "",
+      "dependency": "",
+      "existing_summary": "Manage your communities and custom feeds",
+      "help_treatment": "REVIEW_EXISTING_SUMMARY",
+      "key": "pref_edit_subscriptions",
+      "leaf_section": "Manage subscriptions",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Navigation",
+          "key": "pref_edit_subscriptions",
+          "logical_kind": "action",
+          "resource": "pref_general_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "action",
+      "page": "Feeds & subscriptions",
+      "page_intro": "Manage communities, custom feeds, and subscription-related behavior.",
+      "proposed_summary": "Manage your communities and custom feeds",
+      "root": "Reading & interaction",
+      "screen_depth": 2,
+      "screen_path": [
+        "Reading & interaction",
+        "Feeds & subscriptions",
+        "Manage subscriptions"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "none_or_custom",
+      "subscreen": "Manage subscriptions",
+      "title": "Subscriptions"
+    },
+    {
+      "default_value": "",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "OMIT_OR_ONE_LINE_ACTION_HINT",
+      "key": "pref_default_sort",
+      "leaf_section": "Feed behavior",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": null,
+          "key": "pref_default_sort",
+          "logical_kind": "action",
+          "resource": "pref_posts_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "action",
+      "page": "Posts",
+      "page_intro": "Choose how posts behave while browsing and reading.",
+      "proposed_summary": "",
+      "root": "Reading & interaction",
+      "screen_depth": 2,
+      "screen_path": [
+        "Reading & interaction",
+        "Posts",
+        "Feed behavior"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "none_or_custom",
+      "subscreen": "Feed behavior",
+      "title": "Default sort"
+    },
+    {
+      "default_value": "false",
+      "dependency": "",
+      "existing_summary": "Each community will remember the last sort you selected for that community",
+      "help_treatment": "REVIEW_EXISTING_SUMMARY",
+      "key": "pref_sort_per_subscription",
+      "leaf_section": "Feed behavior",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": null,
+          "key": "pref_sort_per_subscription",
+          "logical_kind": "stored_setting",
+          "resource": "pref_posts_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Posts",
+      "page_intro": "Choose how posts behave while browsing and reading.",
+      "proposed_summary": "Each community will remember the last sort you selected for that community",
+      "root": "Reading & interaction",
+      "screen_depth": 2,
+      "screen_path": [
+        "Reading & interaction",
+        "Posts",
+        "Feed behavior"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Feed behavior",
+      "title": "Remember per community"
+    },
+    {
+      "default_value": "",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "OMIT_OR_ONE_LINE_ACTION_HINT",
+      "key": "pref_frontpage_sort",
+      "leaf_section": "Feed behavior",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": null,
+          "key": "pref_frontpage_sort",
+          "logical_kind": "action",
+          "resource": "pref_posts_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "action",
+      "page": "Posts",
+      "page_intro": "Choose how posts behave while browsing and reading.",
+      "proposed_summary": "",
+      "root": "Reading & interaction",
+      "screen_depth": 2,
+      "screen_path": [
+        "Reading & interaction",
+        "Posts",
+        "Feed behavior"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "none_or_custom",
+      "subscreen": "Feed behavior",
+      "title": "Sort Home posts by"
+    },
+    {
+      "default_value": "true",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE",
+      "key": "pref_post_show_comments_button",
+      "leaf_section": "Post actions",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Visible buttons",
+          "key": "pref_post_show_comments_button",
+          "logical_kind": "stored_setting",
+          "resource": "pref_posts_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Posts",
+      "page_intro": "Choose how posts behave while browsing and reading.",
+      "proposed_summary": "",
+      "root": "Reading & interaction",
+      "screen_depth": 2,
+      "screen_path": [
+        "Reading & interaction",
+        "Posts",
+        "Post actions"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Post actions",
+      "title": "Comments"
+    },
+    {
+      "default_value": "false",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE",
+      "key": "pref_show_hide",
+      "leaf_section": "Post actions",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Visible buttons",
+          "key": "pref_show_hide",
+          "logical_kind": "stored_setting",
+          "resource": "pref_posts_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Posts",
+      "page_intro": "Choose how posts behave while browsing and reading.",
+      "proposed_summary": "",
+      "root": "Reading & interaction",
+      "screen_depth": 2,
+      "screen_path": [
+        "Reading & interaction",
+        "Posts",
+        "Post actions"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Post actions",
+      "title": "Hide"
+    },
+    {
+      "default_value": "",
+      "dependency": "pref_sort_per_subscription",
+      "existing_summary": "",
+      "help_treatment": "OMIT_OR_ONE_LINE_ACTION_HINT",
+      "key": "pref_sort_per_sub",
+      "leaf_section": "Post actions",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": null,
+          "key": "pref_sort_per_sub",
+          "logical_kind": "action",
+          "resource": "pref_posts_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "action",
+      "page": "Posts",
+      "page_intro": "Choose how posts behave while browsing and reading.",
+      "proposed_summary": "",
+      "root": "Reading & interaction",
+      "screen_depth": 2,
+      "screen_path": [
+        "Reading & interaction",
+        "Posts",
+        "Post actions"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "none_or_custom",
+      "subscreen": "Post actions",
+      "title": "Manage saved sorts"
+    },
+    {
+      "default_value": "false",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE",
+      "key": "pref_show_read",
+      "leaf_section": "Post actions",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Visible buttons",
+          "key": "pref_show_read",
+          "logical_kind": "stored_setting",
+          "resource": "pref_posts_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Posts",
+      "page_intro": "Choose how posts behave while browsing and reading.",
+      "proposed_summary": "",
+      "root": "Reading & interaction",
+      "screen_depth": 2,
+      "screen_path": [
+        "Reading & interaction",
+        "Posts",
+        "Post actions"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Post actions",
+      "title": "Mark read"
+    },
+    {
+      "default_value": "true",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE",
+      "key": "pref_post_show_open_button",
+      "leaf_section": "Post actions",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Visible buttons",
+          "key": "pref_post_show_open_button",
+          "logical_kind": "stored_setting",
+          "resource": "pref_posts_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Posts",
+      "page_intro": "Choose how posts behave while browsing and reading.",
+      "proposed_summary": "",
+      "root": "Reading & interaction",
+      "screen_depth": 2,
+      "screen_path": [
+        "Reading & interaction",
+        "Posts",
+        "Post actions"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Post actions",
+      "title": "Open in external app"
+    },
+    {
+      "default_value": "false",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE",
+      "key": "pref_post_show_share_button",
+      "leaf_section": "Post actions",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Visible buttons",
+          "key": "pref_post_show_share_button",
+          "logical_kind": "stored_setting",
+          "resource": "pref_posts_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Posts",
+      "page_intro": "Choose how posts behave while browsing and reading.",
+      "proposed_summary": "",
+      "root": "Reading & interaction",
+      "screen_depth": 2,
+      "screen_path": [
+        "Reading & interaction",
+        "Posts",
+        "Post actions"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Post actions",
+      "title": "Share"
+    },
+    {
+      "default_value": "true",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE",
+      "key": "pref_posts_floating_button",
+      "leaf_section": "Post actions",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Post info",
+          "key": "pref_posts_floating_button",
+          "logical_kind": "stored_setting",
+          "resource": "pref_posts_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Posts",
+      "page_intro": "Choose how posts behave while browsing and reading.",
+      "proposed_summary": "",
+      "root": "Reading & interaction",
+      "screen_depth": 2,
+      "screen_path": [
+        "Reading & interaction",
+        "Posts",
+        "Post actions"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Post actions",
+      "title": "Show floating button"
+    },
+    {
+      "default_value": "false",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE",
+      "key": "pref_upvote_on_save",
+      "leaf_section": "Post actions",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Links",
+          "key": "pref_upvote_on_save",
+          "logical_kind": "stored_setting",
+          "resource": "pref_general_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Posts",
+      "page_intro": "Choose how posts behave while browsing and reading.",
+      "proposed_summary": "",
+      "root": "Reading & interaction",
+      "screen_depth": 2,
+      "screen_path": [
+        "Reading & interaction",
+        "Posts",
+        "Post actions"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Post actions",
+      "title": "Upvote on save"
+    },
+    {
+      "default_value": "true",
+      "dependency": "pref_show_awards_posts",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE",
+      "key": "pref_clickable_awards_posts",
+      "leaf_section": "Post behavior",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Awards",
+          "key": "pref_clickable_awards_posts",
+          "logical_kind": "stored_setting",
+          "resource": "pref_posts_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Posts",
+      "page_intro": "Choose how posts behave while browsing and reading.",
+      "proposed_summary": "",
+      "root": "Reading & interaction",
+      "screen_depth": 2,
+      "screen_path": [
+        "Reading & interaction",
+        "Posts",
+        "Post behavior"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Post behavior",
+      "title": "Clickable awards"
+    },
+    {
+      "default_value": "false",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE",
+      "key": "pref_info_username",
+      "leaf_section": "Post behavior",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Post info",
+          "key": "pref_info_username",
+          "logical_kind": "stored_setting",
+          "resource": "pref_posts_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Posts",
+      "page_intro": "Choose how posts behave while browsing and reading.",
+      "proposed_summary": "",
+      "root": "Reading & interaction",
+      "screen_depth": 2,
+      "screen_path": [
+        "Reading & interaction",
+        "Posts",
+        "Post behavior"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Post behavior",
+      "title": "Show author"
+    },
+    {
+      "default_value": "true",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE",
+      "key": "pref_show_awards_posts",
+      "leaf_section": "Post behavior",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Awards",
+          "key": "pref_show_awards_posts",
+          "logical_kind": "stored_setting",
+          "resource": "pref_posts_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Posts",
+      "page_intro": "Choose how posts behave while browsing and reading.",
+      "proposed_summary": "",
+      "root": "Reading & interaction",
+      "screen_depth": 2,
+      "screen_path": [
+        "Reading & interaction",
+        "Posts",
+        "Post behavior"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Post behavior",
+      "title": "Show awards"
+    },
+    {
+      "default_value": "true",
+      "dependency": "pref_info_post_flair",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE",
+      "key": "pref_flair_emojis",
+      "leaf_section": "Post behavior",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Flairs",
+          "key": "pref_flair_emojis",
+          "logical_kind": "stored_setting",
+          "resource": "pref_posts_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Posts",
+      "page_intro": "Choose how posts behave while browsing and reading.",
+      "proposed_summary": "",
+      "root": "Reading & interaction",
+      "screen_depth": 2,
+      "screen_path": [
+        "Reading & interaction",
+        "Posts",
+        "Post behavior"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Post behavior",
+      "title": "Show emojis"
+    },
+    {
+      "default_value": "true",
+      "dependency": "pref_info_post_flair",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE",
+      "key": "pref_flair_colors",
+      "leaf_section": "Post behavior",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Flairs",
+          "key": "pref_flair_colors",
+          "logical_kind": "stored_setting",
+          "resource": "pref_posts_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Posts",
+      "page_intro": "Choose how posts behave while browsing and reading.",
+      "proposed_summary": "",
+      "root": "Reading & interaction",
+      "screen_depth": 2,
+      "screen_path": [
+        "Reading & interaction",
+        "Posts",
+        "Post behavior"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Post behavior",
+      "title": "Show flair colors"
+    },
+    {
+      "default_value": "true",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE",
+      "key": "pref_info_post_flair",
+      "leaf_section": "Post behavior",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Flairs",
+          "key": "pref_info_post_flair",
+          "logical_kind": "stored_setting",
+          "resource": "pref_posts_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Posts",
+      "page_intro": "Choose how posts behave while browsing and reading.",
+      "proposed_summary": "",
+      "root": "Reading & interaction",
+      "screen_depth": 2,
+      "screen_path": [
+        "Reading & interaction",
+        "Posts",
+        "Post behavior"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Post behavior",
+      "title": "Show post flair"
+    },
+    {
+      "default_value": "true",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE",
+      "key": "pref_post_clickable_subreddit",
+      "leaf_section": "Post behavior",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Post info",
+          "key": "pref_post_clickable_subreddit",
+          "logical_kind": "stored_setting",
+          "resource": "pref_posts_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Posts",
+      "page_intro": "Choose how posts behave while browsing and reading.",
+      "proposed_summary": "",
+      "root": "Reading & interaction",
+      "screen_depth": 2,
+      "screen_path": [
+        "Reading & interaction",
+        "Posts",
+        "Post behavior"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Post behavior",
+      "title": "Tap community to visit"
+    },
+    {
+      "default_value": "false",
+      "dependency": "pref_info_post_flair",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE",
+      "key": "pref_flair_clickable",
+      "leaf_section": "Post behavior",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Flairs",
+          "key": "pref_flair_clickable",
+          "logical_kind": "stored_setting",
+          "resource": "pref_posts_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Posts",
+      "page_intro": "Choose how posts behave while browsing and reading.",
+      "proposed_summary": "",
+      "root": "Reading & interaction",
+      "screen_depth": 2,
+      "screen_path": [
+        "Reading & interaction",
+        "Posts",
+        "Post behavior"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Post behavior",
+      "title": "Tap flair to search"
+    },
+    {
+      "default_value": "true",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE",
+      "key": "pref_post_clickable_username",
+      "leaf_section": "Post behavior",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Post info",
+          "key": "pref_post_clickable_username",
+          "logical_kind": "stored_setting",
+          "resource": "pref_posts_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Posts",
+      "page_intro": "Choose how posts behave while browsing and reading.",
+      "proposed_summary": "",
+      "root": "Reading & interaction",
+      "screen_depth": 2,
+      "screen_path": [
+        "Reading & interaction",
+        "Posts",
+        "Post behavior"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Post behavior",
+      "title": "Tap username to view profile"
+    },
+    {
+      "default_value": "",
+      "dependency": "",
+      "existing_summary": "Sync read posts between devices with synccit.com",
+      "help_treatment": "REVIEW_EXISTING_SUMMARY+PROGRESSIVE_DISCLOSURE",
+      "key": "synncit_config",
+      "leaf_section": "Reading state",
+      "legacy_route_count": 2,
+      "legacy_routes": [
+        {
+          "category": "Mark as read",
+          "key": "synncit_config",
+          "logical_kind": "action",
+          "resource": "pref_posts_v2",
+          "root_referenced": true
+        },
+        {
+          "category": "Mark as read",
+          "key": "synncit_config",
+          "logical_kind": "action",
+          "resource": "pref_privacy_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "action",
+      "page": "Posts",
+      "page_intro": "Choose how posts behave while browsing and reading.",
+      "proposed_summary": "Sync read posts between devices with synccit.com",
+      "root": "Reading & interaction",
+      "screen_depth": 2,
+      "screen_path": [
+        "Reading & interaction",
+        "Posts",
+        "Reading state"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "none_or_custom",
+      "subscreen": "Reading state",
+      "title": "Configure Synccit"
+    },
+    {
+      "default_value": "false",
+      "dependency": "pref_mark_read",
+      "existing_summary": "Post images will be dimmed when marked as read",
+      "help_treatment": "REVIEW_EXISTING_SUMMARY",
+      "key": "pref_mark_read_dim_images",
+      "leaf_section": "Reading state",
+      "legacy_route_count": 2,
+      "legacy_routes": [
+        {
+          "category": "Mark as read",
+          "key": "pref_mark_read_dim_images",
+          "logical_kind": "stored_setting",
+          "resource": "pref_posts_v2",
+          "root_referenced": true
+        },
+        {
+          "category": "Mark as read",
+          "key": "pref_mark_read_dim_images",
+          "logical_kind": "stored_setting",
+          "resource": "pref_privacy_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Posts",
+      "page_intro": "Choose how posts behave while browsing and reading.",
+      "proposed_summary": "Post images will be dimmed when marked as read",
+      "root": "Reading & interaction",
+      "screen_depth": 2,
+      "screen_path": [
+        "Reading & interaction",
+        "Posts",
+        "Reading state"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Reading state",
+      "title": "Dim images in read posts"
+    },
+    {
+      "default_value": "false",
+      "dependency": "pref_mark_read",
+      "existing_summary": "Pressing \\\"Hide read\\\" will move read posts on screen to Profile->Hidden (requires login)",
+      "help_treatment": "REVIEW_EXISTING_SUMMARY",
+      "key": "pref_hide_read_permanently",
+      "leaf_section": "Reading state",
+      "legacy_route_count": 2,
+      "legacy_routes": [
+        {
+          "category": "Mark as read",
+          "key": "pref_hide_read_permanently",
+          "logical_kind": "stored_setting",
+          "resource": "pref_posts_v2",
+          "root_referenced": true
+        },
+        {
+          "category": "Mark as read",
+          "key": "pref_hide_read_permanently",
+          "logical_kind": "stored_setting",
+          "resource": "pref_privacy_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Posts",
+      "page_intro": "Choose how posts behave while browsing and reading.",
+      "proposed_summary": "Pressing \\\"Hide read\\\" will move read posts on screen to Profile->Hidden (requires login)",
+      "root": "Reading & interaction",
+      "screen_depth": 2,
+      "screen_path": [
+        "Reading & interaction",
+        "Posts",
+        "Reading state"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Reading state",
+      "title": "Hide read permanently"
+    },
+    {
+      "default_value": "false",
+      "dependency": "pref_mark_read",
+      "existing_summary": "Post will be marked as read when it leaves the screen",
+      "help_treatment": "REVIEW_EXISTING_SUMMARY",
+      "key": "pref_mark_read_on_scroll",
+      "leaf_section": "Reading state",
+      "legacy_route_count": 2,
+      "legacy_routes": [
+        {
+          "category": "Mark as read",
+          "key": "pref_mark_read_on_scroll",
+          "logical_kind": "stored_setting",
+          "resource": "pref_posts_v2",
+          "root_referenced": true
+        },
+        {
+          "category": "Mark as read",
+          "key": "pref_mark_read_on_scroll",
+          "logical_kind": "stored_setting",
+          "resource": "pref_privacy_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Posts",
+      "page_intro": "Choose how posts behave while browsing and reading.",
+      "proposed_summary": "Post will be marked as read when it leaves the screen",
+      "root": "Reading & interaction",
+      "screen_depth": 2,
+      "screen_path": [
+        "Reading & interaction",
+        "Posts",
+        "Reading state"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Reading state",
+      "title": "Mark as read on scroll"
+    },
+    {
+      "default_value": "true",
+      "dependency": "",
+      "existing_summary": "Clicking on a post will mark as read",
+      "help_treatment": "REVIEW_EXISTING_SUMMARY",
+      "key": "pref_mark_read",
+      "leaf_section": "Reading state",
+      "legacy_route_count": 2,
+      "legacy_routes": [
+        {
+          "category": "Mark as read",
+          "key": "pref_mark_read",
+          "logical_kind": "stored_setting",
+          "resource": "pref_posts_v2",
+          "root_referenced": true
+        },
+        {
+          "category": "Mark as read",
+          "key": "pref_mark_read",
+          "logical_kind": "stored_setting",
+          "resource": "pref_privacy_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Posts",
+      "page_intro": "Choose how posts behave while browsing and reading.",
+      "proposed_summary": "Clicking on a post will mark as read",
+      "root": "Reading & interaction",
+      "screen_depth": 2,
+      "screen_path": [
+        "Reading & interaction",
+        "Posts",
+        "Reading state"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Reading state",
+      "title": "Mark posts as read"
+    },
+    {
+      "default_value": "false",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE",
+      "key": "pref_history_delete_read",
+      "leaf_section": "Reading state",
+      "legacy_route_count": 2,
+      "legacy_routes": [
+        {
+          "category": "Mark as read",
+          "key": "pref_history_delete_read",
+          "logical_kind": "special_preference",
+          "resource": "pref_posts_v2",
+          "root_referenced": true
+        },
+        {
+          "category": "Mark as read",
+          "key": "pref_history_delete_read",
+          "logical_kind": "special_preference",
+          "resource": "pref_privacy_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "special_preference",
+      "page": "Posts",
+      "page_intro": "Choose how posts behave while browsing and reading.",
+      "proposed_summary": "",
+      "root": "Reading & interaction",
+      "screen_depth": 2,
+      "screen_path": [
+        "Reading & interaction",
+        "Posts",
+        "Reading state"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "none_or_custom",
+      "subscreen": "Reading state",
+      "title": "Reset read posts"
+    },
+    {
+      "default_value": "false",
+      "dependency": "pref_load_nsfw_images",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE",
+      "key": "pref_blur_nsfw_images",
+      "leaf_section": "Filter behavior",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "More options",
+          "key": "pref_blur_nsfw_images",
+          "logical_kind": "stored_setting",
+          "resource": "pref_filters_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Search & filters",
+      "page_intro": "Configure search entry, search behavior, and content filtering.",
+      "proposed_summary": "",
+      "root": "Reading & interaction",
+      "screen_depth": 3,
+      "screen_path": [
+        "Reading & interaction",
+        "Search & filters",
+        "Content filters",
+        "Filter behavior"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Filter behavior",
+      "title": "Blur images in NSFW posts"
+    },
+    {
+      "default_value": "false",
+      "dependency": "pref_nsfw",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE",
+      "key": "pref_load_nsfw_images",
+      "leaf_section": "Filter behavior",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "More options",
+          "key": "pref_load_nsfw_images",
+          "logical_kind": "stored_setting",
+          "resource": "pref_filters_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Search & filters",
+      "page_intro": "Configure search entry, search behavior, and content filtering.",
+      "proposed_summary": "",
+      "root": "Reading & interaction",
+      "screen_depth": 3,
+      "screen_path": [
+        "Reading & interaction",
+        "Search & filters",
+        "Content filters",
+        "Filter behavior"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Filter behavior",
+      "title": "Show images in NSFW posts"
+    },
+    {
+      "default_value": "false",
+      "dependency": "",
+      "existing_summary": "Show content labeled Not Safe For Work",
+      "help_treatment": "REVIEW_EXISTING_SUMMARY",
+      "key": "pref_nsfw",
+      "leaf_section": "Filter behavior",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "More options",
+          "key": "pref_nsfw",
+          "logical_kind": "stored_setting",
+          "resource": "pref_filters_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Search & filters",
+      "page_intro": "Configure search entry, search behavior, and content filtering.",
+      "proposed_summary": "Show content labeled Not Safe For Work",
+      "root": "Reading & interaction",
+      "screen_depth": 3,
+      "screen_path": [
+        "Reading & interaction",
+        "Search & filters",
+        "Content filters",
+        "Filter behavior"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Filter behavior",
+      "title": "Show NSFW"
+    },
+    {
+      "default_value": "",
+      "dependency": "",
+      "existing_summary": "Hide posts from these communities. Use * wildcards to group communities (\\\"ask*\\\" hides AskReddit, AskScience…)",
+      "help_treatment": "REVIEW_EXISTING_SUMMARY",
+      "key": "pref_filter_subreddit",
+      "leaf_section": "Muted content",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Muting options",
+          "key": "pref_filter_subreddit",
+          "logical_kind": "special_preference",
+          "resource": "pref_filters_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "special_preference",
+      "page": "Search & filters",
+      "page_intro": "Configure search entry, search behavior, and content filtering.",
+      "proposed_summary": "Hide posts from these communities. Use * wildcards to group communities (\\\"ask*\\\" hides AskReddit, AskScience…)",
+      "root": "Reading & interaction",
+      "screen_depth": 3,
+      "screen_path": [
+        "Reading & interaction",
+        "Search & filters",
+        "Content filters",
+        "Muted content"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "none_or_custom",
+      "subscreen": "Muting options",
+      "title": "Communities"
+    },
+    {
+      "default_value": "",
+      "dependency": "",
+      "existing_summary": "Hide posts from these domains",
+      "help_treatment": "REVIEW_EXISTING_SUMMARY",
+      "key": "pref_filter_domain",
+      "leaf_section": "Muted content",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Muting options",
+          "key": "pref_filter_domain",
+          "logical_kind": "special_preference",
+          "resource": "pref_filters_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "special_preference",
+      "page": "Search & filters",
+      "page_intro": "Configure search entry, search behavior, and content filtering.",
+      "proposed_summary": "Hide posts from these domains",
+      "root": "Reading & interaction",
+      "screen_depth": 3,
+      "screen_path": [
+        "Reading & interaction",
+        "Search & filters",
+        "Content filters",
+        "Muted content"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "none_or_custom",
+      "subscreen": "Muting options",
+      "title": "Domains"
+    },
+    {
+      "default_value": "",
+      "dependency": "",
+      "existing_summary": "Hide posts with these flairs. Use * wildcards to group flairs (\\\"*meme\\\" hides meme, wholesomememe…)",
+      "help_treatment": "REVIEW_EXISTING_SUMMARY",
+      "key": "pref_filter_flair",
+      "leaf_section": "Muted content",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Muting options",
+          "key": "pref_filter_flair",
+          "logical_kind": "special_preference",
+          "resource": "pref_filters_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "special_preference",
+      "page": "Search & filters",
+      "page_intro": "Configure search entry, search behavior, and content filtering.",
+      "proposed_summary": "Hide posts with these flairs. Use * wildcards to group flairs (\\\"*meme\\\" hides meme, wholesomememe…)",
+      "root": "Reading & interaction",
+      "screen_depth": 3,
+      "screen_path": [
+        "Reading & interaction",
+        "Search & filters",
+        "Content filters",
+        "Muted content"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "none_or_custom",
+      "subscreen": "Muting options",
+      "title": "Flairs"
+    },
+    {
+      "default_value": "",
+      "dependency": "",
+      "existing_summary": "Hide posts from these users",
+      "help_treatment": "REVIEW_EXISTING_SUMMARY",
+      "key": "pref_filter_username",
+      "leaf_section": "Muted content",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Muting options",
+          "key": "pref_filter_username",
+          "logical_kind": "special_preference",
+          "resource": "pref_filters_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "special_preference",
+      "page": "Search & filters",
+      "page_intro": "Configure search entry, search behavior, and content filtering.",
+      "proposed_summary": "Hide posts from these users",
+      "root": "Reading & interaction",
+      "screen_depth": 3,
+      "screen_path": [
+        "Reading & interaction",
+        "Search & filters",
+        "Content filters",
+        "Muted content"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "none_or_custom",
+      "subscreen": "Muting options",
+      "title": "Users"
+    },
+    {
+      "default_value": "",
+      "dependency": "",
+      "existing_summary": "Hide posts containing words in title",
+      "help_treatment": "REVIEW_EXISTING_SUMMARY",
+      "key": "pref_filter_keyword",
+      "leaf_section": "Muted content",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Muting options",
+          "key": "pref_filter_keyword",
+          "logical_kind": "special_preference",
+          "resource": "pref_filters_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "special_preference",
+      "page": "Search & filters",
+      "page_intro": "Configure search entry, search behavior, and content filtering.",
+      "proposed_summary": "Hide posts containing words in title",
+      "root": "Reading & interaction",
+      "screen_depth": 3,
+      "screen_path": [
+        "Reading & interaction",
+        "Search & filters",
+        "Content filters",
+        "Muted content"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "none_or_custom",
+      "subscreen": "Muting options",
+      "title": "Words"
+    },
+    {
+      "default_value": "true",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE",
+      "key": "pref_album",
+      "leaf_section": "Post matching",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Show posts with",
+          "key": "pref_album",
+          "logical_kind": "stored_setting",
+          "resource": "pref_filters_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Search & filters",
+      "page_intro": "Configure search entry, search behavior, and content filtering.",
+      "proposed_summary": "",
+      "root": "Reading & interaction",
+      "screen_depth": 3,
+      "screen_path": [
+        "Reading & interaction",
+        "Search & filters",
+        "Content filters",
+        "Post matching"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Show posts with",
+      "title": "Albums"
+    },
+    {
+      "default_value": "true",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE",
+      "key": "pref_gif",
+      "leaf_section": "Post matching",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Show posts with",
+          "key": "pref_gif",
+          "logical_kind": "stored_setting",
+          "resource": "pref_filters_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Search & filters",
+      "page_intro": "Configure search entry, search behavior, and content filtering.",
+      "proposed_summary": "",
+      "root": "Reading & interaction",
+      "screen_depth": 3,
+      "screen_path": [
+        "Reading & interaction",
+        "Search & filters",
+        "Content filters",
+        "Post matching"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Show posts with",
+      "title": "Gifs"
+    },
+    {
+      "default_value": "true",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "OMIT_SELF_EXPLANATORY",
+      "key": "pref_image",
+      "leaf_section": "Post matching",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Show posts with",
+          "key": "pref_image",
+          "logical_kind": "stored_setting",
+          "resource": "pref_filters_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Search & filters",
+      "page_intro": "Configure search entry, search behavior, and content filtering.",
+      "proposed_summary": "",
+      "root": "Reading & interaction",
+      "screen_depth": 3,
+      "screen_path": [
+        "Reading & interaction",
+        "Search & filters",
+        "Content filters",
+        "Post matching"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Show posts with",
+      "title": "Images"
+    },
+    {
+      "default_value": "true",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE",
+      "key": "pref_link",
+      "leaf_section": "Post matching",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Show posts with",
+          "key": "pref_link",
+          "logical_kind": "stored_setting",
+          "resource": "pref_filters_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Search & filters",
+      "page_intro": "Configure search entry, search behavior, and content filtering.",
+      "proposed_summary": "",
+      "root": "Reading & interaction",
+      "screen_depth": 3,
+      "screen_path": [
+        "Reading & interaction",
+        "Search & filters",
+        "Content filters",
+        "Post matching"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Show posts with",
+      "title": "Links"
+    },
+    {
+      "default_value": "true",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE",
+      "key": "pref_self",
+      "leaf_section": "Post matching",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Show posts with",
+          "key": "pref_self",
+          "logical_kind": "stored_setting",
+          "resource": "pref_filters_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Search & filters",
+      "page_intro": "Configure search entry, search behavior, and content filtering.",
+      "proposed_summary": "",
+      "root": "Reading & interaction",
+      "screen_depth": 3,
+      "screen_path": [
+        "Reading & interaction",
+        "Search & filters",
+        "Content filters",
+        "Post matching"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Show posts with",
+      "title": "Text"
+    },
+    {
+      "default_value": "true",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "OMIT_SELF_EXPLANATORY",
+      "key": "pref_video",
+      "leaf_section": "Post matching",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Show posts with",
+          "key": "pref_video",
+          "logical_kind": "stored_setting",
+          "resource": "pref_filters_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Search & filters",
+      "page_intro": "Configure search entry, search behavior, and content filtering.",
+      "proposed_summary": "",
+      "root": "Reading & interaction",
+      "screen_depth": 3,
+      "screen_path": [
+        "Reading & interaction",
+        "Search & filters",
+        "Content filters",
+        "Post matching"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Show posts with",
+      "title": "Videos"
+    },
+    {
+      "default_value": "",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "OMIT_OR_ONE_LINE_ACTION_HINT",
+      "key": "pref_search_advanced_help",
+      "leaf_section": "Advanced search",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Advanced search",
+          "key": "pref_search_advanced_help",
+          "logical_kind": "action",
+          "resource": "pref_search_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "action",
+      "page": "Search & filters",
+      "page_intro": "Configure search entry, search behavior, and content filtering.",
+      "proposed_summary": "",
+      "root": "Reading & interaction",
+      "screen_depth": 3,
+      "screen_path": [
+        "Reading & interaction",
+        "Search & filters",
+        "Search",
+        "Advanced search"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "none_or_custom",
+      "subscreen": "Advanced search",
+      "title": "Field search help"
+    },
+    {
+      "default_value": "5",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE",
+      "key": "pref_default_search_period",
+      "leaf_section": "Search behavior",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": null,
+          "key": "pref_default_search_period",
+          "logical_kind": "stored_setting",
+          "resource": "pref_search_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Search & filters",
+      "page_intro": "Configure search entry, search behavior, and content filtering.",
+      "proposed_summary": "",
+      "root": "Reading & interaction",
+      "screen_depth": 3,
+      "screen_path": [
+        "Reading & interaction",
+        "Search & filters",
+        "Search",
+        "Search behavior"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "string",
+      "subscreen": "Search behavior",
+      "title": "Default period"
+    },
+    {
+      "default_value": "0",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE",
+      "key": "pref_default_search_sorting",
+      "leaf_section": "Search behavior",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": null,
+          "key": "pref_default_search_sorting",
+          "logical_kind": "stored_setting",
+          "resource": "pref_search_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Search & filters",
+      "page_intro": "Configure search entry, search behavior, and content filtering.",
+      "proposed_summary": "",
+      "root": "Reading & interaction",
+      "screen_depth": 3,
+      "screen_path": [
+        "Reading & interaction",
+        "Search & filters",
+        "Search",
+        "Search behavior"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "string",
+      "subscreen": "Search behavior",
+      "title": "Default sort"
+    },
+    {
+      "default_value": "false",
+      "dependency": "",
+      "existing_summary": "Focus the search field and show the keyboard immediately. When disabled, tap Search again to start typing.",
+      "help_treatment": "REVIEW_EXISTING_SUMMARY",
+      "key": "morphe_boost_search_open_keyboard_on_entry",
+      "leaf_section": "Search behavior",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Search",
+          "key": "morphe_boost_search_open_keyboard_on_entry",
+          "logical_kind": "morphe_user_setting",
+          "resource": "morphe_boost_settings_skeleton",
+          "root_referenced": false
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Search & filters",
+      "page_intro": "Configure search entry, search behavior, and content filtering.",
+      "proposed_summary": "Focus the search field and show the keyboard immediately. When disabled, tap Search again to start typing.",
+      "root": "Reading & interaction",
+      "screen_depth": 3,
+      "screen_path": [
+        "Reading & interaction",
+        "Search & filters",
+        "Search",
+        "Search behavior"
+      ],
+      "source_type": "morphe_embedded_xml",
+      "storage_type": "boolean",
+      "subscreen": "Search behavior",
+      "title": "Open keyboard when entering Search"
+    },
+    {
+      "default_value": "",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "OMIT_OR_ONE_LINE_ACTION_HINT",
+      "key": "pref_saved_searches",
+      "leaf_section": "Suggestions",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Suggestions",
+          "key": "pref_saved_searches",
+          "logical_kind": "action",
+          "resource": "pref_search_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "action",
+      "page": "Search & filters",
+      "page_intro": "Configure search entry, search behavior, and content filtering.",
+      "proposed_summary": "",
+      "root": "Reading & interaction",
+      "screen_depth": 3,
+      "screen_path": [
+        "Reading & interaction",
+        "Search & filters",
+        "Search",
+        "Suggestions"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "none_or_custom",
+      "subscreen": "Suggestions",
+      "title": "Saved searches"
+    },
+    {
+      "default_value": "true",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE",
+      "key": "pref_search_show_random",
+      "leaf_section": "Suggestions",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Suggestions",
+          "key": "pref_search_show_random",
+          "logical_kind": "stored_setting",
+          "resource": "pref_search_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Search & filters",
+      "page_intro": "Configure search entry, search behavior, and content filtering.",
+      "proposed_summary": "",
+      "root": "Reading & interaction",
+      "screen_depth": 3,
+      "screen_path": [
+        "Reading & interaction",
+        "Search & filters",
+        "Search",
+        "Suggestions"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Suggestions",
+      "title": "Show random"
+    },
+    {
+      "default_value": "true",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE",
+      "key": "pref_search_show_random_nsfw",
+      "leaf_section": "Suggestions",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Suggestions",
+          "key": "pref_search_show_random_nsfw",
+          "logical_kind": "stored_setting",
+          "resource": "pref_search_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Search & filters",
+      "page_intro": "Configure search entry, search behavior, and content filtering.",
+      "proposed_summary": "",
+      "root": "Reading & interaction",
+      "screen_depth": 3,
+      "screen_path": [
+        "Reading & interaction",
+        "Search & filters",
+        "Search",
+        "Suggestions"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Suggestions",
+      "title": "Show random NSFW"
+    },
+    {
+      "default_value": "false",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE",
+      "key": "pref_search_show_trending",
+      "leaf_section": "Suggestions",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Suggestions",
+          "key": "pref_search_show_trending",
+          "logical_kind": "stored_setting",
+          "resource": "pref_search_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Search & filters",
+      "page_intro": "Configure search entry, search behavior, and content filtering.",
+      "proposed_summary": "",
+      "root": "Reading & interaction",
+      "screen_depth": 3,
+      "screen_path": [
+        "Reading & interaction",
+        "Search & filters",
+        "Search",
+        "Suggestions"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Suggestions",
+      "title": "Show trending communities"
+    },
+    {
+      "default_value": "false",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE",
+      "key": "pref_search_show_trending_searches",
+      "leaf_section": "Suggestions",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Suggestions",
+          "key": "pref_search_show_trending_searches",
+          "logical_kind": "stored_setting",
+          "resource": "pref_search_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Search & filters",
+      "page_intro": "Configure search entry, search behavior, and content filtering.",
+      "proposed_summary": "",
+      "root": "Reading & interaction",
+      "screen_depth": 3,
+      "screen_path": [
+        "Reading & interaction",
+        "Search & filters",
+        "Search",
+        "Suggestions"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Suggestions",
+      "title": "Show trending today"
+    },
+    {
+      "default_value": "true",
+      "dependency": "",
+      "existing_summary": "Show confirmation dialog before exiting",
+      "help_treatment": "REVIEW_EXISTING_SUMMARY",
+      "key": "pref_ask_exit",
+      "leaf_section": "Back & exit",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Exit confirmation",
+          "key": "pref_ask_exit",
+          "logical_kind": "stored_setting",
+          "resource": "pref_general_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Navigation & gestures",
+      "page_intro": "Choose how you move around Boost and which shortcuts are available.",
+      "proposed_summary": "Show confirmation dialog before exiting",
+      "root": "Navigation",
+      "screen_depth": 2,
+      "screen_path": [
+        "Navigation",
+        "Navigation & gestures",
+        "Back & exit"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Back & exit",
+      "title": "Confirm exit"
+    },
+    {
+      "default_value": "true",
+      "dependency": "pref_ask_exit",
+      "existing_summary": "Tap back button twice to exit",
+      "help_treatment": "REVIEW_EXISTING_SUMMARY",
+      "key": "pref_double_exit",
+      "leaf_section": "Back & exit",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Exit confirmation",
+          "key": "pref_double_exit",
+          "logical_kind": "stored_setting",
+          "resource": "pref_general_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Navigation & gestures",
+      "page_intro": "Choose how you move around Boost and which shortcuts are available.",
+      "proposed_summary": "Tap back button twice to exit",
+      "root": "Navigation",
+      "screen_depth": 2,
+      "screen_path": [
+        "Navigation",
+        "Navigation & gestures",
+        "Back & exit"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Back & exit",
+      "title": "Double tap to exit"
+    },
+    {
+      "default_value": "true",
+      "dependency": "pref_bottom_navigation",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE",
+      "key": "pref_bottom_navigation_hide_on_scroll",
+      "leaf_section": "Bottom navigation",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": null,
+          "key": "pref_bottom_navigation_hide_on_scroll",
+          "logical_kind": "stored_setting",
+          "resource": "pref_bottom_navigation_v2",
+          "root_referenced": false
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Navigation & gestures",
+      "page_intro": "Choose how you move around Boost and which shortcuts are available.",
+      "proposed_summary": "",
+      "root": "Navigation",
+      "screen_depth": 2,
+      "screen_path": [
+        "Navigation",
+        "Navigation & gestures",
+        "Bottom navigation"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Bottom navigation",
+      "title": "Hide on scroll"
+    },
+    {
+      "default_value": "false",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE",
+      "key": "pref_bottom_navigation",
+      "leaf_section": "Bottom navigation",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": null,
+          "key": "pref_bottom_navigation",
+          "logical_kind": "stored_setting",
+          "resource": "pref_bottom_navigation_v2",
+          "root_referenced": false
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Navigation & gestures",
+      "page_intro": "Choose how you move around Boost and which shortcuts are available.",
+      "proposed_summary": "",
+      "root": "Navigation",
+      "screen_depth": 2,
+      "screen_path": [
+        "Navigation",
+        "Navigation & gestures",
+        "Bottom navigation"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Bottom navigation",
+      "title": "Show bottom navigation"
+    },
+    {
+      "default_value": "true",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE+PROGRESSIVE_DISCLOSURE",
+      "key": "pref_accounts_show_avatar",
+      "leaf_section": "Account switcher",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Account switcher",
+          "key": "pref_accounts_show_avatar",
+          "logical_kind": "stored_setting",
+          "resource": "pref_drawer_v2",
+          "root_referenced": false
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Navigation & gestures",
+      "page_intro": "Choose how you move around Boost and which shortcuts are available.",
+      "proposed_summary": "",
+      "root": "Navigation",
+      "screen_depth": 3,
+      "screen_path": [
+        "Navigation",
+        "Navigation & gestures",
+        "Navigation drawer",
+        "Account switcher"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Account switcher",
+      "title": "Show avatar"
+    },
+    {
+      "default_value": "true",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE+PROGRESSIVE_DISCLOSURE",
+      "key": "pref_accounts_show_username",
+      "leaf_section": "Account switcher",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Account switcher",
+          "key": "pref_accounts_show_username",
+          "logical_kind": "stored_setting",
+          "resource": "pref_drawer_v2",
+          "root_referenced": false
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Navigation & gestures",
+      "page_intro": "Choose how you move around Boost and which shortcuts are available.",
+      "proposed_summary": "",
+      "root": "Navigation",
+      "screen_depth": 3,
+      "screen_path": [
+        "Navigation",
+        "Navigation & gestures",
+        "Navigation drawer",
+        "Account switcher"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Account switcher",
+      "title": "Show username"
+    },
+    {
+      "default_value": "false",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "OMIT_SELF_EXPLANATORY",
+      "key": "pref_drawer_show_drafts",
+      "leaf_section": "Destinations",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Items to show",
+          "key": "pref_drawer_show_drafts",
+          "logical_kind": "stored_setting",
+          "resource": "pref_drawer_v2",
+          "root_referenced": false
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Navigation & gestures",
+      "page_intro": "Choose how you move around Boost and which shortcuts are available.",
+      "proposed_summary": "",
+      "root": "Navigation",
+      "screen_depth": 3,
+      "screen_path": [
+        "Navigation",
+        "Navigation & gestures",
+        "Navigation drawer",
+        "Destinations"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Destinations",
+      "title": "Drafts"
+    },
+    {
+      "default_value": "true",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "OMIT_SELF_EXPLANATORY",
+      "key": "pref_drawer_show_history",
+      "leaf_section": "Destinations",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Items to show",
+          "key": "pref_drawer_show_history",
+          "logical_kind": "stored_setting",
+          "resource": "pref_drawer_v2",
+          "root_referenced": false
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Navigation & gestures",
+      "page_intro": "Choose how you move around Boost and which shortcuts are available.",
+      "proposed_summary": "",
+      "root": "Navigation",
+      "screen_depth": 3,
+      "screen_path": [
+        "Navigation",
+        "Navigation & gestures",
+        "Navigation drawer",
+        "Destinations"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Destinations",
+      "title": "History"
+    },
+    {
+      "default_value": "true",
+      "dependency": "",
+      "existing_summary": "Posts from subscripions",
+      "help_treatment": "REVIEW_EXISTING_SUMMARY",
+      "key": "pref_drawer_show_frontpage",
+      "leaf_section": "Destinations",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Items to show",
+          "key": "pref_drawer_show_frontpage",
+          "logical_kind": "stored_setting",
+          "resource": "pref_drawer_v2",
+          "root_referenced": false
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Navigation & gestures",
+      "page_intro": "Choose how you move around Boost and which shortcuts are available.",
+      "proposed_summary": "Posts from subscripions",
+      "root": "Navigation",
+      "screen_depth": 3,
+      "screen_path": [
+        "Navigation",
+        "Navigation & gestures",
+        "Navigation drawer",
+        "Destinations"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Destinations",
+      "title": "Home feed"
+    },
+    {
+      "default_value": "true",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "OMIT_SELF_EXPLANATORY",
+      "key": "pref_drawer_show_inbox",
+      "leaf_section": "Destinations",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Items to show",
+          "key": "pref_drawer_show_inbox",
+          "logical_kind": "stored_setting",
+          "resource": "pref_drawer_v2",
+          "root_referenced": false
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Navigation & gestures",
+      "page_intro": "Choose how you move around Boost and which shortcuts are available.",
+      "proposed_summary": "",
+      "root": "Navigation",
+      "screen_depth": 3,
+      "screen_path": [
+        "Navigation",
+        "Navigation & gestures",
+        "Navigation drawer",
+        "Destinations"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Destinations",
+      "title": "Inbox"
+    },
+    {
+      "default_value": "true",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "OMIT_SELF_EXPLANATORY",
+      "key": "pref_drawer_show_mod",
+      "leaf_section": "Destinations",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Items to show",
+          "key": "pref_drawer_show_mod",
+          "logical_kind": "stored_setting",
+          "resource": "pref_drawer_v2",
+          "root_referenced": false
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Navigation & gestures",
+      "page_intro": "Choose how you move around Boost and which shortcuts are available.",
+      "proposed_summary": "",
+      "root": "Navigation",
+      "screen_depth": 3,
+      "screen_path": [
+        "Navigation",
+        "Navigation & gestures",
+        "Navigation drawer",
+        "Destinations"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Destinations",
+      "title": "Moderation"
+    },
+    {
+      "default_value": "true",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "OMIT_SELF_EXPLANATORY",
+      "key": "pref_drawer_show_popular",
+      "leaf_section": "Destinations",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Items to show",
+          "key": "pref_drawer_show_popular",
+          "logical_kind": "stored_setting",
+          "resource": "pref_drawer_v2",
+          "root_referenced": false
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Navigation & gestures",
+      "page_intro": "Choose how you move around Boost and which shortcuts are available.",
+      "proposed_summary": "",
+      "root": "Navigation",
+      "screen_depth": 3,
+      "screen_path": [
+        "Navigation",
+        "Navigation & gestures",
+        "Navigation drawer",
+        "Destinations"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Destinations",
+      "title": "Popular"
+    },
+    {
+      "default_value": "true",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "OMIT_SELF_EXPLANATORY",
+      "key": "pref_drawer_show_profile",
+      "leaf_section": "Destinations",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Items to show",
+          "key": "pref_drawer_show_profile",
+          "logical_kind": "stored_setting",
+          "resource": "pref_drawer_v2",
+          "root_referenced": false
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Navigation & gestures",
+      "page_intro": "Choose how you move around Boost and which shortcuts are available.",
+      "proposed_summary": "",
+      "root": "Navigation",
+      "screen_depth": 3,
+      "screen_path": [
+        "Navigation",
+        "Navigation & gestures",
+        "Navigation drawer",
+        "Destinations"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Destinations",
+      "title": "Profile"
+    },
+    {
+      "default_value": "true",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "OMIT_SELF_EXPLANATORY",
+      "key": "pref_drawer_show_saved",
+      "leaf_section": "Destinations",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Items to show",
+          "key": "pref_drawer_show_saved",
+          "logical_kind": "stored_setting",
+          "resource": "pref_drawer_v2",
+          "root_referenced": false
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Navigation & gestures",
+      "page_intro": "Choose how you move around Boost and which shortcuts are available.",
+      "proposed_summary": "",
+      "root": "Navigation",
+      "screen_depth": 3,
+      "screen_path": [
+        "Navigation",
+        "Navigation & gestures",
+        "Navigation drawer",
+        "Destinations"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Destinations",
+      "title": "Saved"
+    },
+    {
+      "default_value": "true",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "OMIT_SELF_EXPLANATORY",
+      "key": "pref_drawer_show_search_generic",
+      "leaf_section": "Destinations",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Items to show",
+          "key": "pref_drawer_show_search_generic",
+          "logical_kind": "stored_setting",
+          "resource": "pref_drawer_v2",
+          "root_referenced": false
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Navigation & gestures",
+      "page_intro": "Choose how you move around Boost and which shortcuts are available.",
+      "proposed_summary": "",
+      "root": "Navigation",
+      "screen_depth": 3,
+      "screen_path": [
+        "Navigation",
+        "Navigation & gestures",
+        "Navigation drawer",
+        "Destinations"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Destinations",
+      "title": "Search"
+    },
+    {
+      "default_value": "true",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "OMIT_SELF_EXPLANATORY",
+      "key": "pref_drawer_show_all",
+      "leaf_section": "Drawer behavior",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Items to show",
+          "key": "pref_drawer_show_all",
+          "logical_kind": "stored_setting",
+          "resource": "pref_drawer_v2",
+          "root_referenced": false
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Navigation & gestures",
+      "page_intro": "Choose how you move around Boost and which shortcuts are available.",
+      "proposed_summary": "",
+      "root": "Navigation",
+      "screen_depth": 3,
+      "screen_path": [
+        "Navigation",
+        "Navigation & gestures",
+        "Navigation drawer",
+        "Drawer behavior"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Drawer behavior",
+      "title": "All"
+    },
+    {
+      "default_value": "true",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE",
+      "key": "pref_drawer_show_friends",
+      "leaf_section": "Drawer behavior",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Items to show",
+          "key": "pref_drawer_show_friends",
+          "logical_kind": "stored_setting",
+          "resource": "pref_drawer_v2",
+          "root_referenced": false
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Navigation & gestures",
+      "page_intro": "Choose how you move around Boost and which shortcuts are available.",
+      "proposed_summary": "",
+      "root": "Navigation",
+      "screen_depth": 3,
+      "screen_path": [
+        "Navigation",
+        "Navigation & gestures",
+        "Navigation drawer",
+        "Drawer behavior"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Drawer behavior",
+      "title": "Friends"
+    },
+    {
+      "default_value": "true",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE",
+      "key": "pref_drawer_sticky_settings",
+      "leaf_section": "Drawer behavior",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Items to show",
+          "key": "pref_drawer_sticky_settings",
+          "logical_kind": "stored_setting",
+          "resource": "pref_drawer_v2",
+          "root_referenced": false
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Navigation & gestures",
+      "page_intro": "Choose how you move around Boost and which shortcuts are available.",
+      "proposed_summary": "",
+      "root": "Navigation",
+      "screen_depth": 3,
+      "screen_path": [
+        "Navigation",
+        "Navigation & gestures",
+        "Navigation drawer",
+        "Drawer behavior"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Drawer behavior",
+      "title": "Sticky Settings"
+    },
+    {
+      "default_value": "false",
+      "dependency": "",
+      "existing_summary": "Open menu from the opposite edge",
+      "help_treatment": "REVIEW_EXISTING_SUMMARY",
+      "key": "pref_drawer_end",
+      "leaf_section": "Drawer behavior",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "General",
+          "key": "pref_drawer_end",
+          "logical_kind": "stored_setting",
+          "resource": "pref_drawer_v2",
+          "root_referenced": false
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Navigation & gestures",
+      "page_intro": "Choose how you move around Boost and which shortcuts are available.",
+      "proposed_summary": "Open menu from the opposite edge",
+      "root": "Navigation",
+      "screen_depth": 3,
+      "screen_path": [
+        "Navigation",
+        "Navigation & gestures",
+        "Navigation drawer",
+        "Drawer behavior"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Drawer behavior",
+      "title": "Switch side"
+    },
+    {
+      "default_value": "false",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE",
+      "key": "pref_drawer_show_go_to_subreddit",
+      "leaf_section": "Go-to shortcuts",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Items to show",
+          "key": "pref_drawer_show_go_to_subreddit",
+          "logical_kind": "stored_setting",
+          "resource": "pref_drawer_v2",
+          "root_referenced": false
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Navigation & gestures",
+      "page_intro": "Choose how you move around Boost and which shortcuts are available.",
+      "proposed_summary": "",
+      "root": "Navigation",
+      "screen_depth": 3,
+      "screen_path": [
+        "Navigation",
+        "Navigation & gestures",
+        "Navigation drawer",
+        "Go-to shortcuts"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Go-to shortcuts",
+      "title": "Go to community"
+    },
+    {
+      "default_value": "true",
+      "dependency": "",
+      "existing_summary": "Including Community, user or random (Long press to go to community)",
+      "help_treatment": "REVIEW_EXISTING_SUMMARY",
+      "key": "pref_drawer_show_go_to",
+      "leaf_section": "Go-to shortcuts",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Items to show",
+          "key": "pref_drawer_show_go_to",
+          "logical_kind": "stored_setting",
+          "resource": "pref_drawer_v2",
+          "root_referenced": false
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Navigation & gestures",
+      "page_intro": "Choose how you move around Boost and which shortcuts are available.",
+      "proposed_summary": "Including Community, user or random (Long press to go to community)",
+      "root": "Navigation",
+      "screen_depth": 3,
+      "screen_path": [
+        "Navigation",
+        "Navigation & gestures",
+        "Navigation drawer",
+        "Go-to shortcuts"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Go-to shortcuts",
+      "title": "Go to dropdown"
+    },
+    {
+      "default_value": "false",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE",
+      "key": "pref_drawer_show_go_to_user",
+      "leaf_section": "Go-to shortcuts",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Items to show",
+          "key": "pref_drawer_show_go_to_user",
+          "logical_kind": "stored_setting",
+          "resource": "pref_drawer_v2",
+          "root_referenced": false
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Navigation & gestures",
+      "page_intro": "Choose how you move around Boost and which shortcuts are available.",
+      "proposed_summary": "",
+      "root": "Navigation",
+      "screen_depth": 3,
+      "screen_path": [
+        "Navigation",
+        "Navigation & gestures",
+        "Navigation drawer",
+        "Go-to shortcuts"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Go-to shortcuts",
+      "title": "Go to user"
+    },
+    {
+      "default_value": "false",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "OMIT_SELF_EXPLANATORY",
+      "key": "pref_drawer_show_blur_switch",
+      "leaf_section": "Quick toggles",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Items to show",
+          "key": "pref_drawer_show_blur_switch",
+          "logical_kind": "stored_setting",
+          "resource": "pref_drawer_v2",
+          "root_referenced": false
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Navigation & gestures",
+      "page_intro": "Choose how you move around Boost and which shortcuts are available.",
+      "proposed_summary": "",
+      "root": "Navigation",
+      "screen_depth": 3,
+      "screen_path": [
+        "Navigation",
+        "Navigation & gestures",
+        "Navigation drawer",
+        "Quick toggles"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Quick toggles",
+      "title": "Blur NSFW"
+    },
+    {
+      "default_value": "false",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "OMIT_SELF_EXPLANATORY",
+      "key": "pref_drawer_show_night_mode",
+      "leaf_section": "Quick toggles",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Items to show",
+          "key": "pref_drawer_show_night_mode",
+          "logical_kind": "stored_setting",
+          "resource": "pref_drawer_v2",
+          "root_referenced": false
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Navigation & gestures",
+      "page_intro": "Choose how you move around Boost and which shortcuts are available.",
+      "proposed_summary": "",
+      "root": "Navigation",
+      "screen_depth": 3,
+      "screen_path": [
+        "Navigation",
+        "Navigation & gestures",
+        "Navigation drawer",
+        "Quick toggles"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Quick toggles",
+      "title": "Dark mode"
+    },
+    {
+      "default_value": "false",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "OMIT_SELF_EXPLANATORY",
+      "key": "pref_drawer_show_nsfw_switch",
+      "leaf_section": "Quick toggles",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Items to show",
+          "key": "pref_drawer_show_nsfw_switch",
+          "logical_kind": "stored_setting",
+          "resource": "pref_drawer_v2",
+          "root_referenced": false
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Navigation & gestures",
+      "page_intro": "Choose how you move around Boost and which shortcuts are available.",
+      "proposed_summary": "",
+      "root": "Navigation",
+      "screen_depth": 3,
+      "screen_path": [
+        "Navigation",
+        "Navigation & gestures",
+        "Navigation drawer",
+        "Quick toggles"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Quick toggles",
+      "title": "Show NSFW"
+    },
+    {
+      "default_value": "true",
+      "dependency": "",
+      "existing_summary": "Default feed. To set any community, go to Subscriptions list and select \\\"Set as default\\\"",
+      "help_treatment": "REVIEW_EXISTING_SUMMARY",
+      "key": "pref_drawer_show_home",
+      "leaf_section": "Subscriptions",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Items to show",
+          "key": "pref_drawer_show_home",
+          "logical_kind": "stored_setting",
+          "resource": "pref_drawer_v2",
+          "root_referenced": false
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Navigation & gestures",
+      "page_intro": "Choose how you move around Boost and which shortcuts are available.",
+      "proposed_summary": "Default feed. To set any community, go to Subscriptions list and select \\\"Set as default\\\"",
+      "root": "Navigation",
+      "screen_depth": 3,
+      "screen_path": [
+        "Navigation",
+        "Navigation & gestures",
+        "Navigation drawer",
+        "Subscriptions"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Subscriptions",
+      "title": "Home"
+    },
+    {
+      "default_value": "true",
+      "dependency": "pref_subscriptions_drawer",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE",
+      "key": "pref_subscriptions_drawer_show_icon",
+      "leaf_section": "Subscriptions",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Subscriptions list",
+          "key": "pref_subscriptions_drawer_show_icon",
+          "logical_kind": "stored_setting",
+          "resource": "pref_drawer_v2",
+          "root_referenced": false
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Navigation & gestures",
+      "page_intro": "Choose how you move around Boost and which shortcuts are available.",
+      "proposed_summary": "",
+      "root": "Navigation",
+      "screen_depth": 3,
+      "screen_path": [
+        "Navigation",
+        "Navigation & gestures",
+        "Navigation drawer",
+        "Subscriptions"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Subscriptions",
+      "title": "Show icons"
+    },
+    {
+      "default_value": "true",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE",
+      "key": "pref_subscriptions_drawer",
+      "leaf_section": "Subscriptions",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Subscriptions list",
+          "key": "pref_subscriptions_drawer",
+          "logical_kind": "stored_setting",
+          "resource": "pref_drawer_v2",
+          "root_referenced": false
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Navigation & gestures",
+      "page_intro": "Choose how you move around Boost and which shortcuts are available.",
+      "proposed_summary": "",
+      "root": "Navigation",
+      "screen_depth": 3,
+      "screen_path": [
+        "Navigation",
+        "Navigation & gestures",
+        "Navigation drawer",
+        "Subscriptions"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Subscriptions",
+      "title": "Show in menu"
+    },
+    {
+      "default_value": "false",
+      "dependency": "pref_subscriptions_drawer",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE",
+      "key": "pref_subscriptions_only_casual",
+      "leaf_section": "Subscriptions",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Subscriptions list",
+          "key": "pref_subscriptions_only_casual",
+          "logical_kind": "stored_setting",
+          "resource": "pref_drawer_v2",
+          "root_referenced": false
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Navigation & gestures",
+      "page_intro": "Choose how you move around Boost and which shortcuts are available.",
+      "proposed_summary": "",
+      "root": "Navigation",
+      "screen_depth": 3,
+      "screen_path": [
+        "Navigation",
+        "Navigation & gestures",
+        "Navigation drawer",
+        "Subscriptions"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Subscriptions",
+      "title": "Show only favorites"
+    },
+    {
+      "default_value": "true",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE",
+      "key": "pref_toolbar",
+      "leaf_section": "Toolbar",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": null,
+          "key": "pref_toolbar",
+          "logical_kind": "stored_setting",
+          "resource": "pref_toolbar_v2",
+          "root_referenced": false
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Navigation & gestures",
+      "page_intro": "Choose how you move around Boost and which shortcuts are available.",
+      "proposed_summary": "",
+      "root": "Navigation",
+      "screen_depth": 2,
+      "screen_path": [
+        "Navigation",
+        "Navigation & gestures",
+        "Toolbar"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Toolbar",
+      "title": "Hide on scroll"
+    },
+    {
+      "default_value": "1",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE",
+      "key": "pref_toolbar_main_action",
+      "leaf_section": "Toolbar",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": null,
+          "key": "pref_toolbar_main_action",
+          "logical_kind": "stored_setting",
+          "resource": "pref_toolbar_v2",
+          "root_referenced": false
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Navigation & gestures",
+      "page_intro": "Choose how you move around Boost and which shortcuts are available.",
+      "proposed_summary": "",
+      "root": "Navigation",
+      "screen_depth": 2,
+      "screen_path": [
+        "Navigation",
+        "Navigation & gestures",
+        "Toolbar"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "string",
+      "subscreen": "Toolbar",
+      "title": "Main action"
+    },
+    {
+      "default_value": "false",
+      "dependency": "",
+      "existing_summary": "Organize downloaded media into community folders",
+      "help_treatment": "REVIEW_EXISTING_SUMMARY+PROGRESSIVE_DISCLOSURE",
+      "key": "pref_download_folder_per_subreddit",
+      "leaf_section": "Download folders",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": null,
+          "key": "pref_download_folder_per_subreddit",
+          "logical_kind": "stored_setting",
+          "resource": "pref_downloads_v2",
+          "root_referenced": false
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Downloads & cache",
+      "page_intro": "Manage download locations and downloaded media behavior.",
+      "proposed_summary": "Organize downloaded media into community folders",
+      "root": "Media",
+      "screen_depth": 2,
+      "screen_path": [
+        "Media",
+        "Downloads & cache",
+        "Download folders"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Download folders",
+      "title": "Community subfolders"
+    },
+    {
+      "default_value": "",
+      "dependency": "",
+      "existing_summary": "Choose the default folder used for downloaded media.",
+      "help_treatment": "DIRECT_CONTROL_SUMMARY",
+      "key": "pref_download_folder_default",
+      "leaf_section": "Download folders",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Download folders",
+          "logical_kind": "direct_action_state",
+          "resource": "MorpheSettingsV4DownloadsFragment",
+          "root_referenced": false
+        }
+      ],
+      "logical_kind": "action_state",
+      "page": "Downloads & cache",
+      "page_intro": "Manage download locations and downloaded media behavior.",
+      "proposed_summary": "Choose the default folder used for downloaded media.",
+      "root": "Media",
+      "screen_depth": 2,
+      "screen_path": [
+        "Media",
+        "Downloads & cache",
+        "Download folders"
+      ],
+      "source_type": "boost_direct_ui",
+      "storage_type": "string",
+      "subscreen": "Download folders",
+      "title": "Default folder"
+    },
+    {
+      "default_value": "",
+      "dependency": "",
+      "existing_summary": "Choose the folder used for downloaded GIFs.",
+      "help_treatment": "DIRECT_CONTROL_SUMMARY",
+      "key": "pref_download_folder_gif",
+      "leaf_section": "Download folders",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Download folders",
+          "logical_kind": "direct_action_state",
+          "resource": "MorpheSettingsV4DownloadsFragment",
+          "root_referenced": false
+        }
+      ],
+      "logical_kind": "action_state",
+      "page": "Downloads & cache",
+      "page_intro": "Manage download locations and downloaded media behavior.",
+      "proposed_summary": "Choose the folder used for downloaded GIFs.",
+      "root": "Media",
+      "screen_depth": 2,
+      "screen_path": [
+        "Media",
+        "Downloads & cache",
+        "Download folders"
+      ],
+      "source_type": "boost_direct_ui",
+      "storage_type": "string",
+      "subscreen": "Download folders",
+      "title": "GIFs"
+    },
+    {
+      "default_value": "",
+      "dependency": "",
+      "existing_summary": "Choose the folder used for downloaded images.",
+      "help_treatment": "DIRECT_CONTROL_SUMMARY",
+      "key": "pref_download_folder_img",
+      "leaf_section": "Download folders",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Download folders",
+          "logical_kind": "direct_action_state",
+          "resource": "MorpheSettingsV4DownloadsFragment",
+          "root_referenced": false
+        }
+      ],
+      "logical_kind": "action_state",
+      "page": "Downloads & cache",
+      "page_intro": "Manage download locations and downloaded media behavior.",
+      "proposed_summary": "Choose the folder used for downloaded images.",
+      "root": "Media",
+      "screen_depth": 2,
+      "screen_path": [
+        "Media",
+        "Downloads & cache",
+        "Download folders"
+      ],
+      "source_type": "boost_direct_ui",
+      "storage_type": "string",
+      "subscreen": "Download folders",
+      "title": "Images"
+    },
+    {
+      "default_value": "",
+      "dependency": "",
+      "existing_summary": "Choose the folder used for downloaded videos.",
+      "help_treatment": "DIRECT_CONTROL_SUMMARY",
+      "key": "pref_download_folder_mp4",
+      "leaf_section": "Download folders",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Download folders",
+          "logical_kind": "direct_action_state",
+          "resource": "MorpheSettingsV4DownloadsFragment",
+          "root_referenced": false
+        }
+      ],
+      "logical_kind": "action_state",
+      "page": "Downloads & cache",
+      "page_intro": "Manage download locations and downloaded media behavior.",
+      "proposed_summary": "Choose the folder used for downloaded videos.",
+      "root": "Media",
+      "screen_depth": 2,
+      "screen_path": [
+        "Media",
+        "Downloads & cache",
+        "Download folders"
+      ],
+      "source_type": "boost_direct_ui",
+      "storage_type": "string",
+      "subscreen": "Download folders",
+      "title": "Videos"
+    },
+    {
+      "default_value": "glide",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE",
+      "key": "pref_image_loader",
+      "leaf_section": "Native image behavior",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Image viewer",
+          "key": "pref_image_loader",
+          "logical_kind": "stored_setting",
+          "resource": "pref_media_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Images, GIFs & previews",
+      "page_intro": "Configure media previews, image behavior, and tap actions.",
+      "proposed_summary": "",
+      "root": "Media",
+      "screen_depth": 2,
+      "screen_path": [
+        "Media",
+        "Images, GIFs & previews",
+        "Native image behavior"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "string",
+      "subscreen": "Native image behavior",
+      "title": "Image loader"
+    },
+    {
+      "default_value": "false",
+      "dependency": "",
+      "existing_summary": "Load images with deep zoom by default",
+      "help_treatment": "REVIEW_EXISTING_SUMMARY",
+      "key": "pref_images_deepzoom",
+      "leaf_section": "Native image behavior",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Image viewer",
+          "key": "pref_images_deepzoom",
+          "logical_kind": "stored_setting",
+          "resource": "pref_media_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Images, GIFs & previews",
+      "page_intro": "Configure media previews, image behavior, and tap actions.",
+      "proposed_summary": "Load images with deep zoom by default",
+      "root": "Media",
+      "screen_depth": 2,
+      "screen_path": [
+        "Media",
+        "Images, GIFs & previews",
+        "Native image behavior"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Native image behavior",
+      "title": "Load HQ images"
+    },
+    {
+      "default_value": "false",
+      "dependency": "pref_images_deepzoom",
+      "existing_summary": "Fit smallest dimension to screen size",
+      "help_treatment": "REVIEW_EXISTING_SUMMARY",
+      "key": "pref_images_fit",
+      "leaf_section": "Native image behavior",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Image viewer",
+          "key": "pref_images_fit",
+          "logical_kind": "stored_setting",
+          "resource": "pref_media_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Images, GIFs & previews",
+      "page_intro": "Configure media previews, image behavior, and tap actions.",
+      "proposed_summary": "Fit smallest dimension to screen size",
+      "root": "Media",
+      "screen_depth": 2,
+      "screen_path": [
+        "Media",
+        "Images, GIFs & previews",
+        "Native image behavior"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Native image behavior",
+      "title": "Load zoomed in"
+    },
+    {
+      "default_value": "true",
+      "dependency": "",
+      "existing_summary": "Swipe or fling content to close viewer",
+      "help_treatment": "REVIEW_EXISTING_SUMMARY",
+      "key": "pref_swipe_up_to_dismiss_image",
+      "leaf_section": "Native image behavior",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Interface",
+          "key": "pref_swipe_up_to_dismiss_image",
+          "logical_kind": "stored_setting",
+          "resource": "pref_media_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Images, GIFs & previews",
+      "page_intro": "Configure media previews, image behavior, and tap actions.",
+      "proposed_summary": "Swipe or fling content to close viewer",
+      "root": "Media",
+      "screen_depth": 2,
+      "screen_path": [
+        "Media",
+        "Images, GIFs & previews",
+        "Native image behavior"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Native image behavior",
+      "title": "Swipe to dismiss"
+    },
+    {
+      "default_value": "vertical",
+      "dependency": "pref_swipe_up_to_dismiss_image",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE",
+      "key": "pref_swipe_dismiss_direction_mode_image",
+      "leaf_section": "Native image behavior",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Interface",
+          "key": "pref_swipe_dismiss_direction_mode_image",
+          "logical_kind": "stored_setting",
+          "resource": "pref_media_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Images, GIFs & previews",
+      "page_intro": "Configure media previews, image behavior, and tap actions.",
+      "proposed_summary": "",
+      "root": "Media",
+      "screen_depth": 2,
+      "screen_path": [
+        "Media",
+        "Images, GIFs & previews",
+        "Native image behavior"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "string",
+      "subscreen": "Native image behavior",
+      "title": "Swipe to dismiss direction"
+    },
+    {
+      "default_value": "true",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE",
+      "key": "pref_tap_to_dismiss_image",
+      "leaf_section": "Native image behavior",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Interface",
+          "key": "pref_tap_to_dismiss_image",
+          "logical_kind": "stored_setting",
+          "resource": "pref_media_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Images, GIFs & previews",
+      "page_intro": "Configure media previews, image behavior, and tap actions.",
+      "proposed_summary": "",
+      "root": "Media",
+      "screen_depth": 2,
+      "screen_path": [
+        "Media",
+        "Images, GIFs & previews",
+        "Native image behavior"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Native image behavior",
+      "title": "Tap to dismiss"
+    },
+    {
+      "default_value": "image_viewer",
+      "dependency": "",
+      "existing_summary": "Image viewer",
+      "help_treatment": "REVIEW_EXISTING_SUMMARY",
+      "key": "morphe_boost_direct_reddit_gif_tap_action",
+      "leaf_section": "Open behavior",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Open behavior",
+          "key": "morphe_boost_direct_reddit_gif_tap_action",
+          "logical_kind": "morphe_user_setting",
+          "resource": "morphe_boost_settings_skeleton",
+          "root_referenced": false
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Images, GIFs & previews",
+      "page_intro": "Configure media previews, image behavior, and tap actions.",
+      "proposed_summary": "Image viewer",
+      "root": "Media",
+      "screen_depth": 2,
+      "screen_path": [
+        "Media",
+        "Images, GIFs & previews",
+        "Open behavior"
+      ],
+      "source_type": "morphe_embedded_xml",
+      "storage_type": "string",
+      "subscreen": "Open behavior",
+      "title": "Direct Reddit GIF tap action"
+    },
+    {
+      "default_value": "video_viewer",
+      "dependency": "",
+      "existing_summary": "Video viewer",
+      "help_treatment": "REVIEW_EXISTING_SUMMARY",
+      "key": "morphe_boost_giphy_preview_tap_action",
+      "leaf_section": "Open behavior",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Open behavior",
+          "key": "morphe_boost_giphy_preview_tap_action",
+          "logical_kind": "morphe_user_setting",
+          "resource": "morphe_boost_settings_skeleton",
+          "root_referenced": false
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Images, GIFs & previews",
+      "page_intro": "Configure media previews, image behavior, and tap actions.",
+      "proposed_summary": "Video viewer",
+      "root": "Media",
+      "screen_depth": 2,
+      "screen_path": [
+        "Media",
+        "Images, GIFs & previews",
+        "Open behavior"
+      ],
+      "source_type": "morphe_embedded_xml",
+      "storage_type": "string",
+      "subscreen": "Open behavior",
+      "title": "Giphy preview tap action"
+    },
+    {
+      "default_value": "image_viewer",
+      "dependency": "",
+      "existing_summary": "Image viewer",
+      "help_treatment": "REVIEW_EXISTING_SUMMARY",
+      "key": "morphe_boost_static_preview_tap_action",
+      "leaf_section": "Open behavior",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Open behavior",
+          "key": "morphe_boost_static_preview_tap_action",
+          "logical_kind": "morphe_user_setting",
+          "resource": "morphe_boost_settings_skeleton",
+          "root_referenced": false
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Images, GIFs & previews",
+      "page_intro": "Configure media previews, image behavior, and tap actions.",
+      "proposed_summary": "Image viewer",
+      "root": "Media",
+      "screen_depth": 2,
+      "screen_path": [
+        "Media",
+        "Images, GIFs & previews",
+        "Open behavior"
+      ],
+      "source_type": "morphe_embedded_xml",
+      "storage_type": "string",
+      "subscreen": "Open behavior",
+      "title": "Static preview tap action"
+    },
+    {
+      "default_value": "true",
+      "dependency": "",
+      "existing_summary": "Show supported media previews directly in comments.",
+      "help_treatment": "REVIEW_EXISTING_SUMMARY",
+      "key": "morphe_boost_inline_media_previews_enabled",
+      "leaf_section": "Preview behavior",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Media previews",
+          "key": "morphe_boost_inline_media_previews_enabled",
+          "logical_kind": "morphe_user_setting",
+          "resource": "morphe_boost_settings_skeleton",
+          "root_referenced": false
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Images, GIFs & previews",
+      "page_intro": "Configure media previews, image behavior, and tap actions.",
+      "proposed_summary": "Show supported media previews directly in comments.",
+      "root": "Media",
+      "screen_depth": 2,
+      "screen_path": [
+        "Media",
+        "Images, GIFs & previews",
+        "Preview behavior"
+      ],
+      "source_type": "morphe_embedded_xml",
+      "storage_type": "boolean",
+      "subscreen": "Preview behavior",
+      "title": "Enable inline media previews"
+    },
+    {
+      "default_value": "false",
+      "dependency": "",
+      "existing_summary": "Keep the original link text visible with the preview.",
+      "help_treatment": "REVIEW_EXISTING_SUMMARY",
+      "key": "morphe_boost_inline_media_preview_show_source_text",
+      "leaf_section": "Preview behavior",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Media previews",
+          "key": "morphe_boost_inline_media_preview_show_source_text",
+          "logical_kind": "morphe_user_setting",
+          "resource": "morphe_boost_settings_skeleton",
+          "root_referenced": false
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Images, GIFs & previews",
+      "page_intro": "Configure media previews, image behavior, and tap actions.",
+      "proposed_summary": "Keep the original link text visible with the preview.",
+      "root": "Media",
+      "screen_depth": 2,
+      "screen_path": [
+        "Media",
+        "Images, GIFs & previews",
+        "Preview behavior"
+      ],
+      "source_type": "morphe_embedded_xml",
+      "storage_type": "boolean",
+      "subscreen": "Preview behavior",
+      "title": "Show source text with preview"
+    },
+    {
+      "default_value": "center",
+      "dependency": "",
+      "existing_summary": "Center",
+      "help_treatment": "REVIEW_EXISTING_SUMMARY",
+      "key": "morphe_boost_inline_media_preview_alignment",
+      "leaf_section": "Preview layout",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Media previews",
+          "key": "morphe_boost_inline_media_preview_alignment",
+          "logical_kind": "morphe_user_setting",
+          "resource": "morphe_boost_settings_skeleton",
+          "root_referenced": false
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Images, GIFs & previews",
+      "page_intro": "Configure media previews, image behavior, and tap actions.",
+      "proposed_summary": "Center",
+      "root": "Media",
+      "screen_depth": 2,
+      "screen_path": [
+        "Media",
+        "Images, GIFs & previews",
+        "Preview layout"
+      ],
+      "source_type": "morphe_embedded_xml",
+      "storage_type": "string",
+      "subscreen": "Preview layout",
+      "title": "Preview alignment"
+    },
+    {
+      "default_value": "balanced",
+      "dependency": "",
+      "existing_summary": "Balanced",
+      "help_treatment": "REVIEW_EXISTING_SUMMARY",
+      "key": "morphe_boost_inline_media_preview_size",
+      "leaf_section": "Preview layout",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Media previews",
+          "key": "morphe_boost_inline_media_preview_size",
+          "logical_kind": "morphe_user_setting",
+          "resource": "morphe_boost_settings_skeleton",
+          "root_referenced": false
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Images, GIFs & previews",
+      "page_intro": "Configure media previews, image behavior, and tap actions.",
+      "proposed_summary": "Balanced",
+      "root": "Media",
+      "screen_depth": 2,
+      "screen_path": [
+        "Media",
+        "Images, GIFs & previews",
+        "Preview layout"
+      ],
+      "source_type": "morphe_embedded_xml",
+      "storage_type": "string",
+      "subscreen": "Preview layout",
+      "title": "Preview size"
+    },
+    {
+      "default_value": "0",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE",
+      "key": "pref_browser",
+      "leaf_section": "Browser",
+      "legacy_route_count": 2,
+      "legacy_routes": [
+        {
+          "category": "Links",
+          "key": "pref_browser",
+          "logical_kind": "stored_setting",
+          "resource": "pref_general_v2",
+          "root_referenced": true
+        },
+        {
+          "category": null,
+          "key": "pref_browser",
+          "logical_kind": "stored_setting",
+          "resource": "pref_links_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Links & browser",
+      "page_intro": "Choose how links open and which browser behavior Boost uses.",
+      "proposed_summary": "",
+      "root": "Media",
+      "screen_depth": 2,
+      "screen_path": [
+        "Media",
+        "Links & browser",
+        "Browser"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "string",
+      "subscreen": "Browser",
+      "title": "Default browser"
+    },
+    {
+      "default_value": "",
+      "dependency": "",
+      "existing_summary": "Domains that will always open in external app",
+      "help_treatment": "REVIEW_EXISTING_SUMMARY",
+      "key": "pref_domain_exceptions",
+      "leaf_section": "Link handling",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": null,
+          "key": "pref_domain_exceptions",
+          "logical_kind": "special_preference",
+          "resource": "pref_links_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "special_preference",
+      "page": "Links & browser",
+      "page_intro": "Choose how links open and which browser behavior Boost uses.",
+      "proposed_summary": "Domains that will always open in external app",
+      "root": "Media",
+      "screen_depth": 2,
+      "screen_path": [
+        "Media",
+        "Links & browser",
+        "Link handling"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "none_or_custom",
+      "subscreen": "Link handling",
+      "title": "Domain exceptions"
+    },
+    {
+      "default_value": "true",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE",
+      "key": "pref_link_album",
+      "leaf_section": "Links to open in app",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Links to open in app",
+          "key": "pref_link_album",
+          "logical_kind": "stored_setting",
+          "resource": "pref_links_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Links & browser",
+      "page_intro": "Choose how links open and which browser behavior Boost uses.",
+      "proposed_summary": "",
+      "root": "Media",
+      "screen_depth": 2,
+      "screen_path": [
+        "Media",
+        "Links & browser",
+        "Links to open in app"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Links to open in app",
+      "title": "Albums"
+    },
+    {
+      "default_value": "true",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE",
+      "key": "pref_link_deviant",
+      "leaf_section": "Links to open in app",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Links to open in app",
+          "key": "pref_link_deviant",
+          "logical_kind": "stored_setting",
+          "resource": "pref_links_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Links & browser",
+      "page_intro": "Choose how links open and which browser behavior Boost uses.",
+      "proposed_summary": "",
+      "root": "Media",
+      "screen_depth": 2,
+      "screen_path": [
+        "Media",
+        "Links & browser",
+        "Links to open in app"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Links to open in app",
+      "title": "Deviant Art"
+    },
+    {
+      "default_value": "true",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE",
+      "key": "pref_link_gif",
+      "leaf_section": "Links to open in app",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Links to open in app",
+          "key": "pref_link_gif",
+          "logical_kind": "stored_setting",
+          "resource": "pref_links_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Links & browser",
+      "page_intro": "Choose how links open and which browser behavior Boost uses.",
+      "proposed_summary": "",
+      "root": "Media",
+      "screen_depth": 2,
+      "screen_path": [
+        "Media",
+        "Links & browser",
+        "Links to open in app"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Links to open in app",
+      "title": "Gifs"
+    },
+    {
+      "default_value": "true",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "OMIT_SELF_EXPLANATORY",
+      "key": "pref_link_image",
+      "leaf_section": "Links to open in app",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Links to open in app",
+          "key": "pref_link_image",
+          "logical_kind": "stored_setting",
+          "resource": "pref_links_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Links & browser",
+      "page_intro": "Choose how links open and which browser behavior Boost uses.",
+      "proposed_summary": "",
+      "root": "Media",
+      "screen_depth": 2,
+      "screen_path": [
+        "Media",
+        "Links & browser",
+        "Links to open in app"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Links to open in app",
+      "title": "Images"
+    },
+    {
+      "default_value": "true",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE",
+      "key": "pref_link_neatclip",
+      "leaf_section": "Links to open in app",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Links to open in app",
+          "key": "pref_link_neatclip",
+          "logical_kind": "stored_setting",
+          "resource": "pref_links_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Links & browser",
+      "page_intro": "Choose how links open and which browser behavior Boost uses.",
+      "proposed_summary": "",
+      "root": "Media",
+      "screen_depth": 2,
+      "screen_path": [
+        "Media",
+        "Links & browser",
+        "Links to open in app"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Links to open in app",
+      "title": "NeatClip"
+    },
+    {
+      "default_value": "true",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE",
+      "key": "pref_link_vreddit",
+      "leaf_section": "Links to open in app",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Links to open in app",
+          "key": "pref_link_vreddit",
+          "logical_kind": "stored_setting",
+          "resource": "pref_links_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Links & browser",
+      "page_intro": "Choose how links open and which browser behavior Boost uses.",
+      "proposed_summary": "",
+      "root": "Media",
+      "screen_depth": 2,
+      "screen_path": [
+        "Media",
+        "Links & browser",
+        "Links to open in app"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Links to open in app",
+      "title": "Reddit videos"
+    },
+    {
+      "default_value": "true",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE",
+      "key": "pref_link_streamable",
+      "leaf_section": "Links to open in app",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Links to open in app",
+          "key": "pref_link_streamable",
+          "logical_kind": "stored_setting",
+          "resource": "pref_links_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Links & browser",
+      "page_intro": "Choose how links open and which browser behavior Boost uses.",
+      "proposed_summary": "",
+      "root": "Media",
+      "screen_depth": 2,
+      "screen_path": [
+        "Media",
+        "Links & browser",
+        "Links to open in app"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Links to open in app",
+      "title": "Streamable"
+    },
+    {
+      "default_value": "true",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE",
+      "key": "pref_link_xkcd",
+      "leaf_section": "Links to open in app",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Links to open in app",
+          "key": "pref_link_xkcd",
+          "logical_kind": "stored_setting",
+          "resource": "pref_links_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Links & browser",
+      "page_intro": "Choose how links open and which browser behavior Boost uses.",
+      "proposed_summary": "",
+      "root": "Media",
+      "screen_depth": 2,
+      "screen_path": [
+        "Media",
+        "Links & browser",
+        "Links to open in app"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Links to open in app",
+      "title": "XKCD"
+    },
+    {
+      "default_value": "true",
+      "dependency": "",
+      "existing_summary": "Disable to open with external app",
+      "help_treatment": "REVIEW_EXISTING_SUMMARY",
+      "key": "pref_link_video",
+      "leaf_section": "Video links",
+      "legacy_route_count": 2,
+      "legacy_routes": [
+        {
+          "category": "Links",
+          "key": "pref_link_video",
+          "logical_kind": "stored_setting",
+          "resource": "pref_general_v2",
+          "root_referenced": true
+        },
+        {
+          "category": "Links to open in app",
+          "key": "pref_link_video",
+          "logical_kind": "stored_setting",
+          "resource": "pref_links_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Links & browser",
+      "page_intro": "Choose how links open and which browser behavior Boost uses.",
+      "proposed_summary": "Disable to open with external app",
+      "root": "Media",
+      "screen_depth": 2,
+      "screen_path": [
+        "Media",
+        "Links & browser",
+        "Video links"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Video links",
+      "title": "Internal Youtube player"
+    },
+    {
+      "default_value": "false",
+      "dependency": "",
+      "existing_summary": "Start videos muted by default",
+      "help_treatment": "REVIEW_EXISTING_SUMMARY",
+      "key": "pref_video_audio_start_muted",
+      "leaf_section": "Audio",
+      "legacy_route_count": 2,
+      "legacy_routes": [
+        {
+          "category": "Links",
+          "key": "pref_video_audio_start_muted",
+          "logical_kind": "stored_setting",
+          "resource": "pref_general_v2",
+          "root_referenced": true
+        },
+        {
+          "category": "Video viewer",
+          "key": "pref_video_audio_start_muted",
+          "logical_kind": "stored_setting",
+          "resource": "pref_media_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Playback & autoplay",
+      "page_intro": "Control video, audio, autoplay, and player behavior.",
+      "proposed_summary": "Start videos muted by default",
+      "root": "Media",
+      "screen_depth": 2,
+      "screen_path": [
+        "Media",
+        "Playback & autoplay",
+        "Audio"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Audio",
+      "title": "Mute audio"
+    },
+    {
+      "default_value": "1",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE+PROGRESSIVE_DISCLOSURE",
+      "key": "pref_autoplay_cards",
+      "leaf_section": "Autoplay",
+      "legacy_route_count": 2,
+      "legacy_routes": [
+        {
+          "category": "Videos",
+          "key": "pref_autoplay_cards",
+          "logical_kind": "stored_setting",
+          "resource": "pref_data_v2",
+          "root_referenced": true
+        },
+        {
+          "category": "Links",
+          "key": "pref_autoplay_cards",
+          "logical_kind": "stored_setting",
+          "resource": "pref_general_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Playback & autoplay",
+      "page_intro": "Control video, audio, autoplay, and player behavior.",
+      "proposed_summary": "",
+      "root": "Media",
+      "screen_depth": 2,
+      "screen_path": [
+        "Media",
+        "Playback & autoplay",
+        "Autoplay"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "string",
+      "subscreen": "Autoplay",
+      "title": "Autoplay videos"
+    },
+    {
+      "default_value": "boost",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE",
+      "key": "pref_media_viewer",
+      "leaf_section": "Media behavior",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Interface",
+          "key": "pref_media_viewer",
+          "logical_kind": "stored_setting",
+          "resource": "pref_media_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Playback & autoplay",
+      "page_intro": "Control video, audio, autoplay, and player behavior.",
+      "proposed_summary": "",
+      "root": "Media",
+      "screen_depth": 2,
+      "screen_path": [
+        "Media",
+        "Playback & autoplay",
+        "Media behavior"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "string",
+      "subscreen": "Media behavior",
+      "title": "Media viewer"
+    },
+    {
+      "default_value": "show",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE",
+      "key": "pref_media_overlay_visibility",
+      "leaf_section": "Media behavior",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Interface",
+          "key": "pref_media_overlay_visibility",
+          "logical_kind": "stored_setting",
+          "resource": "pref_media_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Playback & autoplay",
+      "page_intro": "Control video, audio, autoplay, and player behavior.",
+      "proposed_summary": "",
+      "root": "Media",
+      "screen_depth": 2,
+      "screen_path": [
+        "Media",
+        "Playback & autoplay",
+        "Media behavior"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "string",
+      "subscreen": "Media behavior",
+      "title": "Overlay elements"
+    },
+    {
+      "default_value": "false",
+      "dependency": "",
+      "existing_summary": "Tap outside video to close (If enabled, vertical videos will be played horizontally)",
+      "help_treatment": "REVIEW_EXISTING_SUMMARY",
+      "key": "pref_tap_to_dismiss_youtube_videos",
+      "leaf_section": "Playback & autoplay",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Youtube",
+          "key": "pref_tap_to_dismiss_youtube_videos",
+          "logical_kind": "stored_setting",
+          "resource": "pref_media_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Playback & autoplay",
+      "page_intro": "Control video, audio, autoplay, and player behavior.",
+      "proposed_summary": "Tap outside video to close (If enabled, vertical videos will be played horizontally)",
+      "root": "Media",
+      "screen_depth": 2,
+      "screen_path": [
+        "Media",
+        "Playback & autoplay",
+        "Playback & autoplay"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Playback & autoplay",
+      "title": "Tap to dismiss Youtube"
+    },
+    {
+      "default_value": "0",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE",
+      "key": "pref_video_player",
+      "leaf_section": "Playback & autoplay",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Video viewer",
+          "key": "pref_video_player",
+          "logical_kind": "stored_setting",
+          "resource": "pref_media_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Playback & autoplay",
+      "page_intro": "Control video, audio, autoplay, and player behavior.",
+      "proposed_summary": "",
+      "root": "Media",
+      "screen_depth": 2,
+      "screen_path": [
+        "Media",
+        "Playback & autoplay",
+        "Playback & autoplay"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "string",
+      "subscreen": "Playback & autoplay",
+      "title": "Video player"
+    },
+    {
+      "default_value": "false",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE",
+      "key": "pref_all_delete",
+      "leaf_section": "History",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "History",
+          "key": "pref_all_delete",
+          "logical_kind": "special_preference",
+          "resource": "pref_privacy_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "special_preference",
+      "page": "History, privacy & recovery",
+      "page_intro": "Manage history, privacy, and supported archive recovery.",
+      "proposed_summary": "",
+      "root": "Notifications & account",
+      "screen_depth": 2,
+      "screen_path": [
+        "Notifications & account",
+        "History, privacy & recovery",
+        "History"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "none_or_custom",
+      "subscreen": "History",
+      "title": "Clear all history"
+    },
+    {
+      "default_value": "false",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE",
+      "key": "pref_history_delete",
+      "leaf_section": "History",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "History",
+          "key": "pref_history_delete",
+          "logical_kind": "special_preference",
+          "resource": "pref_privacy_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "special_preference",
+      "page": "History, privacy & recovery",
+      "page_intro": "Manage history, privacy, and supported archive recovery.",
+      "proposed_summary": "",
+      "root": "Notifications & account",
+      "screen_depth": 2,
+      "screen_path": [
+        "Notifications & account",
+        "History, privacy & recovery",
+        "History"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "none_or_custom",
+      "subscreen": "History",
+      "title": "Clear community history"
+    },
+    {
+      "default_value": "false",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE",
+      "key": "pref_recent_posts_delete",
+      "leaf_section": "History",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "History",
+          "key": "pref_recent_posts_delete",
+          "logical_kind": "special_preference",
+          "resource": "pref_privacy_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "special_preference",
+      "page": "History, privacy & recovery",
+      "page_intro": "Manage history, privacy, and supported archive recovery.",
+      "proposed_summary": "",
+      "root": "Notifications & account",
+      "screen_depth": 2,
+      "screen_path": [
+        "Notifications & account",
+        "History, privacy & recovery",
+        "History"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "none_or_custom",
+      "subscreen": "History",
+      "title": "Clear post history"
+    },
+    {
+      "default_value": "false",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE",
+      "key": "pref_searches_delete",
+      "leaf_section": "History",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "History",
+          "key": "pref_searches_delete",
+          "logical_kind": "special_preference",
+          "resource": "pref_privacy_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "special_preference",
+      "page": "History, privacy & recovery",
+      "page_intro": "Manage history, privacy, and supported archive recovery.",
+      "proposed_summary": "",
+      "root": "Notifications & account",
+      "screen_depth": 2,
+      "screen_path": [
+        "Notifications & account",
+        "History, privacy & recovery",
+        "History"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "none_or_custom",
+      "subscreen": "History",
+      "title": "Clear search history"
+    },
+    {
+      "default_value": "true",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE",
+      "key": "pref_recent_posts_save_nsfw",
+      "leaf_section": "History",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "History",
+          "key": "pref_recent_posts_save_nsfw",
+          "logical_kind": "stored_setting",
+          "resource": "pref_privacy_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "History, privacy & recovery",
+      "page_intro": "Manage history, privacy, and supported archive recovery.",
+      "proposed_summary": "",
+      "root": "Notifications & account",
+      "screen_depth": 2,
+      "screen_path": [
+        "Notifications & account",
+        "History, privacy & recovery",
+        "History"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "History",
+      "title": "Include NSFW posts"
+    },
+    {
+      "default_value": "true",
+      "dependency": "",
+      "existing_summary": "Visited communities show in autocomplete fields",
+      "help_treatment": "REVIEW_EXISTING_SUMMARY",
+      "key": "pref_history_save",
+      "leaf_section": "History",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "History",
+          "key": "pref_history_save",
+          "logical_kind": "stored_setting",
+          "resource": "pref_privacy_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "History, privacy & recovery",
+      "page_intro": "Manage history, privacy, and supported archive recovery.",
+      "proposed_summary": "Visited communities show in autocomplete fields",
+      "root": "Notifications & account",
+      "screen_depth": 2,
+      "screen_path": [
+        "Notifications & account",
+        "History, privacy & recovery",
+        "History"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "History",
+      "title": "Save recent communities"
+    },
+    {
+      "default_value": "true",
+      "dependency": "",
+      "existing_summary": "Visited posts show in History screen",
+      "help_treatment": "REVIEW_EXISTING_SUMMARY",
+      "key": "pref_recent_posts_save",
+      "leaf_section": "History",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "History",
+          "key": "pref_recent_posts_save",
+          "logical_kind": "stored_setting",
+          "resource": "pref_privacy_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "History, privacy & recovery",
+      "page_intro": "Manage history, privacy, and supported archive recovery.",
+      "proposed_summary": "Visited posts show in History screen",
+      "root": "Notifications & account",
+      "screen_depth": 2,
+      "screen_path": [
+        "Notifications & account",
+        "History, privacy & recovery",
+        "History"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "History",
+      "title": "Save recent posts"
+    },
+    {
+      "default_value": "true",
+      "dependency": "",
+      "existing_summary": "Recent searches are cleared on exit",
+      "help_treatment": "REVIEW_EXISTING_SUMMARY",
+      "key": "pref_search_history_save",
+      "leaf_section": "History",
+      "legacy_route_count": 2,
+      "legacy_routes": [
+        {
+          "category": "History",
+          "key": "pref_search_history_save",
+          "logical_kind": "stored_setting",
+          "resource": "pref_privacy_v2",
+          "root_referenced": true
+        },
+        {
+          "category": "Suggestions",
+          "key": "pref_search_history_save",
+          "logical_kind": "stored_setting",
+          "resource": "pref_search_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "History, privacy & recovery",
+      "page_intro": "Manage history, privacy, and supported archive recovery.",
+      "proposed_summary": "Recent searches are cleared on exit",
+      "root": "Notifications & account",
+      "screen_depth": 2,
+      "screen_path": [
+        "Notifications & account",
+        "History, privacy & recovery",
+        "History"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "History",
+      "title": "Show recent searches"
+    },
+    {
+      "default_value": "false",
+      "dependency": "",
+      "existing_summary": "Try to restore supported missing Imgur media from archive sources. Disabled by default.",
+      "help_treatment": "REVIEW_EXISTING_SUMMARY+PROGRESSIVE_DISCLOSURE",
+      "key": "morphe_boost_imgur_undelete_enabled",
+      "leaf_section": "Recovery & archives",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Recovery & archives",
+          "key": "morphe_boost_imgur_undelete_enabled",
+          "logical_kind": "morphe_user_setting",
+          "resource": "morphe_boost_settings_skeleton",
+          "root_referenced": false
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "History, privacy & recovery",
+      "page_intro": "Manage history, privacy, and supported archive recovery.",
+      "proposed_summary": "Try to restore supported missing Imgur media from archive sources. Disabled by default.",
+      "root": "Notifications & account",
+      "screen_depth": 2,
+      "screen_path": [
+        "Notifications & account",
+        "History, privacy & recovery",
+        "Recovery & archives"
+      ],
+      "source_type": "morphe_embedded_xml",
+      "storage_type": "boolean",
+      "subscreen": "Recovery & archives",
+      "title": "Automatically undelete Imgur images"
+    },
+    {
+      "default_value": "false",
+      "dependency": "",
+      "existing_summary": "Try to restore supported deleted Reddit posts/comments from archive sources. Disabled by default to keep normal browsing stable.",
+      "help_treatment": "REVIEW_EXISTING_SUMMARY+PROGRESSIVE_DISCLOSURE",
+      "key": "morphe_boost_reddit_undelete_enabled",
+      "leaf_section": "Recovery & archives",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Recovery & archives",
+          "key": "morphe_boost_reddit_undelete_enabled",
+          "logical_kind": "morphe_user_setting",
+          "resource": "morphe_boost_settings_skeleton",
+          "root_referenced": false
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "History, privacy & recovery",
+      "page_intro": "Manage history, privacy, and supported archive recovery.",
+      "proposed_summary": "Try to restore supported deleted Reddit posts/comments from archive sources. Disabled by default to keep normal browsing stable.",
+      "root": "Notifications & account",
+      "screen_depth": 2,
+      "screen_path": [
+        "Notifications & account",
+        "History, privacy & recovery",
+        "Recovery & archives"
+      ],
+      "source_type": "morphe_embedded_xml",
+      "storage_type": "boolean",
+      "subscreen": "Recovery & archives",
+      "title": "Automatically undelete Reddit content"
+    },
+    {
+      "default_value": "true",
+      "dependency": "pref_check_messages_push",
+      "existing_summary": "Show only Boost notification",
+      "help_treatment": "REVIEW_EXISTING_SUMMARY+PROGRESSIVE_DISCLOSURE",
+      "key": "pref_check_messages_push_clear",
+      "leaf_section": "Advanced",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Advanced",
+          "key": "pref_check_messages_push_clear",
+          "logical_kind": "stored_setting",
+          "resource": "pref_messages_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Notifications & inbox",
+      "page_intro": "Control notifications, messages, and inbox behavior.",
+      "proposed_summary": "Show only Boost notification",
+      "root": "Notifications & account",
+      "screen_depth": 2,
+      "screen_path": [
+        "Notifications & account",
+        "Notifications & inbox",
+        "Advanced"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Advanced",
+      "title": "Clear source notification"
+    },
+    {
+      "default_value": "false",
+      "dependency": "pref_check_messages",
+      "existing_summary": "Requires the reddit app to be installed. Boost will show its own notifications when a push notification from reddit is received. Make sure your account is added to the reddit app and notifications are enabled",
+      "help_treatment": "REVIEW_EXISTING_SUMMARY+PROGRESSIVE_DISCLOSURE",
+      "key": "pref_check_messages_push",
+      "leaf_section": "Advanced",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Advanced",
+          "key": "pref_check_messages_push",
+          "logical_kind": "stored_setting",
+          "resource": "pref_messages_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Notifications & inbox",
+      "page_intro": "Control notifications, messages, and inbox behavior.",
+      "proposed_summary": "Requires the reddit app to be installed. Boost will show its own notifications when a push notification from reddit is received. Make sure your account is added to the reddit app and notifications are enabled",
+      "root": "Notifications & account",
+      "screen_depth": 2,
+      "screen_path": [
+        "Notifications & account",
+        "Notifications & inbox",
+        "Advanced"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Advanced",
+      "title": "Reddit push"
+    },
+    {
+      "default_value": "60",
+      "dependency": "pref_check_messages",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE",
+      "key": "pref_check_messages_interval",
+      "leaf_section": "Notifications",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": null,
+          "key": "pref_check_messages_interval",
+          "logical_kind": "stored_setting",
+          "resource": "pref_messages_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Notifications & inbox",
+      "page_intro": "Control notifications, messages, and inbox behavior.",
+      "proposed_summary": "",
+      "root": "Notifications & account",
+      "screen_depth": 2,
+      "screen_path": [
+        "Notifications & account",
+        "Notifications & inbox",
+        "Notifications"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "string",
+      "subscreen": "Notifications",
+      "title": "Check interval"
+    },
+    {
+      "default_value": "true",
+      "dependency": "pref_check_messages",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE",
+      "key": "pref_check_modmail",
+      "leaf_section": "Notifications",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": null,
+          "key": "pref_check_modmail",
+          "logical_kind": "stored_setting",
+          "resource": "pref_messages_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Notifications & inbox",
+      "page_intro": "Control notifications, messages, and inbox behavior.",
+      "proposed_summary": "",
+      "root": "Notifications & account",
+      "screen_depth": 2,
+      "screen_path": [
+        "Notifications & account",
+        "Notifications & inbox",
+        "Notifications"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Notifications",
+      "title": "Check moderator mail"
+    },
+    {
+      "default_value": "true",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE+PROGRESSIVE_DISCLOSURE",
+      "key": "pref_check_messages",
+      "leaf_section": "Notifications",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": null,
+          "key": "pref_check_messages",
+          "logical_kind": "stored_setting",
+          "resource": "pref_messages_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Notifications & inbox",
+      "page_intro": "Control notifications, messages, and inbox behavior.",
+      "proposed_summary": "",
+      "root": "Notifications & account",
+      "screen_depth": 2,
+      "screen_path": [
+        "Notifications & account",
+        "Notifications & inbox",
+        "Notifications"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Notifications",
+      "title": "Check notifications"
+    },
+    {
+      "default_value": "",
+      "dependency": "",
+      "existing_summary": "Open system notification settings",
+      "help_treatment": "REVIEW_EXISTING_SUMMARY+PROGRESSIVE_DISCLOSURE",
+      "key": "pref_notifications_configure",
+      "leaf_section": "Notifications",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": null,
+          "key": "pref_notifications_configure",
+          "logical_kind": "action",
+          "resource": "pref_messages_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "action",
+      "page": "Notifications & inbox",
+      "page_intro": "Control notifications, messages, and inbox behavior.",
+      "proposed_summary": "Open system notification settings",
+      "root": "Notifications & account",
+      "screen_depth": 2,
+      "screen_path": [
+        "Notifications & account",
+        "Notifications & inbox",
+        "Notifications"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "none_or_custom",
+      "subscreen": "Notifications",
+      "title": "Configure notifications"
+    },
+    {
+      "default_value": "",
+      "dependency": "",
+      "existing_summary": "Version",
+      "help_treatment": "REVIEW_EXISTING_SUMMARY",
+      "key": "about_version",
+      "leaf_section": "About Boost",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": null,
+          "key": "about_version",
+          "logical_kind": "action",
+          "resource": "pref_about_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "action",
+      "page": "About & support",
+      "page_intro": "View app information, legal information, and support actions.",
+      "proposed_summary": "Version",
+      "root": "Data & app",
+      "screen_depth": 2,
+      "screen_path": [
+        "Data & app",
+        "About & support",
+        "About Boost"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "none_or_custom",
+      "subscreen": "About Boost",
+      "title": "Changelog"
+    },
+    {
+      "default_value": "",
+      "dependency": "",
+      "existing_summary": "Rate it in Google Play",
+      "help_treatment": "REVIEW_EXISTING_SUMMARY",
+      "key": "rate_app",
+      "leaf_section": "About Boost",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": null,
+          "key": "rate_app",
+          "logical_kind": "action",
+          "resource": "pref_about_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "action",
+      "page": "About & support",
+      "page_intro": "View app information, legal information, and support actions.",
+      "proposed_summary": "Rate it in Google Play",
+      "root": "Data & app",
+      "screen_depth": 2,
+      "screen_path": [
+        "Data & app",
+        "About & support",
+        "About Boost"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "none_or_custom",
+      "subscreen": "About Boost",
+      "title": "Do you like this app?"
+    },
+    {
+      "default_value": "",
+      "dependency": "",
+      "existing_summary": "r/BoostForReddit",
+      "help_treatment": "REVIEW_EXISTING_SUMMARY",
+      "key": "about_subreddit",
+      "leaf_section": "About Boost",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": null,
+          "key": "about_subreddit",
+          "logical_kind": "action",
+          "resource": "pref_about_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "action",
+      "page": "About & support",
+      "page_intro": "View app information, legal information, and support actions.",
+      "proposed_summary": "r/BoostForReddit",
+      "root": "Data & app",
+      "screen_depth": 2,
+      "screen_path": [
+        "Data & app",
+        "About & support",
+        "About Boost"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "none_or_custom",
+      "subscreen": "About Boost",
+      "title": "Feedback and support"
+    },
+    {
+      "default_value": "",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "OMIT_OR_ONE_LINE_ACTION_HINT",
+      "key": "about_faq",
+      "leaf_section": "About Boost",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": null,
+          "key": "about_faq",
+          "logical_kind": "action",
+          "resource": "pref_about_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "action",
+      "page": "About & support",
+      "page_intro": "View app information, legal information, and support actions.",
+      "proposed_summary": "",
+      "root": "Data & app",
+      "screen_depth": 2,
+      "screen_path": [
+        "Data & app",
+        "About & support",
+        "About Boost"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "none_or_custom",
+      "subscreen": "About Boost",
+      "title": "Help/FAQ"
+    },
+    {
+      "default_value": "",
+      "dependency": "",
+      "existing_summary": "Give Boost some love!",
+      "help_treatment": "REVIEW_EXISTING_SUMMARY",
+      "key": "support_launch",
+      "leaf_section": "About Boost",
+      "legacy_route_count": 2,
+      "legacy_routes": [
+        {
+          "category": null,
+          "key": "support_launch",
+          "logical_kind": "action",
+          "resource": "pref_about_v2",
+          "root_referenced": true
+        },
+        {
+          "category": null,
+          "key": "support_launch",
+          "logical_kind": "action",
+          "resource": "pref_headers_v2",
+          "root_referenced": false
+        }
+      ],
+      "logical_kind": "action",
+      "page": "About & support",
+      "page_intro": "View app information, legal information, and support actions.",
+      "proposed_summary": "Give Boost some love!",
+      "root": "Data & app",
+      "screen_depth": 2,
+      "screen_path": [
+        "Data & app",
+        "About & support",
+        "About Boost"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "none_or_custom",
+      "subscreen": "About Boost",
+      "title": "Launch the rocket"
+    },
+    {
+      "default_value": "",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "OMIT_OR_ONE_LINE_ACTION_HINT",
+      "key": "licenses_preference",
+      "leaf_section": "About Boost",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": null,
+          "key": "licenses_preference",
+          "logical_kind": "action",
+          "resource": "pref_about_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "action",
+      "page": "About & support",
+      "page_intro": "View app information, legal information, and support actions.",
+      "proposed_summary": "",
+      "root": "Data & app",
+      "screen_depth": 2,
+      "screen_path": [
+        "Data & app",
+        "About & support",
+        "About Boost"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "none_or_custom",
+      "subscreen": "About Boost",
+      "title": "Licenses"
+    },
+    {
+      "default_value": "",
+      "dependency": "",
+      "existing_summary": "mayayo.dev@gmail.com",
+      "help_treatment": "REVIEW_EXISTING_SUMMARY",
+      "key": "contact_dev_key",
+      "leaf_section": "Author",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Author",
+          "key": "contact_dev_key",
+          "logical_kind": "action",
+          "resource": "pref_about_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "action",
+      "page": "About & support",
+      "page_intro": "View app information, legal information, and support actions.",
+      "proposed_summary": "mayayo.dev@gmail.com",
+      "root": "Data & app",
+      "screen_depth": 2,
+      "screen_path": [
+        "Data & app",
+        "About & support",
+        "Author"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "none_or_custom",
+      "subscreen": "Author",
+      "title": "Email"
+    },
+    {
+      "default_value": "",
+      "dependency": "",
+      "existing_summary": "u/rmayayo",
+      "help_treatment": "REVIEW_EXISTING_SUMMARY",
+      "key": "about_reddit",
+      "leaf_section": "Author",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Author",
+          "key": "about_reddit",
+          "logical_kind": "action",
+          "resource": "pref_about_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "action",
+      "page": "About & support",
+      "page_intro": "View app information, legal information, and support actions.",
+      "proposed_summary": "u/rmayayo",
+      "root": "Data & app",
+      "screen_depth": 2,
+      "screen_path": [
+        "Data & app",
+        "About & support",
+        "Author"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "none_or_custom",
+      "subscreen": "Author",
+      "title": "reddit"
+    },
+    {
+      "default_value": "",
+      "dependency": "",
+      "existing_summary": "@rmayayo",
+      "help_treatment": "REVIEW_EXISTING_SUMMARY",
+      "key": "about_twitter",
+      "leaf_section": "Author",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Author",
+          "key": "about_twitter",
+          "logical_kind": "action",
+          "resource": "pref_about_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "action",
+      "page": "About & support",
+      "page_intro": "View app information, legal information, and support actions.",
+      "proposed_summary": "@rmayayo",
+      "root": "Data & app",
+      "screen_depth": 2,
+      "screen_path": [
+        "Data & app",
+        "About & support",
+        "Author"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "none_or_custom",
+      "subscreen": "Author",
+      "title": "Twitter"
+    },
+    {
+      "default_value": "",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "OMIT_OR_ONE_LINE_ACTION_HINT+PROGRESSIVE_DISCLOSURE",
+      "key": "privacy_policy",
+      "leaf_section": "Privacy",
+      "legacy_route_count": 2,
+      "legacy_routes": [
+        {
+          "category": "Privacy",
+          "key": "privacy_policy",
+          "logical_kind": "action",
+          "resource": "pref_about_v2",
+          "root_referenced": true
+        },
+        {
+          "category": null,
+          "key": "privacy_policy",
+          "logical_kind": "action",
+          "resource": "pref_headers_v2",
+          "root_referenced": false
+        }
+      ],
+      "logical_kind": "action",
+      "page": "About & support",
+      "page_intro": "View app information, legal information, and support actions.",
+      "proposed_summary": "",
+      "root": "Data & app",
+      "screen_depth": 2,
+      "screen_path": [
+        "Data & app",
+        "About & support",
+        "Privacy"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "none_or_custom",
+      "subscreen": "Privacy",
+      "title": "Privacy policy"
+    },
+    {
+      "default_value": "false",
+      "dependency": "",
+      "existing_summary": "For users in the European Union",
+      "help_treatment": "REVIEW_EXISTING_SUMMARY",
+      "key": "pref_gdpr_revoke",
+      "leaf_section": "Privacy",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Privacy",
+          "key": "pref_gdpr_revoke",
+          "logical_kind": "special_preference",
+          "resource": "pref_about_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "special_preference",
+      "page": "About & support",
+      "page_intro": "View app information, legal information, and support actions.",
+      "proposed_summary": "For users in the European Union",
+      "root": "Data & app",
+      "screen_depth": 2,
+      "screen_path": [
+        "Data & app",
+        "About & support",
+        "Privacy"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "none_or_custom",
+      "subscreen": "Privacy",
+      "title": "Revoke GDPR consent"
+    },
+    {
+      "default_value": "true",
+      "dependency": "",
+      "existing_summary": "Automatically send usage statistics and crash reports to help us improve Boost for reddit",
+      "help_treatment": "REVIEW_EXISTING_SUMMARY",
+      "key": "pref_statistics",
+      "leaf_section": "Privacy",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Privacy",
+          "key": "pref_statistics",
+          "logical_kind": "stored_setting",
+          "resource": "pref_about_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "About & support",
+      "page_intro": "View app information, legal information, and support actions.",
+      "proposed_summary": "Automatically send usage statistics and crash reports to help us improve Boost for reddit",
+      "root": "Data & app",
+      "screen_depth": 2,
+      "screen_path": [
+        "Data & app",
+        "About & support",
+        "Privacy"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Privacy",
+      "title": "Send statistics"
+    },
+    {
+      "default_value": "true",
+      "dependency": "",
+      "existing_summary": "Crop community icon into a circular shape. Recommended if your launcher uses round icons",
+      "help_treatment": "REVIEW_EXISTING_SUMMARY",
+      "key": "pref_shortcut_icon_crop",
+      "leaf_section": "Community shortcuts",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Community shortcuts",
+          "key": "pref_shortcut_icon_crop",
+          "logical_kind": "stored_setting",
+          "resource": "pref_misc_v2",
+          "root_referenced": false
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "App behavior & compatibility",
+      "page_intro": "Manage app-wide compatibility options and remaining global behavior.",
+      "proposed_summary": "Crop community icon into a circular shape. Recommended if your launcher uses round icons",
+      "root": "Data & app",
+      "screen_depth": 2,
+      "screen_path": [
+        "Data & app",
+        "App behavior & compatibility",
+        "Community shortcuts"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Community shortcuts",
+      "title": "Crop community icon"
+    },
+    {
+      "default_value": "3",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE+PROGRESSIVE_DISCLOSURE",
+      "key": "pref_autoplay_swipe",
+      "leaf_section": "Compatibility & legacy",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Legacy features",
+          "key": "pref_autoplay_swipe",
+          "logical_kind": "stored_setting",
+          "resource": "pref_misc_v2",
+          "root_referenced": false
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "App behavior & compatibility",
+      "page_intro": "Manage app-wide compatibility options and remaining global behavior.",
+      "proposed_summary": "",
+      "root": "Data & app",
+      "screen_depth": 2,
+      "screen_path": [
+        "Data & app",
+        "App behavior & compatibility",
+        "Compatibility & legacy"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "string",
+      "subscreen": "Compatibility & legacy",
+      "title": "Autoplay videos in Swipe view"
+    },
+    {
+      "default_value": "true",
+      "dependency": "",
+      "existing_summary": "Color tags in images indicating the link type",
+      "help_treatment": "REVIEW_EXISTING_SUMMARY",
+      "key": "pref_info_color_indicators",
+      "leaf_section": "Compatibility & legacy",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Legacy features",
+          "key": "pref_info_color_indicators",
+          "logical_kind": "stored_setting",
+          "resource": "pref_misc_v2",
+          "root_referenced": false
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "App behavior & compatibility",
+      "page_intro": "Manage app-wide compatibility options and remaining global behavior.",
+      "proposed_summary": "Color tags in images indicating the link type",
+      "root": "Data & app",
+      "screen_depth": 2,
+      "screen_path": [
+        "Data & app",
+        "App behavior & compatibility",
+        "Compatibility & legacy"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Compatibility & legacy",
+      "title": "Colored link type indicators"
+    },
+    {
+      "default_value": "false",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE",
+      "key": "pref_go_to_sub_dialog",
+      "leaf_section": "Compatibility & legacy",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Legacy features",
+          "key": "pref_go_to_sub_dialog",
+          "logical_kind": "stored_setting",
+          "resource": "pref_misc_v2",
+          "root_referenced": false
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "App behavior & compatibility",
+      "page_intro": "Manage app-wide compatibility options and remaining global behavior.",
+      "proposed_summary": "",
+      "root": "Data & app",
+      "screen_depth": 2,
+      "screen_path": [
+        "Data & app",
+        "App behavior & compatibility",
+        "Compatibility & legacy"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Compatibility & legacy",
+      "title": "Go to community in a dialog"
+    },
+    {
+      "default_value": "false",
+      "dependency": "",
+      "existing_summary": "Show image preview above post title",
+      "help_treatment": "REVIEW_EXISTING_SUMMARY",
+      "key": "pref_cards_preview_top",
+      "leaf_section": "Compatibility & legacy",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Legacy features",
+          "key": "pref_cards_preview_top",
+          "logical_kind": "stored_setting",
+          "resource": "pref_misc_v2",
+          "root_referenced": false
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "App behavior & compatibility",
+      "page_intro": "Manage app-wide compatibility options and remaining global behavior.",
+      "proposed_summary": "Show image preview above post title",
+      "root": "Data & app",
+      "screen_depth": 2,
+      "screen_path": [
+        "Data & app",
+        "App behavior & compatibility",
+        "Compatibility & legacy"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Compatibility & legacy",
+      "title": "Previews on top"
+    },
+    {
+      "default_value": "true",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE",
+      "key": "pref_info_post_shorten_score",
+      "leaf_section": "Compatibility & legacy",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Legacy features",
+          "key": "pref_info_post_shorten_score",
+          "logical_kind": "stored_setting",
+          "resource": "pref_misc_v2",
+          "root_referenced": false
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "App behavior & compatibility",
+      "page_intro": "Manage app-wide compatibility options and remaining global behavior.",
+      "proposed_summary": "",
+      "root": "Data & app",
+      "screen_depth": 2,
+      "screen_path": [
+        "Data & app",
+        "App behavior & compatibility",
+        "Compatibility & legacy"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Compatibility & legacy",
+      "title": "Shorten score"
+    },
+    {
+      "default_value": "false",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE",
+      "key": "pref_send_floating_button",
+      "leaf_section": "Compatibility & legacy",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Legacy features",
+          "key": "pref_send_floating_button",
+          "logical_kind": "stored_setting",
+          "resource": "pref_misc_v2",
+          "root_referenced": false
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "App behavior & compatibility",
+      "page_intro": "Manage app-wide compatibility options and remaining global behavior.",
+      "proposed_summary": "",
+      "root": "Data & app",
+      "screen_depth": 2,
+      "screen_path": [
+        "Data & app",
+        "App behavior & compatibility",
+        "Compatibility & legacy"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Compatibility & legacy",
+      "title": "Show floating send button"
+    },
+    {
+      "default_value": "true",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE",
+      "key": "pref_info_post_self_image",
+      "leaf_section": "Compatibility & legacy",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Legacy features",
+          "key": "pref_info_post_self_image",
+          "logical_kind": "stored_setting",
+          "resource": "pref_misc_v2",
+          "root_referenced": false
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "App behavior & compatibility",
+      "page_intro": "Manage app-wide compatibility options and remaining global behavior.",
+      "proposed_summary": "",
+      "root": "Data & app",
+      "screen_depth": 2,
+      "screen_path": [
+        "Data & app",
+        "App behavior & compatibility",
+        "Compatibility & legacy"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Compatibility & legacy",
+      "title": "Show images from text posts"
+    },
+    {
+      "default_value": "true",
+      "dependency": "",
+      "existing_summary": "Own posts and moderator",
+      "help_treatment": "REVIEW_EXISTING_SUMMARY",
+      "key": "pref_info_post_view_count",
+      "leaf_section": "Compatibility & legacy",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Legacy features",
+          "key": "pref_info_post_view_count",
+          "logical_kind": "stored_setting",
+          "resource": "pref_misc_v2",
+          "root_referenced": false
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "App behavior & compatibility",
+      "page_intro": "Manage app-wide compatibility options and remaining global behavior.",
+      "proposed_summary": "Own posts and moderator",
+      "root": "Data & app",
+      "screen_depth": 2,
+      "screen_path": [
+        "Data & app",
+        "App behavior & compatibility",
+        "Compatibility & legacy"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Compatibility & legacy",
+      "title": "Show view count"
+    },
+    {
+      "default_value": "false",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE",
+      "key": "pref_toolbar_dropdown",
+      "leaf_section": "Compatibility & legacy",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Legacy features",
+          "key": "pref_toolbar_dropdown",
+          "logical_kind": "stored_setting",
+          "resource": "pref_misc_v2",
+          "root_referenced": false
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "App behavior & compatibility",
+      "page_intro": "Manage app-wide compatibility options and remaining global behavior.",
+      "proposed_summary": "",
+      "root": "Data & app",
+      "screen_depth": 2,
+      "screen_path": [
+        "Data & app",
+        "App behavior & compatibility",
+        "Compatibility & legacy"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Compatibility & legacy",
+      "title": "Subscriptions dropdown in toolbar"
+    },
+    {
+      "default_value": "true",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE",
+      "key": "pref_toolbar_tap_to_go",
+      "leaf_section": "Compatibility & legacy",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Legacy features",
+          "key": "pref_toolbar_tap_to_go",
+          "logical_kind": "stored_setting",
+          "resource": "pref_misc_v2",
+          "root_referenced": false
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "App behavior & compatibility",
+      "page_intro": "Manage app-wide compatibility options and remaining global behavior.",
+      "proposed_summary": "",
+      "root": "Data & app",
+      "screen_depth": 2,
+      "screen_path": [
+        "Data & app",
+        "App behavior & compatibility",
+        "Compatibility & legacy"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Compatibility & legacy",
+      "title": "Tap toolbar to show subs"
+    },
+    {
+      "default_value": "false",
+      "dependency": "",
+      "existing_summary": "Community and post info below title, no icon",
+      "help_treatment": "REVIEW_EXISTING_SUMMARY",
+      "key": "pref_cards_legacy",
+      "leaf_section": "Compatibility & legacy",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Legacy features",
+          "key": "pref_cards_legacy",
+          "logical_kind": "stored_setting",
+          "resource": "pref_misc_v2",
+          "root_referenced": false
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "App behavior & compatibility",
+      "page_intro": "Manage app-wide compatibility options and remaining global behavior.",
+      "proposed_summary": "Community and post info below title, no icon",
+      "root": "Data & app",
+      "screen_depth": 2,
+      "screen_path": [
+        "Data & app",
+        "App behavior & compatibility",
+        "Compatibility & legacy"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Compatibility & legacy",
+      "title": "Use legacy cards layout"
+    },
+    {
+      "default_value": "0",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE",
+      "key": "pref_ad_format",
+      "leaf_section": "Other app behavior",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Misc",
+          "key": "pref_ad_format",
+          "logical_kind": "stored_setting",
+          "resource": "pref_misc_v2",
+          "root_referenced": false
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "App behavior & compatibility",
+      "page_intro": "Manage app-wide compatibility options and remaining global behavior.",
+      "proposed_summary": "",
+      "root": "Data & app",
+      "screen_depth": 2,
+      "screen_path": [
+        "Data & app",
+        "App behavior & compatibility",
+        "Other app behavior"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "string",
+      "subscreen": "Other app behavior",
+      "title": "Preferred Ad format"
+    },
+    {
+      "default_value": "",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "OMIT_OR_ONE_LINE_ACTION_HINT",
+      "key": "reset_tips",
+      "leaf_section": "Other app behavior",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Misc",
+          "key": "reset_tips",
+          "logical_kind": "action",
+          "resource": "pref_misc_v2",
+          "root_referenced": false
+        }
+      ],
+      "logical_kind": "action",
+      "page": "App behavior & compatibility",
+      "page_intro": "Manage app-wide compatibility options and remaining global behavior.",
+      "proposed_summary": "",
+      "root": "Data & app",
+      "screen_depth": 2,
+      "screen_path": [
+        "Data & app",
+        "App behavior & compatibility",
+        "Other app behavior"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "none_or_custom",
+      "subscreen": "Other app behavior",
+      "title": "Reset tips"
+    },
+    {
+      "default_value": "true",
+      "dependency": "",
+      "existing_summary": "Use Morphe's modern task-based settings. Reopen Settings to apply.",
+      "help_treatment": "REVIEW_EXISTING_SUMMARY",
+      "key": "morphe_boost_settings_v4_enabled",
+      "leaf_section": "Settings presentation",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Settings",
+          "key": "morphe_boost_settings_v4_enabled",
+          "logical_kind": "morphe_user_setting",
+          "resource": "morphe_boost_settings_skeleton",
+          "root_referenced": false
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Settings experience",
+      "page_intro": "Choose which Settings presentation Boost uses.",
+      "proposed_summary": "Use Morphe's modern task-based settings. Reopen Settings to apply.",
+      "root": "Data & app",
+      "screen_depth": 2,
+      "screen_path": [
+        "Data & app",
+        "Settings experience",
+        "Settings presentation"
+      ],
+      "source_type": "morphe_embedded_xml",
+      "storage_type": "boolean",
+      "subscreen": "Settings presentation",
+      "title": "Material settings"
+    },
+    {
+      "default_value": "",
+      "dependency": "",
+      "existing_summary": "Delete images and videos from cache",
+      "help_treatment": "REVIEW_EXISTING_SUMMARY+PROGRESSIVE_DISCLOSURE",
+      "key": "pref_cache_current_size",
+      "leaf_section": "Cache",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Cache",
+          "key": "pref_cache_current_size",
+          "logical_kind": "action",
+          "resource": "pref_data_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "action",
+      "page": "Storage & bandwidth",
+      "page_intro": "Control data usage, caching, and bandwidth-sensitive behavior.",
+      "proposed_summary": "Delete images and videos from cache",
+      "root": "Data & app",
+      "screen_depth": 2,
+      "screen_path": [
+        "Data & app",
+        "Storage & bandwidth",
+        "Cache"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "none_or_custom",
+      "subscreen": "Cache",
+      "title": "Clear cache"
+    },
+    {
+      "default_value": "128",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE+PROGRESSIVE_DISCLOSURE",
+      "key": "pref_cache_max_size",
+      "leaf_section": "Cache",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Cache",
+          "key": "pref_cache_max_size",
+          "logical_kind": "stored_setting",
+          "resource": "pref_data_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Storage & bandwidth",
+      "page_intro": "Control data usage, caching, and bandwidth-sensitive behavior.",
+      "proposed_summary": "",
+      "root": "Data & app",
+      "screen_depth": 2,
+      "screen_path": [
+        "Data & app",
+        "Storage & bandwidth",
+        "Cache"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "string",
+      "subscreen": "Cache",
+      "title": "Maximum cache size"
+    },
+    {
+      "default_value": "true",
+      "dependency": "",
+      "existing_summary": "Load lower-size media",
+      "help_treatment": "REVIEW_EXISTING_SUMMARY+PROGRESSIVE_DISCLOSURE",
+      "key": "pref_reduce_mobile",
+      "leaf_section": "Data saver",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Data saver",
+          "key": "pref_reduce_mobile",
+          "logical_kind": "stored_setting",
+          "resource": "pref_data_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Storage & bandwidth",
+      "page_intro": "Control data usage, caching, and bandwidth-sensitive behavior.",
+      "proposed_summary": "Load lower-size media",
+      "root": "Data & app",
+      "screen_depth": 2,
+      "screen_path": [
+        "Data & app",
+        "Storage & bandwidth",
+        "Data saver"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Data saver",
+      "title": "Mobile data saver"
+    },
+    {
+      "default_value": "false",
+      "dependency": "",
+      "existing_summary": "Load lower-size media",
+      "help_treatment": "REVIEW_EXISTING_SUMMARY+PROGRESSIVE_DISCLOSURE",
+      "key": "pref_reduce_wifi",
+      "leaf_section": "Data saver",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Data saver",
+          "key": "pref_reduce_wifi",
+          "logical_kind": "stored_setting",
+          "resource": "pref_data_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Storage & bandwidth",
+      "page_intro": "Control data usage, caching, and bandwidth-sensitive behavior.",
+      "proposed_summary": "Load lower-size media",
+      "root": "Data & app",
+      "screen_depth": 2,
+      "screen_path": [
+        "Data & app",
+        "Storage & bandwidth",
+        "Data saver"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Data saver",
+      "title": "Wifi data saver"
+    },
+    {
+      "default_value": "",
+      "dependency": "",
+      "existing_summary": "Change download folder location",
+      "help_treatment": "REVIEW_EXISTING_SUMMARY+PROGRESSIVE_DISCLOSURE",
+      "key": "pref_download_folders",
+      "leaf_section": "Data usage",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": null,
+          "key": "pref_download_folders",
+          "logical_kind": "action",
+          "resource": "pref_data_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "action",
+      "page": "Storage & bandwidth",
+      "page_intro": "Control data usage, caching, and bandwidth-sensitive behavior.",
+      "proposed_summary": "Change download folder location",
+      "root": "Data & app",
+      "screen_depth": 2,
+      "screen_path": [
+        "Data & app",
+        "Storage & bandwidth",
+        "Data usage"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "none_or_custom",
+      "subscreen": "Data usage",
+      "title": "Configure downloads"
+    },
+    {
+      "default_value": "0",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE",
+      "key": "pref_load_images",
+      "leaf_section": "Images",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Images",
+          "key": "pref_load_images",
+          "logical_kind": "stored_setting",
+          "resource": "pref_data_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Storage & bandwidth",
+      "page_intro": "Control data usage, caching, and bandwidth-sensitive behavior.",
+      "proposed_summary": "",
+      "root": "Data & app",
+      "screen_depth": 2,
+      "screen_path": [
+        "Data & app",
+        "Storage & bandwidth",
+        "Images"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "string",
+      "subscreen": "Images",
+      "title": "Load images"
+    },
+    {
+      "default_value": "1080",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE+PROGRESSIVE_DISCLOSURE",
+      "key": "pref_video_quality_max",
+      "leaf_section": "Videos",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Videos",
+          "key": "pref_video_quality_max",
+          "logical_kind": "stored_setting",
+          "resource": "pref_data_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Storage & bandwidth",
+      "page_intro": "Control data usage, caching, and bandwidth-sensitive behavior.",
+      "proposed_summary": "",
+      "root": "Data & app",
+      "screen_depth": 2,
+      "screen_path": [
+        "Data & app",
+        "Storage & bandwidth",
+        "Videos"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "string",
+      "subscreen": "Videos",
+      "title": "Maximum quality"
+    },
+    {
+      "default_value": "480",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE+PROGRESSIVE_DISCLOSURE",
+      "key": "pref_video_quality_min",
+      "leaf_section": "Videos",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Videos",
+          "key": "pref_video_quality_min",
+          "logical_kind": "stored_setting",
+          "resource": "pref_data_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Storage & bandwidth",
+      "page_intro": "Control data usage, caching, and bandwidth-sensitive behavior.",
+      "proposed_summary": "",
+      "root": "Data & app",
+      "screen_depth": 2,
+      "screen_path": [
+        "Data & app",
+        "Storage & bandwidth",
+        "Videos"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "string",
+      "subscreen": "Videos",
+      "title": "Minimum quality"
+    },
+    {
+      "default_value": "0",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE+PROGRESSIVE_DISCLOSURE",
+      "key": "pref_video_quality",
+      "leaf_section": "Videos",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Videos",
+          "key": "pref_video_quality",
+          "logical_kind": "stored_setting",
+          "resource": "pref_data_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Storage & bandwidth",
+      "page_intro": "Control data usage, caching, and bandwidth-sensitive behavior.",
+      "proposed_summary": "",
+      "root": "Data & app",
+      "screen_depth": 2,
+      "screen_path": [
+        "Data & app",
+        "Storage & bandwidth",
+        "Videos"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "string",
+      "subscreen": "Videos",
+      "title": "Video quality"
+    }
+  ],
+  "moves": [
+    {
+      "from_page": "Search & filters",
+      "from_root": "Reading & interaction",
+      "from_subscreen": "More options",
+      "key": "pref_blur_nsfw_images",
+      "title": "Blur images in NSFW posts",
+      "to_page": "Search & filters",
+      "to_root": "Reading & interaction",
+      "to_subscreen": "Filter behavior"
+    },
+    {
+      "from_page": "Search & filters",
+      "from_root": "Reading & interaction",
+      "from_subscreen": "More options",
+      "key": "pref_load_nsfw_images",
+      "title": "Show images in NSFW posts",
+      "to_page": "Search & filters",
+      "to_root": "Reading & interaction",
+      "to_subscreen": "Filter behavior"
+    },
+    {
+      "from_page": "Search & filters",
+      "from_root": "Reading & interaction",
+      "from_subscreen": "More options",
+      "key": "pref_nsfw",
+      "title": "Show NSFW",
+      "to_page": "Search & filters",
+      "to_root": "Reading & interaction",
+      "to_subscreen": "Filter behavior"
+    },
+    {
+      "from_page": "Navigation & gestures",
+      "from_root": "Navigation",
+      "from_subscreen": "Additional navigation behavior",
+      "key": "pref_edit_subscriptions",
+      "title": "Subscriptions",
+      "to_page": "Feeds & subscriptions",
+      "to_root": "Reading & interaction",
+      "to_subscreen": "Manage subscriptions"
+    },
+    {
+      "from_page": "Navigation & gestures",
+      "from_root": "Navigation",
+      "from_subscreen": "Additional navigation behavior",
+      "key": "pref_split_screen",
+      "title": "Tablet split screen mode",
+      "to_page": "Post layout",
+      "to_root": "Appearance",
+      "to_subscreen": "Tablet layout"
+    },
+    {
+      "from_page": "Links & browser",
+      "from_root": "Media",
+      "from_subscreen": "Additional link behavior",
+      "key": "pref_browser",
+      "title": "Default browser",
+      "to_page": "Links & browser",
+      "to_root": "Media",
+      "to_subscreen": "Browser"
+    },
+    {
+      "from_page": "Links & browser",
+      "from_root": "Media",
+      "from_subscreen": "Additional link behavior",
+      "key": "pref_link_video",
+      "title": "Internal Youtube player",
+      "to_page": "Links & browser",
+      "to_root": "Media",
+      "to_subscreen": "Video links"
+    },
+    {
+      "from_page": "Links & browser",
+      "from_root": "Media",
+      "from_subscreen": "Additional link behavior",
+      "key": "pref_video_audio_start_muted",
+      "title": "Mute audio",
+      "to_page": "Playback & autoplay",
+      "to_root": "Media",
+      "to_subscreen": "Audio"
+    },
+    {
+      "from_page": "Links & browser",
+      "from_root": "Media",
+      "from_subscreen": "Additional link behavior",
+      "key": "pref_upvote_on_save",
+      "title": "Upvote on save",
+      "to_page": "Posts",
+      "to_root": "Reading & interaction",
+      "to_subscreen": "Post actions"
+    },
+    {
+      "from_page": "General behavior",
+      "from_root": "Data & app",
+      "from_subscreen": "Community shortcuts",
+      "key": "pref_shortcut_icon_crop",
+      "title": "Crop community icon",
+      "to_page": "App behavior & compatibility",
+      "to_root": "Data & app",
+      "to_subscreen": "Community shortcuts"
+    },
+    {
+      "from_page": "General behavior",
+      "from_root": "Data & app",
+      "from_subscreen": "Composing",
+      "key": "pref_use_advanced_editor",
+      "title": "Advanced fullscreen editor",
+      "to_page": "Composing & drafts",
+      "to_root": "Reading & interaction",
+      "to_subscreen": "Editor"
+    },
+    {
+      "from_page": "General behavior",
+      "from_root": "Data & app",
+      "from_subscreen": "Composing",
+      "key": "pref_manage_drafts",
+      "title": "Post drafts",
+      "to_page": "Composing & drafts",
+      "to_root": "Reading & interaction",
+      "to_subscreen": "Drafts"
+    },
+    {
+      "from_page": "General behavior",
+      "from_root": "Data & app",
+      "from_subscreen": "Composing",
+      "key": "pref_drafts",
+      "title": "Save drafts",
+      "to_page": "Composing & drafts",
+      "to_root": "Reading & interaction",
+      "to_subscreen": "Drafts"
+    },
+    {
+      "from_page": "General behavior",
+      "from_root": "Data & app",
+      "from_subscreen": "Composing",
+      "key": "pref_imgur_uploads",
+      "title": "Uploaded images",
+      "to_page": "Composing & drafts",
+      "to_root": "Reading & interaction",
+      "to_subscreen": "Uploads"
+    },
+    {
+      "from_page": "General behavior",
+      "from_root": "Data & app",
+      "from_subscreen": "Legacy features",
+      "key": "pref_autoplay_swipe",
+      "title": "Autoplay videos in Swipe view",
+      "to_page": "App behavior & compatibility",
+      "to_root": "Data & app",
+      "to_subscreen": "Compatibility & legacy"
+    },
+    {
+      "from_page": "General behavior",
+      "from_root": "Data & app",
+      "from_subscreen": "Legacy features",
+      "key": "pref_info_color_indicators",
+      "title": "Colored link type indicators",
+      "to_page": "App behavior & compatibility",
+      "to_root": "Data & app",
+      "to_subscreen": "Compatibility & legacy"
+    },
+    {
+      "from_page": "General behavior",
+      "from_root": "Data & app",
+      "from_subscreen": "Legacy features",
+      "key": "pref_go_to_sub_dialog",
+      "title": "Go to community in a dialog",
+      "to_page": "App behavior & compatibility",
+      "to_root": "Data & app",
+      "to_subscreen": "Compatibility & legacy"
+    },
+    {
+      "from_page": "General behavior",
+      "from_root": "Data & app",
+      "from_subscreen": "Legacy features",
+      "key": "pref_cards_preview_top",
+      "title": "Previews on top",
+      "to_page": "App behavior & compatibility",
+      "to_root": "Data & app",
+      "to_subscreen": "Compatibility & legacy"
+    },
+    {
+      "from_page": "General behavior",
+      "from_root": "Data & app",
+      "from_subscreen": "Legacy features",
+      "key": "pref_info_post_shorten_score",
+      "title": "Shorten score",
+      "to_page": "App behavior & compatibility",
+      "to_root": "Data & app",
+      "to_subscreen": "Compatibility & legacy"
+    },
+    {
+      "from_page": "General behavior",
+      "from_root": "Data & app",
+      "from_subscreen": "Legacy features",
+      "key": "pref_send_floating_button",
+      "title": "Show floating send button",
+      "to_page": "App behavior & compatibility",
+      "to_root": "Data & app",
+      "to_subscreen": "Compatibility & legacy"
+    },
+    {
+      "from_page": "General behavior",
+      "from_root": "Data & app",
+      "from_subscreen": "Legacy features",
+      "key": "pref_info_post_self_image",
+      "title": "Show images from text posts",
+      "to_page": "App behavior & compatibility",
+      "to_root": "Data & app",
+      "to_subscreen": "Compatibility & legacy"
+    },
+    {
+      "from_page": "General behavior",
+      "from_root": "Data & app",
+      "from_subscreen": "Legacy features",
+      "key": "pref_info_post_view_count",
+      "title": "Show view count",
+      "to_page": "App behavior & compatibility",
+      "to_root": "Data & app",
+      "to_subscreen": "Compatibility & legacy"
+    },
+    {
+      "from_page": "General behavior",
+      "from_root": "Data & app",
+      "from_subscreen": "Legacy features",
+      "key": "pref_toolbar_dropdown",
+      "title": "Subscriptions dropdown in toolbar",
+      "to_page": "App behavior & compatibility",
+      "to_root": "Data & app",
+      "to_subscreen": "Compatibility & legacy"
+    },
+    {
+      "from_page": "General behavior",
+      "from_root": "Data & app",
+      "from_subscreen": "Legacy features",
+      "key": "pref_toolbar_tap_to_go",
+      "title": "Tap toolbar to show subs",
+      "to_page": "App behavior & compatibility",
+      "to_root": "Data & app",
+      "to_subscreen": "Compatibility & legacy"
+    },
+    {
+      "from_page": "General behavior",
+      "from_root": "Data & app",
+      "from_subscreen": "Legacy features",
+      "key": "pref_cards_legacy",
+      "title": "Use legacy cards layout",
+      "to_page": "App behavior & compatibility",
+      "to_root": "Data & app",
+      "to_subscreen": "Compatibility & legacy"
+    },
+    {
+      "from_page": "General behavior",
+      "from_root": "Data & app",
+      "from_subscreen": "Misc",
+      "key": "pref_ad_format",
+      "title": "Preferred Ad format",
+      "to_page": "App behavior & compatibility",
+      "to_root": "Data & app",
+      "to_subscreen": "Other app behavior"
+    },
+    {
+      "from_page": "General behavior",
+      "from_root": "Data & app",
+      "from_subscreen": "Misc",
+      "key": "reset_tips",
+      "title": "Reset tips",
+      "to_page": "App behavior & compatibility",
+      "to_root": "Data & app",
+      "to_subscreen": "Other app behavior"
+    },
+    {
+      "from_page": "Storage & bandwidth",
+      "from_root": "Data & app",
+      "from_subscreen": "Videos",
+      "key": "pref_autoplay_cards",
+      "title": "Autoplay videos",
+      "to_page": "Playback & autoplay",
+      "to_root": "Media",
+      "to_subscreen": "Autoplay"
+    }
+  ],
+  "page_intros": {
+    "About & support": "View app information, legal information, and support actions.",
+    "App behavior & compatibility": "Manage app-wide compatibility options and remaining global behavior.",
+    "Backup & restore": "Export or restore supported Boost and Morphe preferences.",
+    "Comments": "Control comment display, actions, navigation, and thread behavior.",
+    "Community header": "Control the title, description, and header shown for communities.",
+    "Composing & drafts": "Configure editors, draft storage, and uploaded composing media.",
+    "Display & motion": "Adjust display behavior, animation, and refresh-rate preferences.",
+    "Downloads & cache": "Manage download locations and downloaded media behavior.",
+    "Feeds & subscriptions": "Manage communities, custom feeds, and subscription-related behavior.",
+    "General behavior": "Configure app-wide behavior that does not belong to another task.",
+    "History, privacy & recovery": "Manage history, privacy, and supported archive recovery.",
+    "Images, GIFs & previews": "Configure media previews, image behavior, and tap actions.",
+    "Links & browser": "Choose how links open and which browser behavior Boost uses.",
+    "Navigation & gestures": "Choose how you move around Boost and which shortcuts are available.",
+    "Notifications & inbox": "Control notifications, messages, and inbox behavior.",
+    "Patch features": "Configure features added by Morphe patches.",
+    "Playback & autoplay": "Control video, audio, autoplay, and player behavior.",
+    "Post layout": "Control how posts and feed cards are arranged.",
+    "Posts": "Choose how posts behave while browsing and reading.",
+    "Reddit account": "Open account and Reddit-specific preferences.",
+    "Search & filters": "Configure search entry, search behavior, and content filtering.",
+    "Settings experience": "Choose which Settings presentation Boost uses.",
+    "Storage & bandwidth": "Control data usage, caching, and bandwidth-sensitive behavior.",
+    "Theme & colors": "Choose the app theme, color behavior, and night-mode presentation.",
+    "Typography": "Adjust text size and font presentation throughout Boost."
+  },
+  "root_intros": {
+    "Appearance": "Control themes, layout, typography, and visual presentation.",
+    "Data & app": "Manage storage, backup, general behavior, Settings, and app information.",
+    "Media": "Configure playback, previews, links, downloads, and bandwidth.",
+    "Morphe": "Features added by Morphe patches and the Settings experience.",
+    "Navigation": "Control how you move around Boost and reach common destinations.",
+    "Notifications & account": "Manage inbox behavior, account-related options, history, and privacy.",
+    "Reading & interaction": "Choose how posts, comments, feeds, and search behave."
+  },
+  "root_order": [
+    "Morphe",
+    "Appearance",
+    "Reading & interaction",
+    "Navigation",
+    "Media",
+    "Notifications & account",
+    "Data & app"
+  ],
+  "schema": 3,
+  "scope": "semantically_reviewed_task_based_settings_screen_graph",
+  "screens": [
+    {
+      "child_count": 5,
+      "control_count": 0,
+      "depth": 0,
+      "max_children_contract": "",
+      "path": "Appearance",
+      "role": "root_group",
+      "root": "Appearance",
+      "task_page": "",
+      "title": "Appearance"
+    },
+    {
+      "child_count": 1,
+      "control_count": 0,
+      "depth": 1,
+      "max_children_contract": 5,
+      "path": "Appearance / Community header",
+      "role": "task_page",
+      "root": "Appearance",
+      "task_page": "Community header",
+      "title": "Community header"
+    },
+    {
+      "child_count": 0,
+      "control_count": 5,
+      "depth": 2,
+      "max_children_contract": 0,
+      "path": "Appearance / Community header / Community header",
+      "role": "leaf_section",
+      "root": "Appearance",
+      "task_page": "Community header",
+      "title": "Community header"
+    },
+    {
+      "child_count": 1,
+      "control_count": 0,
+      "depth": 1,
+      "max_children_contract": 5,
+      "path": "Appearance / Display & motion",
+      "role": "task_page",
+      "root": "Appearance",
+      "task_page": "Display & motion",
+      "title": "Display & motion"
+    },
+    {
+      "child_count": 0,
+      "control_count": 1,
+      "depth": 2,
+      "max_children_contract": 0,
+      "path": "Appearance / Display & motion / Display performance",
+      "role": "leaf_section",
+      "root": "Appearance",
+      "task_page": "Display & motion",
+      "title": "Display performance"
+    },
+    {
+      "child_count": 5,
+      "control_count": 0,
+      "depth": 1,
+      "max_children_contract": 5,
+      "path": "Appearance / Post layout",
+      "role": "task_page",
+      "root": "Appearance",
+      "task_page": "Post layout",
+      "title": "Post layout"
+    },
+    {
+      "child_count": 0,
+      "control_count": 8,
+      "depth": 2,
+      "max_children_contract": 0,
+      "path": "Appearance / Post layout / Cards",
+      "role": "leaf_section",
+      "root": "Appearance",
+      "task_page": "Post layout",
+      "title": "Cards"
+    },
+    {
+      "child_count": 2,
+      "control_count": 0,
+      "depth": 2,
+      "max_children_contract": 6,
+      "path": "Appearance / Post layout / Compact layouts",
+      "role": "intermediate_page",
+      "root": "Appearance",
+      "task_page": "Post layout",
+      "title": "Compact layouts"
+    },
+    {
+      "child_count": 0,
+      "control_count": 1,
+      "depth": 3,
+      "max_children_contract": 0,
+      "path": "Appearance / Post layout / Compact layouts / Dense",
+      "role": "leaf_section",
+      "root": "Appearance",
+      "task_page": "Post layout",
+      "title": "Dense"
+    },
+    {
+      "child_count": 0,
+      "control_count": 4,
+      "depth": 3,
+      "max_children_contract": 0,
+      "path": "Appearance / Post layout / Compact layouts / Small cards",
+      "role": "leaf_section",
+      "root": "Appearance",
+      "task_page": "Post layout",
+      "title": "Small cards"
+    },
+    {
+      "child_count": 2,
+      "control_count": 0,
+      "depth": 2,
+      "max_children_contract": 6,
+      "path": "Appearance / Post layout / Layout & saved views",
+      "role": "intermediate_page",
+      "root": "Appearance",
+      "task_page": "Post layout",
+      "title": "Layout & saved views"
+    },
+    {
+      "child_count": 0,
+      "control_count": 5,
+      "depth": 3,
+      "max_children_contract": 0,
+      "path": "Appearance / Post layout / Layout & saved views / Post layout",
+      "role": "leaf_section",
+      "root": "Appearance",
+      "task_page": "Post layout",
+      "title": "Post layout"
+    },
+    {
+      "child_count": 0,
+      "control_count": 3,
+      "depth": 3,
+      "max_children_contract": 0,
+      "path": "Appearance / Post layout / Layout & saved views / Saved community views",
+      "role": "leaf_section",
+      "root": "Appearance",
+      "task_page": "Post layout",
+      "title": "Saved community views"
+    },
+    {
+      "child_count": 0,
+      "control_count": 2,
+      "depth": 2,
+      "max_children_contract": 0,
+      "path": "Appearance / Post layout / Swipe",
+      "role": "leaf_section",
+      "root": "Appearance",
+      "task_page": "Post layout",
+      "title": "Swipe"
+    },
+    {
+      "child_count": 0,
+      "control_count": 1,
+      "depth": 2,
+      "max_children_contract": 0,
+      "path": "Appearance / Post layout / Tablet layout",
+      "role": "leaf_section",
+      "root": "Appearance",
+      "task_page": "Post layout",
+      "title": "Tablet layout"
+    },
+    {
+      "child_count": 3,
+      "control_count": 0,
+      "depth": 1,
+      "max_children_contract": 5,
+      "path": "Appearance / Theme & colors",
+      "role": "task_page",
+      "root": "Appearance",
+      "task_page": "Theme & colors",
+      "title": "Theme & colors"
+    },
+    {
+      "child_count": 0,
+      "control_count": 2,
+      "depth": 2,
+      "max_children_contract": 0,
+      "path": "Appearance / Theme & colors / Advanced appearance",
+      "role": "leaf_section",
+      "root": "Appearance",
+      "task_page": "Theme & colors",
+      "title": "Advanced appearance"
+    },
+    {
+      "child_count": 0,
+      "control_count": 1,
+      "depth": 2,
+      "max_children_contract": 0,
+      "path": "Appearance / Theme & colors / Personalization",
+      "role": "leaf_section",
+      "root": "Appearance",
+      "task_page": "Theme & colors",
+      "title": "Personalization"
+    },
+    {
+      "child_count": 0,
+      "control_count": 7,
+      "depth": 2,
+      "max_children_contract": 0,
+      "path": "Appearance / Theme & colors / Theme",
+      "role": "leaf_section",
+      "root": "Appearance",
+      "task_page": "Theme & colors",
+      "title": "Theme"
+    },
+    {
+      "child_count": 3,
+      "control_count": 0,
+      "depth": 1,
+      "max_children_contract": 5,
+      "path": "Appearance / Typography",
+      "role": "task_page",
+      "root": "Appearance",
+      "task_page": "Typography",
+      "title": "Typography"
+    },
+    {
+      "child_count": 0,
+      "control_count": 2,
+      "depth": 2,
+      "max_children_contract": 0,
+      "path": "Appearance / Typography / Comments",
+      "role": "leaf_section",
+      "root": "Appearance",
+      "task_page": "Typography",
+      "title": "Comments"
+    },
+    {
+      "child_count": 0,
+      "control_count": 2,
+      "depth": 2,
+      "max_children_contract": 0,
+      "path": "Appearance / Typography / Posts",
+      "role": "leaf_section",
+      "root": "Appearance",
+      "task_page": "Typography",
+      "title": "Posts"
+    },
+    {
+      "child_count": 0,
+      "control_count": 1,
+      "depth": 2,
+      "max_children_contract": 0,
+      "path": "Appearance / Typography / Reset",
+      "role": "leaf_section",
+      "root": "Appearance",
+      "task_page": "Typography",
+      "title": "Reset"
+    },
+    {
+      "child_count": 5,
+      "control_count": 0,
+      "depth": 0,
+      "max_children_contract": "",
+      "path": "Data & app",
+      "role": "root_group",
+      "root": "Data & app",
+      "task_page": "",
+      "title": "Data & app"
+    },
+    {
+      "child_count": 3,
+      "control_count": 0,
+      "depth": 1,
+      "max_children_contract": 5,
+      "path": "Data & app / About & support",
+      "role": "task_page",
+      "root": "Data & app",
+      "task_page": "About & support",
+      "title": "About & support"
+    },
+    {
+      "child_count": 0,
+      "control_count": 6,
+      "depth": 2,
+      "max_children_contract": 0,
+      "path": "Data & app / About & support / About Boost",
+      "role": "leaf_section",
+      "root": "Data & app",
+      "task_page": "About & support",
+      "title": "About Boost"
+    },
+    {
+      "child_count": 0,
+      "control_count": 3,
+      "depth": 2,
+      "max_children_contract": 0,
+      "path": "Data & app / About & support / Author",
+      "role": "leaf_section",
+      "root": "Data & app",
+      "task_page": "About & support",
+      "title": "Author"
+    },
+    {
+      "child_count": 0,
+      "control_count": 3,
+      "depth": 2,
+      "max_children_contract": 0,
+      "path": "Data & app / About & support / Privacy",
+      "role": "leaf_section",
+      "root": "Data & app",
+      "task_page": "About & support",
+      "title": "Privacy"
+    },
+    {
+      "child_count": 3,
+      "control_count": 0,
+      "depth": 1,
+      "max_children_contract": 5,
+      "path": "Data & app / App behavior & compatibility",
+      "role": "task_page",
+      "root": "Data & app",
+      "task_page": "App behavior & compatibility",
+      "title": "App behavior & compatibility"
+    },
+    {
+      "child_count": 0,
+      "control_count": 1,
+      "depth": 2,
+      "max_children_contract": 0,
+      "path": "Data & app / App behavior & compatibility / Community shortcuts",
+      "role": "leaf_section",
+      "root": "Data & app",
+      "task_page": "App behavior & compatibility",
+      "title": "Community shortcuts"
+    },
+    {
+      "child_count": 0,
+      "control_count": 11,
+      "depth": 2,
+      "max_children_contract": 0,
+      "path": "Data & app / App behavior & compatibility / Compatibility & legacy",
+      "role": "leaf_section",
+      "root": "Data & app",
+      "task_page": "App behavior & compatibility",
+      "title": "Compatibility & legacy"
+    },
+    {
+      "child_count": 0,
+      "control_count": 2,
+      "depth": 2,
+      "max_children_contract": 0,
+      "path": "Data & app / App behavior & compatibility / Other app behavior",
+      "role": "leaf_section",
+      "root": "Data & app",
+      "task_page": "App behavior & compatibility",
+      "title": "Other app behavior"
+    },
+    {
+      "child_count": 0,
+      "control_count": 0,
+      "depth": 1,
+      "max_children_contract": 5,
+      "path": "Data & app / Backup & restore",
+      "role": "task_page",
+      "root": "Data & app",
+      "task_page": "Backup & restore",
+      "title": "Backup & restore"
+    },
+    {
+      "child_count": 1,
+      "control_count": 0,
+      "depth": 1,
+      "max_children_contract": 5,
+      "path": "Data & app / Settings experience",
+      "role": "task_page",
+      "root": "Data & app",
+      "task_page": "Settings experience",
+      "title": "Settings experience"
+    },
+    {
+      "child_count": 0,
+      "control_count": 1,
+      "depth": 2,
+      "max_children_contract": 0,
+      "path": "Data & app / Settings experience / Settings presentation",
+      "role": "leaf_section",
+      "root": "Data & app",
+      "task_page": "Settings experience",
+      "title": "Settings presentation"
+    },
+    {
+      "child_count": 5,
+      "control_count": 0,
+      "depth": 1,
+      "max_children_contract": 5,
+      "path": "Data & app / Storage & bandwidth",
+      "role": "task_page",
+      "root": "Data & app",
+      "task_page": "Storage & bandwidth",
+      "title": "Storage & bandwidth"
+    },
+    {
+      "child_count": 0,
+      "control_count": 2,
+      "depth": 2,
+      "max_children_contract": 0,
+      "path": "Data & app / Storage & bandwidth / Cache",
+      "role": "leaf_section",
+      "root": "Data & app",
+      "task_page": "Storage & bandwidth",
+      "title": "Cache"
+    },
+    {
+      "child_count": 0,
+      "control_count": 2,
+      "depth": 2,
+      "max_children_contract": 0,
+      "path": "Data & app / Storage & bandwidth / Data saver",
+      "role": "leaf_section",
+      "root": "Data & app",
+      "task_page": "Storage & bandwidth",
+      "title": "Data saver"
+    },
+    {
+      "child_count": 0,
+      "control_count": 1,
+      "depth": 2,
+      "max_children_contract": 0,
+      "path": "Data & app / Storage & bandwidth / Data usage",
+      "role": "leaf_section",
+      "root": "Data & app",
+      "task_page": "Storage & bandwidth",
+      "title": "Data usage"
+    },
+    {
+      "child_count": 0,
+      "control_count": 1,
+      "depth": 2,
+      "max_children_contract": 0,
+      "path": "Data & app / Storage & bandwidth / Images",
+      "role": "leaf_section",
+      "root": "Data & app",
+      "task_page": "Storage & bandwidth",
+      "title": "Images"
+    },
+    {
+      "child_count": 0,
+      "control_count": 3,
+      "depth": 2,
+      "max_children_contract": 0,
+      "path": "Data & app / Storage & bandwidth / Videos",
+      "role": "leaf_section",
+      "root": "Data & app",
+      "task_page": "Storage & bandwidth",
+      "title": "Videos"
+    },
+    {
+      "child_count": 4,
+      "control_count": 0,
+      "depth": 0,
+      "max_children_contract": "",
+      "path": "Media",
+      "role": "root_group",
+      "root": "Media",
+      "task_page": "",
+      "title": "Media"
+    },
+    {
+      "child_count": 1,
+      "control_count": 0,
+      "depth": 1,
+      "max_children_contract": 5,
+      "path": "Media / Downloads & cache",
+      "role": "task_page",
+      "root": "Media",
+      "task_page": "Downloads & cache",
+      "title": "Downloads & cache"
+    },
+    {
+      "child_count": 0,
+      "control_count": 5,
+      "depth": 2,
+      "max_children_contract": 0,
+      "path": "Media / Downloads & cache / Download folders",
+      "role": "leaf_section",
+      "root": "Media",
+      "task_page": "Downloads & cache",
+      "title": "Download folders"
+    },
+    {
+      "child_count": 4,
+      "control_count": 0,
+      "depth": 1,
+      "max_children_contract": 5,
+      "path": "Media / Images, GIFs & previews",
+      "role": "task_page",
+      "root": "Media",
+      "task_page": "Images, GIFs & previews",
+      "title": "Images, GIFs & previews"
+    },
+    {
+      "child_count": 0,
+      "control_count": 6,
+      "depth": 2,
+      "max_children_contract": 0,
+      "path": "Media / Images, GIFs & previews / Native image behavior",
+      "role": "leaf_section",
+      "root": "Media",
+      "task_page": "Images, GIFs & previews",
+      "title": "Native image behavior"
+    },
+    {
+      "child_count": 0,
+      "control_count": 3,
+      "depth": 2,
+      "max_children_contract": 0,
+      "path": "Media / Images, GIFs & previews / Open behavior",
+      "role": "leaf_section",
+      "root": "Media",
+      "task_page": "Images, GIFs & previews",
+      "title": "Open behavior"
+    },
+    {
+      "child_count": 0,
+      "control_count": 2,
+      "depth": 2,
+      "max_children_contract": 0,
+      "path": "Media / Images, GIFs & previews / Preview behavior",
+      "role": "leaf_section",
+      "root": "Media",
+      "task_page": "Images, GIFs & previews",
+      "title": "Preview behavior"
+    },
+    {
+      "child_count": 0,
+      "control_count": 2,
+      "depth": 2,
+      "max_children_contract": 0,
+      "path": "Media / Images, GIFs & previews / Preview layout",
+      "role": "leaf_section",
+      "root": "Media",
+      "task_page": "Images, GIFs & previews",
+      "title": "Preview layout"
+    },
+    {
+      "child_count": 4,
+      "control_count": 0,
+      "depth": 1,
+      "max_children_contract": 5,
+      "path": "Media / Links & browser",
+      "role": "task_page",
+      "root": "Media",
+      "task_page": "Links & browser",
+      "title": "Links & browser"
+    },
+    {
+      "child_count": 0,
+      "control_count": 1,
+      "depth": 2,
+      "max_children_contract": 0,
+      "path": "Media / Links & browser / Browser",
+      "role": "leaf_section",
+      "root": "Media",
+      "task_page": "Links & browser",
+      "title": "Browser"
+    },
+    {
+      "child_count": 0,
+      "control_count": 1,
+      "depth": 2,
+      "max_children_contract": 0,
+      "path": "Media / Links & browser / Link handling",
+      "role": "leaf_section",
+      "root": "Media",
+      "task_page": "Links & browser",
+      "title": "Link handling"
+    },
+    {
+      "child_count": 0,
+      "control_count": 8,
+      "depth": 2,
+      "max_children_contract": 0,
+      "path": "Media / Links & browser / Links to open in app",
+      "role": "leaf_section",
+      "root": "Media",
+      "task_page": "Links & browser",
+      "title": "Links to open in app"
+    },
+    {
+      "child_count": 0,
+      "control_count": 1,
+      "depth": 2,
+      "max_children_contract": 0,
+      "path": "Media / Links & browser / Video links",
+      "role": "leaf_section",
+      "root": "Media",
+      "task_page": "Links & browser",
+      "title": "Video links"
+    },
+    {
+      "child_count": 4,
+      "control_count": 0,
+      "depth": 1,
+      "max_children_contract": 5,
+      "path": "Media / Playback & autoplay",
+      "role": "task_page",
+      "root": "Media",
+      "task_page": "Playback & autoplay",
+      "title": "Playback & autoplay"
+    },
+    {
+      "child_count": 0,
+      "control_count": 1,
+      "depth": 2,
+      "max_children_contract": 0,
+      "path": "Media / Playback & autoplay / Audio",
+      "role": "leaf_section",
+      "root": "Media",
+      "task_page": "Playback & autoplay",
+      "title": "Audio"
+    },
+    {
+      "child_count": 0,
+      "control_count": 1,
+      "depth": 2,
+      "max_children_contract": 0,
+      "path": "Media / Playback & autoplay / Autoplay",
+      "role": "leaf_section",
+      "root": "Media",
+      "task_page": "Playback & autoplay",
+      "title": "Autoplay"
+    },
+    {
+      "child_count": 0,
+      "control_count": 2,
+      "depth": 2,
+      "max_children_contract": 0,
+      "path": "Media / Playback & autoplay / Media behavior",
+      "role": "leaf_section",
+      "root": "Media",
+      "task_page": "Playback & autoplay",
+      "title": "Media behavior"
+    },
+    {
+      "child_count": 0,
+      "control_count": 2,
+      "depth": 2,
+      "max_children_contract": 0,
+      "path": "Media / Playback & autoplay / Playback & autoplay",
+      "role": "leaf_section",
+      "root": "Media",
+      "task_page": "Playback & autoplay",
+      "title": "Playback & autoplay"
+    },
+    {
+      "child_count": 1,
+      "control_count": 0,
+      "depth": 0,
+      "max_children_contract": "",
+      "path": "Morphe",
+      "role": "root_group",
+      "root": "Morphe",
+      "task_page": "",
+      "title": "Morphe"
+    },
+    {
+      "child_count": 0,
+      "control_count": 0,
+      "depth": 1,
+      "max_children_contract": 5,
+      "path": "Morphe / Patch features",
+      "role": "task_page",
+      "root": "Morphe",
+      "task_page": "Patch features",
+      "title": "Patch features"
+    },
+    {
+      "child_count": 1,
+      "control_count": 0,
+      "depth": 0,
+      "max_children_contract": "",
+      "path": "Navigation",
+      "role": "root_group",
+      "root": "Navigation",
+      "task_page": "",
+      "title": "Navigation"
+    },
+    {
+      "child_count": 4,
+      "control_count": 0,
+      "depth": 1,
+      "max_children_contract": 5,
+      "path": "Navigation / Navigation & gestures",
+      "role": "task_page",
+      "root": "Navigation",
+      "task_page": "Navigation & gestures",
+      "title": "Navigation & gestures"
+    },
+    {
+      "child_count": 0,
+      "control_count": 2,
+      "depth": 2,
+      "max_children_contract": 0,
+      "path": "Navigation / Navigation & gestures / Back & exit",
+      "role": "leaf_section",
+      "root": "Navigation",
+      "task_page": "Navigation & gestures",
+      "title": "Back & exit"
+    },
+    {
+      "child_count": 0,
+      "control_count": 2,
+      "depth": 2,
+      "max_children_contract": 0,
+      "path": "Navigation / Navigation & gestures / Bottom navigation",
+      "role": "leaf_section",
+      "root": "Navigation",
+      "task_page": "Navigation & gestures",
+      "title": "Bottom navigation"
+    },
+    {
+      "child_count": 6,
+      "control_count": 0,
+      "depth": 2,
+      "max_children_contract": 6,
+      "path": "Navigation / Navigation & gestures / Navigation drawer",
+      "role": "intermediate_page",
+      "root": "Navigation",
+      "task_page": "Navigation & gestures",
+      "title": "Navigation drawer"
+    },
+    {
+      "child_count": 0,
+      "control_count": 2,
+      "depth": 3,
+      "max_children_contract": 0,
+      "path": "Navigation / Navigation & gestures / Navigation drawer / Account switcher",
+      "role": "leaf_section",
+      "root": "Navigation",
+      "task_page": "Navigation & gestures",
+      "title": "Account switcher"
+    },
+    {
+      "child_count": 0,
+      "control_count": 9,
+      "depth": 3,
+      "max_children_contract": 0,
+      "path": "Navigation / Navigation & gestures / Navigation drawer / Destinations",
+      "role": "leaf_section",
+      "root": "Navigation",
+      "task_page": "Navigation & gestures",
+      "title": "Destinations"
+    },
+    {
+      "child_count": 0,
+      "control_count": 4,
+      "depth": 3,
+      "max_children_contract": 0,
+      "path": "Navigation / Navigation & gestures / Navigation drawer / Drawer behavior",
+      "role": "leaf_section",
+      "root": "Navigation",
+      "task_page": "Navigation & gestures",
+      "title": "Drawer behavior"
+    },
+    {
+      "child_count": 0,
+      "control_count": 3,
+      "depth": 3,
+      "max_children_contract": 0,
+      "path": "Navigation / Navigation & gestures / Navigation drawer / Go-to shortcuts",
+      "role": "leaf_section",
+      "root": "Navigation",
+      "task_page": "Navigation & gestures",
+      "title": "Go-to shortcuts"
+    },
+    {
+      "child_count": 0,
+      "control_count": 3,
+      "depth": 3,
+      "max_children_contract": 0,
+      "path": "Navigation / Navigation & gestures / Navigation drawer / Quick toggles",
+      "role": "leaf_section",
+      "root": "Navigation",
+      "task_page": "Navigation & gestures",
+      "title": "Quick toggles"
+    },
+    {
+      "child_count": 0,
+      "control_count": 4,
+      "depth": 3,
+      "max_children_contract": 0,
+      "path": "Navigation / Navigation & gestures / Navigation drawer / Subscriptions",
+      "role": "leaf_section",
+      "root": "Navigation",
+      "task_page": "Navigation & gestures",
+      "title": "Subscriptions"
+    },
+    {
+      "child_count": 0,
+      "control_count": 2,
+      "depth": 2,
+      "max_children_contract": 0,
+      "path": "Navigation / Navigation & gestures / Toolbar",
+      "role": "leaf_section",
+      "root": "Navigation",
+      "task_page": "Navigation & gestures",
+      "title": "Toolbar"
+    },
+    {
+      "child_count": 3,
+      "control_count": 0,
+      "depth": 0,
+      "max_children_contract": "",
+      "path": "Notifications & account",
+      "role": "root_group",
+      "root": "Notifications & account",
+      "task_page": "",
+      "title": "Notifications & account"
+    },
+    {
+      "child_count": 2,
+      "control_count": 0,
+      "depth": 1,
+      "max_children_contract": 5,
+      "path": "Notifications & account / History, privacy & recovery",
+      "role": "task_page",
+      "root": "Notifications & account",
+      "task_page": "History, privacy & recovery",
+      "title": "History, privacy & recovery"
+    },
+    {
+      "child_count": 0,
+      "control_count": 8,
+      "depth": 2,
+      "max_children_contract": 0,
+      "path": "Notifications & account / History, privacy & recovery / History",
+      "role": "leaf_section",
+      "root": "Notifications & account",
+      "task_page": "History, privacy & recovery",
+      "title": "History"
+    },
+    {
+      "child_count": 0,
+      "control_count": 2,
+      "depth": 2,
+      "max_children_contract": 0,
+      "path": "Notifications & account / History, privacy & recovery / Recovery & archives",
+      "role": "leaf_section",
+      "root": "Notifications & account",
+      "task_page": "History, privacy & recovery",
+      "title": "Recovery & archives"
+    },
+    {
+      "child_count": 2,
+      "control_count": 0,
+      "depth": 1,
+      "max_children_contract": 5,
+      "path": "Notifications & account / Notifications & inbox",
+      "role": "task_page",
+      "root": "Notifications & account",
+      "task_page": "Notifications & inbox",
+      "title": "Notifications & inbox"
+    },
+    {
+      "child_count": 0,
+      "control_count": 2,
+      "depth": 2,
+      "max_children_contract": 0,
+      "path": "Notifications & account / Notifications & inbox / Advanced",
+      "role": "leaf_section",
+      "root": "Notifications & account",
+      "task_page": "Notifications & inbox",
+      "title": "Advanced"
+    },
+    {
+      "child_count": 0,
+      "control_count": 4,
+      "depth": 2,
+      "max_children_contract": 0,
+      "path": "Notifications & account / Notifications & inbox / Notifications",
+      "role": "leaf_section",
+      "root": "Notifications & account",
+      "task_page": "Notifications & inbox",
+      "title": "Notifications"
+    },
+    {
+      "child_count": 0,
+      "control_count": 0,
+      "depth": 1,
+      "max_children_contract": 5,
+      "path": "Notifications & account / Reddit account",
+      "role": "task_page",
+      "root": "Notifications & account",
+      "task_page": "Reddit account",
+      "title": "Reddit account"
+    },
+    {
+      "child_count": 5,
+      "control_count": 0,
+      "depth": 0,
+      "max_children_contract": "",
+      "path": "Reading & interaction",
+      "role": "root_group",
+      "root": "Reading & interaction",
+      "task_page": "",
+      "title": "Reading & interaction"
+    },
+    {
+      "child_count": 4,
+      "control_count": 0,
+      "depth": 1,
+      "max_children_contract": 5,
+      "path": "Reading & interaction / Comments",
+      "role": "task_page",
+      "root": "Reading & interaction",
+      "task_page": "Comments",
+      "title": "Comments"
+    },
+    {
+      "child_count": 0,
+      "control_count": 9,
+      "depth": 2,
+      "max_children_contract": 0,
+      "path": "Reading & interaction / Comments / Comment actions",
+      "role": "leaf_section",
+      "root": "Reading & interaction",
+      "task_page": "Comments",
+      "title": "Comment actions"
+    },
+    {
+      "child_count": 0,
+      "control_count": 5,
+      "depth": 2,
+      "max_children_contract": 0,
+      "path": "Reading & interaction / Comments / Comment appearance",
+      "role": "leaf_section",
+      "root": "Reading & interaction",
+      "task_page": "Comments",
+      "title": "Comment appearance"
+    },
+    {
+      "child_count": 0,
+      "control_count": 7,
+      "depth": 2,
+      "max_children_contract": 0,
+      "path": "Reading & interaction / Comments / Comment behavior",
+      "role": "leaf_section",
+      "root": "Reading & interaction",
+      "task_page": "Comments",
+      "title": "Comment behavior"
+    },
+    {
+      "child_count": 0,
+      "control_count": 12,
+      "depth": 2,
+      "max_children_contract": 0,
+      "path": "Reading & interaction / Comments / Thread navigation",
+      "role": "leaf_section",
+      "root": "Reading & interaction",
+      "task_page": "Comments",
+      "title": "Thread navigation"
+    },
+    {
+      "child_count": 3,
+      "control_count": 0,
+      "depth": 1,
+      "max_children_contract": 5,
+      "path": "Reading & interaction / Composing & drafts",
+      "role": "task_page",
+      "root": "Reading & interaction",
+      "task_page": "Composing & drafts",
+      "title": "Composing & drafts"
+    },
+    {
+      "child_count": 0,
+      "control_count": 2,
+      "depth": 2,
+      "max_children_contract": 0,
+      "path": "Reading & interaction / Composing & drafts / Drafts",
+      "role": "leaf_section",
+      "root": "Reading & interaction",
+      "task_page": "Composing & drafts",
+      "title": "Drafts"
+    },
+    {
+      "child_count": 0,
+      "control_count": 1,
+      "depth": 2,
+      "max_children_contract": 0,
+      "path": "Reading & interaction / Composing & drafts / Editor",
+      "role": "leaf_section",
+      "root": "Reading & interaction",
+      "task_page": "Composing & drafts",
+      "title": "Editor"
+    },
+    {
+      "child_count": 0,
+      "control_count": 1,
+      "depth": 2,
+      "max_children_contract": 0,
+      "path": "Reading & interaction / Composing & drafts / Uploads",
+      "role": "leaf_section",
+      "root": "Reading & interaction",
+      "task_page": "Composing & drafts",
+      "title": "Uploads"
+    },
+    {
+      "child_count": 1,
+      "control_count": 0,
+      "depth": 1,
+      "max_children_contract": 5,
+      "path": "Reading & interaction / Feeds & subscriptions",
+      "role": "task_page",
+      "root": "Reading & interaction",
+      "task_page": "Feeds & subscriptions",
+      "title": "Feeds & subscriptions"
+    },
+    {
+      "child_count": 0,
+      "control_count": 1,
+      "depth": 2,
+      "max_children_contract": 0,
+      "path": "Reading & interaction / Feeds & subscriptions / Manage subscriptions",
+      "role": "leaf_section",
+      "root": "Reading & interaction",
+      "task_page": "Feeds & subscriptions",
+      "title": "Manage subscriptions"
+    },
+    {
+      "child_count": 4,
+      "control_count": 0,
+      "depth": 1,
+      "max_children_contract": 5,
+      "path": "Reading & interaction / Posts",
+      "role": "task_page",
+      "root": "Reading & interaction",
+      "task_page": "Posts",
+      "title": "Posts"
+    },
+    {
+      "child_count": 0,
+      "control_count": 3,
+      "depth": 2,
+      "max_children_contract": 0,
+      "path": "Reading & interaction / Posts / Feed behavior",
+      "role": "leaf_section",
+      "root": "Reading & interaction",
+      "task_page": "Posts",
+      "title": "Feed behavior"
+    },
+    {
+      "child_count": 0,
+      "control_count": 8,
+      "depth": 2,
+      "max_children_contract": 0,
+      "path": "Reading & interaction / Posts / Post actions",
+      "role": "leaf_section",
+      "root": "Reading & interaction",
+      "task_page": "Posts",
+      "title": "Post actions"
+    },
+    {
+      "child_count": 0,
+      "control_count": 9,
+      "depth": 2,
+      "max_children_contract": 0,
+      "path": "Reading & interaction / Posts / Post behavior",
+      "role": "leaf_section",
+      "root": "Reading & interaction",
+      "task_page": "Posts",
+      "title": "Post behavior"
+    },
+    {
+      "child_count": 0,
+      "control_count": 6,
+      "depth": 2,
+      "max_children_contract": 0,
+      "path": "Reading & interaction / Posts / Reading state",
+      "role": "leaf_section",
+      "root": "Reading & interaction",
+      "task_page": "Posts",
+      "title": "Reading state"
+    },
+    {
+      "child_count": 2,
+      "control_count": 0,
+      "depth": 1,
+      "max_children_contract": 5,
+      "path": "Reading & interaction / Search & filters",
+      "role": "task_page",
+      "root": "Reading & interaction",
+      "task_page": "Search & filters",
+      "title": "Search & filters"
+    },
+    {
+      "child_count": 3,
+      "control_count": 0,
+      "depth": 2,
+      "max_children_contract": 6,
+      "path": "Reading & interaction / Search & filters / Content filters",
+      "role": "intermediate_page",
+      "root": "Reading & interaction",
+      "task_page": "Search & filters",
+      "title": "Content filters"
+    },
+    {
+      "child_count": 0,
+      "control_count": 3,
+      "depth": 3,
+      "max_children_contract": 0,
+      "path": "Reading & interaction / Search & filters / Content filters / Filter behavior",
+      "role": "leaf_section",
+      "root": "Reading & interaction",
+      "task_page": "Search & filters",
+      "title": "Filter behavior"
+    },
+    {
+      "child_count": 0,
+      "control_count": 5,
+      "depth": 3,
+      "max_children_contract": 0,
+      "path": "Reading & interaction / Search & filters / Content filters / Muted content",
+      "role": "leaf_section",
+      "root": "Reading & interaction",
+      "task_page": "Search & filters",
+      "title": "Muted content"
+    },
+    {
+      "child_count": 0,
+      "control_count": 6,
+      "depth": 3,
+      "max_children_contract": 0,
+      "path": "Reading & interaction / Search & filters / Content filters / Post matching",
+      "role": "leaf_section",
+      "root": "Reading & interaction",
+      "task_page": "Search & filters",
+      "title": "Post matching"
+    },
+    {
+      "child_count": 3,
+      "control_count": 0,
+      "depth": 2,
+      "max_children_contract": 6,
+      "path": "Reading & interaction / Search & filters / Search",
+      "role": "intermediate_page",
+      "root": "Reading & interaction",
+      "task_page": "Search & filters",
+      "title": "Search"
+    },
+    {
+      "child_count": 0,
+      "control_count": 1,
+      "depth": 3,
+      "max_children_contract": 0,
+      "path": "Reading & interaction / Search & filters / Search / Advanced search",
+      "role": "leaf_section",
+      "root": "Reading & interaction",
+      "task_page": "Search & filters",
+      "title": "Advanced search"
+    },
+    {
+      "child_count": 0,
+      "control_count": 3,
+      "depth": 3,
+      "max_children_contract": 0,
+      "path": "Reading & interaction / Search & filters / Search / Search behavior",
+      "role": "leaf_section",
+      "root": "Reading & interaction",
+      "task_page": "Search & filters",
+      "title": "Search behavior"
+    },
+    {
+      "child_count": 0,
+      "control_count": 5,
+      "depth": 3,
+      "max_children_contract": 0,
+      "path": "Reading & interaction / Search & filters / Search / Suggestions",
+      "role": "leaf_section",
+      "root": "Reading & interaction",
+      "task_page": "Search & filters",
+      "title": "Suggestions"
+    }
+  ],
+  "summary": {
+    "destination_only_page_count": 3,
+    "explicit_mapping_count": 13,
+    "forbidden_label_count": 0,
+    "help_treatment_counts": {
+      "DIRECT_CONTROL_SUMMARY": 8,
+      "DIRECT_CONTROL_SUMMARY+CONFIRMATION_REQUIRED": 1,
+      "OMIT_OR_ONE_LINE_ACTION_HINT": 12,
+      "OMIT_OR_ONE_LINE_ACTION_HINT+PROGRESSIVE_DISCLOSURE": 1,
+      "OMIT_SELF_EXPLANATORY": 15,
+      "REVIEW_EXISTING_SUMMARY": 77,
+      "REVIEW_EXISTING_SUMMARY+PROGRESSIVE_DISCLOSURE": 12,
+      "WRITE_ONE_SHORT_SENTENCE": 115,
+      "WRITE_ONE_SHORT_SENTENCE+PROGRESSIVE_DISCLOSURE": 9
+    },
+    "intermediate_child_violation_count": 0,
+    "intermediate_page_count": 5,
+    "leaf_control_violation_count": 0,
+    "leaf_section_count": 71,
+    "root_group_count": 7,
+    "screen_graph_edge_count": 100,
+    "screen_graph_node_count": 107,
+    "semantic_move_count": 28,
+    "source_type_counts": {
+      "boost_direct_ui": 4,
+      "boost_xml": 229,
+      "morphe_direct_ui": 5,
+      "morphe_embedded_xml": 12
+    },
+    "static_blueprint_item_count": 250,
+    "task_child_violation_count": 0,
+    "task_page_count": 24
+  }
+}

--- a/tools/contracts/boost-settings-material-visual-foundation-v1.json
+++ b/tools/contracts/boost-settings-material-visual-foundation-v1.json
@@ -1,0 +1,47 @@
+{
+  "schema": 1,
+  "issue": 121,
+  "phase": "2.1/7 Material visual foundation",
+  "depth_model": {
+    "root": "large_category_cards",
+    "root_group": "compact_segmented_task_rows",
+    "task_hub": "compact_segmented_task_rows",
+    "intermediate_hub": "semantic_groups_with_icons",
+    "leaf_page": "standard_compact_settings_rows"
+  },
+  "duplicate_content_title": "forbidden_below_root",
+  "geometry": {
+    "row_single_dp": 52,
+    "row_two_line_dp": 64,
+    "group_gap_dp": 1,
+    "outer_radius_dp": 20,
+    "inner_radius_dp": 0,
+    "compact_icon_container_dp": 36,
+    "compact_icon_glyph_dp": 20,
+    "root_icon_container_dp": 44,
+    "root_icon_glyph_dp": 24
+  },
+  "navigation_drawer_groups": {
+    "Destinations": [
+      "Feeds & library",
+      "Account & tools"
+    ],
+    "Shortcuts": [
+      "Go-to shortcuts",
+      "Quick toggles"
+    ],
+    "Personalization": [
+      "Subscriptions",
+      "Account switcher",
+      "Drawer behavior"
+    ]
+  },
+  "behavior_changes": "none",
+  "preference_key_changes": 0,
+  "route_changes": 0,
+  "classic_fallback": "preserved",
+  "global_search": "preserved",
+  "status": "superseded",
+  "superseded_by": "boost-settings-android-guidance-pilot-v1.json",
+  "compliance_claim": "none"
+}

--- a/tools/contracts/boost-settings-navigation-phase2-v1.json
+++ b/tools/contracts/boost-settings-navigation-phase2-v1.json
@@ -1,0 +1,198 @@
+{
+  "schema": 1,
+  "issue": 121,
+  "phase": "2/7 Navigation",
+  "root_group": "Navigation",
+  "task_page": {
+    "title": "Navigation & gestures",
+    "intro": "Choose how you move around Boost and which navigation surfaces are available.",
+    "children": [
+      "Toolbar",
+      "Bottom navigation",
+      "Navigation drawer",
+      "Back & exit"
+    ]
+  },
+  "drawer_hub": {
+    "title": "Navigation drawer",
+    "intro": "Choose destinations, shortcuts, subscription behavior, account details, and drawer behavior.",
+    "children": [
+      "Feeds & library",
+      "Account & tools",
+      "Go-to shortcuts",
+      "Quick toggles",
+      "Subscriptions",
+      "Account switcher",
+      "Drawer behavior"
+    ]
+  },
+  "leaf_pages": [
+    {
+      "id": "toolbar",
+      "title": "Toolbar",
+      "summary": "Main action and hide-on-scroll behavior",
+      "icon": "ic_toolbar_24dp",
+      "fragment_constant": "V4_NAVIGATION_TOOLBAR_FRAGMENT",
+      "fragment_class": "NavigationToolbar",
+      "resource": "pref_toolbar_v2",
+      "intro": "Choose the toolbar's primary action and whether it stays visible while scrolling.",
+      "keys": [
+        "pref_toolbar_main_action",
+        "pref_toolbar"
+      ],
+      "parent": "Navigation & gestures"
+    },
+    {
+      "id": "bottom_navigation",
+      "title": "Bottom navigation",
+      "summary": "Visibility and hide-on-scroll behavior",
+      "icon": "ic_view_carousel_24dp",
+      "fragment_constant": "V4_NAVIGATION_BOTTOM_FRAGMENT",
+      "fragment_class": "NavigationBottom",
+      "resource": "pref_bottom_navigation_v2",
+      "intro": "Control whether bottom navigation is shown and how it behaves while scrolling.",
+      "keys": [
+        "pref_bottom_navigation",
+        "pref_bottom_navigation_hide_on_scroll"
+      ],
+      "parent": "Navigation & gestures"
+    },
+    {
+      "id": "back_exit",
+      "title": "Back & exit",
+      "summary": "Exit confirmation and double-back behavior",
+      "icon": "ic_restore_black_24dp",
+      "fragment_constant": "V4_NAVIGATION_BACK_EXIT_FRAGMENT",
+      "fragment_class": "NavigationBackExit",
+      "resource": "pref_general_v2",
+      "intro": "Choose how Boost responds when Back would leave the app.",
+      "keys": [
+        "pref_ask_exit",
+        "pref_double_exit"
+      ],
+      "parent": "Navigation & gestures"
+    },
+    {
+      "id": "drawer_feeds_library",
+      "title": "Feeds & library",
+      "summary": "Home, feeds, saved posts, and history",
+      "icon": "ic_subreddit_24dp",
+      "fragment_constant": "V4_DRAWER_FEEDS_LIBRARY_FRAGMENT",
+      "fragment_class": "DrawerFeedsLibrary",
+      "resource": "pref_drawer_v2",
+      "intro": "Choose which feed and library destinations appear in the navigation drawer.",
+      "keys": [
+        "pref_drawer_show_home",
+        "pref_drawer_show_frontpage",
+        "pref_drawer_show_popular",
+        "pref_drawer_show_all",
+        "pref_drawer_show_saved",
+        "pref_drawer_show_history"
+      ],
+      "parent": "Navigation drawer"
+    },
+    {
+      "id": "drawer_account_tools",
+      "title": "Account & tools",
+      "summary": "Profile, inbox, drafts, moderation, and search",
+      "icon": "ic_person_24dp",
+      "fragment_constant": "V4_DRAWER_ACCOUNT_TOOLS_FRAGMENT",
+      "fragment_class": "DrawerAccountTools",
+      "resource": "pref_drawer_v2",
+      "intro": "Choose which account and utility destinations appear in the navigation drawer.",
+      "keys": [
+        "pref_drawer_show_profile",
+        "pref_drawer_show_inbox",
+        "pref_drawer_show_drafts",
+        "pref_drawer_show_mod",
+        "pref_drawer_show_search_generic"
+      ],
+      "parent": "Navigation drawer"
+    },
+    {
+      "id": "drawer_go_to",
+      "title": "Go-to shortcuts",
+      "summary": "Community, user, and combined go-to shortcuts",
+      "icon": "ic_search_color_24dp",
+      "fragment_constant": "V4_DRAWER_GO_TO_FRAGMENT",
+      "fragment_class": "DrawerGoToShortcuts",
+      "resource": "pref_drawer_v2",
+      "intro": "Choose which direct navigation shortcuts appear in the drawer.",
+      "keys": [
+        "pref_drawer_show_go_to",
+        "pref_drawer_show_go_to_subreddit",
+        "pref_drawer_show_go_to_user"
+      ],
+      "parent": "Navigation drawer"
+    },
+    {
+      "id": "drawer_quick_toggles",
+      "title": "Quick toggles",
+      "summary": "Dark mode and NSFW controls in the drawer",
+      "icon": "ic_settings_24dp",
+      "fragment_constant": "V4_DRAWER_QUICK_TOGGLES_FRAGMENT",
+      "fragment_class": "DrawerQuickToggles",
+      "resource": "pref_drawer_v2",
+      "intro": "Choose which frequently used display controls appear in the drawer.",
+      "keys": [
+        "pref_drawer_show_night_mode",
+        "pref_drawer_show_nsfw_switch",
+        "pref_drawer_show_blur_switch"
+      ],
+      "parent": "Navigation drawer"
+    },
+    {
+      "id": "drawer_subscriptions",
+      "title": "Subscriptions",
+      "summary": "Subscription list visibility, icons, and favorites",
+      "icon": "ic_subreddit_24dp",
+      "fragment_constant": "V4_DRAWER_SUBSCRIPTIONS_FRAGMENT",
+      "fragment_class": "DrawerSubscriptions",
+      "resource": "pref_drawer_v2",
+      "intro": "Configure the subscription list shown inside the navigation drawer.",
+      "keys": [
+        "pref_subscriptions_drawer",
+        "pref_subscriptions_drawer_show_icon",
+        "pref_subscriptions_only_casual"
+      ],
+      "parent": "Navigation drawer"
+    },
+    {
+      "id": "drawer_account_switcher",
+      "title": "Account switcher",
+      "summary": "Avatar and username visibility",
+      "icon": "ic_person_24dp",
+      "fragment_constant": "V4_DRAWER_ACCOUNT_SWITCHER_FRAGMENT",
+      "fragment_class": "DrawerAccountSwitcher",
+      "resource": "pref_drawer_v2",
+      "intro": "Choose which identity details are visible in the drawer's account switcher.",
+      "keys": [
+        "pref_accounts_show_avatar",
+        "pref_accounts_show_username"
+      ],
+      "parent": "Navigation drawer"
+    },
+    {
+      "id": "drawer_behavior",
+      "title": "Drawer behavior",
+      "summary": "Sticky Settings and which edge opens the drawer",
+      "icon": "ic_toolbar_24dp",
+      "fragment_constant": "V4_DRAWER_BEHAVIOR_FRAGMENT",
+      "fragment_class": "DrawerBehavior",
+      "resource": "pref_drawer_v2",
+      "intro": "Control persistent Settings access and which side opens the navigation drawer.",
+      "keys": [
+        "pref_drawer_sticky_settings",
+        "pref_drawer_end"
+      ],
+      "parent": "Navigation drawer"
+    }
+  ],
+  "exposed_key_count": 30,
+  "withheld_keys": [
+    "pref_drawer_show_friends"
+  ],
+  "max_controls_per_leaf": 6,
+  "classic_fallback": "preserved",
+  "global_search": "available_on_task_hub_and_all_leaf_pages"
+}

--- a/tools/contracts/boost-settings-ux-depth-v1.json
+++ b/tools/contracts/boost-settings-ux-depth-v1.json
@@ -1,0 +1,55 @@
+{
+  "comments_topology": {
+    "child_pages": [
+      "Sorting & loading",
+      "Appearance",
+      "Collapse behavior",
+      "Navigation & controls"
+    ],
+    "leaf_sections": {
+      "Appearance": [
+        "Author & media",
+        "Thread styling",
+        "Awards & flair"
+      ],
+      "Collapse behavior": [
+        "Collapse rules",
+        "Collapsed presentation"
+      ],
+      "Navigation & controls": [
+        "Comment navigation",
+        "Visible buttons",
+        "Gestures"
+      ],
+      "Sorting & loading": [
+        "Sorting",
+        "Loading"
+      ]
+    },
+    "task_page": "Comments"
+  },
+  "global_search": {
+    "androidx_navigation_calls": "forbidden",
+    "back_callback_priority": "platform_overlay",
+    "deeper_morphe_pages": "top_app_bar_action",
+    "navigation_mode": "platform_dialog_overlay",
+    "opens_with_keyboard": true,
+    "result_back_stack": "returns_to_originating_page",
+    "root_surface": "inline_search_field",
+    "scope": "all_settings",
+    "single_back_behavior": "dismiss_overlay_and_ime"
+  },
+  "intermediate_pages_required_when_domains_mix": true,
+  "issue": 121,
+  "leaf_hard_max_controls": 12,
+  "leaf_target_controls": {
+    "max": 9,
+    "min": 4
+  },
+  "root_group_count": 7,
+  "root_screen": "seven_category_list_rows",
+  "schema": 1,
+  "section_headers_do_not_replace_navigation": true,
+  "task_pages": "one_level_below_root",
+  "task_pages_must_not_be_xml_dumps": true
+}

--- a/tools/contracts/boost-settings-v5-appearance-wave-v1.json
+++ b/tools/contracts/boost-settings-v5-appearance-wave-v1.json
@@ -1,0 +1,585 @@
+{
+  "activation_policy": "parallel_hidden_until_complete",
+  "binding_capture": {
+    "archive_sha256": "1953af26eb18a1f00a9adeb02252696551d394867892afa0b62ac65ad0b53ae3",
+    "base_apk_sha256": "a68c22d632a5dd1f446c3759a171c7dbb9edab2afc3c2f87e39323f198606742",
+    "source_mpp_sha256": "c238c79d16f17877a46483e6f467f36a0086f50fe8c4172b64663e4ab30016f7",
+    "v5_contract_sha256": "4c8e081069d7444938c3ff5ad0e451bb3b16183592114a6b8adf77cd1208d3f7"
+  },
+  "dependencies": {
+    "action:saved_views:add": "pref_view_per_subscription",
+    "action:saved_views:clear_all": "saved_views_not_empty",
+    "pref_cards_preview_self_lines": "pref_cards_preview_self",
+    "pref_header_show_description": "pref_show_subreddit_header",
+    "pref_theme": "not:pref_dynamic_colors",
+    "pref_toolbar_header_type": "pref_show_subreddit_header",
+    "pref_view_per_sub": "pref_view_per_subscription"
+  },
+  "issue": 121,
+  "items": [
+    {
+      "default_value": "center",
+      "dependency": "pref_show_subreddit_header",
+      "key": "pref_toolbar_header_type",
+      "logical_kind": "stored_setting",
+      "page_id": "v5/appearance/community_header/community_header",
+      "storage_type": "string",
+      "title": "Community info alignment"
+    },
+    {
+      "default_value": "true",
+      "dependency": "pref_show_subreddit_header",
+      "key": "pref_header_show_description",
+      "logical_kind": "stored_setting",
+      "page_id": "v5/appearance/community_header/community_header",
+      "storage_type": "boolean",
+      "title": "Show community description"
+    },
+    {
+      "default_value": "false",
+      "dependency": "",
+      "key": "pref_show_subreddit_header",
+      "logical_kind": "stored_setting",
+      "page_id": "v5/appearance/community_header/community_header",
+      "storage_type": "boolean",
+      "title": "Show community header"
+    },
+    {
+      "default_value": "true",
+      "dependency": "",
+      "key": "morphe_boost_prefer_high_refresh_rate",
+      "logical_kind": "stored_setting",
+      "page_id": "v5/appearance/display_and_motion/display_performance",
+      "storage_type": "boolean",
+      "title": "Prefer high refresh rate"
+    },
+    {
+      "default_value": "true",
+      "dependency": "",
+      "key": "pref_cards_gallery_carousel",
+      "logical_kind": "stored_setting",
+      "page_id": "v5/appearance/post_layout/cards",
+      "storage_type": "boolean",
+      "title": "Carousel for multiple images"
+    },
+    {
+      "default_value": "true",
+      "dependency": "",
+      "key": "pref_cards_full",
+      "logical_kind": "stored_setting",
+      "page_id": "v5/appearance/post_layout/cards",
+      "storage_type": "boolean",
+      "title": "Fill the screen width"
+    },
+    {
+      "default_value": "false",
+      "dependency": "",
+      "key": "pref_cards_full_preview",
+      "logical_kind": "stored_setting",
+      "page_id": "v5/appearance/post_layout/cards",
+      "storage_type": "boolean",
+      "title": "Full height images"
+    },
+    {
+      "default_value": "5",
+      "dependency": "pref_cards_preview_self",
+      "key": "pref_cards_preview_self_lines",
+      "logical_kind": "stored_setting",
+      "page_id": "v5/appearance/post_layout/cards",
+      "storage_type": "integer",
+      "title": "Lines to preview"
+    },
+    {
+      "default_value": "true",
+      "dependency": "",
+      "key": "pref_cards_preview_self",
+      "logical_kind": "stored_setting",
+      "page_id": "v5/appearance/post_layout/cards",
+      "storage_type": "boolean",
+      "title": "Preview text from posts"
+    },
+    {
+      "default_value": "false",
+      "dependency": "",
+      "key": "pref_cards_rounded_corners",
+      "logical_kind": "stored_setting",
+      "page_id": "v5/appearance/post_layout/cards",
+      "storage_type": "boolean",
+      "title": "Rounded corners"
+    },
+    {
+      "default_value": "true",
+      "dependency": "",
+      "key": "pref_cards_subreddit_icon",
+      "logical_kind": "stored_setting",
+      "page_id": "v5/appearance/post_layout/cards",
+      "storage_type": "boolean",
+      "title": "Show community icon"
+    },
+    {
+      "default_value": "true",
+      "dependency": "",
+      "key": "pref_cards_links_as_thumbnails",
+      "logical_kind": "stored_setting",
+      "page_id": "v5/appearance/post_layout/cards",
+      "storage_type": "boolean",
+      "title": "Show thumbnails for link posts"
+    },
+    {
+      "default_value": "false",
+      "dependency": "",
+      "key": "pref_dense_buttons_visible",
+      "logical_kind": "stored_setting",
+      "page_id": "v5/appearance/post_layout/compact_layouts/dense",
+      "storage_type": "boolean",
+      "title": "Buttons always visible"
+    },
+    {
+      "default_value": "false",
+      "dependency": "",
+      "key": "pref_mini_cards_buttons_visible",
+      "logical_kind": "stored_setting",
+      "page_id": "v5/appearance/post_layout/compact_layouts/small_cards",
+      "storage_type": "boolean",
+      "title": "Buttons always visible"
+    },
+    {
+      "default_value": "false",
+      "dependency": "",
+      "key": "pref_mini_cards_full",
+      "logical_kind": "stored_setting",
+      "page_id": "v5/appearance/post_layout/compact_layouts/small_cards",
+      "storage_type": "boolean",
+      "title": "Fill the screen width"
+    },
+    {
+      "default_value": "true",
+      "dependency": "",
+      "key": "pref_mini_cards_rounded_corners",
+      "logical_kind": "stored_setting",
+      "page_id": "v5/appearance/post_layout/compact_layouts/small_cards",
+      "storage_type": "boolean",
+      "title": "Rounded corners"
+    },
+    {
+      "default_value": "true",
+      "dependency": "",
+      "key": "pref_mini_cards_truncate_title",
+      "logical_kind": "stored_setting",
+      "page_id": "v5/appearance/post_layout/compact_layouts/small_cards",
+      "storage_type": "boolean",
+      "title": "Truncate title"
+    },
+    {
+      "default_value": "false",
+      "dependency": "",
+      "key": "pref_show_subreddit_prefix",
+      "logical_kind": "stored_setting",
+      "page_id": "v5/appearance/post_layout/layout_and_saved_views/post_layout",
+      "storage_type": "boolean",
+      "title": "Communities start with r/"
+    },
+    {
+      "default_value": "0",
+      "dependency": "",
+      "key": "pref_view",
+      "logical_kind": "stored_setting",
+      "page_id": "v5/appearance/post_layout/layout_and_saved_views/post_layout",
+      "storage_type": "string",
+      "title": "Default view"
+    },
+    {
+      "default_value": "",
+      "dependency": "pref_view_per_subscription",
+      "key": "pref_view_per_sub",
+      "logical_kind": "action",
+      "page_id": "v5/appearance/post_layout/layout_and_saved_views/post_layout",
+      "storage_type": "none_or_custom",
+      "title": "Manage saved views"
+    },
+    {
+      "default_value": "false",
+      "dependency": "",
+      "key": "pref_view_per_subscription",
+      "logical_kind": "stored_setting",
+      "page_id": "v5/appearance/post_layout/layout_and_saved_views/post_layout",
+      "storage_type": "boolean",
+      "title": "Remember per community"
+    },
+    {
+      "default_value": "false",
+      "dependency": "",
+      "key": "pref_left_handed",
+      "logical_kind": "stored_setting",
+      "page_id": "v5/appearance/post_layout/layout_and_saved_views/post_layout",
+      "storage_type": "boolean",
+      "title": "Thumbnails on left"
+    },
+    {
+      "default_value": "",
+      "dependency": "pref_view_per_subscription",
+      "key": "action:saved_views:add",
+      "logical_kind": "action",
+      "page_id": "v5/appearance/post_layout/layout_and_saved_views/saved_community_views",
+      "storage_type": "private_preferences",
+      "title": "Add saved view"
+    },
+    {
+      "default_value": "",
+      "dependency": "saved_views_not_empty",
+      "key": "action:saved_views:clear_all",
+      "logical_kind": "destructive_action",
+      "page_id": "v5/appearance/post_layout/layout_and_saved_views/saved_community_views",
+      "storage_type": "private_preferences",
+      "title": "Clear all saved views"
+    },
+    {
+      "default_value": "true",
+      "dependency": "",
+      "key": "pref_split_screen",
+      "logical_kind": "stored_setting",
+      "page_id": "v5/appearance/post_layout/tablet_layout",
+      "storage_type": "boolean",
+      "title": "Tablet split screen mode"
+    },
+    {
+      "default_value": "false",
+      "dependency": "",
+      "key": "pref_colored_nav_bar",
+      "logical_kind": "stored_setting",
+      "page_id": "v5/appearance/theme_and_colors/advanced_appearance",
+      "storage_type": "boolean",
+      "title": "Colored navigation bar"
+    },
+    {
+      "default_value": "true",
+      "dependency": "",
+      "key": "pref_colored_status_bar",
+      "logical_kind": "stored_setting",
+      "page_id": "v5/appearance/theme_and_colors/advanced_appearance",
+      "storage_type": "boolean",
+      "title": "Colored status bar"
+    },
+    {
+      "default_value": "",
+      "dependency": "",
+      "key": "pref_app_icon",
+      "logical_kind": "action",
+      "page_id": "v5/appearance/theme_and_colors/personalization",
+      "storage_type": "none_or_custom",
+      "title": "App icon"
+    },
+    {
+      "default_value": "0",
+      "dependency": "pref_dynamic_colors",
+      "key": "pref_theme",
+      "logical_kind": "action",
+      "page_id": "v5/appearance/theme_and_colors/theme",
+      "storage_type": "none_or_custom",
+      "title": "Customize colors"
+    },
+    {
+      "default_value": "1140",
+      "dependency": "",
+      "key": "pref_theme_night_start_minutes",
+      "logical_kind": "special_preference",
+      "page_id": "v5/appearance/theme_and_colors/theme",
+      "storage_type": "none_or_custom",
+      "title": "Dark start time"
+    },
+    {
+      "default_value": "8",
+      "dependency": "",
+      "key": "pref_theme_night",
+      "logical_kind": "special_preference",
+      "page_id": "v5/appearance/theme_and_colors/theme",
+      "storage_type": "none_or_custom",
+      "title": "Dark theme"
+    },
+    {
+      "default_value": "false",
+      "dependency": "",
+      "key": "pref_dynamic_colors",
+      "logical_kind": "stored_setting",
+      "page_id": "v5/appearance/theme_and_colors/theme",
+      "storage_type": "boolean",
+      "title": "Dynamic color"
+    },
+    {
+      "default_value": "420",
+      "dependency": "",
+      "key": "pref_theme_night_end_minutes",
+      "logical_kind": "special_preference",
+      "page_id": "v5/appearance/theme_and_colors/theme",
+      "storage_type": "none_or_custom",
+      "title": "Light start time"
+    },
+    {
+      "default_value": "system",
+      "dependency": "",
+      "key": "pref_theme_mode_type",
+      "logical_kind": "stored_setting",
+      "page_id": "v5/appearance/theme_and_colors/theme",
+      "storage_type": "string",
+      "title": "Theme"
+    },
+    {
+      "default_value": "",
+      "dependency": "",
+      "key": "pref_comments_font",
+      "logical_kind": "special_preference",
+      "page_id": "v5/appearance/typography/comments",
+      "storage_type": "none_or_custom",
+      "title": "Comments font"
+    },
+    {
+      "default_value": "Medium",
+      "dependency": "",
+      "key": "pref_font_size",
+      "logical_kind": "stored_setting",
+      "page_id": "v5/appearance/typography/comments",
+      "storage_type": "string",
+      "title": "Comments text size"
+    },
+    {
+      "default_value": "",
+      "dependency": "",
+      "key": "pref_title_font",
+      "logical_kind": "special_preference",
+      "page_id": "v5/appearance/typography/posts",
+      "storage_type": "none_or_custom",
+      "title": "Title font"
+    },
+    {
+      "default_value": "Medium",
+      "dependency": "",
+      "key": "pref_font_size_title",
+      "logical_kind": "stored_setting",
+      "page_id": "v5/appearance/typography/posts",
+      "storage_type": "string",
+      "title": "Title text size"
+    },
+    {
+      "default_value": "",
+      "dependency": "",
+      "key": "action:typography:restore_defaults",
+      "logical_kind": "destructive_action",
+      "page_id": "v5/appearance/typography/reset",
+      "storage_type": "none",
+      "title": "Restore font defaults"
+    }
+  ],
+  "runtime_gate": "not_authorized_until_static_build_and_dev_only_audit",
+  "schema": 1,
+  "screens": [
+    {
+      "child_count": 5,
+      "control_count": 0,
+      "page_id": "v5/appearance",
+      "path": "Appearance",
+      "role": "root_group"
+    },
+    {
+      "child_count": 1,
+      "control_count": 0,
+      "page_id": "v5/appearance/community_header",
+      "path": "Appearance / Community header",
+      "role": "task_page"
+    },
+    {
+      "child_count": 1,
+      "control_count": 0,
+      "page_id": "v5/appearance/display_and_motion",
+      "path": "Appearance / Display & motion",
+      "role": "task_page"
+    },
+    {
+      "child_count": 4,
+      "control_count": 0,
+      "page_id": "v5/appearance/post_layout",
+      "path": "Appearance / Post layout",
+      "role": "task_page"
+    },
+    {
+      "child_count": 3,
+      "control_count": 0,
+      "page_id": "v5/appearance/theme_and_colors",
+      "path": "Appearance / Theme & colors",
+      "role": "task_page"
+    },
+    {
+      "child_count": 3,
+      "control_count": 0,
+      "page_id": "v5/appearance/typography",
+      "path": "Appearance / Typography",
+      "role": "task_page"
+    },
+    {
+      "child_count": 0,
+      "control_count": 3,
+      "page_id": "v5/appearance/community_header/community_header",
+      "path": "Appearance / Community header / Community header",
+      "role": "leaf_section"
+    },
+    {
+      "child_count": 0,
+      "control_count": 1,
+      "page_id": "v5/appearance/display_and_motion/display_performance",
+      "path": "Appearance / Display & motion / Display performance",
+      "role": "leaf_section"
+    },
+    {
+      "child_count": 0,
+      "control_count": 8,
+      "page_id": "v5/appearance/post_layout/cards",
+      "path": "Appearance / Post layout / Cards",
+      "role": "leaf_section"
+    },
+    {
+      "child_count": 2,
+      "control_count": 0,
+      "page_id": "v5/appearance/post_layout/compact_layouts",
+      "path": "Appearance / Post layout / Compact layouts",
+      "role": "intermediate_page"
+    },
+    {
+      "child_count": 2,
+      "control_count": 0,
+      "page_id": "v5/appearance/post_layout/layout_and_saved_views",
+      "path": "Appearance / Post layout / Layout & saved views",
+      "role": "intermediate_page"
+    },
+    {
+      "child_count": 0,
+      "control_count": 1,
+      "page_id": "v5/appearance/post_layout/tablet_layout",
+      "path": "Appearance / Post layout / Tablet layout",
+      "role": "leaf_section"
+    },
+    {
+      "child_count": 0,
+      "control_count": 2,
+      "page_id": "v5/appearance/theme_and_colors/advanced_appearance",
+      "path": "Appearance / Theme & colors / Advanced appearance",
+      "role": "leaf_section"
+    },
+    {
+      "child_count": 0,
+      "control_count": 1,
+      "page_id": "v5/appearance/theme_and_colors/personalization",
+      "path": "Appearance / Theme & colors / Personalization",
+      "role": "leaf_section"
+    },
+    {
+      "child_count": 0,
+      "control_count": 6,
+      "page_id": "v5/appearance/theme_and_colors/theme",
+      "path": "Appearance / Theme & colors / Theme",
+      "role": "leaf_section"
+    },
+    {
+      "child_count": 0,
+      "control_count": 2,
+      "page_id": "v5/appearance/typography/comments",
+      "path": "Appearance / Typography / Comments",
+      "role": "leaf_section"
+    },
+    {
+      "child_count": 0,
+      "control_count": 2,
+      "page_id": "v5/appearance/typography/posts",
+      "path": "Appearance / Typography / Posts",
+      "role": "leaf_section"
+    },
+    {
+      "child_count": 0,
+      "control_count": 1,
+      "page_id": "v5/appearance/typography/reset",
+      "path": "Appearance / Typography / Reset",
+      "role": "leaf_section"
+    },
+    {
+      "child_count": 0,
+      "control_count": 1,
+      "page_id": "v5/appearance/post_layout/compact_layouts/dense",
+      "path": "Appearance / Post layout / Compact layouts / Dense",
+      "role": "leaf_section"
+    },
+    {
+      "child_count": 0,
+      "control_count": 4,
+      "page_id": "v5/appearance/post_layout/compact_layouts/small_cards",
+      "path": "Appearance / Post layout / Compact layouts / Small cards",
+      "role": "leaf_section"
+    },
+    {
+      "child_count": 0,
+      "control_count": 5,
+      "page_id": "v5/appearance/post_layout/layout_and_saved_views/post_layout",
+      "path": "Appearance / Post layout / Layout & saved views / Post layout",
+      "role": "leaf_section"
+    },
+    {
+      "child_count": 0,
+      "control_count": 2,
+      "page_id": "v5/appearance/post_layout/layout_and_saved_views/saved_community_views",
+      "path": "Appearance / Post layout / Layout & saved views / Saved community views",
+      "role": "leaf_section"
+    }
+  ],
+  "source_files": [
+    "MorpheSettingsV5Registry.java",
+    "MorpheSettingsV5AppearanceFragment.java",
+    "MorpheSettingsV5AppearanceBindings.java",
+    "MorpheSettingsV5Search.java"
+  ],
+  "special_handlers": {
+    "app_icon": [
+      "pref_app_icon"
+    ],
+    "fonts": [
+      "pref_title_font",
+      "pref_comments_font",
+      "pref_font_size_title",
+      "pref_font_size",
+      "action:typography:restore_defaults"
+    ],
+    "high_refresh": [
+      "morphe_boost_prefer_high_refresh_rate"
+    ],
+    "post_layout": [
+      "pref_view",
+      "pref_view_per_subscription",
+      "pref_show_subreddit_prefix",
+      "pref_cards_preview_self_lines"
+    ],
+    "saved_views": [
+      "pref_view_per_sub",
+      "action:saved_views:add",
+      "action:saved_views:clear_all"
+    ],
+    "system_bars": [
+      "pref_colored_status_bar",
+      "pref_colored_nav_bar"
+    ],
+    "theme_mode": [
+      "pref_theme_mode_type",
+      "pref_theme",
+      "pref_theme_night",
+      "pref_theme_night_start_minutes",
+      "pref_theme_night_end_minutes",
+      "pref_dynamic_colors"
+    ]
+  },
+  "status": "HIDDEN_COMPLETE_WAVE_STATIC_TARGET",
+  "target": {
+    "legacy_routes": 0,
+    "max_controls_per_leaf": 8,
+    "placeholder_pages": 0,
+    "screen_nodes": 22,
+    "visible_by_default": false,
+    "visible_items": 39,
+    "withheld_items": 0
+  },
+  "wave": "Appearance"
+}

--- a/tools/contracts/boost-settings-v5-completeness-v1.json
+++ b/tools/contracts/boost-settings-v5-completeness-v1.json
@@ -1,0 +1,10671 @@
+{
+  "activation_gate": {
+    "activation_policy": "parallel_hidden_until_complete",
+    "allowed_classic_fallbacks": 1,
+    "allowed_external_action_destinations": 1,
+    "allowed_legacy_fragments": 0,
+    "allowed_legacy_xml_routes": 0,
+    "allowed_placeholder_pages": 0,
+    "allowed_title_route_mismatches": 0,
+    "allowed_unmapped_keys": 0,
+    "canonical_item_accounting": 250,
+    "classic_fallback_location": "root_only",
+    "external_action_destination_allowlist": [
+      "BackupActivity"
+    ],
+    "partial_completion_must_not_replace_current_visible_tree": true,
+    "required_complete_screen_nodes": 108,
+    "required_complete_visible_items": 249,
+    "root_overview_shell_count": 1,
+    "root_overview_shell_must_be_complete": true,
+    "target_screen_edge_count": 101,
+    "target_screen_node_count": 108,
+    "visible_item_target": 249,
+    "withheld_controls_must_have_evidence": true,
+    "withheld_item_target": 1
+  },
+  "canonical_item_count": 250,
+  "graph_edges": [
+    {
+      "child_path": "Appearance / Community header",
+      "child_title": "Community header",
+      "parent_path": "Appearance"
+    },
+    {
+      "child_path": "Appearance / Community header / Community header",
+      "child_title": "Community header",
+      "parent_path": "Appearance / Community header"
+    },
+    {
+      "child_path": "Appearance / Display & motion",
+      "child_title": "Display & motion",
+      "parent_path": "Appearance"
+    },
+    {
+      "child_path": "Appearance / Display & motion / Display performance",
+      "child_title": "Display performance",
+      "parent_path": "Appearance / Display & motion"
+    },
+    {
+      "child_path": "Appearance / Post layout",
+      "child_title": "Post layout",
+      "parent_path": "Appearance"
+    },
+    {
+      "child_path": "Appearance / Post layout / Cards",
+      "child_title": "Cards",
+      "parent_path": "Appearance / Post layout"
+    },
+    {
+      "child_path": "Appearance / Post layout / Compact layouts",
+      "child_title": "Compact layouts",
+      "parent_path": "Appearance / Post layout"
+    },
+    {
+      "child_path": "Appearance / Post layout / Compact layouts / Dense",
+      "child_title": "Dense",
+      "parent_path": "Appearance / Post layout / Compact layouts"
+    },
+    {
+      "child_path": "Appearance / Post layout / Compact layouts / Small cards",
+      "child_title": "Small cards",
+      "parent_path": "Appearance / Post layout / Compact layouts"
+    },
+    {
+      "child_path": "Appearance / Post layout / Layout & saved views",
+      "child_title": "Layout & saved views",
+      "parent_path": "Appearance / Post layout"
+    },
+    {
+      "child_path": "Appearance / Post layout / Layout & saved views / Post layout",
+      "child_title": "Post layout",
+      "parent_path": "Appearance / Post layout / Layout & saved views"
+    },
+    {
+      "child_path": "Appearance / Post layout / Layout & saved views / Saved community views",
+      "child_title": "Saved community views",
+      "parent_path": "Appearance / Post layout / Layout & saved views"
+    },
+    {
+      "child_path": "Appearance / Post layout / Swipe",
+      "child_title": "Swipe",
+      "parent_path": "Appearance / Post layout"
+    },
+    {
+      "child_path": "Appearance / Post layout / Tablet layout",
+      "child_title": "Tablet layout",
+      "parent_path": "Appearance / Post layout"
+    },
+    {
+      "child_path": "Appearance / Theme & colors",
+      "child_title": "Theme & colors",
+      "parent_path": "Appearance"
+    },
+    {
+      "child_path": "Appearance / Theme & colors / Advanced appearance",
+      "child_title": "Advanced appearance",
+      "parent_path": "Appearance / Theme & colors"
+    },
+    {
+      "child_path": "Appearance / Theme & colors / Personalization",
+      "child_title": "Personalization",
+      "parent_path": "Appearance / Theme & colors"
+    },
+    {
+      "child_path": "Appearance / Theme & colors / Theme",
+      "child_title": "Theme",
+      "parent_path": "Appearance / Theme & colors"
+    },
+    {
+      "child_path": "Appearance / Typography",
+      "child_title": "Typography",
+      "parent_path": "Appearance"
+    },
+    {
+      "child_path": "Appearance / Typography / Comments",
+      "child_title": "Comments",
+      "parent_path": "Appearance / Typography"
+    },
+    {
+      "child_path": "Appearance / Typography / Posts",
+      "child_title": "Posts",
+      "parent_path": "Appearance / Typography"
+    },
+    {
+      "child_path": "Appearance / Typography / Reset",
+      "child_title": "Reset",
+      "parent_path": "Appearance / Typography"
+    },
+    {
+      "child_path": "Data & app / About & support",
+      "child_title": "About & support",
+      "parent_path": "Data & app"
+    },
+    {
+      "child_path": "Data & app / About & support / About Boost",
+      "child_title": "About Boost",
+      "parent_path": "Data & app / About & support"
+    },
+    {
+      "child_path": "Data & app / About & support / Author",
+      "child_title": "Author",
+      "parent_path": "Data & app / About & support"
+    },
+    {
+      "child_path": "Data & app / About & support / Privacy",
+      "child_title": "Privacy",
+      "parent_path": "Data & app / About & support"
+    },
+    {
+      "child_path": "Data & app / App behavior & compatibility",
+      "child_title": "App behavior & compatibility",
+      "parent_path": "Data & app"
+    },
+    {
+      "child_path": "Data & app / App behavior & compatibility / Community shortcuts",
+      "child_title": "Community shortcuts",
+      "parent_path": "Data & app / App behavior & compatibility"
+    },
+    {
+      "child_path": "Data & app / App behavior & compatibility / Compatibility & legacy",
+      "child_title": "Compatibility & legacy",
+      "parent_path": "Data & app / App behavior & compatibility"
+    },
+    {
+      "child_path": "Data & app / App behavior & compatibility / Other app behavior",
+      "child_title": "Other app behavior",
+      "parent_path": "Data & app / App behavior & compatibility"
+    },
+    {
+      "child_path": "Data & app / Backup & restore",
+      "child_title": "Backup & restore",
+      "parent_path": "Data & app"
+    },
+    {
+      "child_path": "Data & app / Settings experience",
+      "child_title": "Settings experience",
+      "parent_path": "Data & app"
+    },
+    {
+      "child_path": "Data & app / Settings experience / Settings presentation",
+      "child_title": "Settings presentation",
+      "parent_path": "Data & app / Settings experience"
+    },
+    {
+      "child_path": "Data & app / Storage & bandwidth",
+      "child_title": "Storage & bandwidth",
+      "parent_path": "Data & app"
+    },
+    {
+      "child_path": "Data & app / Storage & bandwidth / Cache",
+      "child_title": "Cache",
+      "parent_path": "Data & app / Storage & bandwidth"
+    },
+    {
+      "child_path": "Data & app / Storage & bandwidth / Data saver",
+      "child_title": "Data saver",
+      "parent_path": "Data & app / Storage & bandwidth"
+    },
+    {
+      "child_path": "Data & app / Storage & bandwidth / Data usage",
+      "child_title": "Data usage",
+      "parent_path": "Data & app / Storage & bandwidth"
+    },
+    {
+      "child_path": "Data & app / Storage & bandwidth / Images",
+      "child_title": "Images",
+      "parent_path": "Data & app / Storage & bandwidth"
+    },
+    {
+      "child_path": "Data & app / Storage & bandwidth / Videos",
+      "child_title": "Videos",
+      "parent_path": "Data & app / Storage & bandwidth"
+    },
+    {
+      "child_path": "Media / Downloads & cache",
+      "child_title": "Downloads & cache",
+      "parent_path": "Media"
+    },
+    {
+      "child_path": "Media / Downloads & cache / Download folders",
+      "child_title": "Download folders",
+      "parent_path": "Media / Downloads & cache"
+    },
+    {
+      "child_path": "Media / Images, GIFs & previews",
+      "child_title": "Images, GIFs & previews",
+      "parent_path": "Media"
+    },
+    {
+      "child_path": "Media / Images, GIFs & previews / Native image behavior",
+      "child_title": "Native image behavior",
+      "parent_path": "Media / Images, GIFs & previews"
+    },
+    {
+      "child_path": "Media / Images, GIFs & previews / Open behavior",
+      "child_title": "Open behavior",
+      "parent_path": "Media / Images, GIFs & previews"
+    },
+    {
+      "child_path": "Media / Images, GIFs & previews / Preview behavior",
+      "child_title": "Preview behavior",
+      "parent_path": "Media / Images, GIFs & previews"
+    },
+    {
+      "child_path": "Media / Images, GIFs & previews / Preview layout",
+      "child_title": "Preview layout",
+      "parent_path": "Media / Images, GIFs & previews"
+    },
+    {
+      "child_path": "Media / Links & browser",
+      "child_title": "Links & browser",
+      "parent_path": "Media"
+    },
+    {
+      "child_path": "Media / Links & browser / Browser",
+      "child_title": "Browser",
+      "parent_path": "Media / Links & browser"
+    },
+    {
+      "child_path": "Media / Links & browser / Link handling",
+      "child_title": "Link handling",
+      "parent_path": "Media / Links & browser"
+    },
+    {
+      "child_path": "Media / Links & browser / Links to open in app",
+      "child_title": "Links to open in app",
+      "parent_path": "Media / Links & browser"
+    },
+    {
+      "child_path": "Media / Links & browser / Video links",
+      "child_title": "Video links",
+      "parent_path": "Media / Links & browser"
+    },
+    {
+      "child_path": "Media / Playback & autoplay",
+      "child_title": "Playback & autoplay",
+      "parent_path": "Media"
+    },
+    {
+      "child_path": "Media / Playback & autoplay / Audio",
+      "child_title": "Audio",
+      "parent_path": "Media / Playback & autoplay"
+    },
+    {
+      "child_path": "Media / Playback & autoplay / Autoplay",
+      "child_title": "Autoplay",
+      "parent_path": "Media / Playback & autoplay"
+    },
+    {
+      "child_path": "Media / Playback & autoplay / Media behavior",
+      "child_title": "Media behavior",
+      "parent_path": "Media / Playback & autoplay"
+    },
+    {
+      "child_path": "Media / Playback & autoplay / Playback & autoplay",
+      "child_title": "Playback & autoplay",
+      "parent_path": "Media / Playback & autoplay"
+    },
+    {
+      "child_path": "Morphe / Patch features",
+      "child_title": "Patch features",
+      "parent_path": "Morphe"
+    },
+    {
+      "child_path": "Navigation / Navigation & gestures",
+      "child_title": "Navigation & gestures",
+      "parent_path": "Navigation"
+    },
+    {
+      "child_path": "Navigation / Navigation & gestures / Back & exit",
+      "child_title": "Back & exit",
+      "parent_path": "Navigation / Navigation & gestures"
+    },
+    {
+      "child_path": "Navigation / Navigation & gestures / Bottom navigation",
+      "child_title": "Bottom navigation",
+      "parent_path": "Navigation / Navigation & gestures"
+    },
+    {
+      "child_path": "Navigation / Navigation & gestures / Navigation drawer",
+      "child_title": "Navigation drawer",
+      "parent_path": "Navigation / Navigation & gestures"
+    },
+    {
+      "child_path": "Navigation / Navigation & gestures / Navigation drawer / Account & tools",
+      "child_title": "Account & tools",
+      "parent_path": "Navigation / Navigation & gestures / Navigation drawer"
+    },
+    {
+      "child_path": "Navigation / Navigation & gestures / Navigation drawer / Account switcher",
+      "child_title": "Account switcher",
+      "parent_path": "Navigation / Navigation & gestures / Navigation drawer"
+    },
+    {
+      "child_path": "Navigation / Navigation & gestures / Navigation drawer / Drawer behavior",
+      "child_title": "Drawer behavior",
+      "parent_path": "Navigation / Navigation & gestures / Navigation drawer"
+    },
+    {
+      "child_path": "Navigation / Navigation & gestures / Navigation drawer / Feeds & library",
+      "child_title": "Feeds & library",
+      "parent_path": "Navigation / Navigation & gestures / Navigation drawer"
+    },
+    {
+      "child_path": "Navigation / Navigation & gestures / Navigation drawer / Go-to shortcuts",
+      "child_title": "Go-to shortcuts",
+      "parent_path": "Navigation / Navigation & gestures / Navigation drawer"
+    },
+    {
+      "child_path": "Navigation / Navigation & gestures / Navigation drawer / Quick toggles",
+      "child_title": "Quick toggles",
+      "parent_path": "Navigation / Navigation & gestures / Navigation drawer"
+    },
+    {
+      "child_path": "Navigation / Navigation & gestures / Navigation drawer / Subscriptions",
+      "child_title": "Subscriptions",
+      "parent_path": "Navigation / Navigation & gestures / Navigation drawer"
+    },
+    {
+      "child_path": "Navigation / Navigation & gestures / Toolbar",
+      "child_title": "Toolbar",
+      "parent_path": "Navigation / Navigation & gestures"
+    },
+    {
+      "child_path": "Notifications & account / History, privacy & recovery",
+      "child_title": "History, privacy & recovery",
+      "parent_path": "Notifications & account"
+    },
+    {
+      "child_path": "Notifications & account / History, privacy & recovery / History",
+      "child_title": "History",
+      "parent_path": "Notifications & account / History, privacy & recovery"
+    },
+    {
+      "child_path": "Notifications & account / History, privacy & recovery / Recovery & archives",
+      "child_title": "Recovery & archives",
+      "parent_path": "Notifications & account / History, privacy & recovery"
+    },
+    {
+      "child_path": "Notifications & account / Notifications & inbox",
+      "child_title": "Notifications & inbox",
+      "parent_path": "Notifications & account"
+    },
+    {
+      "child_path": "Notifications & account / Notifications & inbox / Advanced",
+      "child_title": "Advanced",
+      "parent_path": "Notifications & account / Notifications & inbox"
+    },
+    {
+      "child_path": "Notifications & account / Notifications & inbox / Notifications",
+      "child_title": "Notifications",
+      "parent_path": "Notifications & account / Notifications & inbox"
+    },
+    {
+      "child_path": "Notifications & account / Reddit account",
+      "child_title": "Reddit account",
+      "parent_path": "Notifications & account"
+    },
+    {
+      "child_path": "Reading & interaction / Comments",
+      "child_title": "Comments",
+      "parent_path": "Reading & interaction"
+    },
+    {
+      "child_path": "Reading & interaction / Comments / Comment actions",
+      "child_title": "Comment actions",
+      "parent_path": "Reading & interaction / Comments"
+    },
+    {
+      "child_path": "Reading & interaction / Comments / Comment appearance",
+      "child_title": "Comment appearance",
+      "parent_path": "Reading & interaction / Comments"
+    },
+    {
+      "child_path": "Reading & interaction / Comments / Comment behavior",
+      "child_title": "Comment behavior",
+      "parent_path": "Reading & interaction / Comments"
+    },
+    {
+      "child_path": "Reading & interaction / Comments / Thread navigation",
+      "child_title": "Thread navigation",
+      "parent_path": "Reading & interaction / Comments"
+    },
+    {
+      "child_path": "Reading & interaction / Composing & drafts",
+      "child_title": "Composing & drafts",
+      "parent_path": "Reading & interaction"
+    },
+    {
+      "child_path": "Reading & interaction / Composing & drafts / Drafts",
+      "child_title": "Drafts",
+      "parent_path": "Reading & interaction / Composing & drafts"
+    },
+    {
+      "child_path": "Reading & interaction / Composing & drafts / Editor",
+      "child_title": "Editor",
+      "parent_path": "Reading & interaction / Composing & drafts"
+    },
+    {
+      "child_path": "Reading & interaction / Composing & drafts / Uploads",
+      "child_title": "Uploads",
+      "parent_path": "Reading & interaction / Composing & drafts"
+    },
+    {
+      "child_path": "Reading & interaction / Feeds & subscriptions",
+      "child_title": "Feeds & subscriptions",
+      "parent_path": "Reading & interaction"
+    },
+    {
+      "child_path": "Reading & interaction / Feeds & subscriptions / Manage subscriptions",
+      "child_title": "Manage subscriptions",
+      "parent_path": "Reading & interaction / Feeds & subscriptions"
+    },
+    {
+      "child_path": "Reading & interaction / Posts",
+      "child_title": "Posts",
+      "parent_path": "Reading & interaction"
+    },
+    {
+      "child_path": "Reading & interaction / Posts / Feed behavior",
+      "child_title": "Feed behavior",
+      "parent_path": "Reading & interaction / Posts"
+    },
+    {
+      "child_path": "Reading & interaction / Posts / Post actions",
+      "child_title": "Post actions",
+      "parent_path": "Reading & interaction / Posts"
+    },
+    {
+      "child_path": "Reading & interaction / Posts / Post behavior",
+      "child_title": "Post behavior",
+      "parent_path": "Reading & interaction / Posts"
+    },
+    {
+      "child_path": "Reading & interaction / Posts / Reading state",
+      "child_title": "Reading state",
+      "parent_path": "Reading & interaction / Posts"
+    },
+    {
+      "child_path": "Reading & interaction / Search & filters",
+      "child_title": "Search & filters",
+      "parent_path": "Reading & interaction"
+    },
+    {
+      "child_path": "Reading & interaction / Search & filters / Content filters",
+      "child_title": "Content filters",
+      "parent_path": "Reading & interaction / Search & filters"
+    },
+    {
+      "child_path": "Reading & interaction / Search & filters / Content filters / Filter behavior",
+      "child_title": "Filter behavior",
+      "parent_path": "Reading & interaction / Search & filters / Content filters"
+    },
+    {
+      "child_path": "Reading & interaction / Search & filters / Content filters / Muted content",
+      "child_title": "Muted content",
+      "parent_path": "Reading & interaction / Search & filters / Content filters"
+    },
+    {
+      "child_path": "Reading & interaction / Search & filters / Content filters / Post matching",
+      "child_title": "Post matching",
+      "parent_path": "Reading & interaction / Search & filters / Content filters"
+    },
+    {
+      "child_path": "Reading & interaction / Search & filters / Search",
+      "child_title": "Search",
+      "parent_path": "Reading & interaction / Search & filters"
+    },
+    {
+      "child_path": "Reading & interaction / Search & filters / Search / Advanced search",
+      "child_title": "Advanced search",
+      "parent_path": "Reading & interaction / Search & filters / Search"
+    },
+    {
+      "child_path": "Reading & interaction / Search & filters / Search / Search behavior",
+      "child_title": "Search behavior",
+      "parent_path": "Reading & interaction / Search & filters / Search"
+    },
+    {
+      "child_path": "Reading & interaction / Search & filters / Search / Suggestions",
+      "child_title": "Suggestions",
+      "parent_path": "Reading & interaction / Search & filters / Search"
+    }
+  ],
+  "issue": 121,
+  "items": [
+    {
+      "default_value": "",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "OMIT_OR_ONE_LINE_ACTION_HINT",
+      "key": "buy_pro",
+      "leaf_section": "Community header",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": null,
+          "key": "buy_pro",
+          "logical_kind": "action",
+          "resource": "pref_headers_v2",
+          "root_referenced": false
+        }
+      ],
+      "logical_kind": "action",
+      "page": "Community header",
+      "page_intro": "Control the title, description, and header shown for communities.",
+      "proposed_summary": "",
+      "root": "Appearance",
+      "screen_depth": 2,
+      "screen_path": [
+        "Appearance",
+        "Community header",
+        "Community header"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "none_or_custom",
+      "subscreen": "Community header",
+      "title": "Boost PRO",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "center",
+      "dependency": "pref_show_subreddit_header",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE",
+      "key": "pref_toolbar_header_type",
+      "leaf_section": "Community header",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": null,
+          "key": "pref_toolbar_header_type",
+          "logical_kind": "stored_setting",
+          "resource": "pref_toolbar_v2",
+          "root_referenced": false
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Community header",
+      "page_intro": "Control the title, description, and header shown for communities.",
+      "proposed_summary": "",
+      "root": "Appearance",
+      "screen_depth": 2,
+      "screen_path": [
+        "Appearance",
+        "Community header",
+        "Community header"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "string",
+      "subscreen": "Community header",
+      "title": "Community info alignment",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "",
+      "dependency": "",
+      "existing_summary": "Support Boost",
+      "help_treatment": "REVIEW_EXISTING_SUMMARY",
+      "key": "remove_ads",
+      "leaf_section": "Community header",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": null,
+          "key": "remove_ads",
+          "logical_kind": "action",
+          "resource": "pref_headers_v2",
+          "root_referenced": false
+        }
+      ],
+      "logical_kind": "action",
+      "page": "Community header",
+      "page_intro": "Control the title, description, and header shown for communities.",
+      "proposed_summary": "Support Boost",
+      "root": "Appearance",
+      "screen_depth": 2,
+      "screen_path": [
+        "Appearance",
+        "Community header",
+        "Community header"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "none_or_custom",
+      "subscreen": "Community header",
+      "title": "Remove ads",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "true",
+      "dependency": "pref_show_subreddit_header",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE",
+      "key": "pref_header_show_description",
+      "leaf_section": "Community header",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": null,
+          "key": "pref_header_show_description",
+          "logical_kind": "stored_setting",
+          "resource": "pref_toolbar_v2",
+          "root_referenced": false
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Community header",
+      "page_intro": "Control the title, description, and header shown for communities.",
+      "proposed_summary": "",
+      "root": "Appearance",
+      "screen_depth": 2,
+      "screen_path": [
+        "Appearance",
+        "Community header",
+        "Community header"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Community header",
+      "title": "Show community description",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "false",
+      "dependency": "",
+      "existing_summary": "Show banner and icon in communities",
+      "help_treatment": "REVIEW_EXISTING_SUMMARY",
+      "key": "pref_show_subreddit_header",
+      "leaf_section": "Community header",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": null,
+          "key": "pref_show_subreddit_header",
+          "logical_kind": "stored_setting",
+          "resource": "pref_toolbar_v2",
+          "root_referenced": false
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Community header",
+      "page_intro": "Control the title, description, and header shown for communities.",
+      "proposed_summary": "Show banner and icon in communities",
+      "root": "Appearance",
+      "screen_depth": 2,
+      "screen_path": [
+        "Appearance",
+        "Community header",
+        "Community header"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Community header",
+      "title": "Show community header",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "true",
+      "dependency": "",
+      "existing_summary": "Ask Android to use a high refresh rate for Boost windows on adaptive-refresh displays.",
+      "help_treatment": "REVIEW_EXISTING_SUMMARY+PROGRESSIVE_DISCLOSURE",
+      "key": "morphe_boost_prefer_high_refresh_rate",
+      "leaf_section": "Display performance",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Display & performance",
+          "key": "morphe_boost_prefer_high_refresh_rate",
+          "logical_kind": "morphe_user_setting",
+          "resource": "morphe_boost_settings_skeleton",
+          "root_referenced": false
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Display & motion",
+      "page_intro": "Adjust display behavior, animation, and refresh-rate preferences.",
+      "proposed_summary": "Ask Android to use a high refresh rate for Boost windows on adaptive-refresh displays.",
+      "root": "Appearance",
+      "screen_depth": 2,
+      "screen_path": [
+        "Appearance",
+        "Display & motion",
+        "Display performance"
+      ],
+      "source_type": "morphe_embedded_xml",
+      "storage_type": "boolean",
+      "subscreen": "Display performance",
+      "title": "Prefer high refresh rate",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "true",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE",
+      "key": "pref_cards_gallery_carousel",
+      "leaf_section": "Cards",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Cards",
+          "key": "pref_cards_gallery_carousel",
+          "logical_kind": "stored_setting",
+          "resource": "pref_views_v2",
+          "root_referenced": false
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Post layout",
+      "page_intro": "Control how posts and feed cards are arranged.",
+      "proposed_summary": "",
+      "root": "Appearance",
+      "screen_depth": 2,
+      "screen_path": [
+        "Appearance",
+        "Post layout",
+        "Cards"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Cards",
+      "title": "Carousel for multiple images",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "true",
+      "dependency": "",
+      "existing_summary": "Remove horizontal margins",
+      "help_treatment": "REVIEW_EXISTING_SUMMARY",
+      "key": "pref_cards_full",
+      "leaf_section": "Cards",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Cards",
+          "key": "pref_cards_full",
+          "logical_kind": "stored_setting",
+          "resource": "pref_views_v2",
+          "root_referenced": false
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Post layout",
+      "page_intro": "Control how posts and feed cards are arranged.",
+      "proposed_summary": "Remove horizontal margins",
+      "root": "Appearance",
+      "screen_depth": 2,
+      "screen_path": [
+        "Appearance",
+        "Post layout",
+        "Cards"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Cards",
+      "title": "Fill the screen width",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "false",
+      "dependency": "",
+      "existing_summary": "Disable for fixed height images",
+      "help_treatment": "REVIEW_EXISTING_SUMMARY",
+      "key": "pref_cards_full_preview",
+      "leaf_section": "Cards",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Cards",
+          "key": "pref_cards_full_preview",
+          "logical_kind": "stored_setting",
+          "resource": "pref_views_v2",
+          "root_referenced": false
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Post layout",
+      "page_intro": "Control how posts and feed cards are arranged.",
+      "proposed_summary": "Disable for fixed height images",
+      "root": "Appearance",
+      "screen_depth": 2,
+      "screen_path": [
+        "Appearance",
+        "Post layout",
+        "Cards"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Cards",
+      "title": "Full height images",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "5",
+      "dependency": "pref_cards_preview_self",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE",
+      "key": "pref_cards_preview_self_lines",
+      "leaf_section": "Cards",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Cards",
+          "key": "pref_cards_preview_self_lines",
+          "logical_kind": "stored_setting",
+          "resource": "pref_views_v2",
+          "root_referenced": false
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Post layout",
+      "page_intro": "Control how posts and feed cards are arranged.",
+      "proposed_summary": "",
+      "root": "Appearance",
+      "screen_depth": 2,
+      "screen_path": [
+        "Appearance",
+        "Post layout",
+        "Cards"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "integer",
+      "subscreen": "Cards",
+      "title": "Lines to preview",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "true",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE",
+      "key": "pref_cards_preview_self",
+      "leaf_section": "Cards",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Cards",
+          "key": "pref_cards_preview_self",
+          "logical_kind": "stored_setting",
+          "resource": "pref_views_v2",
+          "root_referenced": false
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Post layout",
+      "page_intro": "Control how posts and feed cards are arranged.",
+      "proposed_summary": "",
+      "root": "Appearance",
+      "screen_depth": 2,
+      "screen_path": [
+        "Appearance",
+        "Post layout",
+        "Cards"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Cards",
+      "title": "Preview text from posts",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "false",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE",
+      "key": "pref_cards_rounded_corners",
+      "leaf_section": "Cards",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Cards",
+          "key": "pref_cards_rounded_corners",
+          "logical_kind": "stored_setting",
+          "resource": "pref_views_v2",
+          "root_referenced": false
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Post layout",
+      "page_intro": "Control how posts and feed cards are arranged.",
+      "proposed_summary": "",
+      "root": "Appearance",
+      "screen_depth": 2,
+      "screen_path": [
+        "Appearance",
+        "Post layout",
+        "Cards"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Cards",
+      "title": "Rounded corners",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "true",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE",
+      "key": "pref_cards_subreddit_icon",
+      "leaf_section": "Cards",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Cards",
+          "key": "pref_cards_subreddit_icon",
+          "logical_kind": "stored_setting",
+          "resource": "pref_views_v2",
+          "root_referenced": false
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Post layout",
+      "page_intro": "Control how posts and feed cards are arranged.",
+      "proposed_summary": "",
+      "root": "Appearance",
+      "screen_depth": 2,
+      "screen_path": [
+        "Appearance",
+        "Post layout",
+        "Cards"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Cards",
+      "title": "Show community icon",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "true",
+      "dependency": "",
+      "existing_summary": "Disable to use large image previews",
+      "help_treatment": "REVIEW_EXISTING_SUMMARY",
+      "key": "pref_cards_links_as_thumbnails",
+      "leaf_section": "Cards",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Cards",
+          "key": "pref_cards_links_as_thumbnails",
+          "logical_kind": "stored_setting",
+          "resource": "pref_views_v2",
+          "root_referenced": false
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Post layout",
+      "page_intro": "Control how posts and feed cards are arranged.",
+      "proposed_summary": "Disable to use large image previews",
+      "root": "Appearance",
+      "screen_depth": 2,
+      "screen_path": [
+        "Appearance",
+        "Post layout",
+        "Cards"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Cards",
+      "title": "Show thumbnails for link posts",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "false",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE",
+      "key": "pref_dense_buttons_visible",
+      "leaf_section": "Dense",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Dense",
+          "key": "pref_dense_buttons_visible",
+          "logical_kind": "stored_setting",
+          "resource": "pref_views_v2",
+          "root_referenced": false
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Post layout",
+      "page_intro": "Control how posts and feed cards are arranged.",
+      "proposed_summary": "",
+      "root": "Appearance",
+      "screen_depth": 3,
+      "screen_path": [
+        "Appearance",
+        "Post layout",
+        "Compact layouts",
+        "Dense"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Dense",
+      "title": "Buttons always visible",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "false",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE",
+      "key": "pref_mini_cards_buttons_visible",
+      "leaf_section": "Small cards",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Small cards",
+          "key": "pref_mini_cards_buttons_visible",
+          "logical_kind": "stored_setting",
+          "resource": "pref_views_v2",
+          "root_referenced": false
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Post layout",
+      "page_intro": "Control how posts and feed cards are arranged.",
+      "proposed_summary": "",
+      "root": "Appearance",
+      "screen_depth": 3,
+      "screen_path": [
+        "Appearance",
+        "Post layout",
+        "Compact layouts",
+        "Small cards"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Small cards",
+      "title": "Buttons always visible",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "false",
+      "dependency": "",
+      "existing_summary": "Remove horizontal margins",
+      "help_treatment": "REVIEW_EXISTING_SUMMARY",
+      "key": "pref_mini_cards_full",
+      "leaf_section": "Small cards",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Small cards",
+          "key": "pref_mini_cards_full",
+          "logical_kind": "stored_setting",
+          "resource": "pref_views_v2",
+          "root_referenced": false
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Post layout",
+      "page_intro": "Control how posts and feed cards are arranged.",
+      "proposed_summary": "Remove horizontal margins",
+      "root": "Appearance",
+      "screen_depth": 3,
+      "screen_path": [
+        "Appearance",
+        "Post layout",
+        "Compact layouts",
+        "Small cards"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Small cards",
+      "title": "Fill the screen width",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "true",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE",
+      "key": "pref_mini_cards_rounded_corners",
+      "leaf_section": "Small cards",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Small cards",
+          "key": "pref_mini_cards_rounded_corners",
+          "logical_kind": "stored_setting",
+          "resource": "pref_views_v2",
+          "root_referenced": false
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Post layout",
+      "page_intro": "Control how posts and feed cards are arranged.",
+      "proposed_summary": "",
+      "root": "Appearance",
+      "screen_depth": 3,
+      "screen_path": [
+        "Appearance",
+        "Post layout",
+        "Compact layouts",
+        "Small cards"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Small cards",
+      "title": "Rounded corners",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "true",
+      "dependency": "",
+      "existing_summary": "Limit title to 2 lines",
+      "help_treatment": "REVIEW_EXISTING_SUMMARY",
+      "key": "pref_mini_cards_truncate_title",
+      "leaf_section": "Small cards",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Small cards",
+          "key": "pref_mini_cards_truncate_title",
+          "logical_kind": "stored_setting",
+          "resource": "pref_views_v2",
+          "root_referenced": false
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Post layout",
+      "page_intro": "Control how posts and feed cards are arranged.",
+      "proposed_summary": "Limit title to 2 lines",
+      "root": "Appearance",
+      "screen_depth": 3,
+      "screen_path": [
+        "Appearance",
+        "Post layout",
+        "Compact layouts",
+        "Small cards"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Small cards",
+      "title": "Truncate title",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "false",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE",
+      "key": "pref_show_subreddit_prefix",
+      "leaf_section": "Post layout",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": null,
+          "key": "pref_show_subreddit_prefix",
+          "logical_kind": "stored_setting",
+          "resource": "pref_views_v2",
+          "root_referenced": false
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Post layout",
+      "page_intro": "Control how posts and feed cards are arranged.",
+      "proposed_summary": "",
+      "root": "Appearance",
+      "screen_depth": 3,
+      "screen_path": [
+        "Appearance",
+        "Post layout",
+        "Layout & saved views",
+        "Post layout"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Post layout",
+      "title": "Communities start with r/",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "0",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE",
+      "key": "pref_view",
+      "leaf_section": "Post layout",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": null,
+          "key": "pref_view",
+          "logical_kind": "stored_setting",
+          "resource": "pref_views_v2",
+          "root_referenced": false
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Post layout",
+      "page_intro": "Control how posts and feed cards are arranged.",
+      "proposed_summary": "",
+      "root": "Appearance",
+      "screen_depth": 3,
+      "screen_path": [
+        "Appearance",
+        "Post layout",
+        "Layout & saved views",
+        "Post layout"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "string",
+      "subscreen": "Post layout",
+      "title": "Default view",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "",
+      "dependency": "pref_view_per_subscription",
+      "existing_summary": "",
+      "help_treatment": "OMIT_OR_ONE_LINE_ACTION_HINT",
+      "key": "pref_view_per_sub",
+      "leaf_section": "Post layout",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": null,
+          "key": "pref_view_per_sub",
+          "logical_kind": "action",
+          "resource": "pref_views_v2",
+          "root_referenced": false
+        }
+      ],
+      "logical_kind": "action",
+      "page": "Post layout",
+      "page_intro": "Control how posts and feed cards are arranged.",
+      "proposed_summary": "",
+      "root": "Appearance",
+      "screen_depth": 3,
+      "screen_path": [
+        "Appearance",
+        "Post layout",
+        "Layout & saved views",
+        "Post layout"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "none_or_custom",
+      "subscreen": "Post layout",
+      "title": "Manage saved views",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "false",
+      "dependency": "",
+      "existing_summary": "Each community will remember the last view you selected for that community",
+      "help_treatment": "REVIEW_EXISTING_SUMMARY",
+      "key": "pref_view_per_subscription",
+      "leaf_section": "Post layout",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": null,
+          "key": "pref_view_per_subscription",
+          "logical_kind": "stored_setting",
+          "resource": "pref_views_v2",
+          "root_referenced": false
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Post layout",
+      "page_intro": "Control how posts and feed cards are arranged.",
+      "proposed_summary": "Each community will remember the last view you selected for that community",
+      "root": "Appearance",
+      "screen_depth": 3,
+      "screen_path": [
+        "Appearance",
+        "Post layout",
+        "Layout & saved views",
+        "Post layout"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Post layout",
+      "title": "Remember per community",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "false",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE",
+      "key": "pref_left_handed",
+      "leaf_section": "Post layout",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": null,
+          "key": "pref_left_handed",
+          "logical_kind": "stored_setting",
+          "resource": "pref_views_v2",
+          "root_referenced": false
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Post layout",
+      "page_intro": "Control how posts and feed cards are arranged.",
+      "proposed_summary": "",
+      "root": "Appearance",
+      "screen_depth": 3,
+      "screen_path": [
+        "Appearance",
+        "Post layout",
+        "Layout & saved views",
+        "Post layout"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Post layout",
+      "title": "Thumbnails on left",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "",
+      "dependency": "pref_view_per_subscription",
+      "existing_summary": "Choose a community or custom feed and its view.",
+      "help_treatment": "DIRECT_CONTROL_SUMMARY",
+      "key": "action:saved_views:add",
+      "leaf_section": "Saved community views",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Community views",
+          "logical_kind": "direct_action",
+          "resource": "MorpheSettingsV4SavedViewsFragment",
+          "root_referenced": false
+        }
+      ],
+      "logical_kind": "action",
+      "page": "Post layout",
+      "page_intro": "Control how posts and feed cards are arranged.",
+      "proposed_summary": "Choose a community or custom feed and its view.",
+      "root": "Appearance",
+      "screen_depth": 3,
+      "screen_path": [
+        "Appearance",
+        "Post layout",
+        "Layout & saved views",
+        "Saved community views"
+      ],
+      "source_type": "morphe_direct_ui",
+      "storage_type": "private_preferences",
+      "subscreen": "Saved community views",
+      "title": "Add saved view",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "",
+      "dependency": "saved_views_not_empty",
+      "existing_summary": "Remove the saved view for every community.",
+      "help_treatment": "DIRECT_CONTROL_SUMMARY+CONFIRMATION_REQUIRED",
+      "key": "action:saved_views:clear_all",
+      "leaf_section": "Saved community views",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Community views",
+          "logical_kind": "direct_action",
+          "resource": "MorpheSettingsV4SavedViewsFragment",
+          "root_referenced": false
+        }
+      ],
+      "logical_kind": "destructive_action",
+      "page": "Post layout",
+      "page_intro": "Control how posts and feed cards are arranged.",
+      "proposed_summary": "Remove the saved view for every community.",
+      "root": "Appearance",
+      "screen_depth": 3,
+      "screen_path": [
+        "Appearance",
+        "Post layout",
+        "Layout & saved views",
+        "Saved community views"
+      ],
+      "source_type": "morphe_direct_ui",
+      "storage_type": "private_preferences",
+      "subscreen": "Saved community views",
+      "title": "Clear all saved views",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "",
+      "dependency": "pref_view_per_subscription",
+      "existing_summary": "Review or clear community-specific views.",
+      "help_treatment": "DIRECT_CONTROL_SUMMARY",
+      "key": "action:post_layout:manage_saved_views",
+      "leaf_section": "Saved community views",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Layout",
+          "logical_kind": "direct_destination",
+          "resource": "MorpheSettingsV4PostViewsFragment",
+          "root_referenced": false
+        }
+      ],
+      "logical_kind": "destination",
+      "page": "Post layout",
+      "page_intro": "Control how posts and feed cards are arranged.",
+      "proposed_summary": "Review or clear community-specific views.",
+      "root": "Appearance",
+      "screen_depth": 3,
+      "screen_path": [
+        "Appearance",
+        "Post layout",
+        "Layout & saved views",
+        "Saved community views"
+      ],
+      "source_type": "morphe_direct_ui",
+      "storage_type": "none",
+      "subscreen": "Saved community views",
+      "title": "Manage saved views",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "false",
+      "dependency": "",
+      "existing_summary": "Disables opening the sidebar with a swipe",
+      "help_treatment": "REVIEW_EXISTING_SUMMARY",
+      "key": "pref_lock_sidebar",
+      "leaf_section": "Swipe",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Swipe",
+          "key": "pref_lock_sidebar",
+          "logical_kind": "stored_setting",
+          "resource": "pref_views_v2",
+          "root_referenced": false
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Post layout",
+      "page_intro": "Control how posts and feed cards are arranged.",
+      "proposed_summary": "Disables opening the sidebar with a swipe",
+      "root": "Appearance",
+      "screen_depth": 2,
+      "screen_path": [
+        "Appearance",
+        "Post layout",
+        "Swipe"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Swipe",
+      "title": "Lock sidebar",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "false",
+      "dependency": "",
+      "existing_summary": "Automatically load text preview for external links",
+      "help_treatment": "REVIEW_EXISTING_SUMMARY",
+      "key": "pref_load_readability",
+      "leaf_section": "Swipe",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Swipe",
+          "key": "pref_load_readability",
+          "logical_kind": "stored_setting",
+          "resource": "pref_views_v2",
+          "root_referenced": false
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Post layout",
+      "page_intro": "Control how posts and feed cards are arranged.",
+      "proposed_summary": "Automatically load text preview for external links",
+      "root": "Appearance",
+      "screen_depth": 2,
+      "screen_path": [
+        "Appearance",
+        "Post layout",
+        "Swipe"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Swipe",
+      "title": "Preview external links",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "true",
+      "dependency": "",
+      "existing_summary": "Show posts and comments in landscape",
+      "help_treatment": "REVIEW_EXISTING_SUMMARY",
+      "key": "pref_split_screen",
+      "leaf_section": "Tablet layout",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Navigation",
+          "key": "pref_split_screen",
+          "logical_kind": "stored_setting",
+          "resource": "pref_general_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Post layout",
+      "page_intro": "Control how posts and feed cards are arranged.",
+      "proposed_summary": "Show posts and comments in landscape",
+      "root": "Appearance",
+      "screen_depth": 2,
+      "screen_path": [
+        "Appearance",
+        "Post layout",
+        "Tablet layout"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Tablet layout",
+      "title": "Tablet split screen mode",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "false",
+      "dependency": "",
+      "existing_summary": "Same color as toolbar",
+      "help_treatment": "REVIEW_EXISTING_SUMMARY",
+      "key": "pref_colored_nav_bar",
+      "leaf_section": "Advanced appearance",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": null,
+          "key": "pref_colored_nav_bar",
+          "logical_kind": "stored_setting",
+          "resource": "pref_appearance_advanced_v2",
+          "root_referenced": false
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Theme & colors",
+      "page_intro": "Choose the app theme, color behavior, and night-mode presentation.",
+      "proposed_summary": "Same color as toolbar",
+      "root": "Appearance",
+      "screen_depth": 2,
+      "screen_path": [
+        "Appearance",
+        "Theme & colors",
+        "Advanced appearance"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Advanced appearance",
+      "title": "Colored navigation bar",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "true",
+      "dependency": "",
+      "existing_summary": "Same color as toolbar",
+      "help_treatment": "REVIEW_EXISTING_SUMMARY",
+      "key": "pref_colored_status_bar",
+      "leaf_section": "Advanced appearance",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": null,
+          "key": "pref_colored_status_bar",
+          "logical_kind": "stored_setting",
+          "resource": "pref_appearance_advanced_v2",
+          "root_referenced": false
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Theme & colors",
+      "page_intro": "Choose the app theme, color behavior, and night-mode presentation.",
+      "proposed_summary": "Same color as toolbar",
+      "root": "Appearance",
+      "screen_depth": 2,
+      "screen_path": [
+        "Appearance",
+        "Theme & colors",
+        "Advanced appearance"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Advanced appearance",
+      "title": "Colored status bar",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "Default",
+      "dependency": "",
+      "existing_summary": "Choose the icon shown by your launcher.",
+      "help_treatment": "DIRECT_CONTROL_SUMMARY",
+      "key": "action:appearance:app_icon",
+      "leaf_section": "Personalization",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Personalization",
+          "logical_kind": "direct_destination",
+          "resource": "MorpheSettingsV4AppearanceFragment",
+          "root_referenced": false
+        }
+      ],
+      "logical_kind": "choice_destination",
+      "page": "Theme & colors",
+      "page_intro": "Choose the app theme, color behavior, and night-mode presentation.",
+      "proposed_summary": "Choose the icon shown by your launcher.",
+      "root": "Appearance",
+      "screen_depth": 2,
+      "screen_path": [
+        "Appearance",
+        "Theme & colors",
+        "Personalization"
+      ],
+      "source_type": "morphe_direct_ui",
+      "storage_type": "component_alias",
+      "subscreen": "Personalization",
+      "title": "App icon",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "OMIT_OR_ONE_LINE_ACTION_HINT",
+      "key": "pref_app_icon",
+      "leaf_section": "Theme",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": null,
+          "key": "pref_app_icon",
+          "logical_kind": "action",
+          "resource": "pref_appearance_v2",
+          "root_referenced": false
+        }
+      ],
+      "logical_kind": "action",
+      "page": "Theme & colors",
+      "page_intro": "Choose the app theme, color behavior, and night-mode presentation.",
+      "proposed_summary": "",
+      "root": "Appearance",
+      "screen_depth": 2,
+      "screen_path": [
+        "Appearance",
+        "Theme & colors",
+        "Theme"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "none_or_custom",
+      "subscreen": "Theme",
+      "title": "App icon",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "0",
+      "dependency": "pref_dynamic_colors",
+      "existing_summary": "",
+      "help_treatment": "OMIT_OR_ONE_LINE_ACTION_HINT",
+      "key": "pref_theme",
+      "leaf_section": "Theme",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": null,
+          "key": "pref_theme",
+          "logical_kind": "action",
+          "resource": "pref_appearance_v2",
+          "root_referenced": false
+        }
+      ],
+      "logical_kind": "action",
+      "page": "Theme & colors",
+      "page_intro": "Choose the app theme, color behavior, and night-mode presentation.",
+      "proposed_summary": "",
+      "root": "Appearance",
+      "screen_depth": 2,
+      "screen_path": [
+        "Appearance",
+        "Theme & colors",
+        "Theme"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "none_or_custom",
+      "subscreen": "Theme",
+      "title": "Customize colors",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "1140",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE",
+      "key": "pref_theme_night_start_minutes",
+      "leaf_section": "Theme",
+      "legacy_route_count": 2,
+      "legacy_routes": [
+        {
+          "category": null,
+          "key": "pref_theme_night_start_minutes",
+          "logical_kind": "special_preference",
+          "resource": "pref_appearance_v2",
+          "root_referenced": false
+        },
+        {
+          "category": null,
+          "key": "pref_theme_night_start_minutes",
+          "logical_kind": "special_preference",
+          "resource": "pref_night_mode_v2",
+          "root_referenced": false
+        }
+      ],
+      "logical_kind": "special_preference",
+      "page": "Theme & colors",
+      "page_intro": "Choose the app theme, color behavior, and night-mode presentation.",
+      "proposed_summary": "",
+      "root": "Appearance",
+      "screen_depth": 2,
+      "screen_path": [
+        "Appearance",
+        "Theme & colors",
+        "Theme"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "none_or_custom",
+      "subscreen": "Theme",
+      "title": "Dark start time",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "8",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE",
+      "key": "pref_theme_night",
+      "leaf_section": "Theme",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": null,
+          "key": "pref_theme_night",
+          "logical_kind": "special_preference",
+          "resource": "pref_appearance_v2",
+          "root_referenced": false
+        }
+      ],
+      "logical_kind": "special_preference",
+      "page": "Theme & colors",
+      "page_intro": "Choose the app theme, color behavior, and night-mode presentation.",
+      "proposed_summary": "",
+      "root": "Appearance",
+      "screen_depth": 2,
+      "screen_path": [
+        "Appearance",
+        "Theme & colors",
+        "Theme"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "none_or_custom",
+      "subscreen": "Theme",
+      "title": "Dark theme",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "false",
+      "dependency": "",
+      "existing_summary": "Apply color palette from your system",
+      "help_treatment": "REVIEW_EXISTING_SUMMARY",
+      "key": "pref_dynamic_colors",
+      "leaf_section": "Theme",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": null,
+          "key": "pref_dynamic_colors",
+          "logical_kind": "stored_setting",
+          "resource": "pref_appearance_v2",
+          "root_referenced": false
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Theme & colors",
+      "page_intro": "Choose the app theme, color behavior, and night-mode presentation.",
+      "proposed_summary": "Apply color palette from your system",
+      "root": "Appearance",
+      "screen_depth": 2,
+      "screen_path": [
+        "Appearance",
+        "Theme & colors",
+        "Theme"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Theme",
+      "title": "Dynamic color",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "420",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE",
+      "key": "pref_theme_night_end_minutes",
+      "leaf_section": "Theme",
+      "legacy_route_count": 2,
+      "legacy_routes": [
+        {
+          "category": null,
+          "key": "pref_theme_night_end_minutes",
+          "logical_kind": "special_preference",
+          "resource": "pref_appearance_v2",
+          "root_referenced": false
+        },
+        {
+          "category": null,
+          "key": "pref_theme_night_end_minutes",
+          "logical_kind": "special_preference",
+          "resource": "pref_night_mode_v2",
+          "root_referenced": false
+        }
+      ],
+      "logical_kind": "special_preference",
+      "page": "Theme & colors",
+      "page_intro": "Choose the app theme, color behavior, and night-mode presentation.",
+      "proposed_summary": "",
+      "root": "Appearance",
+      "screen_depth": 2,
+      "screen_path": [
+        "Appearance",
+        "Theme & colors",
+        "Theme"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "none_or_custom",
+      "subscreen": "Theme",
+      "title": "Light start time",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "system",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE",
+      "key": "pref_theme_mode_type",
+      "leaf_section": "Theme",
+      "legacy_route_count": 2,
+      "legacy_routes": [
+        {
+          "category": null,
+          "key": "pref_theme_mode_type",
+          "logical_kind": "stored_setting",
+          "resource": "pref_appearance_v2",
+          "root_referenced": false
+        },
+        {
+          "category": null,
+          "key": "pref_theme_mode_type",
+          "logical_kind": "stored_setting",
+          "resource": "pref_night_mode_v2",
+          "root_referenced": false
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Theme & colors",
+      "page_intro": "Choose the app theme, color behavior, and night-mode presentation.",
+      "proposed_summary": "",
+      "root": "Appearance",
+      "screen_depth": 2,
+      "screen_path": [
+        "Appearance",
+        "Theme & colors",
+        "Theme"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "string",
+      "subscreen": "Theme",
+      "title": "Theme",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE",
+      "key": "pref_comments_font",
+      "leaf_section": "Comments",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Comments",
+          "key": "pref_comments_font",
+          "logical_kind": "special_preference",
+          "resource": "pref_fonts_v2",
+          "root_referenced": false
+        }
+      ],
+      "logical_kind": "special_preference",
+      "page": "Typography",
+      "page_intro": "Adjust text size and font presentation throughout Boost.",
+      "proposed_summary": "",
+      "root": "Appearance",
+      "screen_depth": 2,
+      "screen_path": [
+        "Appearance",
+        "Typography",
+        "Comments"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "none_or_custom",
+      "subscreen": "Comments",
+      "title": "Comments font",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "Medium",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE",
+      "key": "pref_font_size",
+      "leaf_section": "Comments",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Comments",
+          "key": "pref_font_size",
+          "logical_kind": "stored_setting",
+          "resource": "pref_fonts_v2",
+          "root_referenced": false
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Typography",
+      "page_intro": "Adjust text size and font presentation throughout Boost.",
+      "proposed_summary": "",
+      "root": "Appearance",
+      "screen_depth": 2,
+      "screen_path": [
+        "Appearance",
+        "Typography",
+        "Comments"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "string",
+      "subscreen": "Comments",
+      "title": "Comments text size",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE",
+      "key": "pref_title_font",
+      "leaf_section": "Posts",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Posts",
+          "key": "pref_title_font",
+          "logical_kind": "special_preference",
+          "resource": "pref_fonts_v2",
+          "root_referenced": false
+        }
+      ],
+      "logical_kind": "special_preference",
+      "page": "Typography",
+      "page_intro": "Adjust text size and font presentation throughout Boost.",
+      "proposed_summary": "",
+      "root": "Appearance",
+      "screen_depth": 2,
+      "screen_path": [
+        "Appearance",
+        "Typography",
+        "Posts"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "none_or_custom",
+      "subscreen": "Posts",
+      "title": "Title font",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "Medium",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE",
+      "key": "pref_font_size_title",
+      "leaf_section": "Posts",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Posts",
+          "key": "pref_font_size_title",
+          "logical_kind": "stored_setting",
+          "resource": "pref_fonts_v2",
+          "root_referenced": false
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Typography",
+      "page_intro": "Adjust text size and font presentation throughout Boost.",
+      "proposed_summary": "",
+      "root": "Appearance",
+      "screen_depth": 2,
+      "screen_path": [
+        "Appearance",
+        "Typography",
+        "Posts"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "string",
+      "subscreen": "Posts",
+      "title": "Title text size",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "",
+      "dependency": "",
+      "existing_summary": "Reset post and comment fonts to their default values.",
+      "help_treatment": "DIRECT_CONTROL_SUMMARY",
+      "key": "action:typography:restore_defaults",
+      "leaf_section": "Reset",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Reset",
+          "logical_kind": "direct_action",
+          "resource": "MorpheSettingsV4FontsFragment",
+          "root_referenced": false
+        }
+      ],
+      "logical_kind": "destructive_action",
+      "page": "Typography",
+      "page_intro": "Adjust text size and font presentation throughout Boost.",
+      "proposed_summary": "Reset post and comment fonts to their default values.",
+      "root": "Appearance",
+      "screen_depth": 2,
+      "screen_path": [
+        "Appearance",
+        "Typography",
+        "Reset"
+      ],
+      "source_type": "morphe_direct_ui",
+      "storage_type": "none",
+      "subscreen": "Reset",
+      "title": "Restore font defaults",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "false",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE",
+      "key": "pref_comments_buttons",
+      "leaf_section": "Comment actions",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Appearance",
+          "key": "pref_comments_buttons",
+          "logical_kind": "stored_setting",
+          "resource": "pref_comments_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Comments",
+      "page_intro": "Control comment display, actions, navigation, and thread behavior.",
+      "proposed_summary": "",
+      "root": "Reading & interaction",
+      "screen_depth": 2,
+      "screen_path": [
+        "Reading & interaction",
+        "Comments",
+        "Comment actions"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Comment actions",
+      "title": "Buttons always visible",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "35",
+      "dependency": "pref_swipe_back",
+      "existing_summary": "Dragging distance from edge as percentage of screen width to close and go back",
+      "help_treatment": "REVIEW_EXISTING_SUMMARY",
+      "key": "pref_swipe_threshold_percentage",
+      "leaf_section": "Comment actions",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Gestures",
+          "key": "pref_swipe_threshold_percentage",
+          "logical_kind": "stored_setting",
+          "resource": "pref_comments_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Comments",
+      "page_intro": "Control comment display, actions, navigation, and thread behavior.",
+      "proposed_summary": "Dragging distance from edge as percentage of screen width to close and go back",
+      "root": "Reading & interaction",
+      "screen_depth": 2,
+      "screen_path": [
+        "Reading & interaction",
+        "Comments",
+        "Comment actions"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "integer",
+      "subscreen": "Comment actions",
+      "title": "Distance threshold",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "false",
+      "dependency": "pref_comments_buttons",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE",
+      "key": "pref_comments_buttons_collapse_after_action",
+      "leaf_section": "Comment actions",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Appearance",
+          "key": "pref_comments_buttons_collapse_after_action",
+          "logical_kind": "stored_setting",
+          "resource": "pref_comments_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Comments",
+      "page_intro": "Control comment display, actions, navigation, and thread behavior.",
+      "proposed_summary": "",
+      "root": "Reading & interaction",
+      "screen_depth": 2,
+      "screen_path": [
+        "Reading & interaction",
+        "Comments",
+        "Comment actions"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Comment actions",
+      "title": "Hide buttons after voting/saving",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "true",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE",
+      "key": "pref_comments_button_save",
+      "leaf_section": "Comment actions",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Visible buttons",
+          "key": "pref_comments_button_save",
+          "logical_kind": "stored_setting",
+          "resource": "pref_comments_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Comments",
+      "page_intro": "Control comment display, actions, navigation, and thread behavior.",
+      "proposed_summary": "",
+      "root": "Reading & interaction",
+      "screen_depth": 2,
+      "screen_path": [
+        "Reading & interaction",
+        "Comments",
+        "Comment actions"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Comment actions",
+      "title": "Save",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "true",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE",
+      "key": "pref_comments_floating_button",
+      "leaf_section": "Comment actions",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Appearance",
+          "key": "pref_comments_floating_button",
+          "logical_kind": "stored_setting",
+          "resource": "pref_comments_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Comments",
+      "page_intro": "Control comment display, actions, navigation, and thread behavior.",
+      "proposed_summary": "",
+      "root": "Reading & interaction",
+      "screen_depth": 2,
+      "screen_path": [
+        "Reading & interaction",
+        "Comments",
+        "Comment actions"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Comment actions",
+      "title": "Show floating button",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "false",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE",
+      "key": "pref_info_post_upvote_percentage",
+      "leaf_section": "Comment actions",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Appearance",
+          "key": "pref_info_post_upvote_percentage",
+          "logical_kind": "stored_setting",
+          "resource": "pref_comments_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Comments",
+      "page_intro": "Control comment display, actions, navigation, and thread behavior.",
+      "proposed_summary": "",
+      "root": "Reading & interaction",
+      "screen_depth": 2,
+      "screen_path": [
+        "Reading & interaction",
+        "Comments",
+        "Comment actions"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Comment actions",
+      "title": "Show post upvote percentage",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "80",
+      "dependency": "pref_swipe_back",
+      "existing_summary": "Touch sensitivity to start the dragging. Higher means easier.",
+      "help_treatment": "REVIEW_EXISTING_SUMMARY",
+      "key": "pref_swipe_sensitivity_percentage",
+      "leaf_section": "Comment actions",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Gestures",
+          "key": "pref_swipe_sensitivity_percentage",
+          "logical_kind": "stored_setting",
+          "resource": "pref_comments_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Comments",
+      "page_intro": "Control comment display, actions, navigation, and thread behavior.",
+      "proposed_summary": "Touch sensitivity to start the dragging. Higher means easier.",
+      "root": "Reading & interaction",
+      "screen_depth": 2,
+      "screen_path": [
+        "Reading & interaction",
+        "Comments",
+        "Comment actions"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "integer",
+      "subscreen": "Comment actions",
+      "title": "Swipe sensitivity",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "true",
+      "dependency": "",
+      "existing_summary": "Swipe right to go back",
+      "help_treatment": "REVIEW_EXISTING_SUMMARY",
+      "key": "pref_swipe_back",
+      "leaf_section": "Comment actions",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Gestures",
+          "key": "pref_swipe_back",
+          "logical_kind": "stored_setting",
+          "resource": "pref_comments_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Comments",
+      "page_intro": "Control comment display, actions, navigation, and thread behavior.",
+      "proposed_summary": "Swipe right to go back",
+      "root": "Reading & interaction",
+      "screen_depth": 2,
+      "screen_path": [
+        "Reading & interaction",
+        "Comments",
+        "Comment actions"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Comment actions",
+      "title": "Swipe to close",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "1",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE",
+      "key": "pref_comments_button_parent",
+      "leaf_section": "Comment actions",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Visible buttons",
+          "key": "pref_comments_button_parent",
+          "logical_kind": "stored_setting",
+          "resource": "pref_comments_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Comments",
+      "page_intro": "Control comment display, actions, navigation, and thread behavior.",
+      "proposed_summary": "",
+      "root": "Reading & interaction",
+      "screen_depth": 2,
+      "screen_path": [
+        "Reading & interaction",
+        "Comments",
+        "Comment actions"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "string",
+      "subscreen": "Comment actions",
+      "title": "Up button",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "true",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE",
+      "key": "pref_comments_color_pattern",
+      "leaf_section": "Comment appearance",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Appearance",
+          "key": "pref_comments_color_pattern",
+          "logical_kind": "special_preference",
+          "resource": "pref_comments_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "special_preference",
+      "page": "Comments",
+      "page_intro": "Control comment display, actions, navigation, and thread behavior.",
+      "proposed_summary": "",
+      "root": "Reading & interaction",
+      "screen_depth": 2,
+      "screen_path": [
+        "Reading & interaction",
+        "Comments",
+        "Comment appearance"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "none_or_custom",
+      "subscreen": "Comment appearance",
+      "title": "Color pattern",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "true",
+      "dependency": "pref_comments_user_flair",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE",
+      "key": "pref_user_flair_emojis",
+      "leaf_section": "Comment appearance",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Flairs",
+          "key": "pref_user_flair_emojis",
+          "logical_kind": "stored_setting",
+          "resource": "pref_comments_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Comments",
+      "page_intro": "Control comment display, actions, navigation, and thread behavior.",
+      "proposed_summary": "",
+      "root": "Reading & interaction",
+      "screen_depth": 2,
+      "screen_path": [
+        "Reading & interaction",
+        "Comments",
+        "Comment appearance"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Comment appearance",
+      "title": "Show emojis",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "false",
+      "dependency": "pref_comments_user_flair",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE",
+      "key": "pref_user_flair_colors",
+      "leaf_section": "Comment appearance",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Flairs",
+          "key": "pref_user_flair_colors",
+          "logical_kind": "stored_setting",
+          "resource": "pref_comments_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Comments",
+      "page_intro": "Control comment display, actions, navigation, and thread behavior.",
+      "proposed_summary": "",
+      "root": "Reading & interaction",
+      "screen_depth": 2,
+      "screen_path": [
+        "Reading & interaction",
+        "Comments",
+        "Comment appearance"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Comment appearance",
+      "title": "Show flair colors",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "false",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE",
+      "key": "pref_comments_show_avatar",
+      "leaf_section": "Comment appearance",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Appearance",
+          "key": "pref_comments_show_avatar",
+          "logical_kind": "stored_setting",
+          "resource": "pref_comments_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Comments",
+      "page_intro": "Control comment display, actions, navigation, and thread behavior.",
+      "proposed_summary": "",
+      "root": "Reading & interaction",
+      "screen_depth": 2,
+      "screen_path": [
+        "Reading & interaction",
+        "Comments",
+        "Comment appearance"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Comment appearance",
+      "title": "Show user avatar",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "true",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE",
+      "key": "pref_comments_user_flair",
+      "leaf_section": "Comment appearance",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Flairs",
+          "key": "pref_comments_user_flair",
+          "logical_kind": "stored_setting",
+          "resource": "pref_comments_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Comments",
+      "page_intro": "Control comment display, actions, navigation, and thread behavior.",
+      "proposed_summary": "",
+      "root": "Reading & interaction",
+      "screen_depth": 2,
+      "screen_path": [
+        "Reading & interaction",
+        "Comments",
+        "Comment appearance"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Comment appearance",
+      "title": "Show user flair",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "true",
+      "dependency": "pref_show_awards_comments",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE",
+      "key": "pref_clickable_awards_comments",
+      "leaf_section": "Comment behavior",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Awards",
+          "key": "pref_clickable_awards_comments",
+          "logical_kind": "stored_setting",
+          "resource": "pref_comments_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Comments",
+      "page_intro": "Control comment display, actions, navigation, and thread behavior.",
+      "proposed_summary": "",
+      "root": "Reading & interaction",
+      "screen_depth": 2,
+      "screen_path": [
+        "Reading & interaction",
+        "Comments",
+        "Comment behavior"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Comment behavior",
+      "title": "Clickable awards",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "0",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE",
+      "key": "pref_default_comment_sorting",
+      "leaf_section": "Comment behavior",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": null,
+          "key": "pref_default_comment_sorting",
+          "logical_kind": "stored_setting",
+          "resource": "pref_comments_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Comments",
+      "page_intro": "Control comment display, actions, navigation, and thread behavior.",
+      "proposed_summary": "",
+      "root": "Reading & interaction",
+      "screen_depth": 2,
+      "screen_path": [
+        "Reading & interaction",
+        "Comments",
+        "Comment behavior"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "string",
+      "subscreen": "Comment behavior",
+      "title": "Default sort",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "true",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE",
+      "key": "pref_comments_highlight_mine",
+      "leaf_section": "Comment behavior",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Appearance",
+          "key": "pref_comments_highlight_mine",
+          "logical_kind": "stored_setting",
+          "resource": "pref_comments_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Comments",
+      "page_intro": "Control comment display, actions, navigation, and thread behavior.",
+      "proposed_summary": "",
+      "root": "Reading & interaction",
+      "screen_depth": 2,
+      "screen_path": [
+        "Reading & interaction",
+        "Comments",
+        "Comment behavior"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Comment behavior",
+      "title": "Highlight my username",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "1",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE",
+      "key": "pref_comments_image",
+      "leaf_section": "Comment behavior",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Appearance",
+          "key": "pref_comments_image",
+          "logical_kind": "stored_setting",
+          "resource": "pref_comments_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Comments",
+      "page_intro": "Control comment display, actions, navigation, and thread behavior.",
+      "proposed_summary": "",
+      "root": "Reading & interaction",
+      "screen_depth": 2,
+      "screen_path": [
+        "Reading & interaction",
+        "Comments",
+        "Comment behavior"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "string",
+      "subscreen": "Comment behavior",
+      "title": "Post media preview size",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "true",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE",
+      "key": "pref_show_awards_comments",
+      "leaf_section": "Comment behavior",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Awards",
+          "key": "pref_show_awards_comments",
+          "logical_kind": "stored_setting",
+          "resource": "pref_comments_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Comments",
+      "page_intro": "Control comment display, actions, navigation, and thread behavior.",
+      "proposed_summary": "",
+      "root": "Reading & interaction",
+      "screen_depth": 2,
+      "screen_path": [
+        "Reading & interaction",
+        "Comments",
+        "Comment behavior"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Comment behavior",
+      "title": "Show awards",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "true",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE",
+      "key": "pref_comments_clickable_username",
+      "leaf_section": "Comment behavior",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Behavior",
+          "key": "pref_comments_clickable_username",
+          "logical_kind": "stored_setting",
+          "resource": "pref_comments_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Comments",
+      "page_intro": "Control comment display, actions, navigation, and thread behavior.",
+      "proposed_summary": "",
+      "root": "Reading & interaction",
+      "screen_depth": 2,
+      "screen_path": [
+        "Reading & interaction",
+        "Comments",
+        "Comment behavior"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Comment behavior",
+      "title": "Tap username to view profile",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "true",
+      "dependency": "",
+      "existing_summary": "Use comment sort suggested by community or post",
+      "help_treatment": "REVIEW_EXISTING_SUMMARY",
+      "key": "pref_suggested_comment_sorting",
+      "leaf_section": "Comment behavior",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": null,
+          "key": "pref_suggested_comment_sorting",
+          "logical_kind": "stored_setting",
+          "resource": "pref_comments_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Comments",
+      "page_intro": "Control comment display, actions, navigation, and thread behavior.",
+      "proposed_summary": "Use comment sort suggested by community or post",
+      "root": "Reading & interaction",
+      "screen_depth": 2,
+      "screen_path": [
+        "Reading & interaction",
+        "Comments",
+        "Comment behavior"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Comment behavior",
+      "title": "Use suggested sort",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "false",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE",
+      "key": "pref_comments_scroll_animation",
+      "leaf_section": "Thread navigation",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Navigation",
+          "key": "pref_comments_scroll_animation",
+          "logical_kind": "stored_setting",
+          "resource": "pref_comments_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Comments",
+      "page_intro": "Control comment display, actions, navigation, and thread behavior.",
+      "proposed_summary": "",
+      "root": "Reading & interaction",
+      "screen_depth": 2,
+      "screen_path": [
+        "Reading & interaction",
+        "Comments",
+        "Thread navigation"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Thread navigation",
+      "title": "Animate navigation",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "false",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE",
+      "key": "pref_comments_click",
+      "leaf_section": "Thread navigation",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Behavior",
+          "key": "pref_comments_click",
+          "logical_kind": "stored_setting",
+          "resource": "pref_comments_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Comments",
+      "page_intro": "Control comment display, actions, navigation, and thread behavior.",
+      "proposed_summary": "",
+      "root": "Reading & interaction",
+      "screen_depth": 2,
+      "screen_path": [
+        "Reading & interaction",
+        "Comments",
+        "Thread navigation"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Thread navigation",
+      "title": "Click to collapse comment",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "false",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE",
+      "key": "pref_comments_collapse_automoderator",
+      "leaf_section": "Thread navigation",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Appearance",
+          "key": "pref_comments_collapse_automoderator",
+          "logical_kind": "stored_setting",
+          "resource": "pref_comments_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Comments",
+      "page_intro": "Control comment display, actions, navigation, and thread behavior.",
+      "proposed_summary": "",
+      "root": "Reading & interaction",
+      "screen_depth": 2,
+      "screen_path": [
+        "Reading & interaction",
+        "Comments",
+        "Thread navigation"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Thread navigation",
+      "title": "Collapse AutoModerator",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "false",
+      "dependency": "",
+      "existing_summary": "Crowd control, downvoted, deleted…",
+      "help_treatment": "REVIEW_EXISTING_SUMMARY",
+      "key": "pref_comments_collapse_collapsed",
+      "leaf_section": "Thread navigation",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Appearance",
+          "key": "pref_comments_collapse_collapsed",
+          "logical_kind": "stored_setting",
+          "resource": "pref_comments_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Comments",
+      "page_intro": "Control comment display, actions, navigation, and thread behavior.",
+      "proposed_summary": "Crowd control, downvoted, deleted…",
+      "root": "Reading & interaction",
+      "screen_depth": 2,
+      "screen_path": [
+        "Reading & interaction",
+        "Comments",
+        "Thread navigation"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Thread navigation",
+      "title": "Collapse disruptive comments",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "0",
+      "dependency": "pref_comments_highlight_new_comments",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE",
+      "key": "pref_comments_default_navigation",
+      "leaf_section": "Thread navigation",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Navigation",
+          "key": "pref_comments_default_navigation",
+          "logical_kind": "stored_setting",
+          "resource": "pref_comments_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Comments",
+      "page_intro": "Control comment display, actions, navigation, and thread behavior.",
+      "proposed_summary": "",
+      "root": "Reading & interaction",
+      "screen_depth": 2,
+      "screen_path": [
+        "Reading & interaction",
+        "Comments",
+        "Thread navigation"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "string",
+      "subscreen": "Thread navigation",
+      "title": "Default navigation mode",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "true",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE",
+      "key": "pref_comments_animation",
+      "leaf_section": "Thread navigation",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Behavior",
+          "key": "pref_comments_animation",
+          "logical_kind": "stored_setting",
+          "resource": "pref_comments_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Comments",
+      "page_intro": "Control comment display, actions, navigation, and thread behavior.",
+      "proposed_summary": "",
+      "root": "Reading & interaction",
+      "screen_depth": 2,
+      "screen_path": [
+        "Reading & interaction",
+        "Comments",
+        "Thread navigation"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Thread navigation",
+      "title": "Expand/collapse animation",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "false",
+      "dependency": "",
+      "existing_summary": "Show only comment header when collapsed",
+      "help_treatment": "REVIEW_EXISTING_SUMMARY",
+      "key": "pref_comments_full_collapse",
+      "leaf_section": "Thread navigation",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Behavior",
+          "key": "pref_comments_full_collapse",
+          "logical_kind": "stored_setting",
+          "resource": "pref_comments_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Comments",
+      "page_intro": "Control comment display, actions, navigation, and thread behavior.",
+      "proposed_summary": "Show only comment header when collapsed",
+      "root": "Reading & interaction",
+      "screen_depth": 2,
+      "screen_path": [
+        "Reading & interaction",
+        "Comments",
+        "Thread navigation"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Thread navigation",
+      "title": "Hide text of collapsed comments",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "true",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE",
+      "key": "pref_comments_highlight_new_comments",
+      "leaf_section": "Thread navigation",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Navigation",
+          "key": "pref_comments_highlight_new_comments",
+          "logical_kind": "stored_setting",
+          "resource": "pref_comments_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Comments",
+      "page_intro": "Control comment display, actions, navigation, and thread behavior.",
+      "proposed_summary": "",
+      "root": "Reading & interaction",
+      "screen_depth": 2,
+      "screen_path": [
+        "Reading & interaction",
+        "Comments",
+        "Thread navigation"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Thread navigation",
+      "title": "Highlight new comments",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "false",
+      "dependency": "",
+      "existing_summary": "Load top level comments with its replies collapsed",
+      "help_treatment": "REVIEW_EXISTING_SUMMARY",
+      "key": "pref_comments_load_collapsed",
+      "leaf_section": "Thread navigation",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Behavior",
+          "key": "pref_comments_load_collapsed",
+          "logical_kind": "stored_setting",
+          "resource": "pref_comments_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Comments",
+      "page_intro": "Control comment display, actions, navigation, and thread behavior.",
+      "proposed_summary": "Load top level comments with its replies collapsed",
+      "root": "Reading & interaction",
+      "screen_depth": 2,
+      "screen_path": [
+        "Reading & interaction",
+        "Comments",
+        "Thread navigation"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Thread navigation",
+      "title": "Load collapsed by default",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "false",
+      "dependency": "",
+      "existing_summary": "Jump between comments",
+      "help_treatment": "REVIEW_EXISTING_SUMMARY",
+      "key": "pref_comments_navigation_bar",
+      "leaf_section": "Thread navigation",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Appearance",
+          "key": "pref_comments_navigation_bar",
+          "logical_kind": "stored_setting",
+          "resource": "pref_comments_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Comments",
+      "page_intro": "Control comment display, actions, navigation, and thread behavior.",
+      "proposed_summary": "Jump between comments",
+      "root": "Reading & interaction",
+      "screen_depth": 2,
+      "screen_path": [
+        "Reading & interaction",
+        "Comments",
+        "Thread navigation"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Thread navigation",
+      "title": "Show navigation bar",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "0",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE",
+      "key": "pref_indent_style",
+      "leaf_section": "Thread navigation",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Appearance",
+          "key": "pref_indent_style",
+          "logical_kind": "stored_setting",
+          "resource": "pref_comments_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Comments",
+      "page_intro": "Control comment display, actions, navigation, and thread behavior.",
+      "proposed_summary": "",
+      "root": "Reading & interaction",
+      "screen_depth": 2,
+      "screen_path": [
+        "Reading & interaction",
+        "Comments",
+        "Thread navigation"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "string",
+      "subscreen": "Thread navigation",
+      "title": "Thread level indicator",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "false",
+      "dependency": "",
+      "existing_summary": "Use volume keys to go to next and previous comment",
+      "help_treatment": "REVIEW_EXISTING_SUMMARY",
+      "key": "pref_comments_volume_scroll",
+      "leaf_section": "Thread navigation",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Navigation",
+          "key": "pref_comments_volume_scroll",
+          "logical_kind": "stored_setting",
+          "resource": "pref_comments_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Comments",
+      "page_intro": "Control comment display, actions, navigation, and thread behavior.",
+      "proposed_summary": "Use volume keys to go to next and previous comment",
+      "root": "Reading & interaction",
+      "screen_depth": 2,
+      "screen_path": [
+        "Reading & interaction",
+        "Comments",
+        "Thread navigation"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Thread navigation",
+      "title": "Volume key navigation",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "",
+      "dependency": "",
+      "existing_summary": "View or delete drafts saved on reddit",
+      "help_treatment": "REVIEW_EXISTING_SUMMARY",
+      "key": "pref_manage_drafts",
+      "leaf_section": "Drafts",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Composing",
+          "key": "pref_manage_drafts",
+          "logical_kind": "action",
+          "resource": "pref_general_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "action",
+      "page": "Composing & drafts",
+      "page_intro": "Configure editors, draft storage, and uploaded composing media.",
+      "proposed_summary": "View or delete drafts saved on reddit",
+      "root": "Reading & interaction",
+      "screen_depth": 2,
+      "screen_path": [
+        "Reading & interaction",
+        "Composing & drafts",
+        "Drafts"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "none_or_custom",
+      "subscreen": "Drafts",
+      "title": "Post drafts",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "true",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE",
+      "key": "pref_drafts",
+      "leaf_section": "Drafts",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Composing",
+          "key": "pref_drafts",
+          "logical_kind": "stored_setting",
+          "resource": "pref_general_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Composing & drafts",
+      "page_intro": "Configure editors, draft storage, and uploaded composing media.",
+      "proposed_summary": "",
+      "root": "Reading & interaction",
+      "screen_depth": 2,
+      "screen_path": [
+        "Reading & interaction",
+        "Composing & drafts",
+        "Drafts"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Drafts",
+      "title": "Save drafts",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "false",
+      "dependency": "",
+      "existing_summary": "Disable to use quick reply dialog",
+      "help_treatment": "REVIEW_EXISTING_SUMMARY",
+      "key": "pref_use_advanced_editor",
+      "leaf_section": "Editor",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Composing",
+          "key": "pref_use_advanced_editor",
+          "logical_kind": "stored_setting",
+          "resource": "pref_general_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Composing & drafts",
+      "page_intro": "Configure editors, draft storage, and uploaded composing media.",
+      "proposed_summary": "Disable to use quick reply dialog",
+      "root": "Reading & interaction",
+      "screen_depth": 2,
+      "screen_path": [
+        "Reading & interaction",
+        "Composing & drafts",
+        "Editor"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Editor",
+      "title": "Advanced fullscreen editor",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "",
+      "dependency": "",
+      "existing_summary": "\"View or delete images you've uploaded to Imgur\"",
+      "help_treatment": "REVIEW_EXISTING_SUMMARY",
+      "key": "pref_imgur_uploads",
+      "leaf_section": "Uploads",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Composing",
+          "key": "pref_imgur_uploads",
+          "logical_kind": "action",
+          "resource": "pref_general_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "action",
+      "page": "Composing & drafts",
+      "page_intro": "Configure editors, draft storage, and uploaded composing media.",
+      "proposed_summary": "\"View or delete images you've uploaded to Imgur\"",
+      "root": "Reading & interaction",
+      "screen_depth": 2,
+      "screen_path": [
+        "Reading & interaction",
+        "Composing & drafts",
+        "Uploads"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "none_or_custom",
+      "subscreen": "Uploads",
+      "title": "Uploaded images",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "",
+      "dependency": "",
+      "existing_summary": "Manage your communities and custom feeds",
+      "help_treatment": "REVIEW_EXISTING_SUMMARY",
+      "key": "pref_edit_subscriptions",
+      "leaf_section": "Manage subscriptions",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Navigation",
+          "key": "pref_edit_subscriptions",
+          "logical_kind": "action",
+          "resource": "pref_general_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "action",
+      "page": "Feeds & subscriptions",
+      "page_intro": "Manage communities, custom feeds, and subscription-related behavior.",
+      "proposed_summary": "Manage your communities and custom feeds",
+      "root": "Reading & interaction",
+      "screen_depth": 2,
+      "screen_path": [
+        "Reading & interaction",
+        "Feeds & subscriptions",
+        "Manage subscriptions"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "none_or_custom",
+      "subscreen": "Manage subscriptions",
+      "title": "Subscriptions",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "OMIT_OR_ONE_LINE_ACTION_HINT",
+      "key": "pref_default_sort",
+      "leaf_section": "Feed behavior",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": null,
+          "key": "pref_default_sort",
+          "logical_kind": "action",
+          "resource": "pref_posts_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "action",
+      "page": "Posts",
+      "page_intro": "Choose how posts behave while browsing and reading.",
+      "proposed_summary": "",
+      "root": "Reading & interaction",
+      "screen_depth": 2,
+      "screen_path": [
+        "Reading & interaction",
+        "Posts",
+        "Feed behavior"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "none_or_custom",
+      "subscreen": "Feed behavior",
+      "title": "Default sort",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "false",
+      "dependency": "",
+      "existing_summary": "Each community will remember the last sort you selected for that community",
+      "help_treatment": "REVIEW_EXISTING_SUMMARY",
+      "key": "pref_sort_per_subscription",
+      "leaf_section": "Feed behavior",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": null,
+          "key": "pref_sort_per_subscription",
+          "logical_kind": "stored_setting",
+          "resource": "pref_posts_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Posts",
+      "page_intro": "Choose how posts behave while browsing and reading.",
+      "proposed_summary": "Each community will remember the last sort you selected for that community",
+      "root": "Reading & interaction",
+      "screen_depth": 2,
+      "screen_path": [
+        "Reading & interaction",
+        "Posts",
+        "Feed behavior"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Feed behavior",
+      "title": "Remember per community",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "OMIT_OR_ONE_LINE_ACTION_HINT",
+      "key": "pref_frontpage_sort",
+      "leaf_section": "Feed behavior",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": null,
+          "key": "pref_frontpage_sort",
+          "logical_kind": "action",
+          "resource": "pref_posts_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "action",
+      "page": "Posts",
+      "page_intro": "Choose how posts behave while browsing and reading.",
+      "proposed_summary": "",
+      "root": "Reading & interaction",
+      "screen_depth": 2,
+      "screen_path": [
+        "Reading & interaction",
+        "Posts",
+        "Feed behavior"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "none_or_custom",
+      "subscreen": "Feed behavior",
+      "title": "Sort Home posts by",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "true",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE",
+      "key": "pref_post_show_comments_button",
+      "leaf_section": "Post actions",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Visible buttons",
+          "key": "pref_post_show_comments_button",
+          "logical_kind": "stored_setting",
+          "resource": "pref_posts_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Posts",
+      "page_intro": "Choose how posts behave while browsing and reading.",
+      "proposed_summary": "",
+      "root": "Reading & interaction",
+      "screen_depth": 2,
+      "screen_path": [
+        "Reading & interaction",
+        "Posts",
+        "Post actions"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Post actions",
+      "title": "Comments",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "false",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE",
+      "key": "pref_show_hide",
+      "leaf_section": "Post actions",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Visible buttons",
+          "key": "pref_show_hide",
+          "logical_kind": "stored_setting",
+          "resource": "pref_posts_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Posts",
+      "page_intro": "Choose how posts behave while browsing and reading.",
+      "proposed_summary": "",
+      "root": "Reading & interaction",
+      "screen_depth": 2,
+      "screen_path": [
+        "Reading & interaction",
+        "Posts",
+        "Post actions"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Post actions",
+      "title": "Hide",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "",
+      "dependency": "pref_sort_per_subscription",
+      "existing_summary": "",
+      "help_treatment": "OMIT_OR_ONE_LINE_ACTION_HINT",
+      "key": "pref_sort_per_sub",
+      "leaf_section": "Post actions",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": null,
+          "key": "pref_sort_per_sub",
+          "logical_kind": "action",
+          "resource": "pref_posts_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "action",
+      "page": "Posts",
+      "page_intro": "Choose how posts behave while browsing and reading.",
+      "proposed_summary": "",
+      "root": "Reading & interaction",
+      "screen_depth": 2,
+      "screen_path": [
+        "Reading & interaction",
+        "Posts",
+        "Post actions"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "none_or_custom",
+      "subscreen": "Post actions",
+      "title": "Manage saved sorts",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "false",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE",
+      "key": "pref_show_read",
+      "leaf_section": "Post actions",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Visible buttons",
+          "key": "pref_show_read",
+          "logical_kind": "stored_setting",
+          "resource": "pref_posts_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Posts",
+      "page_intro": "Choose how posts behave while browsing and reading.",
+      "proposed_summary": "",
+      "root": "Reading & interaction",
+      "screen_depth": 2,
+      "screen_path": [
+        "Reading & interaction",
+        "Posts",
+        "Post actions"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Post actions",
+      "title": "Mark read",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "true",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE",
+      "key": "pref_post_show_open_button",
+      "leaf_section": "Post actions",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Visible buttons",
+          "key": "pref_post_show_open_button",
+          "logical_kind": "stored_setting",
+          "resource": "pref_posts_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Posts",
+      "page_intro": "Choose how posts behave while browsing and reading.",
+      "proposed_summary": "",
+      "root": "Reading & interaction",
+      "screen_depth": 2,
+      "screen_path": [
+        "Reading & interaction",
+        "Posts",
+        "Post actions"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Post actions",
+      "title": "Open in external app",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "false",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE",
+      "key": "pref_post_show_share_button",
+      "leaf_section": "Post actions",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Visible buttons",
+          "key": "pref_post_show_share_button",
+          "logical_kind": "stored_setting",
+          "resource": "pref_posts_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Posts",
+      "page_intro": "Choose how posts behave while browsing and reading.",
+      "proposed_summary": "",
+      "root": "Reading & interaction",
+      "screen_depth": 2,
+      "screen_path": [
+        "Reading & interaction",
+        "Posts",
+        "Post actions"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Post actions",
+      "title": "Share",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "true",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE",
+      "key": "pref_posts_floating_button",
+      "leaf_section": "Post actions",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Post info",
+          "key": "pref_posts_floating_button",
+          "logical_kind": "stored_setting",
+          "resource": "pref_posts_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Posts",
+      "page_intro": "Choose how posts behave while browsing and reading.",
+      "proposed_summary": "",
+      "root": "Reading & interaction",
+      "screen_depth": 2,
+      "screen_path": [
+        "Reading & interaction",
+        "Posts",
+        "Post actions"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Post actions",
+      "title": "Show floating button",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "false",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE",
+      "key": "pref_upvote_on_save",
+      "leaf_section": "Post actions",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Links",
+          "key": "pref_upvote_on_save",
+          "logical_kind": "stored_setting",
+          "resource": "pref_general_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Posts",
+      "page_intro": "Choose how posts behave while browsing and reading.",
+      "proposed_summary": "",
+      "root": "Reading & interaction",
+      "screen_depth": 2,
+      "screen_path": [
+        "Reading & interaction",
+        "Posts",
+        "Post actions"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Post actions",
+      "title": "Upvote on save",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "true",
+      "dependency": "pref_show_awards_posts",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE",
+      "key": "pref_clickable_awards_posts",
+      "leaf_section": "Post behavior",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Awards",
+          "key": "pref_clickable_awards_posts",
+          "logical_kind": "stored_setting",
+          "resource": "pref_posts_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Posts",
+      "page_intro": "Choose how posts behave while browsing and reading.",
+      "proposed_summary": "",
+      "root": "Reading & interaction",
+      "screen_depth": 2,
+      "screen_path": [
+        "Reading & interaction",
+        "Posts",
+        "Post behavior"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Post behavior",
+      "title": "Clickable awards",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "false",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE",
+      "key": "pref_info_username",
+      "leaf_section": "Post behavior",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Post info",
+          "key": "pref_info_username",
+          "logical_kind": "stored_setting",
+          "resource": "pref_posts_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Posts",
+      "page_intro": "Choose how posts behave while browsing and reading.",
+      "proposed_summary": "",
+      "root": "Reading & interaction",
+      "screen_depth": 2,
+      "screen_path": [
+        "Reading & interaction",
+        "Posts",
+        "Post behavior"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Post behavior",
+      "title": "Show author",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "true",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE",
+      "key": "pref_show_awards_posts",
+      "leaf_section": "Post behavior",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Awards",
+          "key": "pref_show_awards_posts",
+          "logical_kind": "stored_setting",
+          "resource": "pref_posts_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Posts",
+      "page_intro": "Choose how posts behave while browsing and reading.",
+      "proposed_summary": "",
+      "root": "Reading & interaction",
+      "screen_depth": 2,
+      "screen_path": [
+        "Reading & interaction",
+        "Posts",
+        "Post behavior"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Post behavior",
+      "title": "Show awards",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "true",
+      "dependency": "pref_info_post_flair",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE",
+      "key": "pref_flair_emojis",
+      "leaf_section": "Post behavior",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Flairs",
+          "key": "pref_flair_emojis",
+          "logical_kind": "stored_setting",
+          "resource": "pref_posts_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Posts",
+      "page_intro": "Choose how posts behave while browsing and reading.",
+      "proposed_summary": "",
+      "root": "Reading & interaction",
+      "screen_depth": 2,
+      "screen_path": [
+        "Reading & interaction",
+        "Posts",
+        "Post behavior"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Post behavior",
+      "title": "Show emojis",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "true",
+      "dependency": "pref_info_post_flair",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE",
+      "key": "pref_flair_colors",
+      "leaf_section": "Post behavior",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Flairs",
+          "key": "pref_flair_colors",
+          "logical_kind": "stored_setting",
+          "resource": "pref_posts_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Posts",
+      "page_intro": "Choose how posts behave while browsing and reading.",
+      "proposed_summary": "",
+      "root": "Reading & interaction",
+      "screen_depth": 2,
+      "screen_path": [
+        "Reading & interaction",
+        "Posts",
+        "Post behavior"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Post behavior",
+      "title": "Show flair colors",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "true",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE",
+      "key": "pref_info_post_flair",
+      "leaf_section": "Post behavior",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Flairs",
+          "key": "pref_info_post_flair",
+          "logical_kind": "stored_setting",
+          "resource": "pref_posts_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Posts",
+      "page_intro": "Choose how posts behave while browsing and reading.",
+      "proposed_summary": "",
+      "root": "Reading & interaction",
+      "screen_depth": 2,
+      "screen_path": [
+        "Reading & interaction",
+        "Posts",
+        "Post behavior"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Post behavior",
+      "title": "Show post flair",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "true",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE",
+      "key": "pref_post_clickable_subreddit",
+      "leaf_section": "Post behavior",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Post info",
+          "key": "pref_post_clickable_subreddit",
+          "logical_kind": "stored_setting",
+          "resource": "pref_posts_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Posts",
+      "page_intro": "Choose how posts behave while browsing and reading.",
+      "proposed_summary": "",
+      "root": "Reading & interaction",
+      "screen_depth": 2,
+      "screen_path": [
+        "Reading & interaction",
+        "Posts",
+        "Post behavior"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Post behavior",
+      "title": "Tap community to visit",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "false",
+      "dependency": "pref_info_post_flair",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE",
+      "key": "pref_flair_clickable",
+      "leaf_section": "Post behavior",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Flairs",
+          "key": "pref_flair_clickable",
+          "logical_kind": "stored_setting",
+          "resource": "pref_posts_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Posts",
+      "page_intro": "Choose how posts behave while browsing and reading.",
+      "proposed_summary": "",
+      "root": "Reading & interaction",
+      "screen_depth": 2,
+      "screen_path": [
+        "Reading & interaction",
+        "Posts",
+        "Post behavior"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Post behavior",
+      "title": "Tap flair to search",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "true",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE",
+      "key": "pref_post_clickable_username",
+      "leaf_section": "Post behavior",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Post info",
+          "key": "pref_post_clickable_username",
+          "logical_kind": "stored_setting",
+          "resource": "pref_posts_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Posts",
+      "page_intro": "Choose how posts behave while browsing and reading.",
+      "proposed_summary": "",
+      "root": "Reading & interaction",
+      "screen_depth": 2,
+      "screen_path": [
+        "Reading & interaction",
+        "Posts",
+        "Post behavior"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Post behavior",
+      "title": "Tap username to view profile",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "",
+      "dependency": "",
+      "existing_summary": "Sync read posts between devices with synccit.com",
+      "help_treatment": "REVIEW_EXISTING_SUMMARY+PROGRESSIVE_DISCLOSURE",
+      "key": "synncit_config",
+      "leaf_section": "Reading state",
+      "legacy_route_count": 2,
+      "legacy_routes": [
+        {
+          "category": "Mark as read",
+          "key": "synncit_config",
+          "logical_kind": "action",
+          "resource": "pref_posts_v2",
+          "root_referenced": true
+        },
+        {
+          "category": "Mark as read",
+          "key": "synncit_config",
+          "logical_kind": "action",
+          "resource": "pref_privacy_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "action",
+      "page": "Posts",
+      "page_intro": "Choose how posts behave while browsing and reading.",
+      "proposed_summary": "Sync read posts between devices with synccit.com",
+      "root": "Reading & interaction",
+      "screen_depth": 2,
+      "screen_path": [
+        "Reading & interaction",
+        "Posts",
+        "Reading state"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "none_or_custom",
+      "subscreen": "Reading state",
+      "title": "Configure Synccit",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "false",
+      "dependency": "pref_mark_read",
+      "existing_summary": "Post images will be dimmed when marked as read",
+      "help_treatment": "REVIEW_EXISTING_SUMMARY",
+      "key": "pref_mark_read_dim_images",
+      "leaf_section": "Reading state",
+      "legacy_route_count": 2,
+      "legacy_routes": [
+        {
+          "category": "Mark as read",
+          "key": "pref_mark_read_dim_images",
+          "logical_kind": "stored_setting",
+          "resource": "pref_posts_v2",
+          "root_referenced": true
+        },
+        {
+          "category": "Mark as read",
+          "key": "pref_mark_read_dim_images",
+          "logical_kind": "stored_setting",
+          "resource": "pref_privacy_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Posts",
+      "page_intro": "Choose how posts behave while browsing and reading.",
+      "proposed_summary": "Post images will be dimmed when marked as read",
+      "root": "Reading & interaction",
+      "screen_depth": 2,
+      "screen_path": [
+        "Reading & interaction",
+        "Posts",
+        "Reading state"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Reading state",
+      "title": "Dim images in read posts",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "false",
+      "dependency": "pref_mark_read",
+      "existing_summary": "Pressing \\\"Hide read\\\" will move read posts on screen to Profile->Hidden (requires login)",
+      "help_treatment": "REVIEW_EXISTING_SUMMARY",
+      "key": "pref_hide_read_permanently",
+      "leaf_section": "Reading state",
+      "legacy_route_count": 2,
+      "legacy_routes": [
+        {
+          "category": "Mark as read",
+          "key": "pref_hide_read_permanently",
+          "logical_kind": "stored_setting",
+          "resource": "pref_posts_v2",
+          "root_referenced": true
+        },
+        {
+          "category": "Mark as read",
+          "key": "pref_hide_read_permanently",
+          "logical_kind": "stored_setting",
+          "resource": "pref_privacy_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Posts",
+      "page_intro": "Choose how posts behave while browsing and reading.",
+      "proposed_summary": "Pressing \\\"Hide read\\\" will move read posts on screen to Profile->Hidden (requires login)",
+      "root": "Reading & interaction",
+      "screen_depth": 2,
+      "screen_path": [
+        "Reading & interaction",
+        "Posts",
+        "Reading state"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Reading state",
+      "title": "Hide read permanently",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "false",
+      "dependency": "pref_mark_read",
+      "existing_summary": "Post will be marked as read when it leaves the screen",
+      "help_treatment": "REVIEW_EXISTING_SUMMARY",
+      "key": "pref_mark_read_on_scroll",
+      "leaf_section": "Reading state",
+      "legacy_route_count": 2,
+      "legacy_routes": [
+        {
+          "category": "Mark as read",
+          "key": "pref_mark_read_on_scroll",
+          "logical_kind": "stored_setting",
+          "resource": "pref_posts_v2",
+          "root_referenced": true
+        },
+        {
+          "category": "Mark as read",
+          "key": "pref_mark_read_on_scroll",
+          "logical_kind": "stored_setting",
+          "resource": "pref_privacy_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Posts",
+      "page_intro": "Choose how posts behave while browsing and reading.",
+      "proposed_summary": "Post will be marked as read when it leaves the screen",
+      "root": "Reading & interaction",
+      "screen_depth": 2,
+      "screen_path": [
+        "Reading & interaction",
+        "Posts",
+        "Reading state"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Reading state",
+      "title": "Mark as read on scroll",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "true",
+      "dependency": "",
+      "existing_summary": "Clicking on a post will mark as read",
+      "help_treatment": "REVIEW_EXISTING_SUMMARY",
+      "key": "pref_mark_read",
+      "leaf_section": "Reading state",
+      "legacy_route_count": 2,
+      "legacy_routes": [
+        {
+          "category": "Mark as read",
+          "key": "pref_mark_read",
+          "logical_kind": "stored_setting",
+          "resource": "pref_posts_v2",
+          "root_referenced": true
+        },
+        {
+          "category": "Mark as read",
+          "key": "pref_mark_read",
+          "logical_kind": "stored_setting",
+          "resource": "pref_privacy_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Posts",
+      "page_intro": "Choose how posts behave while browsing and reading.",
+      "proposed_summary": "Clicking on a post will mark as read",
+      "root": "Reading & interaction",
+      "screen_depth": 2,
+      "screen_path": [
+        "Reading & interaction",
+        "Posts",
+        "Reading state"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Reading state",
+      "title": "Mark posts as read",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "false",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE",
+      "key": "pref_history_delete_read",
+      "leaf_section": "Reading state",
+      "legacy_route_count": 2,
+      "legacy_routes": [
+        {
+          "category": "Mark as read",
+          "key": "pref_history_delete_read",
+          "logical_kind": "special_preference",
+          "resource": "pref_posts_v2",
+          "root_referenced": true
+        },
+        {
+          "category": "Mark as read",
+          "key": "pref_history_delete_read",
+          "logical_kind": "special_preference",
+          "resource": "pref_privacy_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "special_preference",
+      "page": "Posts",
+      "page_intro": "Choose how posts behave while browsing and reading.",
+      "proposed_summary": "",
+      "root": "Reading & interaction",
+      "screen_depth": 2,
+      "screen_path": [
+        "Reading & interaction",
+        "Posts",
+        "Reading state"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "none_or_custom",
+      "subscreen": "Reading state",
+      "title": "Reset read posts",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "false",
+      "dependency": "pref_load_nsfw_images",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE",
+      "key": "pref_blur_nsfw_images",
+      "leaf_section": "Filter behavior",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "More options",
+          "key": "pref_blur_nsfw_images",
+          "logical_kind": "stored_setting",
+          "resource": "pref_filters_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Search & filters",
+      "page_intro": "Configure search entry, search behavior, and content filtering.",
+      "proposed_summary": "",
+      "root": "Reading & interaction",
+      "screen_depth": 3,
+      "screen_path": [
+        "Reading & interaction",
+        "Search & filters",
+        "Content filters",
+        "Filter behavior"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Filter behavior",
+      "title": "Blur images in NSFW posts",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "false",
+      "dependency": "pref_nsfw",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE",
+      "key": "pref_load_nsfw_images",
+      "leaf_section": "Filter behavior",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "More options",
+          "key": "pref_load_nsfw_images",
+          "logical_kind": "stored_setting",
+          "resource": "pref_filters_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Search & filters",
+      "page_intro": "Configure search entry, search behavior, and content filtering.",
+      "proposed_summary": "",
+      "root": "Reading & interaction",
+      "screen_depth": 3,
+      "screen_path": [
+        "Reading & interaction",
+        "Search & filters",
+        "Content filters",
+        "Filter behavior"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Filter behavior",
+      "title": "Show images in NSFW posts",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "false",
+      "dependency": "",
+      "existing_summary": "Show content labeled Not Safe For Work",
+      "help_treatment": "REVIEW_EXISTING_SUMMARY",
+      "key": "pref_nsfw",
+      "leaf_section": "Filter behavior",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "More options",
+          "key": "pref_nsfw",
+          "logical_kind": "stored_setting",
+          "resource": "pref_filters_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Search & filters",
+      "page_intro": "Configure search entry, search behavior, and content filtering.",
+      "proposed_summary": "Show content labeled Not Safe For Work",
+      "root": "Reading & interaction",
+      "screen_depth": 3,
+      "screen_path": [
+        "Reading & interaction",
+        "Search & filters",
+        "Content filters",
+        "Filter behavior"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Filter behavior",
+      "title": "Show NSFW",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "",
+      "dependency": "",
+      "existing_summary": "Hide posts from these communities. Use * wildcards to group communities (\\\"ask*\\\" hides AskReddit, AskScience…)",
+      "help_treatment": "REVIEW_EXISTING_SUMMARY",
+      "key": "pref_filter_subreddit",
+      "leaf_section": "Muted content",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Muting options",
+          "key": "pref_filter_subreddit",
+          "logical_kind": "special_preference",
+          "resource": "pref_filters_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "special_preference",
+      "page": "Search & filters",
+      "page_intro": "Configure search entry, search behavior, and content filtering.",
+      "proposed_summary": "Hide posts from these communities. Use * wildcards to group communities (\\\"ask*\\\" hides AskReddit, AskScience…)",
+      "root": "Reading & interaction",
+      "screen_depth": 3,
+      "screen_path": [
+        "Reading & interaction",
+        "Search & filters",
+        "Content filters",
+        "Muted content"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "none_or_custom",
+      "subscreen": "Muting options",
+      "title": "Communities",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "",
+      "dependency": "",
+      "existing_summary": "Hide posts from these domains",
+      "help_treatment": "REVIEW_EXISTING_SUMMARY",
+      "key": "pref_filter_domain",
+      "leaf_section": "Muted content",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Muting options",
+          "key": "pref_filter_domain",
+          "logical_kind": "special_preference",
+          "resource": "pref_filters_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "special_preference",
+      "page": "Search & filters",
+      "page_intro": "Configure search entry, search behavior, and content filtering.",
+      "proposed_summary": "Hide posts from these domains",
+      "root": "Reading & interaction",
+      "screen_depth": 3,
+      "screen_path": [
+        "Reading & interaction",
+        "Search & filters",
+        "Content filters",
+        "Muted content"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "none_or_custom",
+      "subscreen": "Muting options",
+      "title": "Domains",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "",
+      "dependency": "",
+      "existing_summary": "Hide posts with these flairs. Use * wildcards to group flairs (\\\"*meme\\\" hides meme, wholesomememe…)",
+      "help_treatment": "REVIEW_EXISTING_SUMMARY",
+      "key": "pref_filter_flair",
+      "leaf_section": "Muted content",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Muting options",
+          "key": "pref_filter_flair",
+          "logical_kind": "special_preference",
+          "resource": "pref_filters_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "special_preference",
+      "page": "Search & filters",
+      "page_intro": "Configure search entry, search behavior, and content filtering.",
+      "proposed_summary": "Hide posts with these flairs. Use * wildcards to group flairs (\\\"*meme\\\" hides meme, wholesomememe…)",
+      "root": "Reading & interaction",
+      "screen_depth": 3,
+      "screen_path": [
+        "Reading & interaction",
+        "Search & filters",
+        "Content filters",
+        "Muted content"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "none_or_custom",
+      "subscreen": "Muting options",
+      "title": "Flairs",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "",
+      "dependency": "",
+      "existing_summary": "Hide posts from these users",
+      "help_treatment": "REVIEW_EXISTING_SUMMARY",
+      "key": "pref_filter_username",
+      "leaf_section": "Muted content",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Muting options",
+          "key": "pref_filter_username",
+          "logical_kind": "special_preference",
+          "resource": "pref_filters_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "special_preference",
+      "page": "Search & filters",
+      "page_intro": "Configure search entry, search behavior, and content filtering.",
+      "proposed_summary": "Hide posts from these users",
+      "root": "Reading & interaction",
+      "screen_depth": 3,
+      "screen_path": [
+        "Reading & interaction",
+        "Search & filters",
+        "Content filters",
+        "Muted content"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "none_or_custom",
+      "subscreen": "Muting options",
+      "title": "Users",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "",
+      "dependency": "",
+      "existing_summary": "Hide posts containing words in title",
+      "help_treatment": "REVIEW_EXISTING_SUMMARY",
+      "key": "pref_filter_keyword",
+      "leaf_section": "Muted content",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Muting options",
+          "key": "pref_filter_keyword",
+          "logical_kind": "special_preference",
+          "resource": "pref_filters_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "special_preference",
+      "page": "Search & filters",
+      "page_intro": "Configure search entry, search behavior, and content filtering.",
+      "proposed_summary": "Hide posts containing words in title",
+      "root": "Reading & interaction",
+      "screen_depth": 3,
+      "screen_path": [
+        "Reading & interaction",
+        "Search & filters",
+        "Content filters",
+        "Muted content"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "none_or_custom",
+      "subscreen": "Muting options",
+      "title": "Words",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "true",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE",
+      "key": "pref_album",
+      "leaf_section": "Post matching",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Show posts with",
+          "key": "pref_album",
+          "logical_kind": "stored_setting",
+          "resource": "pref_filters_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Search & filters",
+      "page_intro": "Configure search entry, search behavior, and content filtering.",
+      "proposed_summary": "",
+      "root": "Reading & interaction",
+      "screen_depth": 3,
+      "screen_path": [
+        "Reading & interaction",
+        "Search & filters",
+        "Content filters",
+        "Post matching"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Show posts with",
+      "title": "Albums",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "true",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE",
+      "key": "pref_gif",
+      "leaf_section": "Post matching",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Show posts with",
+          "key": "pref_gif",
+          "logical_kind": "stored_setting",
+          "resource": "pref_filters_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Search & filters",
+      "page_intro": "Configure search entry, search behavior, and content filtering.",
+      "proposed_summary": "",
+      "root": "Reading & interaction",
+      "screen_depth": 3,
+      "screen_path": [
+        "Reading & interaction",
+        "Search & filters",
+        "Content filters",
+        "Post matching"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Show posts with",
+      "title": "Gifs",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "true",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "OMIT_SELF_EXPLANATORY",
+      "key": "pref_image",
+      "leaf_section": "Post matching",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Show posts with",
+          "key": "pref_image",
+          "logical_kind": "stored_setting",
+          "resource": "pref_filters_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Search & filters",
+      "page_intro": "Configure search entry, search behavior, and content filtering.",
+      "proposed_summary": "",
+      "root": "Reading & interaction",
+      "screen_depth": 3,
+      "screen_path": [
+        "Reading & interaction",
+        "Search & filters",
+        "Content filters",
+        "Post matching"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Show posts with",
+      "title": "Images",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "true",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE",
+      "key": "pref_link",
+      "leaf_section": "Post matching",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Show posts with",
+          "key": "pref_link",
+          "logical_kind": "stored_setting",
+          "resource": "pref_filters_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Search & filters",
+      "page_intro": "Configure search entry, search behavior, and content filtering.",
+      "proposed_summary": "",
+      "root": "Reading & interaction",
+      "screen_depth": 3,
+      "screen_path": [
+        "Reading & interaction",
+        "Search & filters",
+        "Content filters",
+        "Post matching"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Show posts with",
+      "title": "Links",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "true",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE",
+      "key": "pref_self",
+      "leaf_section": "Post matching",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Show posts with",
+          "key": "pref_self",
+          "logical_kind": "stored_setting",
+          "resource": "pref_filters_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Search & filters",
+      "page_intro": "Configure search entry, search behavior, and content filtering.",
+      "proposed_summary": "",
+      "root": "Reading & interaction",
+      "screen_depth": 3,
+      "screen_path": [
+        "Reading & interaction",
+        "Search & filters",
+        "Content filters",
+        "Post matching"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Show posts with",
+      "title": "Text",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "true",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "OMIT_SELF_EXPLANATORY",
+      "key": "pref_video",
+      "leaf_section": "Post matching",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Show posts with",
+          "key": "pref_video",
+          "logical_kind": "stored_setting",
+          "resource": "pref_filters_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Search & filters",
+      "page_intro": "Configure search entry, search behavior, and content filtering.",
+      "proposed_summary": "",
+      "root": "Reading & interaction",
+      "screen_depth": 3,
+      "screen_path": [
+        "Reading & interaction",
+        "Search & filters",
+        "Content filters",
+        "Post matching"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Show posts with",
+      "title": "Videos",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "OMIT_OR_ONE_LINE_ACTION_HINT",
+      "key": "pref_search_advanced_help",
+      "leaf_section": "Advanced search",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Advanced search",
+          "key": "pref_search_advanced_help",
+          "logical_kind": "action",
+          "resource": "pref_search_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "action",
+      "page": "Search & filters",
+      "page_intro": "Configure search entry, search behavior, and content filtering.",
+      "proposed_summary": "",
+      "root": "Reading & interaction",
+      "screen_depth": 3,
+      "screen_path": [
+        "Reading & interaction",
+        "Search & filters",
+        "Search",
+        "Advanced search"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "none_or_custom",
+      "subscreen": "Advanced search",
+      "title": "Field search help",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "5",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE",
+      "key": "pref_default_search_period",
+      "leaf_section": "Search behavior",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": null,
+          "key": "pref_default_search_period",
+          "logical_kind": "stored_setting",
+          "resource": "pref_search_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Search & filters",
+      "page_intro": "Configure search entry, search behavior, and content filtering.",
+      "proposed_summary": "",
+      "root": "Reading & interaction",
+      "screen_depth": 3,
+      "screen_path": [
+        "Reading & interaction",
+        "Search & filters",
+        "Search",
+        "Search behavior"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "string",
+      "subscreen": "Search behavior",
+      "title": "Default period",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "0",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE",
+      "key": "pref_default_search_sorting",
+      "leaf_section": "Search behavior",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": null,
+          "key": "pref_default_search_sorting",
+          "logical_kind": "stored_setting",
+          "resource": "pref_search_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Search & filters",
+      "page_intro": "Configure search entry, search behavior, and content filtering.",
+      "proposed_summary": "",
+      "root": "Reading & interaction",
+      "screen_depth": 3,
+      "screen_path": [
+        "Reading & interaction",
+        "Search & filters",
+        "Search",
+        "Search behavior"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "string",
+      "subscreen": "Search behavior",
+      "title": "Default sort",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "false",
+      "dependency": "",
+      "existing_summary": "Focus the search field and show the keyboard immediately. When disabled, tap Search again to start typing.",
+      "help_treatment": "REVIEW_EXISTING_SUMMARY",
+      "key": "morphe_boost_search_open_keyboard_on_entry",
+      "leaf_section": "Search behavior",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Search",
+          "key": "morphe_boost_search_open_keyboard_on_entry",
+          "logical_kind": "morphe_user_setting",
+          "resource": "morphe_boost_settings_skeleton",
+          "root_referenced": false
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Search & filters",
+      "page_intro": "Configure search entry, search behavior, and content filtering.",
+      "proposed_summary": "Focus the search field and show the keyboard immediately. When disabled, tap Search again to start typing.",
+      "root": "Reading & interaction",
+      "screen_depth": 3,
+      "screen_path": [
+        "Reading & interaction",
+        "Search & filters",
+        "Search",
+        "Search behavior"
+      ],
+      "source_type": "morphe_embedded_xml",
+      "storage_type": "boolean",
+      "subscreen": "Search behavior",
+      "title": "Open keyboard when entering Search",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "OMIT_OR_ONE_LINE_ACTION_HINT",
+      "key": "pref_saved_searches",
+      "leaf_section": "Suggestions",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Suggestions",
+          "key": "pref_saved_searches",
+          "logical_kind": "action",
+          "resource": "pref_search_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "action",
+      "page": "Search & filters",
+      "page_intro": "Configure search entry, search behavior, and content filtering.",
+      "proposed_summary": "",
+      "root": "Reading & interaction",
+      "screen_depth": 3,
+      "screen_path": [
+        "Reading & interaction",
+        "Search & filters",
+        "Search",
+        "Suggestions"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "none_or_custom",
+      "subscreen": "Suggestions",
+      "title": "Saved searches",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "true",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE",
+      "key": "pref_search_show_random",
+      "leaf_section": "Suggestions",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Suggestions",
+          "key": "pref_search_show_random",
+          "logical_kind": "stored_setting",
+          "resource": "pref_search_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Search & filters",
+      "page_intro": "Configure search entry, search behavior, and content filtering.",
+      "proposed_summary": "",
+      "root": "Reading & interaction",
+      "screen_depth": 3,
+      "screen_path": [
+        "Reading & interaction",
+        "Search & filters",
+        "Search",
+        "Suggestions"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Suggestions",
+      "title": "Show random",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "true",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE",
+      "key": "pref_search_show_random_nsfw",
+      "leaf_section": "Suggestions",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Suggestions",
+          "key": "pref_search_show_random_nsfw",
+          "logical_kind": "stored_setting",
+          "resource": "pref_search_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Search & filters",
+      "page_intro": "Configure search entry, search behavior, and content filtering.",
+      "proposed_summary": "",
+      "root": "Reading & interaction",
+      "screen_depth": 3,
+      "screen_path": [
+        "Reading & interaction",
+        "Search & filters",
+        "Search",
+        "Suggestions"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Suggestions",
+      "title": "Show random NSFW",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "false",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE",
+      "key": "pref_search_show_trending",
+      "leaf_section": "Suggestions",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Suggestions",
+          "key": "pref_search_show_trending",
+          "logical_kind": "stored_setting",
+          "resource": "pref_search_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Search & filters",
+      "page_intro": "Configure search entry, search behavior, and content filtering.",
+      "proposed_summary": "",
+      "root": "Reading & interaction",
+      "screen_depth": 3,
+      "screen_path": [
+        "Reading & interaction",
+        "Search & filters",
+        "Search",
+        "Suggestions"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Suggestions",
+      "title": "Show trending communities",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "false",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE",
+      "key": "pref_search_show_trending_searches",
+      "leaf_section": "Suggestions",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Suggestions",
+          "key": "pref_search_show_trending_searches",
+          "logical_kind": "stored_setting",
+          "resource": "pref_search_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Search & filters",
+      "page_intro": "Configure search entry, search behavior, and content filtering.",
+      "proposed_summary": "",
+      "root": "Reading & interaction",
+      "screen_depth": 3,
+      "screen_path": [
+        "Reading & interaction",
+        "Search & filters",
+        "Search",
+        "Suggestions"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Suggestions",
+      "title": "Show trending today",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "true",
+      "dependency": "",
+      "existing_summary": "Show confirmation dialog before exiting",
+      "help_treatment": "REVIEW_EXISTING_SUMMARY",
+      "key": "pref_ask_exit",
+      "leaf_section": "Back & exit",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Exit confirmation",
+          "key": "pref_ask_exit",
+          "logical_kind": "stored_setting",
+          "resource": "pref_general_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Navigation & gestures",
+      "page_intro": "Choose how you move around Boost and which shortcuts are available.",
+      "proposed_summary": "Show confirmation dialog before exiting",
+      "root": "Navigation",
+      "screen_depth": 2,
+      "screen_path": [
+        "Navigation",
+        "Navigation & gestures",
+        "Back & exit"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Back & exit",
+      "title": "Confirm exit",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "true",
+      "dependency": "pref_ask_exit",
+      "existing_summary": "Tap back button twice to exit",
+      "help_treatment": "REVIEW_EXISTING_SUMMARY",
+      "key": "pref_double_exit",
+      "leaf_section": "Back & exit",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Exit confirmation",
+          "key": "pref_double_exit",
+          "logical_kind": "stored_setting",
+          "resource": "pref_general_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Navigation & gestures",
+      "page_intro": "Choose how you move around Boost and which shortcuts are available.",
+      "proposed_summary": "Tap back button twice to exit",
+      "root": "Navigation",
+      "screen_depth": 2,
+      "screen_path": [
+        "Navigation",
+        "Navigation & gestures",
+        "Back & exit"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Back & exit",
+      "title": "Double tap to exit",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "true",
+      "dependency": "pref_bottom_navigation",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE",
+      "key": "pref_bottom_navigation_hide_on_scroll",
+      "leaf_section": "Bottom navigation",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": null,
+          "key": "pref_bottom_navigation_hide_on_scroll",
+          "logical_kind": "stored_setting",
+          "resource": "pref_bottom_navigation_v2",
+          "root_referenced": false
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Navigation & gestures",
+      "page_intro": "Choose how you move around Boost and which shortcuts are available.",
+      "proposed_summary": "",
+      "root": "Navigation",
+      "screen_depth": 2,
+      "screen_path": [
+        "Navigation",
+        "Navigation & gestures",
+        "Bottom navigation"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Bottom navigation",
+      "title": "Hide on scroll",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "false",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE",
+      "key": "pref_bottom_navigation",
+      "leaf_section": "Bottom navigation",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": null,
+          "key": "pref_bottom_navigation",
+          "logical_kind": "stored_setting",
+          "resource": "pref_bottom_navigation_v2",
+          "root_referenced": false
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Navigation & gestures",
+      "page_intro": "Choose how you move around Boost and which shortcuts are available.",
+      "proposed_summary": "",
+      "root": "Navigation",
+      "screen_depth": 2,
+      "screen_path": [
+        "Navigation",
+        "Navigation & gestures",
+        "Bottom navigation"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Bottom navigation",
+      "title": "Show bottom navigation",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "true",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE+PROGRESSIVE_DISCLOSURE",
+      "key": "pref_accounts_show_avatar",
+      "leaf_section": "Account switcher",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Account switcher",
+          "key": "pref_accounts_show_avatar",
+          "logical_kind": "stored_setting",
+          "resource": "pref_drawer_v2",
+          "root_referenced": false
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Navigation & gestures",
+      "page_intro": "Choose how you move around Boost and which shortcuts are available.",
+      "proposed_summary": "",
+      "root": "Navigation",
+      "screen_depth": 3,
+      "screen_path": [
+        "Navigation",
+        "Navigation & gestures",
+        "Navigation drawer",
+        "Account switcher"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Account switcher",
+      "title": "Show avatar",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "true",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE+PROGRESSIVE_DISCLOSURE",
+      "key": "pref_accounts_show_username",
+      "leaf_section": "Account switcher",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Account switcher",
+          "key": "pref_accounts_show_username",
+          "logical_kind": "stored_setting",
+          "resource": "pref_drawer_v2",
+          "root_referenced": false
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Navigation & gestures",
+      "page_intro": "Choose how you move around Boost and which shortcuts are available.",
+      "proposed_summary": "",
+      "root": "Navigation",
+      "screen_depth": 3,
+      "screen_path": [
+        "Navigation",
+        "Navigation & gestures",
+        "Navigation drawer",
+        "Account switcher"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Account switcher",
+      "title": "Show username",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "false",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "OMIT_SELF_EXPLANATORY",
+      "key": "pref_drawer_show_drafts",
+      "leaf_section": "Account & tools",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Items to show",
+          "key": "pref_drawer_show_drafts",
+          "logical_kind": "stored_setting",
+          "resource": "pref_drawer_v2",
+          "root_referenced": false
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Navigation & gestures",
+      "page_intro": "Choose how you move around Boost and which shortcuts are available.",
+      "proposed_summary": "",
+      "root": "Navigation",
+      "screen_depth": 3,
+      "screen_path": [
+        "Navigation",
+        "Navigation & gestures",
+        "Navigation drawer",
+        "Account & tools"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Account & tools",
+      "title": "Drafts",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "true",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "OMIT_SELF_EXPLANATORY",
+      "key": "pref_drawer_show_history",
+      "leaf_section": "Feeds & library",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Items to show",
+          "key": "pref_drawer_show_history",
+          "logical_kind": "stored_setting",
+          "resource": "pref_drawer_v2",
+          "root_referenced": false
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Navigation & gestures",
+      "page_intro": "Choose how you move around Boost and which shortcuts are available.",
+      "proposed_summary": "",
+      "root": "Navigation",
+      "screen_depth": 3,
+      "screen_path": [
+        "Navigation",
+        "Navigation & gestures",
+        "Navigation drawer",
+        "Feeds & library"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Feeds & library",
+      "title": "History",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "true",
+      "dependency": "",
+      "existing_summary": "Posts from subscripions",
+      "help_treatment": "REVIEW_EXISTING_SUMMARY",
+      "key": "pref_drawer_show_frontpage",
+      "leaf_section": "Feeds & library",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Items to show",
+          "key": "pref_drawer_show_frontpage",
+          "logical_kind": "stored_setting",
+          "resource": "pref_drawer_v2",
+          "root_referenced": false
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Navigation & gestures",
+      "page_intro": "Choose how you move around Boost and which shortcuts are available.",
+      "proposed_summary": "Posts from subscripions",
+      "root": "Navigation",
+      "screen_depth": 3,
+      "screen_path": [
+        "Navigation",
+        "Navigation & gestures",
+        "Navigation drawer",
+        "Feeds & library"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Feeds & library",
+      "title": "Home feed",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "true",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "OMIT_SELF_EXPLANATORY",
+      "key": "pref_drawer_show_inbox",
+      "leaf_section": "Account & tools",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Items to show",
+          "key": "pref_drawer_show_inbox",
+          "logical_kind": "stored_setting",
+          "resource": "pref_drawer_v2",
+          "root_referenced": false
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Navigation & gestures",
+      "page_intro": "Choose how you move around Boost and which shortcuts are available.",
+      "proposed_summary": "",
+      "root": "Navigation",
+      "screen_depth": 3,
+      "screen_path": [
+        "Navigation",
+        "Navigation & gestures",
+        "Navigation drawer",
+        "Account & tools"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Account & tools",
+      "title": "Inbox",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "true",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "OMIT_SELF_EXPLANATORY",
+      "key": "pref_drawer_show_mod",
+      "leaf_section": "Account & tools",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Items to show",
+          "key": "pref_drawer_show_mod",
+          "logical_kind": "stored_setting",
+          "resource": "pref_drawer_v2",
+          "root_referenced": false
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Navigation & gestures",
+      "page_intro": "Choose how you move around Boost and which shortcuts are available.",
+      "proposed_summary": "",
+      "root": "Navigation",
+      "screen_depth": 3,
+      "screen_path": [
+        "Navigation",
+        "Navigation & gestures",
+        "Navigation drawer",
+        "Account & tools"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Account & tools",
+      "title": "Moderation",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "true",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "OMIT_SELF_EXPLANATORY",
+      "key": "pref_drawer_show_popular",
+      "leaf_section": "Feeds & library",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Items to show",
+          "key": "pref_drawer_show_popular",
+          "logical_kind": "stored_setting",
+          "resource": "pref_drawer_v2",
+          "root_referenced": false
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Navigation & gestures",
+      "page_intro": "Choose how you move around Boost and which shortcuts are available.",
+      "proposed_summary": "",
+      "root": "Navigation",
+      "screen_depth": 3,
+      "screen_path": [
+        "Navigation",
+        "Navigation & gestures",
+        "Navigation drawer",
+        "Feeds & library"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Feeds & library",
+      "title": "Popular",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "true",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "OMIT_SELF_EXPLANATORY",
+      "key": "pref_drawer_show_profile",
+      "leaf_section": "Account & tools",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Items to show",
+          "key": "pref_drawer_show_profile",
+          "logical_kind": "stored_setting",
+          "resource": "pref_drawer_v2",
+          "root_referenced": false
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Navigation & gestures",
+      "page_intro": "Choose how you move around Boost and which shortcuts are available.",
+      "proposed_summary": "",
+      "root": "Navigation",
+      "screen_depth": 3,
+      "screen_path": [
+        "Navigation",
+        "Navigation & gestures",
+        "Navigation drawer",
+        "Account & tools"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Account & tools",
+      "title": "Profile",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "true",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "OMIT_SELF_EXPLANATORY",
+      "key": "pref_drawer_show_saved",
+      "leaf_section": "Feeds & library",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Items to show",
+          "key": "pref_drawer_show_saved",
+          "logical_kind": "stored_setting",
+          "resource": "pref_drawer_v2",
+          "root_referenced": false
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Navigation & gestures",
+      "page_intro": "Choose how you move around Boost and which shortcuts are available.",
+      "proposed_summary": "",
+      "root": "Navigation",
+      "screen_depth": 3,
+      "screen_path": [
+        "Navigation",
+        "Navigation & gestures",
+        "Navigation drawer",
+        "Feeds & library"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Feeds & library",
+      "title": "Saved",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "true",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "OMIT_SELF_EXPLANATORY",
+      "key": "pref_drawer_show_search_generic",
+      "leaf_section": "Account & tools",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Items to show",
+          "key": "pref_drawer_show_search_generic",
+          "logical_kind": "stored_setting",
+          "resource": "pref_drawer_v2",
+          "root_referenced": false
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Navigation & gestures",
+      "page_intro": "Choose how you move around Boost and which shortcuts are available.",
+      "proposed_summary": "",
+      "root": "Navigation",
+      "screen_depth": 3,
+      "screen_path": [
+        "Navigation",
+        "Navigation & gestures",
+        "Navigation drawer",
+        "Account & tools"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Account & tools",
+      "title": "Search",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "true",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "OMIT_SELF_EXPLANATORY",
+      "key": "pref_drawer_show_all",
+      "leaf_section": "Feeds & library",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Items to show",
+          "key": "pref_drawer_show_all",
+          "logical_kind": "stored_setting",
+          "resource": "pref_drawer_v2",
+          "root_referenced": false
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Navigation & gestures",
+      "page_intro": "Choose how you move around Boost and which shortcuts are available.",
+      "proposed_summary": "",
+      "root": "Navigation",
+      "screen_depth": 3,
+      "screen_path": [
+        "Navigation",
+        "Navigation & gestures",
+        "Navigation drawer",
+        "Feeds & library"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Feeds & library",
+      "title": "All",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "true",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE",
+      "key": "pref_drawer_show_friends",
+      "leaf_section": "Account & tools",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Items to show",
+          "key": "pref_drawer_show_friends",
+          "logical_kind": "stored_setting",
+          "resource": "pref_drawer_v2",
+          "root_referenced": false
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Navigation & gestures",
+      "page_intro": "Choose how you move around Boost and which shortcuts are available.",
+      "proposed_summary": "",
+      "root": "Navigation",
+      "screen_depth": 3,
+      "screen_path": [
+        "Navigation",
+        "Navigation & gestures",
+        "Navigation drawer",
+        "Account & tools"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Account & tools",
+      "title": "Friends",
+      "v5_visibility": "WITHHELD_RUNTIME_UNAVAILABLE",
+      "v5_visibility_reason": "Static implementation exists, but the Friends destination was not proven to return functional Reddit data at runtime."
+    },
+    {
+      "default_value": "true",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE",
+      "key": "pref_drawer_sticky_settings",
+      "leaf_section": "Drawer behavior",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Items to show",
+          "key": "pref_drawer_sticky_settings",
+          "logical_kind": "stored_setting",
+          "resource": "pref_drawer_v2",
+          "root_referenced": false
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Navigation & gestures",
+      "page_intro": "Choose how you move around Boost and which shortcuts are available.",
+      "proposed_summary": "",
+      "root": "Navigation",
+      "screen_depth": 3,
+      "screen_path": [
+        "Navigation",
+        "Navigation & gestures",
+        "Navigation drawer",
+        "Drawer behavior"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Drawer behavior",
+      "title": "Sticky Settings",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "false",
+      "dependency": "",
+      "existing_summary": "Open menu from the opposite edge",
+      "help_treatment": "REVIEW_EXISTING_SUMMARY",
+      "key": "pref_drawer_end",
+      "leaf_section": "Drawer behavior",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "General",
+          "key": "pref_drawer_end",
+          "logical_kind": "stored_setting",
+          "resource": "pref_drawer_v2",
+          "root_referenced": false
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Navigation & gestures",
+      "page_intro": "Choose how you move around Boost and which shortcuts are available.",
+      "proposed_summary": "Open menu from the opposite edge",
+      "root": "Navigation",
+      "screen_depth": 3,
+      "screen_path": [
+        "Navigation",
+        "Navigation & gestures",
+        "Navigation drawer",
+        "Drawer behavior"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Drawer behavior",
+      "title": "Switch side",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "false",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE",
+      "key": "pref_drawer_show_go_to_subreddit",
+      "leaf_section": "Go-to shortcuts",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Items to show",
+          "key": "pref_drawer_show_go_to_subreddit",
+          "logical_kind": "stored_setting",
+          "resource": "pref_drawer_v2",
+          "root_referenced": false
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Navigation & gestures",
+      "page_intro": "Choose how you move around Boost and which shortcuts are available.",
+      "proposed_summary": "",
+      "root": "Navigation",
+      "screen_depth": 3,
+      "screen_path": [
+        "Navigation",
+        "Navigation & gestures",
+        "Navigation drawer",
+        "Go-to shortcuts"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Go-to shortcuts",
+      "title": "Go to community",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "true",
+      "dependency": "",
+      "existing_summary": "Including Community, user or random (Long press to go to community)",
+      "help_treatment": "REVIEW_EXISTING_SUMMARY",
+      "key": "pref_drawer_show_go_to",
+      "leaf_section": "Go-to shortcuts",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Items to show",
+          "key": "pref_drawer_show_go_to",
+          "logical_kind": "stored_setting",
+          "resource": "pref_drawer_v2",
+          "root_referenced": false
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Navigation & gestures",
+      "page_intro": "Choose how you move around Boost and which shortcuts are available.",
+      "proposed_summary": "Including Community, user or random (Long press to go to community)",
+      "root": "Navigation",
+      "screen_depth": 3,
+      "screen_path": [
+        "Navigation",
+        "Navigation & gestures",
+        "Navigation drawer",
+        "Go-to shortcuts"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Go-to shortcuts",
+      "title": "Go to dropdown",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "false",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE",
+      "key": "pref_drawer_show_go_to_user",
+      "leaf_section": "Go-to shortcuts",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Items to show",
+          "key": "pref_drawer_show_go_to_user",
+          "logical_kind": "stored_setting",
+          "resource": "pref_drawer_v2",
+          "root_referenced": false
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Navigation & gestures",
+      "page_intro": "Choose how you move around Boost and which shortcuts are available.",
+      "proposed_summary": "",
+      "root": "Navigation",
+      "screen_depth": 3,
+      "screen_path": [
+        "Navigation",
+        "Navigation & gestures",
+        "Navigation drawer",
+        "Go-to shortcuts"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Go-to shortcuts",
+      "title": "Go to user",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "false",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "OMIT_SELF_EXPLANATORY",
+      "key": "pref_drawer_show_blur_switch",
+      "leaf_section": "Quick toggles",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Items to show",
+          "key": "pref_drawer_show_blur_switch",
+          "logical_kind": "stored_setting",
+          "resource": "pref_drawer_v2",
+          "root_referenced": false
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Navigation & gestures",
+      "page_intro": "Choose how you move around Boost and which shortcuts are available.",
+      "proposed_summary": "",
+      "root": "Navigation",
+      "screen_depth": 3,
+      "screen_path": [
+        "Navigation",
+        "Navigation & gestures",
+        "Navigation drawer",
+        "Quick toggles"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Quick toggles",
+      "title": "Blur NSFW",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "false",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "OMIT_SELF_EXPLANATORY",
+      "key": "pref_drawer_show_night_mode",
+      "leaf_section": "Quick toggles",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Items to show",
+          "key": "pref_drawer_show_night_mode",
+          "logical_kind": "stored_setting",
+          "resource": "pref_drawer_v2",
+          "root_referenced": false
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Navigation & gestures",
+      "page_intro": "Choose how you move around Boost and which shortcuts are available.",
+      "proposed_summary": "",
+      "root": "Navigation",
+      "screen_depth": 3,
+      "screen_path": [
+        "Navigation",
+        "Navigation & gestures",
+        "Navigation drawer",
+        "Quick toggles"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Quick toggles",
+      "title": "Dark mode",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "false",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "OMIT_SELF_EXPLANATORY",
+      "key": "pref_drawer_show_nsfw_switch",
+      "leaf_section": "Quick toggles",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Items to show",
+          "key": "pref_drawer_show_nsfw_switch",
+          "logical_kind": "stored_setting",
+          "resource": "pref_drawer_v2",
+          "root_referenced": false
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Navigation & gestures",
+      "page_intro": "Choose how you move around Boost and which shortcuts are available.",
+      "proposed_summary": "",
+      "root": "Navigation",
+      "screen_depth": 3,
+      "screen_path": [
+        "Navigation",
+        "Navigation & gestures",
+        "Navigation drawer",
+        "Quick toggles"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Quick toggles",
+      "title": "Show NSFW",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "true",
+      "dependency": "",
+      "existing_summary": "Default feed. To set any community, go to Subscriptions list and select \\\"Set as default\\\"",
+      "help_treatment": "REVIEW_EXISTING_SUMMARY",
+      "key": "pref_drawer_show_home",
+      "leaf_section": "Feeds & library",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Items to show",
+          "key": "pref_drawer_show_home",
+          "logical_kind": "stored_setting",
+          "resource": "pref_drawer_v2",
+          "root_referenced": false
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Navigation & gestures",
+      "page_intro": "Choose how you move around Boost and which shortcuts are available.",
+      "proposed_summary": "Default feed. To set any community, go to Subscriptions list and select \\\"Set as default\\\"",
+      "root": "Navigation",
+      "screen_depth": 3,
+      "screen_path": [
+        "Navigation",
+        "Navigation & gestures",
+        "Navigation drawer",
+        "Feeds & library"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Feeds & library",
+      "title": "Home",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "true",
+      "dependency": "pref_subscriptions_drawer",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE",
+      "key": "pref_subscriptions_drawer_show_icon",
+      "leaf_section": "Subscriptions",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Subscriptions list",
+          "key": "pref_subscriptions_drawer_show_icon",
+          "logical_kind": "stored_setting",
+          "resource": "pref_drawer_v2",
+          "root_referenced": false
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Navigation & gestures",
+      "page_intro": "Choose how you move around Boost and which shortcuts are available.",
+      "proposed_summary": "",
+      "root": "Navigation",
+      "screen_depth": 3,
+      "screen_path": [
+        "Navigation",
+        "Navigation & gestures",
+        "Navigation drawer",
+        "Subscriptions"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Subscriptions",
+      "title": "Show icons",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "true",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE",
+      "key": "pref_subscriptions_drawer",
+      "leaf_section": "Subscriptions",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Subscriptions list",
+          "key": "pref_subscriptions_drawer",
+          "logical_kind": "stored_setting",
+          "resource": "pref_drawer_v2",
+          "root_referenced": false
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Navigation & gestures",
+      "page_intro": "Choose how you move around Boost and which shortcuts are available.",
+      "proposed_summary": "",
+      "root": "Navigation",
+      "screen_depth": 3,
+      "screen_path": [
+        "Navigation",
+        "Navigation & gestures",
+        "Navigation drawer",
+        "Subscriptions"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Subscriptions",
+      "title": "Show in menu",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "false",
+      "dependency": "pref_subscriptions_drawer",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE",
+      "key": "pref_subscriptions_only_casual",
+      "leaf_section": "Subscriptions",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Subscriptions list",
+          "key": "pref_subscriptions_only_casual",
+          "logical_kind": "stored_setting",
+          "resource": "pref_drawer_v2",
+          "root_referenced": false
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Navigation & gestures",
+      "page_intro": "Choose how you move around Boost and which shortcuts are available.",
+      "proposed_summary": "",
+      "root": "Navigation",
+      "screen_depth": 3,
+      "screen_path": [
+        "Navigation",
+        "Navigation & gestures",
+        "Navigation drawer",
+        "Subscriptions"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Subscriptions",
+      "title": "Show only favorites",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "true",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE",
+      "key": "pref_toolbar",
+      "leaf_section": "Toolbar",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": null,
+          "key": "pref_toolbar",
+          "logical_kind": "stored_setting",
+          "resource": "pref_toolbar_v2",
+          "root_referenced": false
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Navigation & gestures",
+      "page_intro": "Choose how you move around Boost and which shortcuts are available.",
+      "proposed_summary": "",
+      "root": "Navigation",
+      "screen_depth": 2,
+      "screen_path": [
+        "Navigation",
+        "Navigation & gestures",
+        "Toolbar"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Toolbar",
+      "title": "Hide on scroll",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "1",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE",
+      "key": "pref_toolbar_main_action",
+      "leaf_section": "Toolbar",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": null,
+          "key": "pref_toolbar_main_action",
+          "logical_kind": "stored_setting",
+          "resource": "pref_toolbar_v2",
+          "root_referenced": false
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Navigation & gestures",
+      "page_intro": "Choose how you move around Boost and which shortcuts are available.",
+      "proposed_summary": "",
+      "root": "Navigation",
+      "screen_depth": 2,
+      "screen_path": [
+        "Navigation",
+        "Navigation & gestures",
+        "Toolbar"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "string",
+      "subscreen": "Toolbar",
+      "title": "Main action",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "false",
+      "dependency": "",
+      "existing_summary": "Organize downloaded media into community folders",
+      "help_treatment": "REVIEW_EXISTING_SUMMARY+PROGRESSIVE_DISCLOSURE",
+      "key": "pref_download_folder_per_subreddit",
+      "leaf_section": "Download folders",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": null,
+          "key": "pref_download_folder_per_subreddit",
+          "logical_kind": "stored_setting",
+          "resource": "pref_downloads_v2",
+          "root_referenced": false
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Downloads & cache",
+      "page_intro": "Manage download locations and downloaded media behavior.",
+      "proposed_summary": "Organize downloaded media into community folders",
+      "root": "Media",
+      "screen_depth": 2,
+      "screen_path": [
+        "Media",
+        "Downloads & cache",
+        "Download folders"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Download folders",
+      "title": "Community subfolders",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "",
+      "dependency": "",
+      "existing_summary": "Choose the default folder used for downloaded media.",
+      "help_treatment": "DIRECT_CONTROL_SUMMARY",
+      "key": "pref_download_folder_default",
+      "leaf_section": "Download folders",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Download folders",
+          "logical_kind": "direct_action_state",
+          "resource": "MorpheSettingsV4DownloadsFragment",
+          "root_referenced": false
+        }
+      ],
+      "logical_kind": "action_state",
+      "page": "Downloads & cache",
+      "page_intro": "Manage download locations and downloaded media behavior.",
+      "proposed_summary": "Choose the default folder used for downloaded media.",
+      "root": "Media",
+      "screen_depth": 2,
+      "screen_path": [
+        "Media",
+        "Downloads & cache",
+        "Download folders"
+      ],
+      "source_type": "boost_direct_ui",
+      "storage_type": "string",
+      "subscreen": "Download folders",
+      "title": "Default folder",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "",
+      "dependency": "",
+      "existing_summary": "Choose the folder used for downloaded GIFs.",
+      "help_treatment": "DIRECT_CONTROL_SUMMARY",
+      "key": "pref_download_folder_gif",
+      "leaf_section": "Download folders",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Download folders",
+          "logical_kind": "direct_action_state",
+          "resource": "MorpheSettingsV4DownloadsFragment",
+          "root_referenced": false
+        }
+      ],
+      "logical_kind": "action_state",
+      "page": "Downloads & cache",
+      "page_intro": "Manage download locations and downloaded media behavior.",
+      "proposed_summary": "Choose the folder used for downloaded GIFs.",
+      "root": "Media",
+      "screen_depth": 2,
+      "screen_path": [
+        "Media",
+        "Downloads & cache",
+        "Download folders"
+      ],
+      "source_type": "boost_direct_ui",
+      "storage_type": "string",
+      "subscreen": "Download folders",
+      "title": "GIFs",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "",
+      "dependency": "",
+      "existing_summary": "Choose the folder used for downloaded images.",
+      "help_treatment": "DIRECT_CONTROL_SUMMARY",
+      "key": "pref_download_folder_img",
+      "leaf_section": "Download folders",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Download folders",
+          "logical_kind": "direct_action_state",
+          "resource": "MorpheSettingsV4DownloadsFragment",
+          "root_referenced": false
+        }
+      ],
+      "logical_kind": "action_state",
+      "page": "Downloads & cache",
+      "page_intro": "Manage download locations and downloaded media behavior.",
+      "proposed_summary": "Choose the folder used for downloaded images.",
+      "root": "Media",
+      "screen_depth": 2,
+      "screen_path": [
+        "Media",
+        "Downloads & cache",
+        "Download folders"
+      ],
+      "source_type": "boost_direct_ui",
+      "storage_type": "string",
+      "subscreen": "Download folders",
+      "title": "Images",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "",
+      "dependency": "",
+      "existing_summary": "Choose the folder used for downloaded videos.",
+      "help_treatment": "DIRECT_CONTROL_SUMMARY",
+      "key": "pref_download_folder_mp4",
+      "leaf_section": "Download folders",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Download folders",
+          "logical_kind": "direct_action_state",
+          "resource": "MorpheSettingsV4DownloadsFragment",
+          "root_referenced": false
+        }
+      ],
+      "logical_kind": "action_state",
+      "page": "Downloads & cache",
+      "page_intro": "Manage download locations and downloaded media behavior.",
+      "proposed_summary": "Choose the folder used for downloaded videos.",
+      "root": "Media",
+      "screen_depth": 2,
+      "screen_path": [
+        "Media",
+        "Downloads & cache",
+        "Download folders"
+      ],
+      "source_type": "boost_direct_ui",
+      "storage_type": "string",
+      "subscreen": "Download folders",
+      "title": "Videos",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "glide",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE",
+      "key": "pref_image_loader",
+      "leaf_section": "Native image behavior",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Image viewer",
+          "key": "pref_image_loader",
+          "logical_kind": "stored_setting",
+          "resource": "pref_media_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Images, GIFs & previews",
+      "page_intro": "Configure media previews, image behavior, and tap actions.",
+      "proposed_summary": "",
+      "root": "Media",
+      "screen_depth": 2,
+      "screen_path": [
+        "Media",
+        "Images, GIFs & previews",
+        "Native image behavior"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "string",
+      "subscreen": "Native image behavior",
+      "title": "Image loader",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "false",
+      "dependency": "",
+      "existing_summary": "Load images with deep zoom by default",
+      "help_treatment": "REVIEW_EXISTING_SUMMARY",
+      "key": "pref_images_deepzoom",
+      "leaf_section": "Native image behavior",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Image viewer",
+          "key": "pref_images_deepzoom",
+          "logical_kind": "stored_setting",
+          "resource": "pref_media_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Images, GIFs & previews",
+      "page_intro": "Configure media previews, image behavior, and tap actions.",
+      "proposed_summary": "Load images with deep zoom by default",
+      "root": "Media",
+      "screen_depth": 2,
+      "screen_path": [
+        "Media",
+        "Images, GIFs & previews",
+        "Native image behavior"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Native image behavior",
+      "title": "Load HQ images",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "false",
+      "dependency": "pref_images_deepzoom",
+      "existing_summary": "Fit smallest dimension to screen size",
+      "help_treatment": "REVIEW_EXISTING_SUMMARY",
+      "key": "pref_images_fit",
+      "leaf_section": "Native image behavior",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Image viewer",
+          "key": "pref_images_fit",
+          "logical_kind": "stored_setting",
+          "resource": "pref_media_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Images, GIFs & previews",
+      "page_intro": "Configure media previews, image behavior, and tap actions.",
+      "proposed_summary": "Fit smallest dimension to screen size",
+      "root": "Media",
+      "screen_depth": 2,
+      "screen_path": [
+        "Media",
+        "Images, GIFs & previews",
+        "Native image behavior"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Native image behavior",
+      "title": "Load zoomed in",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "true",
+      "dependency": "",
+      "existing_summary": "Swipe or fling content to close viewer",
+      "help_treatment": "REVIEW_EXISTING_SUMMARY",
+      "key": "pref_swipe_up_to_dismiss_image",
+      "leaf_section": "Native image behavior",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Interface",
+          "key": "pref_swipe_up_to_dismiss_image",
+          "logical_kind": "stored_setting",
+          "resource": "pref_media_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Images, GIFs & previews",
+      "page_intro": "Configure media previews, image behavior, and tap actions.",
+      "proposed_summary": "Swipe or fling content to close viewer",
+      "root": "Media",
+      "screen_depth": 2,
+      "screen_path": [
+        "Media",
+        "Images, GIFs & previews",
+        "Native image behavior"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Native image behavior",
+      "title": "Swipe to dismiss",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "vertical",
+      "dependency": "pref_swipe_up_to_dismiss_image",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE",
+      "key": "pref_swipe_dismiss_direction_mode_image",
+      "leaf_section": "Native image behavior",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Interface",
+          "key": "pref_swipe_dismiss_direction_mode_image",
+          "logical_kind": "stored_setting",
+          "resource": "pref_media_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Images, GIFs & previews",
+      "page_intro": "Configure media previews, image behavior, and tap actions.",
+      "proposed_summary": "",
+      "root": "Media",
+      "screen_depth": 2,
+      "screen_path": [
+        "Media",
+        "Images, GIFs & previews",
+        "Native image behavior"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "string",
+      "subscreen": "Native image behavior",
+      "title": "Swipe to dismiss direction",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "true",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE",
+      "key": "pref_tap_to_dismiss_image",
+      "leaf_section": "Native image behavior",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Interface",
+          "key": "pref_tap_to_dismiss_image",
+          "logical_kind": "stored_setting",
+          "resource": "pref_media_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Images, GIFs & previews",
+      "page_intro": "Configure media previews, image behavior, and tap actions.",
+      "proposed_summary": "",
+      "root": "Media",
+      "screen_depth": 2,
+      "screen_path": [
+        "Media",
+        "Images, GIFs & previews",
+        "Native image behavior"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Native image behavior",
+      "title": "Tap to dismiss",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "image_viewer",
+      "dependency": "",
+      "existing_summary": "Image viewer",
+      "help_treatment": "REVIEW_EXISTING_SUMMARY",
+      "key": "morphe_boost_direct_reddit_gif_tap_action",
+      "leaf_section": "Open behavior",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Open behavior",
+          "key": "morphe_boost_direct_reddit_gif_tap_action",
+          "logical_kind": "morphe_user_setting",
+          "resource": "morphe_boost_settings_skeleton",
+          "root_referenced": false
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Images, GIFs & previews",
+      "page_intro": "Configure media previews, image behavior, and tap actions.",
+      "proposed_summary": "Image viewer",
+      "root": "Media",
+      "screen_depth": 2,
+      "screen_path": [
+        "Media",
+        "Images, GIFs & previews",
+        "Open behavior"
+      ],
+      "source_type": "morphe_embedded_xml",
+      "storage_type": "string",
+      "subscreen": "Open behavior",
+      "title": "Direct Reddit GIF tap action",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "video_viewer",
+      "dependency": "",
+      "existing_summary": "Video viewer",
+      "help_treatment": "REVIEW_EXISTING_SUMMARY",
+      "key": "morphe_boost_giphy_preview_tap_action",
+      "leaf_section": "Open behavior",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Open behavior",
+          "key": "morphe_boost_giphy_preview_tap_action",
+          "logical_kind": "morphe_user_setting",
+          "resource": "morphe_boost_settings_skeleton",
+          "root_referenced": false
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Images, GIFs & previews",
+      "page_intro": "Configure media previews, image behavior, and tap actions.",
+      "proposed_summary": "Video viewer",
+      "root": "Media",
+      "screen_depth": 2,
+      "screen_path": [
+        "Media",
+        "Images, GIFs & previews",
+        "Open behavior"
+      ],
+      "source_type": "morphe_embedded_xml",
+      "storage_type": "string",
+      "subscreen": "Open behavior",
+      "title": "Giphy preview tap action",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "image_viewer",
+      "dependency": "",
+      "existing_summary": "Image viewer",
+      "help_treatment": "REVIEW_EXISTING_SUMMARY",
+      "key": "morphe_boost_static_preview_tap_action",
+      "leaf_section": "Open behavior",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Open behavior",
+          "key": "morphe_boost_static_preview_tap_action",
+          "logical_kind": "morphe_user_setting",
+          "resource": "morphe_boost_settings_skeleton",
+          "root_referenced": false
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Images, GIFs & previews",
+      "page_intro": "Configure media previews, image behavior, and tap actions.",
+      "proposed_summary": "Image viewer",
+      "root": "Media",
+      "screen_depth": 2,
+      "screen_path": [
+        "Media",
+        "Images, GIFs & previews",
+        "Open behavior"
+      ],
+      "source_type": "morphe_embedded_xml",
+      "storage_type": "string",
+      "subscreen": "Open behavior",
+      "title": "Static preview tap action",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "true",
+      "dependency": "",
+      "existing_summary": "Show supported media previews directly in comments.",
+      "help_treatment": "REVIEW_EXISTING_SUMMARY",
+      "key": "morphe_boost_inline_media_previews_enabled",
+      "leaf_section": "Preview behavior",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Media previews",
+          "key": "morphe_boost_inline_media_previews_enabled",
+          "logical_kind": "morphe_user_setting",
+          "resource": "morphe_boost_settings_skeleton",
+          "root_referenced": false
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Images, GIFs & previews",
+      "page_intro": "Configure media previews, image behavior, and tap actions.",
+      "proposed_summary": "Show supported media previews directly in comments.",
+      "root": "Media",
+      "screen_depth": 2,
+      "screen_path": [
+        "Media",
+        "Images, GIFs & previews",
+        "Preview behavior"
+      ],
+      "source_type": "morphe_embedded_xml",
+      "storage_type": "boolean",
+      "subscreen": "Preview behavior",
+      "title": "Enable inline media previews",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "false",
+      "dependency": "",
+      "existing_summary": "Keep the original link text visible with the preview.",
+      "help_treatment": "REVIEW_EXISTING_SUMMARY",
+      "key": "morphe_boost_inline_media_preview_show_source_text",
+      "leaf_section": "Preview behavior",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Media previews",
+          "key": "morphe_boost_inline_media_preview_show_source_text",
+          "logical_kind": "morphe_user_setting",
+          "resource": "morphe_boost_settings_skeleton",
+          "root_referenced": false
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Images, GIFs & previews",
+      "page_intro": "Configure media previews, image behavior, and tap actions.",
+      "proposed_summary": "Keep the original link text visible with the preview.",
+      "root": "Media",
+      "screen_depth": 2,
+      "screen_path": [
+        "Media",
+        "Images, GIFs & previews",
+        "Preview behavior"
+      ],
+      "source_type": "morphe_embedded_xml",
+      "storage_type": "boolean",
+      "subscreen": "Preview behavior",
+      "title": "Show source text with preview",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "center",
+      "dependency": "",
+      "existing_summary": "Center",
+      "help_treatment": "REVIEW_EXISTING_SUMMARY",
+      "key": "morphe_boost_inline_media_preview_alignment",
+      "leaf_section": "Preview layout",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Media previews",
+          "key": "morphe_boost_inline_media_preview_alignment",
+          "logical_kind": "morphe_user_setting",
+          "resource": "morphe_boost_settings_skeleton",
+          "root_referenced": false
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Images, GIFs & previews",
+      "page_intro": "Configure media previews, image behavior, and tap actions.",
+      "proposed_summary": "Center",
+      "root": "Media",
+      "screen_depth": 2,
+      "screen_path": [
+        "Media",
+        "Images, GIFs & previews",
+        "Preview layout"
+      ],
+      "source_type": "morphe_embedded_xml",
+      "storage_type": "string",
+      "subscreen": "Preview layout",
+      "title": "Preview alignment",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "balanced",
+      "dependency": "",
+      "existing_summary": "Balanced",
+      "help_treatment": "REVIEW_EXISTING_SUMMARY",
+      "key": "morphe_boost_inline_media_preview_size",
+      "leaf_section": "Preview layout",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Media previews",
+          "key": "morphe_boost_inline_media_preview_size",
+          "logical_kind": "morphe_user_setting",
+          "resource": "morphe_boost_settings_skeleton",
+          "root_referenced": false
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Images, GIFs & previews",
+      "page_intro": "Configure media previews, image behavior, and tap actions.",
+      "proposed_summary": "Balanced",
+      "root": "Media",
+      "screen_depth": 2,
+      "screen_path": [
+        "Media",
+        "Images, GIFs & previews",
+        "Preview layout"
+      ],
+      "source_type": "morphe_embedded_xml",
+      "storage_type": "string",
+      "subscreen": "Preview layout",
+      "title": "Preview size",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "0",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE",
+      "key": "pref_browser",
+      "leaf_section": "Browser",
+      "legacy_route_count": 2,
+      "legacy_routes": [
+        {
+          "category": "Links",
+          "key": "pref_browser",
+          "logical_kind": "stored_setting",
+          "resource": "pref_general_v2",
+          "root_referenced": true
+        },
+        {
+          "category": null,
+          "key": "pref_browser",
+          "logical_kind": "stored_setting",
+          "resource": "pref_links_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Links & browser",
+      "page_intro": "Choose how links open and which browser behavior Boost uses.",
+      "proposed_summary": "",
+      "root": "Media",
+      "screen_depth": 2,
+      "screen_path": [
+        "Media",
+        "Links & browser",
+        "Browser"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "string",
+      "subscreen": "Browser",
+      "title": "Default browser",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "",
+      "dependency": "",
+      "existing_summary": "Domains that will always open in external app",
+      "help_treatment": "REVIEW_EXISTING_SUMMARY",
+      "key": "pref_domain_exceptions",
+      "leaf_section": "Link handling",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": null,
+          "key": "pref_domain_exceptions",
+          "logical_kind": "special_preference",
+          "resource": "pref_links_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "special_preference",
+      "page": "Links & browser",
+      "page_intro": "Choose how links open and which browser behavior Boost uses.",
+      "proposed_summary": "Domains that will always open in external app",
+      "root": "Media",
+      "screen_depth": 2,
+      "screen_path": [
+        "Media",
+        "Links & browser",
+        "Link handling"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "none_or_custom",
+      "subscreen": "Link handling",
+      "title": "Domain exceptions",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "true",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE",
+      "key": "pref_link_album",
+      "leaf_section": "Links to open in app",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Links to open in app",
+          "key": "pref_link_album",
+          "logical_kind": "stored_setting",
+          "resource": "pref_links_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Links & browser",
+      "page_intro": "Choose how links open and which browser behavior Boost uses.",
+      "proposed_summary": "",
+      "root": "Media",
+      "screen_depth": 2,
+      "screen_path": [
+        "Media",
+        "Links & browser",
+        "Links to open in app"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Links to open in app",
+      "title": "Albums",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "true",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE",
+      "key": "pref_link_deviant",
+      "leaf_section": "Links to open in app",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Links to open in app",
+          "key": "pref_link_deviant",
+          "logical_kind": "stored_setting",
+          "resource": "pref_links_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Links & browser",
+      "page_intro": "Choose how links open and which browser behavior Boost uses.",
+      "proposed_summary": "",
+      "root": "Media",
+      "screen_depth": 2,
+      "screen_path": [
+        "Media",
+        "Links & browser",
+        "Links to open in app"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Links to open in app",
+      "title": "Deviant Art",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "true",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE",
+      "key": "pref_link_gif",
+      "leaf_section": "Links to open in app",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Links to open in app",
+          "key": "pref_link_gif",
+          "logical_kind": "stored_setting",
+          "resource": "pref_links_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Links & browser",
+      "page_intro": "Choose how links open and which browser behavior Boost uses.",
+      "proposed_summary": "",
+      "root": "Media",
+      "screen_depth": 2,
+      "screen_path": [
+        "Media",
+        "Links & browser",
+        "Links to open in app"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Links to open in app",
+      "title": "Gifs",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "true",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "OMIT_SELF_EXPLANATORY",
+      "key": "pref_link_image",
+      "leaf_section": "Links to open in app",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Links to open in app",
+          "key": "pref_link_image",
+          "logical_kind": "stored_setting",
+          "resource": "pref_links_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Links & browser",
+      "page_intro": "Choose how links open and which browser behavior Boost uses.",
+      "proposed_summary": "",
+      "root": "Media",
+      "screen_depth": 2,
+      "screen_path": [
+        "Media",
+        "Links & browser",
+        "Links to open in app"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Links to open in app",
+      "title": "Images",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "true",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE",
+      "key": "pref_link_neatclip",
+      "leaf_section": "Links to open in app",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Links to open in app",
+          "key": "pref_link_neatclip",
+          "logical_kind": "stored_setting",
+          "resource": "pref_links_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Links & browser",
+      "page_intro": "Choose how links open and which browser behavior Boost uses.",
+      "proposed_summary": "",
+      "root": "Media",
+      "screen_depth": 2,
+      "screen_path": [
+        "Media",
+        "Links & browser",
+        "Links to open in app"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Links to open in app",
+      "title": "NeatClip",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "true",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE",
+      "key": "pref_link_vreddit",
+      "leaf_section": "Links to open in app",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Links to open in app",
+          "key": "pref_link_vreddit",
+          "logical_kind": "stored_setting",
+          "resource": "pref_links_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Links & browser",
+      "page_intro": "Choose how links open and which browser behavior Boost uses.",
+      "proposed_summary": "",
+      "root": "Media",
+      "screen_depth": 2,
+      "screen_path": [
+        "Media",
+        "Links & browser",
+        "Links to open in app"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Links to open in app",
+      "title": "Reddit videos",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "true",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE",
+      "key": "pref_link_streamable",
+      "leaf_section": "Links to open in app",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Links to open in app",
+          "key": "pref_link_streamable",
+          "logical_kind": "stored_setting",
+          "resource": "pref_links_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Links & browser",
+      "page_intro": "Choose how links open and which browser behavior Boost uses.",
+      "proposed_summary": "",
+      "root": "Media",
+      "screen_depth": 2,
+      "screen_path": [
+        "Media",
+        "Links & browser",
+        "Links to open in app"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Links to open in app",
+      "title": "Streamable",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "true",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE",
+      "key": "pref_link_xkcd",
+      "leaf_section": "Links to open in app",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Links to open in app",
+          "key": "pref_link_xkcd",
+          "logical_kind": "stored_setting",
+          "resource": "pref_links_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Links & browser",
+      "page_intro": "Choose how links open and which browser behavior Boost uses.",
+      "proposed_summary": "",
+      "root": "Media",
+      "screen_depth": 2,
+      "screen_path": [
+        "Media",
+        "Links & browser",
+        "Links to open in app"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Links to open in app",
+      "title": "XKCD",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "true",
+      "dependency": "",
+      "existing_summary": "Disable to open with external app",
+      "help_treatment": "REVIEW_EXISTING_SUMMARY",
+      "key": "pref_link_video",
+      "leaf_section": "Video links",
+      "legacy_route_count": 2,
+      "legacy_routes": [
+        {
+          "category": "Links",
+          "key": "pref_link_video",
+          "logical_kind": "stored_setting",
+          "resource": "pref_general_v2",
+          "root_referenced": true
+        },
+        {
+          "category": "Links to open in app",
+          "key": "pref_link_video",
+          "logical_kind": "stored_setting",
+          "resource": "pref_links_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Links & browser",
+      "page_intro": "Choose how links open and which browser behavior Boost uses.",
+      "proposed_summary": "Disable to open with external app",
+      "root": "Media",
+      "screen_depth": 2,
+      "screen_path": [
+        "Media",
+        "Links & browser",
+        "Video links"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Video links",
+      "title": "Internal Youtube player",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "false",
+      "dependency": "",
+      "existing_summary": "Start videos muted by default",
+      "help_treatment": "REVIEW_EXISTING_SUMMARY",
+      "key": "pref_video_audio_start_muted",
+      "leaf_section": "Audio",
+      "legacy_route_count": 2,
+      "legacy_routes": [
+        {
+          "category": "Links",
+          "key": "pref_video_audio_start_muted",
+          "logical_kind": "stored_setting",
+          "resource": "pref_general_v2",
+          "root_referenced": true
+        },
+        {
+          "category": "Video viewer",
+          "key": "pref_video_audio_start_muted",
+          "logical_kind": "stored_setting",
+          "resource": "pref_media_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Playback & autoplay",
+      "page_intro": "Control video, audio, autoplay, and player behavior.",
+      "proposed_summary": "Start videos muted by default",
+      "root": "Media",
+      "screen_depth": 2,
+      "screen_path": [
+        "Media",
+        "Playback & autoplay",
+        "Audio"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Audio",
+      "title": "Mute audio",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "1",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE+PROGRESSIVE_DISCLOSURE",
+      "key": "pref_autoplay_cards",
+      "leaf_section": "Autoplay",
+      "legacy_route_count": 2,
+      "legacy_routes": [
+        {
+          "category": "Videos",
+          "key": "pref_autoplay_cards",
+          "logical_kind": "stored_setting",
+          "resource": "pref_data_v2",
+          "root_referenced": true
+        },
+        {
+          "category": "Links",
+          "key": "pref_autoplay_cards",
+          "logical_kind": "stored_setting",
+          "resource": "pref_general_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Playback & autoplay",
+      "page_intro": "Control video, audio, autoplay, and player behavior.",
+      "proposed_summary": "",
+      "root": "Media",
+      "screen_depth": 2,
+      "screen_path": [
+        "Media",
+        "Playback & autoplay",
+        "Autoplay"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "string",
+      "subscreen": "Autoplay",
+      "title": "Autoplay videos",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "boost",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE",
+      "key": "pref_media_viewer",
+      "leaf_section": "Media behavior",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Interface",
+          "key": "pref_media_viewer",
+          "logical_kind": "stored_setting",
+          "resource": "pref_media_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Playback & autoplay",
+      "page_intro": "Control video, audio, autoplay, and player behavior.",
+      "proposed_summary": "",
+      "root": "Media",
+      "screen_depth": 2,
+      "screen_path": [
+        "Media",
+        "Playback & autoplay",
+        "Media behavior"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "string",
+      "subscreen": "Media behavior",
+      "title": "Media viewer",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "show",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE",
+      "key": "pref_media_overlay_visibility",
+      "leaf_section": "Media behavior",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Interface",
+          "key": "pref_media_overlay_visibility",
+          "logical_kind": "stored_setting",
+          "resource": "pref_media_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Playback & autoplay",
+      "page_intro": "Control video, audio, autoplay, and player behavior.",
+      "proposed_summary": "",
+      "root": "Media",
+      "screen_depth": 2,
+      "screen_path": [
+        "Media",
+        "Playback & autoplay",
+        "Media behavior"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "string",
+      "subscreen": "Media behavior",
+      "title": "Overlay elements",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "false",
+      "dependency": "",
+      "existing_summary": "Tap outside video to close (If enabled, vertical videos will be played horizontally)",
+      "help_treatment": "REVIEW_EXISTING_SUMMARY",
+      "key": "pref_tap_to_dismiss_youtube_videos",
+      "leaf_section": "Playback & autoplay",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Youtube",
+          "key": "pref_tap_to_dismiss_youtube_videos",
+          "logical_kind": "stored_setting",
+          "resource": "pref_media_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Playback & autoplay",
+      "page_intro": "Control video, audio, autoplay, and player behavior.",
+      "proposed_summary": "Tap outside video to close (If enabled, vertical videos will be played horizontally)",
+      "root": "Media",
+      "screen_depth": 2,
+      "screen_path": [
+        "Media",
+        "Playback & autoplay",
+        "Playback & autoplay"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Playback & autoplay",
+      "title": "Tap to dismiss Youtube",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "0",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE",
+      "key": "pref_video_player",
+      "leaf_section": "Playback & autoplay",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Video viewer",
+          "key": "pref_video_player",
+          "logical_kind": "stored_setting",
+          "resource": "pref_media_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Playback & autoplay",
+      "page_intro": "Control video, audio, autoplay, and player behavior.",
+      "proposed_summary": "",
+      "root": "Media",
+      "screen_depth": 2,
+      "screen_path": [
+        "Media",
+        "Playback & autoplay",
+        "Playback & autoplay"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "string",
+      "subscreen": "Playback & autoplay",
+      "title": "Video player",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "false",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE",
+      "key": "pref_all_delete",
+      "leaf_section": "History",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "History",
+          "key": "pref_all_delete",
+          "logical_kind": "special_preference",
+          "resource": "pref_privacy_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "special_preference",
+      "page": "History, privacy & recovery",
+      "page_intro": "Manage history, privacy, and supported archive recovery.",
+      "proposed_summary": "",
+      "root": "Notifications & account",
+      "screen_depth": 2,
+      "screen_path": [
+        "Notifications & account",
+        "History, privacy & recovery",
+        "History"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "none_or_custom",
+      "subscreen": "History",
+      "title": "Clear all history",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "false",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE",
+      "key": "pref_history_delete",
+      "leaf_section": "History",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "History",
+          "key": "pref_history_delete",
+          "logical_kind": "special_preference",
+          "resource": "pref_privacy_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "special_preference",
+      "page": "History, privacy & recovery",
+      "page_intro": "Manage history, privacy, and supported archive recovery.",
+      "proposed_summary": "",
+      "root": "Notifications & account",
+      "screen_depth": 2,
+      "screen_path": [
+        "Notifications & account",
+        "History, privacy & recovery",
+        "History"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "none_or_custom",
+      "subscreen": "History",
+      "title": "Clear community history",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "false",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE",
+      "key": "pref_recent_posts_delete",
+      "leaf_section": "History",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "History",
+          "key": "pref_recent_posts_delete",
+          "logical_kind": "special_preference",
+          "resource": "pref_privacy_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "special_preference",
+      "page": "History, privacy & recovery",
+      "page_intro": "Manage history, privacy, and supported archive recovery.",
+      "proposed_summary": "",
+      "root": "Notifications & account",
+      "screen_depth": 2,
+      "screen_path": [
+        "Notifications & account",
+        "History, privacy & recovery",
+        "History"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "none_or_custom",
+      "subscreen": "History",
+      "title": "Clear post history",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "false",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE",
+      "key": "pref_searches_delete",
+      "leaf_section": "History",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "History",
+          "key": "pref_searches_delete",
+          "logical_kind": "special_preference",
+          "resource": "pref_privacy_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "special_preference",
+      "page": "History, privacy & recovery",
+      "page_intro": "Manage history, privacy, and supported archive recovery.",
+      "proposed_summary": "",
+      "root": "Notifications & account",
+      "screen_depth": 2,
+      "screen_path": [
+        "Notifications & account",
+        "History, privacy & recovery",
+        "History"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "none_or_custom",
+      "subscreen": "History",
+      "title": "Clear search history",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "true",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE",
+      "key": "pref_recent_posts_save_nsfw",
+      "leaf_section": "History",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "History",
+          "key": "pref_recent_posts_save_nsfw",
+          "logical_kind": "stored_setting",
+          "resource": "pref_privacy_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "History, privacy & recovery",
+      "page_intro": "Manage history, privacy, and supported archive recovery.",
+      "proposed_summary": "",
+      "root": "Notifications & account",
+      "screen_depth": 2,
+      "screen_path": [
+        "Notifications & account",
+        "History, privacy & recovery",
+        "History"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "History",
+      "title": "Include NSFW posts",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "true",
+      "dependency": "",
+      "existing_summary": "Visited communities show in autocomplete fields",
+      "help_treatment": "REVIEW_EXISTING_SUMMARY",
+      "key": "pref_history_save",
+      "leaf_section": "History",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "History",
+          "key": "pref_history_save",
+          "logical_kind": "stored_setting",
+          "resource": "pref_privacy_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "History, privacy & recovery",
+      "page_intro": "Manage history, privacy, and supported archive recovery.",
+      "proposed_summary": "Visited communities show in autocomplete fields",
+      "root": "Notifications & account",
+      "screen_depth": 2,
+      "screen_path": [
+        "Notifications & account",
+        "History, privacy & recovery",
+        "History"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "History",
+      "title": "Save recent communities",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "true",
+      "dependency": "",
+      "existing_summary": "Visited posts show in History screen",
+      "help_treatment": "REVIEW_EXISTING_SUMMARY",
+      "key": "pref_recent_posts_save",
+      "leaf_section": "History",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "History",
+          "key": "pref_recent_posts_save",
+          "logical_kind": "stored_setting",
+          "resource": "pref_privacy_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "History, privacy & recovery",
+      "page_intro": "Manage history, privacy, and supported archive recovery.",
+      "proposed_summary": "Visited posts show in History screen",
+      "root": "Notifications & account",
+      "screen_depth": 2,
+      "screen_path": [
+        "Notifications & account",
+        "History, privacy & recovery",
+        "History"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "History",
+      "title": "Save recent posts",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "true",
+      "dependency": "",
+      "existing_summary": "Recent searches are cleared on exit",
+      "help_treatment": "REVIEW_EXISTING_SUMMARY",
+      "key": "pref_search_history_save",
+      "leaf_section": "History",
+      "legacy_route_count": 2,
+      "legacy_routes": [
+        {
+          "category": "History",
+          "key": "pref_search_history_save",
+          "logical_kind": "stored_setting",
+          "resource": "pref_privacy_v2",
+          "root_referenced": true
+        },
+        {
+          "category": "Suggestions",
+          "key": "pref_search_history_save",
+          "logical_kind": "stored_setting",
+          "resource": "pref_search_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "History, privacy & recovery",
+      "page_intro": "Manage history, privacy, and supported archive recovery.",
+      "proposed_summary": "Recent searches are cleared on exit",
+      "root": "Notifications & account",
+      "screen_depth": 2,
+      "screen_path": [
+        "Notifications & account",
+        "History, privacy & recovery",
+        "History"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "History",
+      "title": "Show recent searches",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "false",
+      "dependency": "",
+      "existing_summary": "Try to restore supported missing Imgur media from archive sources. Disabled by default.",
+      "help_treatment": "REVIEW_EXISTING_SUMMARY+PROGRESSIVE_DISCLOSURE",
+      "key": "morphe_boost_imgur_undelete_enabled",
+      "leaf_section": "Recovery & archives",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Recovery & archives",
+          "key": "morphe_boost_imgur_undelete_enabled",
+          "logical_kind": "morphe_user_setting",
+          "resource": "morphe_boost_settings_skeleton",
+          "root_referenced": false
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "History, privacy & recovery",
+      "page_intro": "Manage history, privacy, and supported archive recovery.",
+      "proposed_summary": "Try to restore supported missing Imgur media from archive sources. Disabled by default.",
+      "root": "Notifications & account",
+      "screen_depth": 2,
+      "screen_path": [
+        "Notifications & account",
+        "History, privacy & recovery",
+        "Recovery & archives"
+      ],
+      "source_type": "morphe_embedded_xml",
+      "storage_type": "boolean",
+      "subscreen": "Recovery & archives",
+      "title": "Automatically undelete Imgur images",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "false",
+      "dependency": "",
+      "existing_summary": "Try to restore supported deleted Reddit posts/comments from archive sources. Disabled by default to keep normal browsing stable.",
+      "help_treatment": "REVIEW_EXISTING_SUMMARY+PROGRESSIVE_DISCLOSURE",
+      "key": "morphe_boost_reddit_undelete_enabled",
+      "leaf_section": "Recovery & archives",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Recovery & archives",
+          "key": "morphe_boost_reddit_undelete_enabled",
+          "logical_kind": "morphe_user_setting",
+          "resource": "morphe_boost_settings_skeleton",
+          "root_referenced": false
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "History, privacy & recovery",
+      "page_intro": "Manage history, privacy, and supported archive recovery.",
+      "proposed_summary": "Try to restore supported deleted Reddit posts/comments from archive sources. Disabled by default to keep normal browsing stable.",
+      "root": "Notifications & account",
+      "screen_depth": 2,
+      "screen_path": [
+        "Notifications & account",
+        "History, privacy & recovery",
+        "Recovery & archives"
+      ],
+      "source_type": "morphe_embedded_xml",
+      "storage_type": "boolean",
+      "subscreen": "Recovery & archives",
+      "title": "Automatically undelete Reddit content",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "true",
+      "dependency": "pref_check_messages_push",
+      "existing_summary": "Show only Boost notification",
+      "help_treatment": "REVIEW_EXISTING_SUMMARY+PROGRESSIVE_DISCLOSURE",
+      "key": "pref_check_messages_push_clear",
+      "leaf_section": "Advanced",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Advanced",
+          "key": "pref_check_messages_push_clear",
+          "logical_kind": "stored_setting",
+          "resource": "pref_messages_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Notifications & inbox",
+      "page_intro": "Control notifications, messages, and inbox behavior.",
+      "proposed_summary": "Show only Boost notification",
+      "root": "Notifications & account",
+      "screen_depth": 2,
+      "screen_path": [
+        "Notifications & account",
+        "Notifications & inbox",
+        "Advanced"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Advanced",
+      "title": "Clear source notification",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "false",
+      "dependency": "pref_check_messages",
+      "existing_summary": "Requires the reddit app to be installed. Boost will show its own notifications when a push notification from reddit is received. Make sure your account is added to the reddit app and notifications are enabled",
+      "help_treatment": "REVIEW_EXISTING_SUMMARY+PROGRESSIVE_DISCLOSURE",
+      "key": "pref_check_messages_push",
+      "leaf_section": "Advanced",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Advanced",
+          "key": "pref_check_messages_push",
+          "logical_kind": "stored_setting",
+          "resource": "pref_messages_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Notifications & inbox",
+      "page_intro": "Control notifications, messages, and inbox behavior.",
+      "proposed_summary": "Requires the reddit app to be installed. Boost will show its own notifications when a push notification from reddit is received. Make sure your account is added to the reddit app and notifications are enabled",
+      "root": "Notifications & account",
+      "screen_depth": 2,
+      "screen_path": [
+        "Notifications & account",
+        "Notifications & inbox",
+        "Advanced"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Advanced",
+      "title": "Reddit push",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "60",
+      "dependency": "pref_check_messages",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE",
+      "key": "pref_check_messages_interval",
+      "leaf_section": "Notifications",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": null,
+          "key": "pref_check_messages_interval",
+          "logical_kind": "stored_setting",
+          "resource": "pref_messages_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Notifications & inbox",
+      "page_intro": "Control notifications, messages, and inbox behavior.",
+      "proposed_summary": "",
+      "root": "Notifications & account",
+      "screen_depth": 2,
+      "screen_path": [
+        "Notifications & account",
+        "Notifications & inbox",
+        "Notifications"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "string",
+      "subscreen": "Notifications",
+      "title": "Check interval",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "true",
+      "dependency": "pref_check_messages",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE",
+      "key": "pref_check_modmail",
+      "leaf_section": "Notifications",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": null,
+          "key": "pref_check_modmail",
+          "logical_kind": "stored_setting",
+          "resource": "pref_messages_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Notifications & inbox",
+      "page_intro": "Control notifications, messages, and inbox behavior.",
+      "proposed_summary": "",
+      "root": "Notifications & account",
+      "screen_depth": 2,
+      "screen_path": [
+        "Notifications & account",
+        "Notifications & inbox",
+        "Notifications"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Notifications",
+      "title": "Check moderator mail",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "true",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE+PROGRESSIVE_DISCLOSURE",
+      "key": "pref_check_messages",
+      "leaf_section": "Notifications",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": null,
+          "key": "pref_check_messages",
+          "logical_kind": "stored_setting",
+          "resource": "pref_messages_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Notifications & inbox",
+      "page_intro": "Control notifications, messages, and inbox behavior.",
+      "proposed_summary": "",
+      "root": "Notifications & account",
+      "screen_depth": 2,
+      "screen_path": [
+        "Notifications & account",
+        "Notifications & inbox",
+        "Notifications"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Notifications",
+      "title": "Check notifications",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "",
+      "dependency": "",
+      "existing_summary": "Open system notification settings",
+      "help_treatment": "REVIEW_EXISTING_SUMMARY+PROGRESSIVE_DISCLOSURE",
+      "key": "pref_notifications_configure",
+      "leaf_section": "Notifications",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": null,
+          "key": "pref_notifications_configure",
+          "logical_kind": "action",
+          "resource": "pref_messages_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "action",
+      "page": "Notifications & inbox",
+      "page_intro": "Control notifications, messages, and inbox behavior.",
+      "proposed_summary": "Open system notification settings",
+      "root": "Notifications & account",
+      "screen_depth": 2,
+      "screen_path": [
+        "Notifications & account",
+        "Notifications & inbox",
+        "Notifications"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "none_or_custom",
+      "subscreen": "Notifications",
+      "title": "Configure notifications",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "",
+      "dependency": "",
+      "existing_summary": "Version",
+      "help_treatment": "REVIEW_EXISTING_SUMMARY",
+      "key": "about_version",
+      "leaf_section": "About Boost",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": null,
+          "key": "about_version",
+          "logical_kind": "action",
+          "resource": "pref_about_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "action",
+      "page": "About & support",
+      "page_intro": "View app information, legal information, and support actions.",
+      "proposed_summary": "Version",
+      "root": "Data & app",
+      "screen_depth": 2,
+      "screen_path": [
+        "Data & app",
+        "About & support",
+        "About Boost"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "none_or_custom",
+      "subscreen": "About Boost",
+      "title": "Changelog",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "",
+      "dependency": "",
+      "existing_summary": "Rate it in Google Play",
+      "help_treatment": "REVIEW_EXISTING_SUMMARY",
+      "key": "rate_app",
+      "leaf_section": "About Boost",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": null,
+          "key": "rate_app",
+          "logical_kind": "action",
+          "resource": "pref_about_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "action",
+      "page": "About & support",
+      "page_intro": "View app information, legal information, and support actions.",
+      "proposed_summary": "Rate it in Google Play",
+      "root": "Data & app",
+      "screen_depth": 2,
+      "screen_path": [
+        "Data & app",
+        "About & support",
+        "About Boost"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "none_or_custom",
+      "subscreen": "About Boost",
+      "title": "Do you like this app?",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "",
+      "dependency": "",
+      "existing_summary": "r/BoostForReddit",
+      "help_treatment": "REVIEW_EXISTING_SUMMARY",
+      "key": "about_subreddit",
+      "leaf_section": "About Boost",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": null,
+          "key": "about_subreddit",
+          "logical_kind": "action",
+          "resource": "pref_about_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "action",
+      "page": "About & support",
+      "page_intro": "View app information, legal information, and support actions.",
+      "proposed_summary": "r/BoostForReddit",
+      "root": "Data & app",
+      "screen_depth": 2,
+      "screen_path": [
+        "Data & app",
+        "About & support",
+        "About Boost"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "none_or_custom",
+      "subscreen": "About Boost",
+      "title": "Feedback and support",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "OMIT_OR_ONE_LINE_ACTION_HINT",
+      "key": "about_faq",
+      "leaf_section": "About Boost",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": null,
+          "key": "about_faq",
+          "logical_kind": "action",
+          "resource": "pref_about_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "action",
+      "page": "About & support",
+      "page_intro": "View app information, legal information, and support actions.",
+      "proposed_summary": "",
+      "root": "Data & app",
+      "screen_depth": 2,
+      "screen_path": [
+        "Data & app",
+        "About & support",
+        "About Boost"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "none_or_custom",
+      "subscreen": "About Boost",
+      "title": "Help/FAQ",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "",
+      "dependency": "",
+      "existing_summary": "Give Boost some love!",
+      "help_treatment": "REVIEW_EXISTING_SUMMARY",
+      "key": "support_launch",
+      "leaf_section": "About Boost",
+      "legacy_route_count": 2,
+      "legacy_routes": [
+        {
+          "category": null,
+          "key": "support_launch",
+          "logical_kind": "action",
+          "resource": "pref_about_v2",
+          "root_referenced": true
+        },
+        {
+          "category": null,
+          "key": "support_launch",
+          "logical_kind": "action",
+          "resource": "pref_headers_v2",
+          "root_referenced": false
+        }
+      ],
+      "logical_kind": "action",
+      "page": "About & support",
+      "page_intro": "View app information, legal information, and support actions.",
+      "proposed_summary": "Give Boost some love!",
+      "root": "Data & app",
+      "screen_depth": 2,
+      "screen_path": [
+        "Data & app",
+        "About & support",
+        "About Boost"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "none_or_custom",
+      "subscreen": "About Boost",
+      "title": "Launch the rocket",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "OMIT_OR_ONE_LINE_ACTION_HINT",
+      "key": "licenses_preference",
+      "leaf_section": "About Boost",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": null,
+          "key": "licenses_preference",
+          "logical_kind": "action",
+          "resource": "pref_about_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "action",
+      "page": "About & support",
+      "page_intro": "View app information, legal information, and support actions.",
+      "proposed_summary": "",
+      "root": "Data & app",
+      "screen_depth": 2,
+      "screen_path": [
+        "Data & app",
+        "About & support",
+        "About Boost"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "none_or_custom",
+      "subscreen": "About Boost",
+      "title": "Licenses",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "",
+      "dependency": "",
+      "existing_summary": "mayayo.dev@gmail.com",
+      "help_treatment": "REVIEW_EXISTING_SUMMARY",
+      "key": "contact_dev_key",
+      "leaf_section": "Author",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Author",
+          "key": "contact_dev_key",
+          "logical_kind": "action",
+          "resource": "pref_about_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "action",
+      "page": "About & support",
+      "page_intro": "View app information, legal information, and support actions.",
+      "proposed_summary": "mayayo.dev@gmail.com",
+      "root": "Data & app",
+      "screen_depth": 2,
+      "screen_path": [
+        "Data & app",
+        "About & support",
+        "Author"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "none_or_custom",
+      "subscreen": "Author",
+      "title": "Email",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "",
+      "dependency": "",
+      "existing_summary": "u/rmayayo",
+      "help_treatment": "REVIEW_EXISTING_SUMMARY",
+      "key": "about_reddit",
+      "leaf_section": "Author",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Author",
+          "key": "about_reddit",
+          "logical_kind": "action",
+          "resource": "pref_about_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "action",
+      "page": "About & support",
+      "page_intro": "View app information, legal information, and support actions.",
+      "proposed_summary": "u/rmayayo",
+      "root": "Data & app",
+      "screen_depth": 2,
+      "screen_path": [
+        "Data & app",
+        "About & support",
+        "Author"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "none_or_custom",
+      "subscreen": "Author",
+      "title": "reddit",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "",
+      "dependency": "",
+      "existing_summary": "@rmayayo",
+      "help_treatment": "REVIEW_EXISTING_SUMMARY",
+      "key": "about_twitter",
+      "leaf_section": "Author",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Author",
+          "key": "about_twitter",
+          "logical_kind": "action",
+          "resource": "pref_about_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "action",
+      "page": "About & support",
+      "page_intro": "View app information, legal information, and support actions.",
+      "proposed_summary": "@rmayayo",
+      "root": "Data & app",
+      "screen_depth": 2,
+      "screen_path": [
+        "Data & app",
+        "About & support",
+        "Author"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "none_or_custom",
+      "subscreen": "Author",
+      "title": "Twitter",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "OMIT_OR_ONE_LINE_ACTION_HINT+PROGRESSIVE_DISCLOSURE",
+      "key": "privacy_policy",
+      "leaf_section": "Privacy",
+      "legacy_route_count": 2,
+      "legacy_routes": [
+        {
+          "category": "Privacy",
+          "key": "privacy_policy",
+          "logical_kind": "action",
+          "resource": "pref_about_v2",
+          "root_referenced": true
+        },
+        {
+          "category": null,
+          "key": "privacy_policy",
+          "logical_kind": "action",
+          "resource": "pref_headers_v2",
+          "root_referenced": false
+        }
+      ],
+      "logical_kind": "action",
+      "page": "About & support",
+      "page_intro": "View app information, legal information, and support actions.",
+      "proposed_summary": "",
+      "root": "Data & app",
+      "screen_depth": 2,
+      "screen_path": [
+        "Data & app",
+        "About & support",
+        "Privacy"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "none_or_custom",
+      "subscreen": "Privacy",
+      "title": "Privacy policy",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "false",
+      "dependency": "",
+      "existing_summary": "For users in the European Union",
+      "help_treatment": "REVIEW_EXISTING_SUMMARY",
+      "key": "pref_gdpr_revoke",
+      "leaf_section": "Privacy",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Privacy",
+          "key": "pref_gdpr_revoke",
+          "logical_kind": "special_preference",
+          "resource": "pref_about_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "special_preference",
+      "page": "About & support",
+      "page_intro": "View app information, legal information, and support actions.",
+      "proposed_summary": "For users in the European Union",
+      "root": "Data & app",
+      "screen_depth": 2,
+      "screen_path": [
+        "Data & app",
+        "About & support",
+        "Privacy"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "none_or_custom",
+      "subscreen": "Privacy",
+      "title": "Revoke GDPR consent",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "true",
+      "dependency": "",
+      "existing_summary": "Automatically send usage statistics and crash reports to help us improve Boost for reddit",
+      "help_treatment": "REVIEW_EXISTING_SUMMARY",
+      "key": "pref_statistics",
+      "leaf_section": "Privacy",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Privacy",
+          "key": "pref_statistics",
+          "logical_kind": "stored_setting",
+          "resource": "pref_about_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "About & support",
+      "page_intro": "View app information, legal information, and support actions.",
+      "proposed_summary": "Automatically send usage statistics and crash reports to help us improve Boost for reddit",
+      "root": "Data & app",
+      "screen_depth": 2,
+      "screen_path": [
+        "Data & app",
+        "About & support",
+        "Privacy"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Privacy",
+      "title": "Send statistics",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "true",
+      "dependency": "",
+      "existing_summary": "Crop community icon into a circular shape. Recommended if your launcher uses round icons",
+      "help_treatment": "REVIEW_EXISTING_SUMMARY",
+      "key": "pref_shortcut_icon_crop",
+      "leaf_section": "Community shortcuts",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Community shortcuts",
+          "key": "pref_shortcut_icon_crop",
+          "logical_kind": "stored_setting",
+          "resource": "pref_misc_v2",
+          "root_referenced": false
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "App behavior & compatibility",
+      "page_intro": "Manage app-wide compatibility options and remaining global behavior.",
+      "proposed_summary": "Crop community icon into a circular shape. Recommended if your launcher uses round icons",
+      "root": "Data & app",
+      "screen_depth": 2,
+      "screen_path": [
+        "Data & app",
+        "App behavior & compatibility",
+        "Community shortcuts"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Community shortcuts",
+      "title": "Crop community icon",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "3",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE+PROGRESSIVE_DISCLOSURE",
+      "key": "pref_autoplay_swipe",
+      "leaf_section": "Compatibility & legacy",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Legacy features",
+          "key": "pref_autoplay_swipe",
+          "logical_kind": "stored_setting",
+          "resource": "pref_misc_v2",
+          "root_referenced": false
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "App behavior & compatibility",
+      "page_intro": "Manage app-wide compatibility options and remaining global behavior.",
+      "proposed_summary": "",
+      "root": "Data & app",
+      "screen_depth": 2,
+      "screen_path": [
+        "Data & app",
+        "App behavior & compatibility",
+        "Compatibility & legacy"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "string",
+      "subscreen": "Compatibility & legacy",
+      "title": "Autoplay videos in Swipe view",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "true",
+      "dependency": "",
+      "existing_summary": "Color tags in images indicating the link type",
+      "help_treatment": "REVIEW_EXISTING_SUMMARY",
+      "key": "pref_info_color_indicators",
+      "leaf_section": "Compatibility & legacy",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Legacy features",
+          "key": "pref_info_color_indicators",
+          "logical_kind": "stored_setting",
+          "resource": "pref_misc_v2",
+          "root_referenced": false
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "App behavior & compatibility",
+      "page_intro": "Manage app-wide compatibility options and remaining global behavior.",
+      "proposed_summary": "Color tags in images indicating the link type",
+      "root": "Data & app",
+      "screen_depth": 2,
+      "screen_path": [
+        "Data & app",
+        "App behavior & compatibility",
+        "Compatibility & legacy"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Compatibility & legacy",
+      "title": "Colored link type indicators",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "false",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE",
+      "key": "pref_go_to_sub_dialog",
+      "leaf_section": "Compatibility & legacy",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Legacy features",
+          "key": "pref_go_to_sub_dialog",
+          "logical_kind": "stored_setting",
+          "resource": "pref_misc_v2",
+          "root_referenced": false
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "App behavior & compatibility",
+      "page_intro": "Manage app-wide compatibility options and remaining global behavior.",
+      "proposed_summary": "",
+      "root": "Data & app",
+      "screen_depth": 2,
+      "screen_path": [
+        "Data & app",
+        "App behavior & compatibility",
+        "Compatibility & legacy"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Compatibility & legacy",
+      "title": "Go to community in a dialog",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "false",
+      "dependency": "",
+      "existing_summary": "Show image preview above post title",
+      "help_treatment": "REVIEW_EXISTING_SUMMARY",
+      "key": "pref_cards_preview_top",
+      "leaf_section": "Compatibility & legacy",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Legacy features",
+          "key": "pref_cards_preview_top",
+          "logical_kind": "stored_setting",
+          "resource": "pref_misc_v2",
+          "root_referenced": false
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "App behavior & compatibility",
+      "page_intro": "Manage app-wide compatibility options and remaining global behavior.",
+      "proposed_summary": "Show image preview above post title",
+      "root": "Data & app",
+      "screen_depth": 2,
+      "screen_path": [
+        "Data & app",
+        "App behavior & compatibility",
+        "Compatibility & legacy"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Compatibility & legacy",
+      "title": "Previews on top",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "true",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE",
+      "key": "pref_info_post_shorten_score",
+      "leaf_section": "Compatibility & legacy",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Legacy features",
+          "key": "pref_info_post_shorten_score",
+          "logical_kind": "stored_setting",
+          "resource": "pref_misc_v2",
+          "root_referenced": false
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "App behavior & compatibility",
+      "page_intro": "Manage app-wide compatibility options and remaining global behavior.",
+      "proposed_summary": "",
+      "root": "Data & app",
+      "screen_depth": 2,
+      "screen_path": [
+        "Data & app",
+        "App behavior & compatibility",
+        "Compatibility & legacy"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Compatibility & legacy",
+      "title": "Shorten score",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "false",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE",
+      "key": "pref_send_floating_button",
+      "leaf_section": "Compatibility & legacy",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Legacy features",
+          "key": "pref_send_floating_button",
+          "logical_kind": "stored_setting",
+          "resource": "pref_misc_v2",
+          "root_referenced": false
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "App behavior & compatibility",
+      "page_intro": "Manage app-wide compatibility options and remaining global behavior.",
+      "proposed_summary": "",
+      "root": "Data & app",
+      "screen_depth": 2,
+      "screen_path": [
+        "Data & app",
+        "App behavior & compatibility",
+        "Compatibility & legacy"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Compatibility & legacy",
+      "title": "Show floating send button",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "true",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE",
+      "key": "pref_info_post_self_image",
+      "leaf_section": "Compatibility & legacy",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Legacy features",
+          "key": "pref_info_post_self_image",
+          "logical_kind": "stored_setting",
+          "resource": "pref_misc_v2",
+          "root_referenced": false
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "App behavior & compatibility",
+      "page_intro": "Manage app-wide compatibility options and remaining global behavior.",
+      "proposed_summary": "",
+      "root": "Data & app",
+      "screen_depth": 2,
+      "screen_path": [
+        "Data & app",
+        "App behavior & compatibility",
+        "Compatibility & legacy"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Compatibility & legacy",
+      "title": "Show images from text posts",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "true",
+      "dependency": "",
+      "existing_summary": "Own posts and moderator",
+      "help_treatment": "REVIEW_EXISTING_SUMMARY",
+      "key": "pref_info_post_view_count",
+      "leaf_section": "Compatibility & legacy",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Legacy features",
+          "key": "pref_info_post_view_count",
+          "logical_kind": "stored_setting",
+          "resource": "pref_misc_v2",
+          "root_referenced": false
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "App behavior & compatibility",
+      "page_intro": "Manage app-wide compatibility options and remaining global behavior.",
+      "proposed_summary": "Own posts and moderator",
+      "root": "Data & app",
+      "screen_depth": 2,
+      "screen_path": [
+        "Data & app",
+        "App behavior & compatibility",
+        "Compatibility & legacy"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Compatibility & legacy",
+      "title": "Show view count",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "false",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE",
+      "key": "pref_toolbar_dropdown",
+      "leaf_section": "Compatibility & legacy",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Legacy features",
+          "key": "pref_toolbar_dropdown",
+          "logical_kind": "stored_setting",
+          "resource": "pref_misc_v2",
+          "root_referenced": false
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "App behavior & compatibility",
+      "page_intro": "Manage app-wide compatibility options and remaining global behavior.",
+      "proposed_summary": "",
+      "root": "Data & app",
+      "screen_depth": 2,
+      "screen_path": [
+        "Data & app",
+        "App behavior & compatibility",
+        "Compatibility & legacy"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Compatibility & legacy",
+      "title": "Subscriptions dropdown in toolbar",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "true",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE",
+      "key": "pref_toolbar_tap_to_go",
+      "leaf_section": "Compatibility & legacy",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Legacy features",
+          "key": "pref_toolbar_tap_to_go",
+          "logical_kind": "stored_setting",
+          "resource": "pref_misc_v2",
+          "root_referenced": false
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "App behavior & compatibility",
+      "page_intro": "Manage app-wide compatibility options and remaining global behavior.",
+      "proposed_summary": "",
+      "root": "Data & app",
+      "screen_depth": 2,
+      "screen_path": [
+        "Data & app",
+        "App behavior & compatibility",
+        "Compatibility & legacy"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Compatibility & legacy",
+      "title": "Tap toolbar to show subs",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "false",
+      "dependency": "",
+      "existing_summary": "Community and post info below title, no icon",
+      "help_treatment": "REVIEW_EXISTING_SUMMARY",
+      "key": "pref_cards_legacy",
+      "leaf_section": "Compatibility & legacy",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Legacy features",
+          "key": "pref_cards_legacy",
+          "logical_kind": "stored_setting",
+          "resource": "pref_misc_v2",
+          "root_referenced": false
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "App behavior & compatibility",
+      "page_intro": "Manage app-wide compatibility options and remaining global behavior.",
+      "proposed_summary": "Community and post info below title, no icon",
+      "root": "Data & app",
+      "screen_depth": 2,
+      "screen_path": [
+        "Data & app",
+        "App behavior & compatibility",
+        "Compatibility & legacy"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Compatibility & legacy",
+      "title": "Use legacy cards layout",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "0",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE",
+      "key": "pref_ad_format",
+      "leaf_section": "Other app behavior",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Misc",
+          "key": "pref_ad_format",
+          "logical_kind": "stored_setting",
+          "resource": "pref_misc_v2",
+          "root_referenced": false
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "App behavior & compatibility",
+      "page_intro": "Manage app-wide compatibility options and remaining global behavior.",
+      "proposed_summary": "",
+      "root": "Data & app",
+      "screen_depth": 2,
+      "screen_path": [
+        "Data & app",
+        "App behavior & compatibility",
+        "Other app behavior"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "string",
+      "subscreen": "Other app behavior",
+      "title": "Preferred Ad format",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "OMIT_OR_ONE_LINE_ACTION_HINT",
+      "key": "reset_tips",
+      "leaf_section": "Other app behavior",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Misc",
+          "key": "reset_tips",
+          "logical_kind": "action",
+          "resource": "pref_misc_v2",
+          "root_referenced": false
+        }
+      ],
+      "logical_kind": "action",
+      "page": "App behavior & compatibility",
+      "page_intro": "Manage app-wide compatibility options and remaining global behavior.",
+      "proposed_summary": "",
+      "root": "Data & app",
+      "screen_depth": 2,
+      "screen_path": [
+        "Data & app",
+        "App behavior & compatibility",
+        "Other app behavior"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "none_or_custom",
+      "subscreen": "Other app behavior",
+      "title": "Reset tips",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "true",
+      "dependency": "",
+      "existing_summary": "Use Morphe's modern task-based settings. Reopen Settings to apply.",
+      "help_treatment": "REVIEW_EXISTING_SUMMARY",
+      "key": "morphe_boost_settings_v4_enabled",
+      "leaf_section": "Settings presentation",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Settings",
+          "key": "morphe_boost_settings_v4_enabled",
+          "logical_kind": "morphe_user_setting",
+          "resource": "morphe_boost_settings_skeleton",
+          "root_referenced": false
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Settings experience",
+      "page_intro": "Choose which Settings presentation Boost uses.",
+      "proposed_summary": "Use Morphe's modern task-based settings. Reopen Settings to apply.",
+      "root": "Data & app",
+      "screen_depth": 2,
+      "screen_path": [
+        "Data & app",
+        "Settings experience",
+        "Settings presentation"
+      ],
+      "source_type": "morphe_embedded_xml",
+      "storage_type": "boolean",
+      "subscreen": "Settings presentation",
+      "title": "Material settings",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "",
+      "dependency": "",
+      "existing_summary": "Delete images and videos from cache",
+      "help_treatment": "REVIEW_EXISTING_SUMMARY+PROGRESSIVE_DISCLOSURE",
+      "key": "pref_cache_current_size",
+      "leaf_section": "Cache",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Cache",
+          "key": "pref_cache_current_size",
+          "logical_kind": "action",
+          "resource": "pref_data_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "action",
+      "page": "Storage & bandwidth",
+      "page_intro": "Control data usage, caching, and bandwidth-sensitive behavior.",
+      "proposed_summary": "Delete images and videos from cache",
+      "root": "Data & app",
+      "screen_depth": 2,
+      "screen_path": [
+        "Data & app",
+        "Storage & bandwidth",
+        "Cache"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "none_or_custom",
+      "subscreen": "Cache",
+      "title": "Clear cache",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "128",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE+PROGRESSIVE_DISCLOSURE",
+      "key": "pref_cache_max_size",
+      "leaf_section": "Cache",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Cache",
+          "key": "pref_cache_max_size",
+          "logical_kind": "stored_setting",
+          "resource": "pref_data_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Storage & bandwidth",
+      "page_intro": "Control data usage, caching, and bandwidth-sensitive behavior.",
+      "proposed_summary": "",
+      "root": "Data & app",
+      "screen_depth": 2,
+      "screen_path": [
+        "Data & app",
+        "Storage & bandwidth",
+        "Cache"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "string",
+      "subscreen": "Cache",
+      "title": "Maximum cache size",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "true",
+      "dependency": "",
+      "existing_summary": "Load lower-size media",
+      "help_treatment": "REVIEW_EXISTING_SUMMARY+PROGRESSIVE_DISCLOSURE",
+      "key": "pref_reduce_mobile",
+      "leaf_section": "Data saver",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Data saver",
+          "key": "pref_reduce_mobile",
+          "logical_kind": "stored_setting",
+          "resource": "pref_data_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Storage & bandwidth",
+      "page_intro": "Control data usage, caching, and bandwidth-sensitive behavior.",
+      "proposed_summary": "Load lower-size media",
+      "root": "Data & app",
+      "screen_depth": 2,
+      "screen_path": [
+        "Data & app",
+        "Storage & bandwidth",
+        "Data saver"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Data saver",
+      "title": "Mobile data saver",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "false",
+      "dependency": "",
+      "existing_summary": "Load lower-size media",
+      "help_treatment": "REVIEW_EXISTING_SUMMARY+PROGRESSIVE_DISCLOSURE",
+      "key": "pref_reduce_wifi",
+      "leaf_section": "Data saver",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Data saver",
+          "key": "pref_reduce_wifi",
+          "logical_kind": "stored_setting",
+          "resource": "pref_data_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Storage & bandwidth",
+      "page_intro": "Control data usage, caching, and bandwidth-sensitive behavior.",
+      "proposed_summary": "Load lower-size media",
+      "root": "Data & app",
+      "screen_depth": 2,
+      "screen_path": [
+        "Data & app",
+        "Storage & bandwidth",
+        "Data saver"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Data saver",
+      "title": "Wifi data saver",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "",
+      "dependency": "",
+      "existing_summary": "Change download folder location",
+      "help_treatment": "REVIEW_EXISTING_SUMMARY+PROGRESSIVE_DISCLOSURE",
+      "key": "pref_download_folders",
+      "leaf_section": "Data usage",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": null,
+          "key": "pref_download_folders",
+          "logical_kind": "action",
+          "resource": "pref_data_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "action",
+      "page": "Storage & bandwidth",
+      "page_intro": "Control data usage, caching, and bandwidth-sensitive behavior.",
+      "proposed_summary": "Change download folder location",
+      "root": "Data & app",
+      "screen_depth": 2,
+      "screen_path": [
+        "Data & app",
+        "Storage & bandwidth",
+        "Data usage"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "none_or_custom",
+      "subscreen": "Data usage",
+      "title": "Configure downloads",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "0",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE",
+      "key": "pref_load_images",
+      "leaf_section": "Images",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Images",
+          "key": "pref_load_images",
+          "logical_kind": "stored_setting",
+          "resource": "pref_data_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Storage & bandwidth",
+      "page_intro": "Control data usage, caching, and bandwidth-sensitive behavior.",
+      "proposed_summary": "",
+      "root": "Data & app",
+      "screen_depth": 2,
+      "screen_path": [
+        "Data & app",
+        "Storage & bandwidth",
+        "Images"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "string",
+      "subscreen": "Images",
+      "title": "Load images",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "1080",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE+PROGRESSIVE_DISCLOSURE",
+      "key": "pref_video_quality_max",
+      "leaf_section": "Videos",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Videos",
+          "key": "pref_video_quality_max",
+          "logical_kind": "stored_setting",
+          "resource": "pref_data_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Storage & bandwidth",
+      "page_intro": "Control data usage, caching, and bandwidth-sensitive behavior.",
+      "proposed_summary": "",
+      "root": "Data & app",
+      "screen_depth": 2,
+      "screen_path": [
+        "Data & app",
+        "Storage & bandwidth",
+        "Videos"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "string",
+      "subscreen": "Videos",
+      "title": "Maximum quality",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "480",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE+PROGRESSIVE_DISCLOSURE",
+      "key": "pref_video_quality_min",
+      "leaf_section": "Videos",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Videos",
+          "key": "pref_video_quality_min",
+          "logical_kind": "stored_setting",
+          "resource": "pref_data_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Storage & bandwidth",
+      "page_intro": "Control data usage, caching, and bandwidth-sensitive behavior.",
+      "proposed_summary": "",
+      "root": "Data & app",
+      "screen_depth": 2,
+      "screen_path": [
+        "Data & app",
+        "Storage & bandwidth",
+        "Videos"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "string",
+      "subscreen": "Videos",
+      "title": "Minimum quality",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "0",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE+PROGRESSIVE_DISCLOSURE",
+      "key": "pref_video_quality",
+      "leaf_section": "Videos",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Videos",
+          "key": "pref_video_quality",
+          "logical_kind": "stored_setting",
+          "resource": "pref_data_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Storage & bandwidth",
+      "page_intro": "Control data usage, caching, and bandwidth-sensitive behavior.",
+      "proposed_summary": "",
+      "root": "Data & app",
+      "screen_depth": 2,
+      "screen_path": [
+        "Data & app",
+        "Storage & bandwidth",
+        "Videos"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "string",
+      "subscreen": "Videos",
+      "title": "Video quality",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    }
+  ],
+  "morphe_patch_features_reference_count": 12,
+  "root_order": [
+    "Morphe",
+    "Appearance",
+    "Reading & interaction",
+    "Navigation",
+    "Media",
+    "Notifications & account",
+    "Data & app"
+  ],
+  "root_overview_shell": {
+    "classic_fallback_location": "root_only",
+    "count": 1,
+    "status_required": "COMPLETE"
+  },
+  "schema": 1,
+  "screen_edge_count": 101,
+  "screen_node_count": 108,
+  "screens": [
+    {
+      "child_count": 1,
+      "control_count": 0,
+      "depth": 0,
+      "max_children_contract": "",
+      "path": "Morphe",
+      "role": "root_group",
+      "root": "Morphe",
+      "task_page": "",
+      "title": "Morphe"
+    },
+    {
+      "child_count": 0,
+      "control_count": 0,
+      "depth": 1,
+      "max_children_contract": 5,
+      "path": "Morphe / Patch features",
+      "role": "task_page",
+      "root": "Morphe",
+      "task_page": "Patch features",
+      "title": "Patch features"
+    },
+    {
+      "child_count": 5,
+      "control_count": 0,
+      "depth": 0,
+      "max_children_contract": "",
+      "path": "Appearance",
+      "role": "root_group",
+      "root": "Appearance",
+      "task_page": "",
+      "title": "Appearance"
+    },
+    {
+      "child_count": 1,
+      "control_count": 0,
+      "depth": 1,
+      "max_children_contract": 5,
+      "path": "Appearance / Community header",
+      "role": "task_page",
+      "root": "Appearance",
+      "task_page": "Community header",
+      "title": "Community header"
+    },
+    {
+      "child_count": 1,
+      "control_count": 0,
+      "depth": 1,
+      "max_children_contract": 5,
+      "path": "Appearance / Display & motion",
+      "role": "task_page",
+      "root": "Appearance",
+      "task_page": "Display & motion",
+      "title": "Display & motion"
+    },
+    {
+      "child_count": 5,
+      "control_count": 0,
+      "depth": 1,
+      "max_children_contract": 5,
+      "path": "Appearance / Post layout",
+      "role": "task_page",
+      "root": "Appearance",
+      "task_page": "Post layout",
+      "title": "Post layout"
+    },
+    {
+      "child_count": 3,
+      "control_count": 0,
+      "depth": 1,
+      "max_children_contract": 5,
+      "path": "Appearance / Theme & colors",
+      "role": "task_page",
+      "root": "Appearance",
+      "task_page": "Theme & colors",
+      "title": "Theme & colors"
+    },
+    {
+      "child_count": 3,
+      "control_count": 0,
+      "depth": 1,
+      "max_children_contract": 5,
+      "path": "Appearance / Typography",
+      "role": "task_page",
+      "root": "Appearance",
+      "task_page": "Typography",
+      "title": "Typography"
+    },
+    {
+      "child_count": 0,
+      "control_count": 5,
+      "depth": 2,
+      "max_children_contract": 0,
+      "path": "Appearance / Community header / Community header",
+      "role": "leaf_section",
+      "root": "Appearance",
+      "task_page": "Community header",
+      "title": "Community header"
+    },
+    {
+      "child_count": 0,
+      "control_count": 1,
+      "depth": 2,
+      "max_children_contract": 0,
+      "path": "Appearance / Display & motion / Display performance",
+      "role": "leaf_section",
+      "root": "Appearance",
+      "task_page": "Display & motion",
+      "title": "Display performance"
+    },
+    {
+      "child_count": 0,
+      "control_count": 8,
+      "depth": 2,
+      "max_children_contract": 0,
+      "path": "Appearance / Post layout / Cards",
+      "role": "leaf_section",
+      "root": "Appearance",
+      "task_page": "Post layout",
+      "title": "Cards"
+    },
+    {
+      "child_count": 2,
+      "control_count": 0,
+      "depth": 2,
+      "max_children_contract": 6,
+      "path": "Appearance / Post layout / Compact layouts",
+      "role": "intermediate_page",
+      "root": "Appearance",
+      "task_page": "Post layout",
+      "title": "Compact layouts"
+    },
+    {
+      "child_count": 2,
+      "control_count": 0,
+      "depth": 2,
+      "max_children_contract": 6,
+      "path": "Appearance / Post layout / Layout & saved views",
+      "role": "intermediate_page",
+      "root": "Appearance",
+      "task_page": "Post layout",
+      "title": "Layout & saved views"
+    },
+    {
+      "child_count": 0,
+      "control_count": 2,
+      "depth": 2,
+      "max_children_contract": 0,
+      "path": "Appearance / Post layout / Swipe",
+      "role": "leaf_section",
+      "root": "Appearance",
+      "task_page": "Post layout",
+      "title": "Swipe"
+    },
+    {
+      "child_count": 0,
+      "control_count": 1,
+      "depth": 2,
+      "max_children_contract": 0,
+      "path": "Appearance / Post layout / Tablet layout",
+      "role": "leaf_section",
+      "root": "Appearance",
+      "task_page": "Post layout",
+      "title": "Tablet layout"
+    },
+    {
+      "child_count": 0,
+      "control_count": 2,
+      "depth": 2,
+      "max_children_contract": 0,
+      "path": "Appearance / Theme & colors / Advanced appearance",
+      "role": "leaf_section",
+      "root": "Appearance",
+      "task_page": "Theme & colors",
+      "title": "Advanced appearance"
+    },
+    {
+      "child_count": 0,
+      "control_count": 1,
+      "depth": 2,
+      "max_children_contract": 0,
+      "path": "Appearance / Theme & colors / Personalization",
+      "role": "leaf_section",
+      "root": "Appearance",
+      "task_page": "Theme & colors",
+      "title": "Personalization"
+    },
+    {
+      "child_count": 0,
+      "control_count": 7,
+      "depth": 2,
+      "max_children_contract": 0,
+      "path": "Appearance / Theme & colors / Theme",
+      "role": "leaf_section",
+      "root": "Appearance",
+      "task_page": "Theme & colors",
+      "title": "Theme"
+    },
+    {
+      "child_count": 0,
+      "control_count": 2,
+      "depth": 2,
+      "max_children_contract": 0,
+      "path": "Appearance / Typography / Comments",
+      "role": "leaf_section",
+      "root": "Appearance",
+      "task_page": "Typography",
+      "title": "Comments"
+    },
+    {
+      "child_count": 0,
+      "control_count": 2,
+      "depth": 2,
+      "max_children_contract": 0,
+      "path": "Appearance / Typography / Posts",
+      "role": "leaf_section",
+      "root": "Appearance",
+      "task_page": "Typography",
+      "title": "Posts"
+    },
+    {
+      "child_count": 0,
+      "control_count": 1,
+      "depth": 2,
+      "max_children_contract": 0,
+      "path": "Appearance / Typography / Reset",
+      "role": "leaf_section",
+      "root": "Appearance",
+      "task_page": "Typography",
+      "title": "Reset"
+    },
+    {
+      "child_count": 0,
+      "control_count": 1,
+      "depth": 3,
+      "max_children_contract": 0,
+      "path": "Appearance / Post layout / Compact layouts / Dense",
+      "role": "leaf_section",
+      "root": "Appearance",
+      "task_page": "Post layout",
+      "title": "Dense"
+    },
+    {
+      "child_count": 0,
+      "control_count": 4,
+      "depth": 3,
+      "max_children_contract": 0,
+      "path": "Appearance / Post layout / Compact layouts / Small cards",
+      "role": "leaf_section",
+      "root": "Appearance",
+      "task_page": "Post layout",
+      "title": "Small cards"
+    },
+    {
+      "child_count": 0,
+      "control_count": 5,
+      "depth": 3,
+      "max_children_contract": 0,
+      "path": "Appearance / Post layout / Layout & saved views / Post layout",
+      "role": "leaf_section",
+      "root": "Appearance",
+      "task_page": "Post layout",
+      "title": "Post layout"
+    },
+    {
+      "child_count": 0,
+      "control_count": 3,
+      "depth": 3,
+      "max_children_contract": 0,
+      "path": "Appearance / Post layout / Layout & saved views / Saved community views",
+      "role": "leaf_section",
+      "root": "Appearance",
+      "task_page": "Post layout",
+      "title": "Saved community views"
+    },
+    {
+      "child_count": 5,
+      "control_count": 0,
+      "depth": 0,
+      "max_children_contract": "",
+      "path": "Reading & interaction",
+      "role": "root_group",
+      "root": "Reading & interaction",
+      "task_page": "",
+      "title": "Reading & interaction"
+    },
+    {
+      "child_count": 4,
+      "control_count": 0,
+      "depth": 1,
+      "max_children_contract": 5,
+      "path": "Reading & interaction / Comments",
+      "role": "task_page",
+      "root": "Reading & interaction",
+      "task_page": "Comments",
+      "title": "Comments"
+    },
+    {
+      "child_count": 3,
+      "control_count": 0,
+      "depth": 1,
+      "max_children_contract": 5,
+      "path": "Reading & interaction / Composing & drafts",
+      "role": "task_page",
+      "root": "Reading & interaction",
+      "task_page": "Composing & drafts",
+      "title": "Composing & drafts"
+    },
+    {
+      "child_count": 1,
+      "control_count": 0,
+      "depth": 1,
+      "max_children_contract": 5,
+      "path": "Reading & interaction / Feeds & subscriptions",
+      "role": "task_page",
+      "root": "Reading & interaction",
+      "task_page": "Feeds & subscriptions",
+      "title": "Feeds & subscriptions"
+    },
+    {
+      "child_count": 4,
+      "control_count": 0,
+      "depth": 1,
+      "max_children_contract": 5,
+      "path": "Reading & interaction / Posts",
+      "role": "task_page",
+      "root": "Reading & interaction",
+      "task_page": "Posts",
+      "title": "Posts"
+    },
+    {
+      "child_count": 2,
+      "control_count": 0,
+      "depth": 1,
+      "max_children_contract": 5,
+      "path": "Reading & interaction / Search & filters",
+      "role": "task_page",
+      "root": "Reading & interaction",
+      "task_page": "Search & filters",
+      "title": "Search & filters"
+    },
+    {
+      "child_count": 0,
+      "control_count": 9,
+      "depth": 2,
+      "max_children_contract": 0,
+      "path": "Reading & interaction / Comments / Comment actions",
+      "role": "leaf_section",
+      "root": "Reading & interaction",
+      "task_page": "Comments",
+      "title": "Comment actions"
+    },
+    {
+      "child_count": 0,
+      "control_count": 5,
+      "depth": 2,
+      "max_children_contract": 0,
+      "path": "Reading & interaction / Comments / Comment appearance",
+      "role": "leaf_section",
+      "root": "Reading & interaction",
+      "task_page": "Comments",
+      "title": "Comment appearance"
+    },
+    {
+      "child_count": 0,
+      "control_count": 7,
+      "depth": 2,
+      "max_children_contract": 0,
+      "path": "Reading & interaction / Comments / Comment behavior",
+      "role": "leaf_section",
+      "root": "Reading & interaction",
+      "task_page": "Comments",
+      "title": "Comment behavior"
+    },
+    {
+      "child_count": 0,
+      "control_count": 12,
+      "depth": 2,
+      "max_children_contract": 0,
+      "path": "Reading & interaction / Comments / Thread navigation",
+      "role": "leaf_section",
+      "root": "Reading & interaction",
+      "task_page": "Comments",
+      "title": "Thread navigation"
+    },
+    {
+      "child_count": 0,
+      "control_count": 2,
+      "depth": 2,
+      "max_children_contract": 0,
+      "path": "Reading & interaction / Composing & drafts / Drafts",
+      "role": "leaf_section",
+      "root": "Reading & interaction",
+      "task_page": "Composing & drafts",
+      "title": "Drafts"
+    },
+    {
+      "child_count": 0,
+      "control_count": 1,
+      "depth": 2,
+      "max_children_contract": 0,
+      "path": "Reading & interaction / Composing & drafts / Editor",
+      "role": "leaf_section",
+      "root": "Reading & interaction",
+      "task_page": "Composing & drafts",
+      "title": "Editor"
+    },
+    {
+      "child_count": 0,
+      "control_count": 1,
+      "depth": 2,
+      "max_children_contract": 0,
+      "path": "Reading & interaction / Composing & drafts / Uploads",
+      "role": "leaf_section",
+      "root": "Reading & interaction",
+      "task_page": "Composing & drafts",
+      "title": "Uploads"
+    },
+    {
+      "child_count": 0,
+      "control_count": 1,
+      "depth": 2,
+      "max_children_contract": 0,
+      "path": "Reading & interaction / Feeds & subscriptions / Manage subscriptions",
+      "role": "leaf_section",
+      "root": "Reading & interaction",
+      "task_page": "Feeds & subscriptions",
+      "title": "Manage subscriptions"
+    },
+    {
+      "child_count": 0,
+      "control_count": 3,
+      "depth": 2,
+      "max_children_contract": 0,
+      "path": "Reading & interaction / Posts / Feed behavior",
+      "role": "leaf_section",
+      "root": "Reading & interaction",
+      "task_page": "Posts",
+      "title": "Feed behavior"
+    },
+    {
+      "child_count": 0,
+      "control_count": 8,
+      "depth": 2,
+      "max_children_contract": 0,
+      "path": "Reading & interaction / Posts / Post actions",
+      "role": "leaf_section",
+      "root": "Reading & interaction",
+      "task_page": "Posts",
+      "title": "Post actions"
+    },
+    {
+      "child_count": 0,
+      "control_count": 9,
+      "depth": 2,
+      "max_children_contract": 0,
+      "path": "Reading & interaction / Posts / Post behavior",
+      "role": "leaf_section",
+      "root": "Reading & interaction",
+      "task_page": "Posts",
+      "title": "Post behavior"
+    },
+    {
+      "child_count": 0,
+      "control_count": 6,
+      "depth": 2,
+      "max_children_contract": 0,
+      "path": "Reading & interaction / Posts / Reading state",
+      "role": "leaf_section",
+      "root": "Reading & interaction",
+      "task_page": "Posts",
+      "title": "Reading state"
+    },
+    {
+      "child_count": 3,
+      "control_count": 0,
+      "depth": 2,
+      "max_children_contract": 6,
+      "path": "Reading & interaction / Search & filters / Content filters",
+      "role": "intermediate_page",
+      "root": "Reading & interaction",
+      "task_page": "Search & filters",
+      "title": "Content filters"
+    },
+    {
+      "child_count": 3,
+      "control_count": 0,
+      "depth": 2,
+      "max_children_contract": 6,
+      "path": "Reading & interaction / Search & filters / Search",
+      "role": "intermediate_page",
+      "root": "Reading & interaction",
+      "task_page": "Search & filters",
+      "title": "Search"
+    },
+    {
+      "child_count": 0,
+      "control_count": 3,
+      "depth": 3,
+      "max_children_contract": 0,
+      "path": "Reading & interaction / Search & filters / Content filters / Filter behavior",
+      "role": "leaf_section",
+      "root": "Reading & interaction",
+      "task_page": "Search & filters",
+      "title": "Filter behavior"
+    },
+    {
+      "child_count": 0,
+      "control_count": 5,
+      "depth": 3,
+      "max_children_contract": 0,
+      "path": "Reading & interaction / Search & filters / Content filters / Muted content",
+      "role": "leaf_section",
+      "root": "Reading & interaction",
+      "task_page": "Search & filters",
+      "title": "Muted content"
+    },
+    {
+      "child_count": 0,
+      "control_count": 6,
+      "depth": 3,
+      "max_children_contract": 0,
+      "path": "Reading & interaction / Search & filters / Content filters / Post matching",
+      "role": "leaf_section",
+      "root": "Reading & interaction",
+      "task_page": "Search & filters",
+      "title": "Post matching"
+    },
+    {
+      "child_count": 0,
+      "control_count": 1,
+      "depth": 3,
+      "max_children_contract": 0,
+      "path": "Reading & interaction / Search & filters / Search / Advanced search",
+      "role": "leaf_section",
+      "root": "Reading & interaction",
+      "task_page": "Search & filters",
+      "title": "Advanced search"
+    },
+    {
+      "child_count": 0,
+      "control_count": 3,
+      "depth": 3,
+      "max_children_contract": 0,
+      "path": "Reading & interaction / Search & filters / Search / Search behavior",
+      "role": "leaf_section",
+      "root": "Reading & interaction",
+      "task_page": "Search & filters",
+      "title": "Search behavior"
+    },
+    {
+      "child_count": 0,
+      "control_count": 5,
+      "depth": 3,
+      "max_children_contract": 0,
+      "path": "Reading & interaction / Search & filters / Search / Suggestions",
+      "role": "leaf_section",
+      "root": "Reading & interaction",
+      "task_page": "Search & filters",
+      "title": "Suggestions"
+    },
+    {
+      "child_count": 1,
+      "control_count": 0,
+      "depth": 0,
+      "max_children_contract": "",
+      "path": "Navigation",
+      "role": "root_group",
+      "root": "Navigation",
+      "task_page": "",
+      "title": "Navigation"
+    },
+    {
+      "child_count": 4,
+      "control_count": 0,
+      "depth": 1,
+      "max_children_contract": 5,
+      "path": "Navigation / Navigation & gestures",
+      "role": "task_page",
+      "root": "Navigation",
+      "task_page": "Navigation & gestures",
+      "title": "Navigation & gestures"
+    },
+    {
+      "child_count": 0,
+      "control_count": 2,
+      "depth": 2,
+      "max_children_contract": 0,
+      "path": "Navigation / Navigation & gestures / Back & exit",
+      "role": "leaf_section",
+      "root": "Navigation",
+      "task_page": "Navigation & gestures",
+      "title": "Back & exit"
+    },
+    {
+      "child_count": 0,
+      "control_count": 2,
+      "depth": 2,
+      "max_children_contract": 0,
+      "path": "Navigation / Navigation & gestures / Bottom navigation",
+      "role": "leaf_section",
+      "root": "Navigation",
+      "task_page": "Navigation & gestures",
+      "title": "Bottom navigation"
+    },
+    {
+      "child_count": 7,
+      "control_count": 0,
+      "depth": 2,
+      "max_children_contract": 7,
+      "path": "Navigation / Navigation & gestures / Navigation drawer",
+      "role": "intermediate_page",
+      "root": "Navigation",
+      "task_page": "Navigation & gestures",
+      "title": "Navigation drawer"
+    },
+    {
+      "child_count": 0,
+      "control_count": 2,
+      "depth": 2,
+      "max_children_contract": 0,
+      "path": "Navigation / Navigation & gestures / Toolbar",
+      "role": "leaf_section",
+      "root": "Navigation",
+      "task_page": "Navigation & gestures",
+      "title": "Toolbar"
+    },
+    {
+      "child_count": 0,
+      "control_count": 6,
+      "depth": 3,
+      "max_children_contract": 0,
+      "path": "Navigation / Navigation & gestures / Navigation drawer / Account & tools",
+      "role": "leaf_section",
+      "root": "Navigation",
+      "task_page": "Navigation & gestures",
+      "title": "Account & tools"
+    },
+    {
+      "child_count": 0,
+      "control_count": 2,
+      "depth": 3,
+      "max_children_contract": 0,
+      "path": "Navigation / Navigation & gestures / Navigation drawer / Account switcher",
+      "role": "leaf_section",
+      "root": "Navigation",
+      "task_page": "Navigation & gestures",
+      "title": "Account switcher"
+    },
+    {
+      "child_count": 0,
+      "control_count": 2,
+      "depth": 3,
+      "max_children_contract": 0,
+      "path": "Navigation / Navigation & gestures / Navigation drawer / Drawer behavior",
+      "role": "leaf_section",
+      "root": "Navigation",
+      "task_page": "Navigation & gestures",
+      "title": "Drawer behavior"
+    },
+    {
+      "child_count": 0,
+      "control_count": 6,
+      "depth": 3,
+      "max_children_contract": 0,
+      "path": "Navigation / Navigation & gestures / Navigation drawer / Feeds & library",
+      "role": "leaf_section",
+      "root": "Navigation",
+      "task_page": "Navigation & gestures",
+      "title": "Feeds & library"
+    },
+    {
+      "child_count": 0,
+      "control_count": 3,
+      "depth": 3,
+      "max_children_contract": 0,
+      "path": "Navigation / Navigation & gestures / Navigation drawer / Go-to shortcuts",
+      "role": "leaf_section",
+      "root": "Navigation",
+      "task_page": "Navigation & gestures",
+      "title": "Go-to shortcuts"
+    },
+    {
+      "child_count": 0,
+      "control_count": 3,
+      "depth": 3,
+      "max_children_contract": 0,
+      "path": "Navigation / Navigation & gestures / Navigation drawer / Quick toggles",
+      "role": "leaf_section",
+      "root": "Navigation",
+      "task_page": "Navigation & gestures",
+      "title": "Quick toggles"
+    },
+    {
+      "child_count": 0,
+      "control_count": 3,
+      "depth": 3,
+      "max_children_contract": 0,
+      "path": "Navigation / Navigation & gestures / Navigation drawer / Subscriptions",
+      "role": "leaf_section",
+      "root": "Navigation",
+      "task_page": "Navigation & gestures",
+      "title": "Subscriptions"
+    },
+    {
+      "child_count": 4,
+      "control_count": 0,
+      "depth": 0,
+      "max_children_contract": "",
+      "path": "Media",
+      "role": "root_group",
+      "root": "Media",
+      "task_page": "",
+      "title": "Media"
+    },
+    {
+      "child_count": 1,
+      "control_count": 0,
+      "depth": 1,
+      "max_children_contract": 5,
+      "path": "Media / Downloads & cache",
+      "role": "task_page",
+      "root": "Media",
+      "task_page": "Downloads & cache",
+      "title": "Downloads & cache"
+    },
+    {
+      "child_count": 4,
+      "control_count": 0,
+      "depth": 1,
+      "max_children_contract": 5,
+      "path": "Media / Images, GIFs & previews",
+      "role": "task_page",
+      "root": "Media",
+      "task_page": "Images, GIFs & previews",
+      "title": "Images, GIFs & previews"
+    },
+    {
+      "child_count": 4,
+      "control_count": 0,
+      "depth": 1,
+      "max_children_contract": 5,
+      "path": "Media / Links & browser",
+      "role": "task_page",
+      "root": "Media",
+      "task_page": "Links & browser",
+      "title": "Links & browser"
+    },
+    {
+      "child_count": 4,
+      "control_count": 0,
+      "depth": 1,
+      "max_children_contract": 5,
+      "path": "Media / Playback & autoplay",
+      "role": "task_page",
+      "root": "Media",
+      "task_page": "Playback & autoplay",
+      "title": "Playback & autoplay"
+    },
+    {
+      "child_count": 0,
+      "control_count": 5,
+      "depth": 2,
+      "max_children_contract": 0,
+      "path": "Media / Downloads & cache / Download folders",
+      "role": "leaf_section",
+      "root": "Media",
+      "task_page": "Downloads & cache",
+      "title": "Download folders"
+    },
+    {
+      "child_count": 0,
+      "control_count": 6,
+      "depth": 2,
+      "max_children_contract": 0,
+      "path": "Media / Images, GIFs & previews / Native image behavior",
+      "role": "leaf_section",
+      "root": "Media",
+      "task_page": "Images, GIFs & previews",
+      "title": "Native image behavior"
+    },
+    {
+      "child_count": 0,
+      "control_count": 3,
+      "depth": 2,
+      "max_children_contract": 0,
+      "path": "Media / Images, GIFs & previews / Open behavior",
+      "role": "leaf_section",
+      "root": "Media",
+      "task_page": "Images, GIFs & previews",
+      "title": "Open behavior"
+    },
+    {
+      "child_count": 0,
+      "control_count": 2,
+      "depth": 2,
+      "max_children_contract": 0,
+      "path": "Media / Images, GIFs & previews / Preview behavior",
+      "role": "leaf_section",
+      "root": "Media",
+      "task_page": "Images, GIFs & previews",
+      "title": "Preview behavior"
+    },
+    {
+      "child_count": 0,
+      "control_count": 2,
+      "depth": 2,
+      "max_children_contract": 0,
+      "path": "Media / Images, GIFs & previews / Preview layout",
+      "role": "leaf_section",
+      "root": "Media",
+      "task_page": "Images, GIFs & previews",
+      "title": "Preview layout"
+    },
+    {
+      "child_count": 0,
+      "control_count": 1,
+      "depth": 2,
+      "max_children_contract": 0,
+      "path": "Media / Links & browser / Browser",
+      "role": "leaf_section",
+      "root": "Media",
+      "task_page": "Links & browser",
+      "title": "Browser"
+    },
+    {
+      "child_count": 0,
+      "control_count": 1,
+      "depth": 2,
+      "max_children_contract": 0,
+      "path": "Media / Links & browser / Link handling",
+      "role": "leaf_section",
+      "root": "Media",
+      "task_page": "Links & browser",
+      "title": "Link handling"
+    },
+    {
+      "child_count": 0,
+      "control_count": 8,
+      "depth": 2,
+      "max_children_contract": 0,
+      "path": "Media / Links & browser / Links to open in app",
+      "role": "leaf_section",
+      "root": "Media",
+      "task_page": "Links & browser",
+      "title": "Links to open in app"
+    },
+    {
+      "child_count": 0,
+      "control_count": 1,
+      "depth": 2,
+      "max_children_contract": 0,
+      "path": "Media / Links & browser / Video links",
+      "role": "leaf_section",
+      "root": "Media",
+      "task_page": "Links & browser",
+      "title": "Video links"
+    },
+    {
+      "child_count": 0,
+      "control_count": 1,
+      "depth": 2,
+      "max_children_contract": 0,
+      "path": "Media / Playback & autoplay / Audio",
+      "role": "leaf_section",
+      "root": "Media",
+      "task_page": "Playback & autoplay",
+      "title": "Audio"
+    },
+    {
+      "child_count": 0,
+      "control_count": 1,
+      "depth": 2,
+      "max_children_contract": 0,
+      "path": "Media / Playback & autoplay / Autoplay",
+      "role": "leaf_section",
+      "root": "Media",
+      "task_page": "Playback & autoplay",
+      "title": "Autoplay"
+    },
+    {
+      "child_count": 0,
+      "control_count": 2,
+      "depth": 2,
+      "max_children_contract": 0,
+      "path": "Media / Playback & autoplay / Media behavior",
+      "role": "leaf_section",
+      "root": "Media",
+      "task_page": "Playback & autoplay",
+      "title": "Media behavior"
+    },
+    {
+      "child_count": 0,
+      "control_count": 2,
+      "depth": 2,
+      "max_children_contract": 0,
+      "path": "Media / Playback & autoplay / Playback & autoplay",
+      "role": "leaf_section",
+      "root": "Media",
+      "task_page": "Playback & autoplay",
+      "title": "Playback & autoplay"
+    },
+    {
+      "child_count": 3,
+      "control_count": 0,
+      "depth": 0,
+      "max_children_contract": "",
+      "path": "Notifications & account",
+      "role": "root_group",
+      "root": "Notifications & account",
+      "task_page": "",
+      "title": "Notifications & account"
+    },
+    {
+      "child_count": 2,
+      "control_count": 0,
+      "depth": 1,
+      "max_children_contract": 5,
+      "path": "Notifications & account / History, privacy & recovery",
+      "role": "task_page",
+      "root": "Notifications & account",
+      "task_page": "History, privacy & recovery",
+      "title": "History, privacy & recovery"
+    },
+    {
+      "child_count": 2,
+      "control_count": 0,
+      "depth": 1,
+      "max_children_contract": 5,
+      "path": "Notifications & account / Notifications & inbox",
+      "role": "task_page",
+      "root": "Notifications & account",
+      "task_page": "Notifications & inbox",
+      "title": "Notifications & inbox"
+    },
+    {
+      "child_count": 0,
+      "control_count": 0,
+      "depth": 1,
+      "max_children_contract": 5,
+      "path": "Notifications & account / Reddit account",
+      "role": "task_page",
+      "root": "Notifications & account",
+      "task_page": "Reddit account",
+      "title": "Reddit account"
+    },
+    {
+      "child_count": 0,
+      "control_count": 8,
+      "depth": 2,
+      "max_children_contract": 0,
+      "path": "Notifications & account / History, privacy & recovery / History",
+      "role": "leaf_section",
+      "root": "Notifications & account",
+      "task_page": "History, privacy & recovery",
+      "title": "History"
+    },
+    {
+      "child_count": 0,
+      "control_count": 2,
+      "depth": 2,
+      "max_children_contract": 0,
+      "path": "Notifications & account / History, privacy & recovery / Recovery & archives",
+      "role": "leaf_section",
+      "root": "Notifications & account",
+      "task_page": "History, privacy & recovery",
+      "title": "Recovery & archives"
+    },
+    {
+      "child_count": 0,
+      "control_count": 2,
+      "depth": 2,
+      "max_children_contract": 0,
+      "path": "Notifications & account / Notifications & inbox / Advanced",
+      "role": "leaf_section",
+      "root": "Notifications & account",
+      "task_page": "Notifications & inbox",
+      "title": "Advanced"
+    },
+    {
+      "child_count": 0,
+      "control_count": 4,
+      "depth": 2,
+      "max_children_contract": 0,
+      "path": "Notifications & account / Notifications & inbox / Notifications",
+      "role": "leaf_section",
+      "root": "Notifications & account",
+      "task_page": "Notifications & inbox",
+      "title": "Notifications"
+    },
+    {
+      "child_count": 5,
+      "control_count": 0,
+      "depth": 0,
+      "max_children_contract": "",
+      "path": "Data & app",
+      "role": "root_group",
+      "root": "Data & app",
+      "task_page": "",
+      "title": "Data & app"
+    },
+    {
+      "child_count": 3,
+      "control_count": 0,
+      "depth": 1,
+      "max_children_contract": 5,
+      "path": "Data & app / About & support",
+      "role": "task_page",
+      "root": "Data & app",
+      "task_page": "About & support",
+      "title": "About & support"
+    },
+    {
+      "child_count": 3,
+      "control_count": 0,
+      "depth": 1,
+      "max_children_contract": 5,
+      "path": "Data & app / App behavior & compatibility",
+      "role": "task_page",
+      "root": "Data & app",
+      "task_page": "App behavior & compatibility",
+      "title": "App behavior & compatibility"
+    },
+    {
+      "child_count": 0,
+      "control_count": 0,
+      "depth": 1,
+      "max_children_contract": 5,
+      "path": "Data & app / Backup & restore",
+      "role": "task_page",
+      "root": "Data & app",
+      "task_page": "Backup & restore",
+      "title": "Backup & restore"
+    },
+    {
+      "child_count": 1,
+      "control_count": 0,
+      "depth": 1,
+      "max_children_contract": 5,
+      "path": "Data & app / Settings experience",
+      "role": "task_page",
+      "root": "Data & app",
+      "task_page": "Settings experience",
+      "title": "Settings experience"
+    },
+    {
+      "child_count": 5,
+      "control_count": 0,
+      "depth": 1,
+      "max_children_contract": 5,
+      "path": "Data & app / Storage & bandwidth",
+      "role": "task_page",
+      "root": "Data & app",
+      "task_page": "Storage & bandwidth",
+      "title": "Storage & bandwidth"
+    },
+    {
+      "child_count": 0,
+      "control_count": 6,
+      "depth": 2,
+      "max_children_contract": 0,
+      "path": "Data & app / About & support / About Boost",
+      "role": "leaf_section",
+      "root": "Data & app",
+      "task_page": "About & support",
+      "title": "About Boost"
+    },
+    {
+      "child_count": 0,
+      "control_count": 3,
+      "depth": 2,
+      "max_children_contract": 0,
+      "path": "Data & app / About & support / Author",
+      "role": "leaf_section",
+      "root": "Data & app",
+      "task_page": "About & support",
+      "title": "Author"
+    },
+    {
+      "child_count": 0,
+      "control_count": 3,
+      "depth": 2,
+      "max_children_contract": 0,
+      "path": "Data & app / About & support / Privacy",
+      "role": "leaf_section",
+      "root": "Data & app",
+      "task_page": "About & support",
+      "title": "Privacy"
+    },
+    {
+      "child_count": 0,
+      "control_count": 1,
+      "depth": 2,
+      "max_children_contract": 0,
+      "path": "Data & app / App behavior & compatibility / Community shortcuts",
+      "role": "leaf_section",
+      "root": "Data & app",
+      "task_page": "App behavior & compatibility",
+      "title": "Community shortcuts"
+    },
+    {
+      "child_count": 0,
+      "control_count": 11,
+      "depth": 2,
+      "max_children_contract": 0,
+      "path": "Data & app / App behavior & compatibility / Compatibility & legacy",
+      "role": "leaf_section",
+      "root": "Data & app",
+      "task_page": "App behavior & compatibility",
+      "title": "Compatibility & legacy"
+    },
+    {
+      "child_count": 0,
+      "control_count": 2,
+      "depth": 2,
+      "max_children_contract": 0,
+      "path": "Data & app / App behavior & compatibility / Other app behavior",
+      "role": "leaf_section",
+      "root": "Data & app",
+      "task_page": "App behavior & compatibility",
+      "title": "Other app behavior"
+    },
+    {
+      "child_count": 0,
+      "control_count": 1,
+      "depth": 2,
+      "max_children_contract": 0,
+      "path": "Data & app / Settings experience / Settings presentation",
+      "role": "leaf_section",
+      "root": "Data & app",
+      "task_page": "Settings experience",
+      "title": "Settings presentation"
+    },
+    {
+      "child_count": 0,
+      "control_count": 2,
+      "depth": 2,
+      "max_children_contract": 0,
+      "path": "Data & app / Storage & bandwidth / Cache",
+      "role": "leaf_section",
+      "root": "Data & app",
+      "task_page": "Storage & bandwidth",
+      "title": "Cache"
+    },
+    {
+      "child_count": 0,
+      "control_count": 2,
+      "depth": 2,
+      "max_children_contract": 0,
+      "path": "Data & app / Storage & bandwidth / Data saver",
+      "role": "leaf_section",
+      "root": "Data & app",
+      "task_page": "Storage & bandwidth",
+      "title": "Data saver"
+    },
+    {
+      "child_count": 0,
+      "control_count": 1,
+      "depth": 2,
+      "max_children_contract": 0,
+      "path": "Data & app / Storage & bandwidth / Data usage",
+      "role": "leaf_section",
+      "root": "Data & app",
+      "task_page": "Storage & bandwidth",
+      "title": "Data usage"
+    },
+    {
+      "child_count": 0,
+      "control_count": 1,
+      "depth": 2,
+      "max_children_contract": 0,
+      "path": "Data & app / Storage & bandwidth / Images",
+      "role": "leaf_section",
+      "root": "Data & app",
+      "task_page": "Storage & bandwidth",
+      "title": "Images"
+    },
+    {
+      "child_count": 0,
+      "control_count": 3,
+      "depth": 2,
+      "max_children_contract": 0,
+      "path": "Data & app / Storage & bandwidth / Videos",
+      "role": "leaf_section",
+      "root": "Data & app",
+      "task_page": "Storage & bandwidth",
+      "title": "Videos"
+    }
+  ],
+  "target": "Morphe Settings V5 complete tree",
+  "visible_item_target": 249,
+  "withheld_controls": [
+    {
+      "key": "pref_drawer_show_friends",
+      "reason": "Static implementation exists, but the Friends destination was not proven to return functional Reddit data at runtime.",
+      "required_resolution": "runtime destination validation before exposure",
+      "target_path": "Navigation / Navigation & gestures / Navigation drawer / Account & tools"
+    }
+  ],
+  "withheld_item_target": 1
+}

--- a/tools/contracts/boost-settings-v5-completeness-v2.json
+++ b/tools/contracts/boost-settings-v5-completeness-v2.json
@@ -1,0 +1,10606 @@
+{
+  "activation_gate": {
+    "activation_policy": "parallel_hidden_until_complete",
+    "allowed_classic_fallbacks": 1,
+    "allowed_external_action_destinations": 1,
+    "allowed_legacy_fragments": 0,
+    "allowed_legacy_xml_routes": 0,
+    "allowed_placeholder_pages": 0,
+    "allowed_title_route_mismatches": 0,
+    "allowed_unmapped_keys": 0,
+    "canonical_item_accounting": 248,
+    "classic_fallback_location": "root_only",
+    "external_action_destination_allowlist": [
+      "BackupActivity"
+    ],
+    "partial_completion_must_not_replace_current_visible_tree": true,
+    "required_complete_screen_nodes": 105,
+    "required_complete_visible_items": 247,
+    "root_overview_shell_count": 1,
+    "root_overview_shell_must_be_complete": true,
+    "target_screen_edge_count": 98,
+    "target_screen_node_count": 105,
+    "visible_item_target": 247,
+    "withheld_controls_must_have_evidence": true,
+    "withheld_item_target": 1
+  },
+  "canonical_item_count": 248,
+  "graph_edges": [
+    {
+      "child_path": "Appearance / Community header",
+      "child_title": "Community header",
+      "parent_path": "Appearance"
+    },
+    {
+      "child_path": "Appearance / Community header / Community header",
+      "child_title": "Community header",
+      "parent_path": "Appearance / Community header"
+    },
+    {
+      "child_path": "Appearance / Display & motion",
+      "child_title": "Display & motion",
+      "parent_path": "Appearance"
+    },
+    {
+      "child_path": "Appearance / Display & motion / Display performance",
+      "child_title": "Display performance",
+      "parent_path": "Appearance / Display & motion"
+    },
+    {
+      "child_path": "Appearance / Post layout",
+      "child_title": "Post layout",
+      "parent_path": "Appearance"
+    },
+    {
+      "child_path": "Appearance / Post layout / Cards",
+      "child_title": "Cards",
+      "parent_path": "Appearance / Post layout"
+    },
+    {
+      "child_path": "Appearance / Post layout / Compact layouts",
+      "child_title": "Compact layouts",
+      "parent_path": "Appearance / Post layout"
+    },
+    {
+      "child_path": "Appearance / Post layout / Compact layouts / Dense",
+      "child_title": "Dense",
+      "parent_path": "Appearance / Post layout / Compact layouts"
+    },
+    {
+      "child_path": "Appearance / Post layout / Compact layouts / Small cards",
+      "child_title": "Small cards",
+      "parent_path": "Appearance / Post layout / Compact layouts"
+    },
+    {
+      "child_path": "Appearance / Post layout / Layout & saved views",
+      "child_title": "Layout & saved views",
+      "parent_path": "Appearance / Post layout"
+    },
+    {
+      "child_path": "Appearance / Post layout / Layout & saved views / Post layout",
+      "child_title": "Post layout",
+      "parent_path": "Appearance / Post layout / Layout & saved views"
+    },
+    {
+      "child_path": "Appearance / Post layout / Layout & saved views / Saved community views",
+      "child_title": "Saved community views",
+      "parent_path": "Appearance / Post layout / Layout & saved views"
+    },
+    {
+      "child_path": "Appearance / Post layout / Tablet layout",
+      "child_title": "Tablet layout",
+      "parent_path": "Appearance / Post layout"
+    },
+    {
+      "child_path": "Appearance / Theme & colors",
+      "child_title": "Theme & colors",
+      "parent_path": "Appearance"
+    },
+    {
+      "child_path": "Appearance / Theme & colors / Advanced appearance",
+      "child_title": "Advanced appearance",
+      "parent_path": "Appearance / Theme & colors"
+    },
+    {
+      "child_path": "Appearance / Theme & colors / Personalization",
+      "child_title": "Personalization",
+      "parent_path": "Appearance / Theme & colors"
+    },
+    {
+      "child_path": "Appearance / Theme & colors / Theme",
+      "child_title": "Theme",
+      "parent_path": "Appearance / Theme & colors"
+    },
+    {
+      "child_path": "Appearance / Typography",
+      "child_title": "Typography",
+      "parent_path": "Appearance"
+    },
+    {
+      "child_path": "Appearance / Typography / Comments",
+      "child_title": "Comments",
+      "parent_path": "Appearance / Typography"
+    },
+    {
+      "child_path": "Appearance / Typography / Posts",
+      "child_title": "Posts",
+      "parent_path": "Appearance / Typography"
+    },
+    {
+      "child_path": "Appearance / Typography / Reset",
+      "child_title": "Reset",
+      "parent_path": "Appearance / Typography"
+    },
+    {
+      "child_path": "Data & app / About & support",
+      "child_title": "About & support",
+      "parent_path": "Data & app"
+    },
+    {
+      "child_path": "Data & app / About & support / About Boost",
+      "child_title": "About Boost",
+      "parent_path": "Data & app / About & support"
+    },
+    {
+      "child_path": "Data & app / About & support / Author",
+      "child_title": "Author",
+      "parent_path": "Data & app / About & support"
+    },
+    {
+      "child_path": "Data & app / About & support / Privacy",
+      "child_title": "Privacy",
+      "parent_path": "Data & app / About & support"
+    },
+    {
+      "child_path": "Data & app / App behavior & compatibility",
+      "child_title": "App behavior & compatibility",
+      "parent_path": "Data & app"
+    },
+    {
+      "child_path": "Data & app / App behavior & compatibility / Community shortcuts",
+      "child_title": "Community shortcuts",
+      "parent_path": "Data & app / App behavior & compatibility"
+    },
+    {
+      "child_path": "Data & app / App behavior & compatibility / Compatibility & legacy",
+      "child_title": "Compatibility & legacy",
+      "parent_path": "Data & app / App behavior & compatibility"
+    },
+    {
+      "child_path": "Data & app / App behavior & compatibility / Other app behavior",
+      "child_title": "Other app behavior",
+      "parent_path": "Data & app / App behavior & compatibility"
+    },
+    {
+      "child_path": "Data & app / Backup & restore",
+      "child_title": "Backup & restore",
+      "parent_path": "Data & app"
+    },
+    {
+      "child_path": "Data & app / Settings experience",
+      "child_title": "Settings experience",
+      "parent_path": "Data & app"
+    },
+    {
+      "child_path": "Data & app / Settings experience / Settings presentation",
+      "child_title": "Settings presentation",
+      "parent_path": "Data & app / Settings experience"
+    },
+    {
+      "child_path": "Data & app / Storage & bandwidth",
+      "child_title": "Storage & bandwidth",
+      "parent_path": "Data & app"
+    },
+    {
+      "child_path": "Data & app / Storage & bandwidth / Cache",
+      "child_title": "Cache",
+      "parent_path": "Data & app / Storage & bandwidth"
+    },
+    {
+      "child_path": "Data & app / Storage & bandwidth / Data saver",
+      "child_title": "Data saver",
+      "parent_path": "Data & app / Storage & bandwidth"
+    },
+    {
+      "child_path": "Data & app / Storage & bandwidth / Data usage",
+      "child_title": "Data usage",
+      "parent_path": "Data & app / Storage & bandwidth"
+    },
+    {
+      "child_path": "Data & app / Storage & bandwidth / Images",
+      "child_title": "Images",
+      "parent_path": "Data & app / Storage & bandwidth"
+    },
+    {
+      "child_path": "Data & app / Storage & bandwidth / Videos",
+      "child_title": "Videos",
+      "parent_path": "Data & app / Storage & bandwidth"
+    },
+    {
+      "child_path": "Media / Downloads & cache",
+      "child_title": "Downloads & cache",
+      "parent_path": "Media"
+    },
+    {
+      "child_path": "Media / Downloads & cache / Download folders",
+      "child_title": "Download folders",
+      "parent_path": "Media / Downloads & cache"
+    },
+    {
+      "child_path": "Media / Images, GIFs & previews",
+      "child_title": "Images, GIFs & previews",
+      "parent_path": "Media"
+    },
+    {
+      "child_path": "Media / Images, GIFs & previews / Native image behavior",
+      "child_title": "Native image behavior",
+      "parent_path": "Media / Images, GIFs & previews"
+    },
+    {
+      "child_path": "Media / Images, GIFs & previews / Open behavior",
+      "child_title": "Open behavior",
+      "parent_path": "Media / Images, GIFs & previews"
+    },
+    {
+      "child_path": "Media / Images, GIFs & previews / Preview behavior",
+      "child_title": "Preview behavior",
+      "parent_path": "Media / Images, GIFs & previews"
+    },
+    {
+      "child_path": "Media / Images, GIFs & previews / Preview layout",
+      "child_title": "Preview layout",
+      "parent_path": "Media / Images, GIFs & previews"
+    },
+    {
+      "child_path": "Media / Links & browser",
+      "child_title": "Links & browser",
+      "parent_path": "Media"
+    },
+    {
+      "child_path": "Media / Links & browser / Browser",
+      "child_title": "Browser",
+      "parent_path": "Media / Links & browser"
+    },
+    {
+      "child_path": "Media / Links & browser / Link handling",
+      "child_title": "Link handling",
+      "parent_path": "Media / Links & browser"
+    },
+    {
+      "child_path": "Media / Links & browser / Links to open in app",
+      "child_title": "Links to open in app",
+      "parent_path": "Media / Links & browser"
+    },
+    {
+      "child_path": "Media / Links & browser / Video links",
+      "child_title": "Video links",
+      "parent_path": "Media / Links & browser"
+    },
+    {
+      "child_path": "Media / Playback & autoplay",
+      "child_title": "Playback & autoplay",
+      "parent_path": "Media"
+    },
+    {
+      "child_path": "Media / Playback & autoplay / Audio",
+      "child_title": "Audio",
+      "parent_path": "Media / Playback & autoplay"
+    },
+    {
+      "child_path": "Media / Playback & autoplay / Autoplay",
+      "child_title": "Autoplay",
+      "parent_path": "Media / Playback & autoplay"
+    },
+    {
+      "child_path": "Media / Playback & autoplay / Media behavior",
+      "child_title": "Media behavior",
+      "parent_path": "Media / Playback & autoplay"
+    },
+    {
+      "child_path": "Media / Playback & autoplay / Playback & autoplay",
+      "child_title": "Playback & autoplay",
+      "parent_path": "Media / Playback & autoplay"
+    },
+    {
+      "child_path": "Navigation / Back & exit",
+      "child_title": "Back & exit",
+      "parent_path": "Navigation"
+    },
+    {
+      "child_path": "Navigation / Bottom navigation",
+      "child_title": "Bottom navigation",
+      "parent_path": "Navigation"
+    },
+    {
+      "child_path": "Navigation / Navigation drawer",
+      "child_title": "Navigation drawer",
+      "parent_path": "Navigation"
+    },
+    {
+      "child_path": "Navigation / Navigation drawer / Account & tools",
+      "child_title": "Account & tools",
+      "parent_path": "Navigation / Navigation drawer"
+    },
+    {
+      "child_path": "Navigation / Navigation drawer / Account switcher",
+      "child_title": "Account switcher",
+      "parent_path": "Navigation / Navigation drawer"
+    },
+    {
+      "child_path": "Navigation / Navigation drawer / Drawer behavior",
+      "child_title": "Drawer behavior",
+      "parent_path": "Navigation / Navigation drawer"
+    },
+    {
+      "child_path": "Navigation / Navigation drawer / Feeds & library",
+      "child_title": "Feeds & library",
+      "parent_path": "Navigation / Navigation drawer"
+    },
+    {
+      "child_path": "Navigation / Navigation drawer / Go-to shortcuts",
+      "child_title": "Go-to shortcuts",
+      "parent_path": "Navigation / Navigation drawer"
+    },
+    {
+      "child_path": "Navigation / Navigation drawer / Quick toggles",
+      "child_title": "Quick toggles",
+      "parent_path": "Navigation / Navigation drawer"
+    },
+    {
+      "child_path": "Navigation / Navigation drawer / Subscriptions",
+      "child_title": "Subscriptions",
+      "parent_path": "Navigation / Navigation drawer"
+    },
+    {
+      "child_path": "Navigation / Toolbar",
+      "child_title": "Toolbar",
+      "parent_path": "Navigation"
+    },
+    {
+      "child_path": "Notifications & account / History, privacy & recovery",
+      "child_title": "History, privacy & recovery",
+      "parent_path": "Notifications & account"
+    },
+    {
+      "child_path": "Notifications & account / History, privacy & recovery / History",
+      "child_title": "History",
+      "parent_path": "Notifications & account / History, privacy & recovery"
+    },
+    {
+      "child_path": "Notifications & account / History, privacy & recovery / Recovery & archives",
+      "child_title": "Recovery & archives",
+      "parent_path": "Notifications & account / History, privacy & recovery"
+    },
+    {
+      "child_path": "Notifications & account / Notifications & inbox",
+      "child_title": "Notifications & inbox",
+      "parent_path": "Notifications & account"
+    },
+    {
+      "child_path": "Notifications & account / Notifications & inbox / Advanced",
+      "child_title": "Advanced",
+      "parent_path": "Notifications & account / Notifications & inbox"
+    },
+    {
+      "child_path": "Notifications & account / Notifications & inbox / Notifications",
+      "child_title": "Notifications",
+      "parent_path": "Notifications & account / Notifications & inbox"
+    },
+    {
+      "child_path": "Notifications & account / Reddit account",
+      "child_title": "Reddit account",
+      "parent_path": "Notifications & account"
+    },
+    {
+      "child_path": "Reading & interaction / Comments",
+      "child_title": "Comments",
+      "parent_path": "Reading & interaction"
+    },
+    {
+      "child_path": "Reading & interaction / Comments / Comment actions",
+      "child_title": "Comment actions",
+      "parent_path": "Reading & interaction / Comments"
+    },
+    {
+      "child_path": "Reading & interaction / Comments / Comment appearance",
+      "child_title": "Comment appearance",
+      "parent_path": "Reading & interaction / Comments"
+    },
+    {
+      "child_path": "Reading & interaction / Comments / Comment behavior",
+      "child_title": "Comment behavior",
+      "parent_path": "Reading & interaction / Comments"
+    },
+    {
+      "child_path": "Reading & interaction / Comments / Thread navigation",
+      "child_title": "Thread navigation",
+      "parent_path": "Reading & interaction / Comments"
+    },
+    {
+      "child_path": "Reading & interaction / Composing & drafts",
+      "child_title": "Composing & drafts",
+      "parent_path": "Reading & interaction"
+    },
+    {
+      "child_path": "Reading & interaction / Composing & drafts / Drafts",
+      "child_title": "Drafts",
+      "parent_path": "Reading & interaction / Composing & drafts"
+    },
+    {
+      "child_path": "Reading & interaction / Composing & drafts / Editor",
+      "child_title": "Editor",
+      "parent_path": "Reading & interaction / Composing & drafts"
+    },
+    {
+      "child_path": "Reading & interaction / Composing & drafts / Uploads",
+      "child_title": "Uploads",
+      "parent_path": "Reading & interaction / Composing & drafts"
+    },
+    {
+      "child_path": "Reading & interaction / Feeds & subscriptions",
+      "child_title": "Feeds & subscriptions",
+      "parent_path": "Reading & interaction"
+    },
+    {
+      "child_path": "Reading & interaction / Feeds & subscriptions / Manage subscriptions",
+      "child_title": "Manage subscriptions",
+      "parent_path": "Reading & interaction / Feeds & subscriptions"
+    },
+    {
+      "child_path": "Reading & interaction / Posts",
+      "child_title": "Posts",
+      "parent_path": "Reading & interaction"
+    },
+    {
+      "child_path": "Reading & interaction / Posts / Feed behavior",
+      "child_title": "Feed behavior",
+      "parent_path": "Reading & interaction / Posts"
+    },
+    {
+      "child_path": "Reading & interaction / Posts / Post actions",
+      "child_title": "Post actions",
+      "parent_path": "Reading & interaction / Posts"
+    },
+    {
+      "child_path": "Reading & interaction / Posts / Post behavior",
+      "child_title": "Post behavior",
+      "parent_path": "Reading & interaction / Posts"
+    },
+    {
+      "child_path": "Reading & interaction / Posts / Reading state",
+      "child_title": "Reading state",
+      "parent_path": "Reading & interaction / Posts"
+    },
+    {
+      "child_path": "Reading & interaction / Search & filters",
+      "child_title": "Search & filters",
+      "parent_path": "Reading & interaction"
+    },
+    {
+      "child_path": "Reading & interaction / Search & filters / Content filters",
+      "child_title": "Content filters",
+      "parent_path": "Reading & interaction / Search & filters"
+    },
+    {
+      "child_path": "Reading & interaction / Search & filters / Content filters / Filter behavior",
+      "child_title": "Filter behavior",
+      "parent_path": "Reading & interaction / Search & filters / Content filters"
+    },
+    {
+      "child_path": "Reading & interaction / Search & filters / Content filters / Muted content",
+      "child_title": "Muted content",
+      "parent_path": "Reading & interaction / Search & filters / Content filters"
+    },
+    {
+      "child_path": "Reading & interaction / Search & filters / Content filters / Post matching",
+      "child_title": "Post matching",
+      "parent_path": "Reading & interaction / Search & filters / Content filters"
+    },
+    {
+      "child_path": "Reading & interaction / Search & filters / Search",
+      "child_title": "Search",
+      "parent_path": "Reading & interaction / Search & filters"
+    },
+    {
+      "child_path": "Reading & interaction / Search & filters / Search / Advanced search",
+      "child_title": "Advanced search",
+      "parent_path": "Reading & interaction / Search & filters / Search"
+    },
+    {
+      "child_path": "Reading & interaction / Search & filters / Search / Search behavior",
+      "child_title": "Search behavior",
+      "parent_path": "Reading & interaction / Search & filters / Search"
+    },
+    {
+      "child_path": "Reading & interaction / Search & filters / Search / Suggestions",
+      "child_title": "Suggestions",
+      "parent_path": "Reading & interaction / Search & filters / Search"
+    }
+  ],
+  "issue": 121,
+  "items": [
+    {
+      "default_value": "",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "OMIT_OR_ONE_LINE_ACTION_HINT",
+      "key": "buy_pro",
+      "leaf_section": "About Boost",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": null,
+          "key": "buy_pro",
+          "logical_kind": "action",
+          "resource": "pref_headers_v2",
+          "root_referenced": false
+        }
+      ],
+      "logical_kind": "action",
+      "page": "About & support",
+      "page_intro": "View app information, legal information, and support actions.",
+      "proposed_summary": "",
+      "root": "Data & app",
+      "screen_depth": 2,
+      "screen_path": [
+        "Data & app",
+        "About & support",
+        "About Boost"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "none_or_custom",
+      "subscreen": "About Boost",
+      "title": "Boost PRO",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "center",
+      "dependency": "pref_show_subreddit_header",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE",
+      "key": "pref_toolbar_header_type",
+      "leaf_section": "Community header",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": null,
+          "key": "pref_toolbar_header_type",
+          "logical_kind": "stored_setting",
+          "resource": "pref_toolbar_v2",
+          "root_referenced": false
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Community header",
+      "page_intro": "Control the title, description, and header shown for communities.",
+      "proposed_summary": "",
+      "root": "Appearance",
+      "screen_depth": 2,
+      "screen_path": [
+        "Appearance",
+        "Community header",
+        "Community header"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "string",
+      "subscreen": "Community header",
+      "title": "Community info alignment",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "",
+      "dependency": "",
+      "existing_summary": "Support Boost",
+      "help_treatment": "REVIEW_EXISTING_SUMMARY",
+      "key": "remove_ads",
+      "leaf_section": "About Boost",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": null,
+          "key": "remove_ads",
+          "logical_kind": "action",
+          "resource": "pref_headers_v2",
+          "root_referenced": false
+        }
+      ],
+      "logical_kind": "action",
+      "page": "About & support",
+      "page_intro": "View app information, legal information, and support actions.",
+      "proposed_summary": "Support Boost",
+      "root": "Data & app",
+      "screen_depth": 2,
+      "screen_path": [
+        "Data & app",
+        "About & support",
+        "About Boost"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "none_or_custom",
+      "subscreen": "About Boost",
+      "title": "Remove ads",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "true",
+      "dependency": "pref_show_subreddit_header",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE",
+      "key": "pref_header_show_description",
+      "leaf_section": "Community header",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": null,
+          "key": "pref_header_show_description",
+          "logical_kind": "stored_setting",
+          "resource": "pref_toolbar_v2",
+          "root_referenced": false
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Community header",
+      "page_intro": "Control the title, description, and header shown for communities.",
+      "proposed_summary": "",
+      "root": "Appearance",
+      "screen_depth": 2,
+      "screen_path": [
+        "Appearance",
+        "Community header",
+        "Community header"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Community header",
+      "title": "Show community description",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "false",
+      "dependency": "",
+      "existing_summary": "Show banner and icon in communities",
+      "help_treatment": "REVIEW_EXISTING_SUMMARY",
+      "key": "pref_show_subreddit_header",
+      "leaf_section": "Community header",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": null,
+          "key": "pref_show_subreddit_header",
+          "logical_kind": "stored_setting",
+          "resource": "pref_toolbar_v2",
+          "root_referenced": false
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Community header",
+      "page_intro": "Control the title, description, and header shown for communities.",
+      "proposed_summary": "Show banner and icon in communities",
+      "root": "Appearance",
+      "screen_depth": 2,
+      "screen_path": [
+        "Appearance",
+        "Community header",
+        "Community header"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Community header",
+      "title": "Show community header",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "true",
+      "dependency": "",
+      "existing_summary": "Ask Android to use a high refresh rate for Boost windows on adaptive-refresh displays.",
+      "help_treatment": "REVIEW_EXISTING_SUMMARY+PROGRESSIVE_DISCLOSURE",
+      "key": "morphe_boost_prefer_high_refresh_rate",
+      "leaf_section": "Display performance",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Display & performance",
+          "key": "morphe_boost_prefer_high_refresh_rate",
+          "logical_kind": "morphe_user_setting",
+          "resource": "morphe_boost_settings_skeleton",
+          "root_referenced": false
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Display & motion",
+      "page_intro": "Adjust display behavior, animation, and refresh-rate preferences.",
+      "proposed_summary": "Ask Android to use a high refresh rate for Boost windows on adaptive-refresh displays.",
+      "root": "Appearance",
+      "screen_depth": 2,
+      "screen_path": [
+        "Appearance",
+        "Display & motion",
+        "Display performance"
+      ],
+      "source_type": "morphe_embedded_xml",
+      "storage_type": "boolean",
+      "subscreen": "Display performance",
+      "title": "Prefer high refresh rate",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "true",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE",
+      "key": "pref_cards_gallery_carousel",
+      "leaf_section": "Cards",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Cards",
+          "key": "pref_cards_gallery_carousel",
+          "logical_kind": "stored_setting",
+          "resource": "pref_views_v2",
+          "root_referenced": false
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Post layout",
+      "page_intro": "Control how posts and feed cards are arranged.",
+      "proposed_summary": "",
+      "root": "Appearance",
+      "screen_depth": 2,
+      "screen_path": [
+        "Appearance",
+        "Post layout",
+        "Cards"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Cards",
+      "title": "Carousel for multiple images",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "true",
+      "dependency": "",
+      "existing_summary": "Remove horizontal margins",
+      "help_treatment": "REVIEW_EXISTING_SUMMARY",
+      "key": "pref_cards_full",
+      "leaf_section": "Cards",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Cards",
+          "key": "pref_cards_full",
+          "logical_kind": "stored_setting",
+          "resource": "pref_views_v2",
+          "root_referenced": false
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Post layout",
+      "page_intro": "Control how posts and feed cards are arranged.",
+      "proposed_summary": "Remove horizontal margins",
+      "root": "Appearance",
+      "screen_depth": 2,
+      "screen_path": [
+        "Appearance",
+        "Post layout",
+        "Cards"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Cards",
+      "title": "Fill the screen width",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "false",
+      "dependency": "",
+      "existing_summary": "Disable for fixed height images",
+      "help_treatment": "REVIEW_EXISTING_SUMMARY",
+      "key": "pref_cards_full_preview",
+      "leaf_section": "Cards",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Cards",
+          "key": "pref_cards_full_preview",
+          "logical_kind": "stored_setting",
+          "resource": "pref_views_v2",
+          "root_referenced": false
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Post layout",
+      "page_intro": "Control how posts and feed cards are arranged.",
+      "proposed_summary": "Disable for fixed height images",
+      "root": "Appearance",
+      "screen_depth": 2,
+      "screen_path": [
+        "Appearance",
+        "Post layout",
+        "Cards"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Cards",
+      "title": "Full height images",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "5",
+      "dependency": "pref_cards_preview_self",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE",
+      "key": "pref_cards_preview_self_lines",
+      "leaf_section": "Cards",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Cards",
+          "key": "pref_cards_preview_self_lines",
+          "logical_kind": "stored_setting",
+          "resource": "pref_views_v2",
+          "root_referenced": false
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Post layout",
+      "page_intro": "Control how posts and feed cards are arranged.",
+      "proposed_summary": "",
+      "root": "Appearance",
+      "screen_depth": 2,
+      "screen_path": [
+        "Appearance",
+        "Post layout",
+        "Cards"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "integer",
+      "subscreen": "Cards",
+      "title": "Lines to preview",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "true",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE",
+      "key": "pref_cards_preview_self",
+      "leaf_section": "Cards",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Cards",
+          "key": "pref_cards_preview_self",
+          "logical_kind": "stored_setting",
+          "resource": "pref_views_v2",
+          "root_referenced": false
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Post layout",
+      "page_intro": "Control how posts and feed cards are arranged.",
+      "proposed_summary": "",
+      "root": "Appearance",
+      "screen_depth": 2,
+      "screen_path": [
+        "Appearance",
+        "Post layout",
+        "Cards"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Cards",
+      "title": "Preview text from posts",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "false",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE",
+      "key": "pref_cards_rounded_corners",
+      "leaf_section": "Cards",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Cards",
+          "key": "pref_cards_rounded_corners",
+          "logical_kind": "stored_setting",
+          "resource": "pref_views_v2",
+          "root_referenced": false
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Post layout",
+      "page_intro": "Control how posts and feed cards are arranged.",
+      "proposed_summary": "",
+      "root": "Appearance",
+      "screen_depth": 2,
+      "screen_path": [
+        "Appearance",
+        "Post layout",
+        "Cards"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Cards",
+      "title": "Rounded corners",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "true",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE",
+      "key": "pref_cards_subreddit_icon",
+      "leaf_section": "Cards",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Cards",
+          "key": "pref_cards_subreddit_icon",
+          "logical_kind": "stored_setting",
+          "resource": "pref_views_v2",
+          "root_referenced": false
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Post layout",
+      "page_intro": "Control how posts and feed cards are arranged.",
+      "proposed_summary": "",
+      "root": "Appearance",
+      "screen_depth": 2,
+      "screen_path": [
+        "Appearance",
+        "Post layout",
+        "Cards"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Cards",
+      "title": "Show community icon",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "true",
+      "dependency": "",
+      "existing_summary": "Disable to use large image previews",
+      "help_treatment": "REVIEW_EXISTING_SUMMARY",
+      "key": "pref_cards_links_as_thumbnails",
+      "leaf_section": "Cards",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Cards",
+          "key": "pref_cards_links_as_thumbnails",
+          "logical_kind": "stored_setting",
+          "resource": "pref_views_v2",
+          "root_referenced": false
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Post layout",
+      "page_intro": "Control how posts and feed cards are arranged.",
+      "proposed_summary": "Disable to use large image previews",
+      "root": "Appearance",
+      "screen_depth": 2,
+      "screen_path": [
+        "Appearance",
+        "Post layout",
+        "Cards"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Cards",
+      "title": "Show thumbnails for link posts",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "false",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE",
+      "key": "pref_dense_buttons_visible",
+      "leaf_section": "Dense",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Dense",
+          "key": "pref_dense_buttons_visible",
+          "logical_kind": "stored_setting",
+          "resource": "pref_views_v2",
+          "root_referenced": false
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Post layout",
+      "page_intro": "Control how posts and feed cards are arranged.",
+      "proposed_summary": "",
+      "root": "Appearance",
+      "screen_depth": 3,
+      "screen_path": [
+        "Appearance",
+        "Post layout",
+        "Compact layouts",
+        "Dense"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Dense",
+      "title": "Buttons always visible",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "false",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE",
+      "key": "pref_mini_cards_buttons_visible",
+      "leaf_section": "Small cards",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Small cards",
+          "key": "pref_mini_cards_buttons_visible",
+          "logical_kind": "stored_setting",
+          "resource": "pref_views_v2",
+          "root_referenced": false
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Post layout",
+      "page_intro": "Control how posts and feed cards are arranged.",
+      "proposed_summary": "",
+      "root": "Appearance",
+      "screen_depth": 3,
+      "screen_path": [
+        "Appearance",
+        "Post layout",
+        "Compact layouts",
+        "Small cards"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Small cards",
+      "title": "Buttons always visible",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "false",
+      "dependency": "",
+      "existing_summary": "Remove horizontal margins",
+      "help_treatment": "REVIEW_EXISTING_SUMMARY",
+      "key": "pref_mini_cards_full",
+      "leaf_section": "Small cards",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Small cards",
+          "key": "pref_mini_cards_full",
+          "logical_kind": "stored_setting",
+          "resource": "pref_views_v2",
+          "root_referenced": false
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Post layout",
+      "page_intro": "Control how posts and feed cards are arranged.",
+      "proposed_summary": "Remove horizontal margins",
+      "root": "Appearance",
+      "screen_depth": 3,
+      "screen_path": [
+        "Appearance",
+        "Post layout",
+        "Compact layouts",
+        "Small cards"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Small cards",
+      "title": "Fill the screen width",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "true",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE",
+      "key": "pref_mini_cards_rounded_corners",
+      "leaf_section": "Small cards",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Small cards",
+          "key": "pref_mini_cards_rounded_corners",
+          "logical_kind": "stored_setting",
+          "resource": "pref_views_v2",
+          "root_referenced": false
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Post layout",
+      "page_intro": "Control how posts and feed cards are arranged.",
+      "proposed_summary": "",
+      "root": "Appearance",
+      "screen_depth": 3,
+      "screen_path": [
+        "Appearance",
+        "Post layout",
+        "Compact layouts",
+        "Small cards"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Small cards",
+      "title": "Rounded corners",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "true",
+      "dependency": "",
+      "existing_summary": "Limit title to 2 lines",
+      "help_treatment": "REVIEW_EXISTING_SUMMARY",
+      "key": "pref_mini_cards_truncate_title",
+      "leaf_section": "Small cards",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Small cards",
+          "key": "pref_mini_cards_truncate_title",
+          "logical_kind": "stored_setting",
+          "resource": "pref_views_v2",
+          "root_referenced": false
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Post layout",
+      "page_intro": "Control how posts and feed cards are arranged.",
+      "proposed_summary": "Limit title to 2 lines",
+      "root": "Appearance",
+      "screen_depth": 3,
+      "screen_path": [
+        "Appearance",
+        "Post layout",
+        "Compact layouts",
+        "Small cards"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Small cards",
+      "title": "Truncate title",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "false",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE",
+      "key": "pref_show_subreddit_prefix",
+      "leaf_section": "Post layout",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": null,
+          "key": "pref_show_subreddit_prefix",
+          "logical_kind": "stored_setting",
+          "resource": "pref_views_v2",
+          "root_referenced": false
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Post layout",
+      "page_intro": "Control how posts and feed cards are arranged.",
+      "proposed_summary": "",
+      "root": "Appearance",
+      "screen_depth": 3,
+      "screen_path": [
+        "Appearance",
+        "Post layout",
+        "Layout & saved views",
+        "Post layout"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Post layout",
+      "title": "Communities start with r/",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "0",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE",
+      "key": "pref_view",
+      "leaf_section": "Post layout",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": null,
+          "key": "pref_view",
+          "logical_kind": "stored_setting",
+          "resource": "pref_views_v2",
+          "root_referenced": false
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Post layout",
+      "page_intro": "Control how posts and feed cards are arranged.",
+      "proposed_summary": "",
+      "root": "Appearance",
+      "screen_depth": 3,
+      "screen_path": [
+        "Appearance",
+        "Post layout",
+        "Layout & saved views",
+        "Post layout"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "string",
+      "subscreen": "Post layout",
+      "title": "Default view",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "",
+      "dependency": "pref_view_per_subscription",
+      "existing_summary": "",
+      "help_treatment": "OMIT_OR_ONE_LINE_ACTION_HINT",
+      "key": "pref_view_per_sub",
+      "leaf_section": "Post layout",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": null,
+          "key": "pref_view_per_sub",
+          "logical_kind": "action",
+          "resource": "pref_views_v2",
+          "root_referenced": false
+        }
+      ],
+      "logical_kind": "action",
+      "page": "Post layout",
+      "page_intro": "Control how posts and feed cards are arranged.",
+      "proposed_summary": "",
+      "root": "Appearance",
+      "screen_depth": 3,
+      "screen_path": [
+        "Appearance",
+        "Post layout",
+        "Layout & saved views",
+        "Post layout"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "none_or_custom",
+      "subscreen": "Post layout",
+      "title": "Manage saved views",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "false",
+      "dependency": "",
+      "existing_summary": "Each community will remember the last view you selected for that community",
+      "help_treatment": "REVIEW_EXISTING_SUMMARY",
+      "key": "pref_view_per_subscription",
+      "leaf_section": "Post layout",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": null,
+          "key": "pref_view_per_subscription",
+          "logical_kind": "stored_setting",
+          "resource": "pref_views_v2",
+          "root_referenced": false
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Post layout",
+      "page_intro": "Control how posts and feed cards are arranged.",
+      "proposed_summary": "Each community will remember the last view you selected for that community",
+      "root": "Appearance",
+      "screen_depth": 3,
+      "screen_path": [
+        "Appearance",
+        "Post layout",
+        "Layout & saved views",
+        "Post layout"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Post layout",
+      "title": "Remember per community",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "false",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE",
+      "key": "pref_left_handed",
+      "leaf_section": "Post layout",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": null,
+          "key": "pref_left_handed",
+          "logical_kind": "stored_setting",
+          "resource": "pref_views_v2",
+          "root_referenced": false
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Post layout",
+      "page_intro": "Control how posts and feed cards are arranged.",
+      "proposed_summary": "",
+      "root": "Appearance",
+      "screen_depth": 3,
+      "screen_path": [
+        "Appearance",
+        "Post layout",
+        "Layout & saved views",
+        "Post layout"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Post layout",
+      "title": "Thumbnails on left",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "",
+      "dependency": "pref_view_per_subscription",
+      "existing_summary": "Choose a community or custom feed and its view.",
+      "help_treatment": "DIRECT_CONTROL_SUMMARY",
+      "key": "action:saved_views:add",
+      "leaf_section": "Saved community views",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Community views",
+          "logical_kind": "direct_action",
+          "resource": "MorpheSettingsV4SavedViewsFragment",
+          "root_referenced": false
+        }
+      ],
+      "logical_kind": "action",
+      "page": "Post layout",
+      "page_intro": "Control how posts and feed cards are arranged.",
+      "proposed_summary": "Choose a community or custom feed and its view.",
+      "root": "Appearance",
+      "screen_depth": 3,
+      "screen_path": [
+        "Appearance",
+        "Post layout",
+        "Layout & saved views",
+        "Saved community views"
+      ],
+      "source_type": "morphe_direct_ui",
+      "storage_type": "private_preferences",
+      "subscreen": "Saved community views",
+      "title": "Add saved view",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "",
+      "dependency": "saved_views_not_empty",
+      "existing_summary": "Remove the saved view for every community.",
+      "help_treatment": "DIRECT_CONTROL_SUMMARY+CONFIRMATION_REQUIRED",
+      "key": "action:saved_views:clear_all",
+      "leaf_section": "Saved community views",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Community views",
+          "logical_kind": "direct_action",
+          "resource": "MorpheSettingsV4SavedViewsFragment",
+          "root_referenced": false
+        }
+      ],
+      "logical_kind": "destructive_action",
+      "page": "Post layout",
+      "page_intro": "Control how posts and feed cards are arranged.",
+      "proposed_summary": "Remove the saved view for every community.",
+      "root": "Appearance",
+      "screen_depth": 3,
+      "screen_path": [
+        "Appearance",
+        "Post layout",
+        "Layout & saved views",
+        "Saved community views"
+      ],
+      "source_type": "morphe_direct_ui",
+      "storage_type": "private_preferences",
+      "subscreen": "Saved community views",
+      "title": "Clear all saved views",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "false",
+      "dependency": "",
+      "existing_summary": "Disables opening the sidebar with a swipe",
+      "help_treatment": "REVIEW_EXISTING_SUMMARY",
+      "key": "pref_lock_sidebar",
+      "leaf_section": "Drawer behavior",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Swipe",
+          "key": "pref_lock_sidebar",
+          "logical_kind": "stored_setting",
+          "resource": "pref_views_v2",
+          "root_referenced": false
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Navigation & gestures",
+      "page_intro": "Choose how you move around Boost and which shortcuts are available.",
+      "proposed_summary": "Disables opening the sidebar with a swipe",
+      "root": "Navigation",
+      "screen_depth": 2,
+      "screen_path": [
+        "Navigation",
+        "Navigation drawer",
+        "Drawer behavior"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Drawer behavior",
+      "title": "Lock sidebar",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "false",
+      "dependency": "",
+      "existing_summary": "Automatically load text preview for external links",
+      "help_treatment": "REVIEW_EXISTING_SUMMARY",
+      "key": "pref_load_readability",
+      "leaf_section": "Link handling",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Swipe",
+          "key": "pref_load_readability",
+          "logical_kind": "stored_setting",
+          "resource": "pref_views_v2",
+          "root_referenced": false
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Links & browser",
+      "page_intro": "Choose how links open and which browser behavior Boost uses.",
+      "proposed_summary": "Automatically load text preview for external links",
+      "root": "Media",
+      "screen_depth": 2,
+      "screen_path": [
+        "Media",
+        "Links & browser",
+        "Link handling"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Link handling",
+      "title": "Preview external links",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "true",
+      "dependency": "",
+      "existing_summary": "Show posts and comments in landscape",
+      "help_treatment": "REVIEW_EXISTING_SUMMARY",
+      "key": "pref_split_screen",
+      "leaf_section": "Tablet layout",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Navigation",
+          "key": "pref_split_screen",
+          "logical_kind": "stored_setting",
+          "resource": "pref_general_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Post layout",
+      "page_intro": "Control how posts and feed cards are arranged.",
+      "proposed_summary": "Show posts and comments in landscape",
+      "root": "Appearance",
+      "screen_depth": 2,
+      "screen_path": [
+        "Appearance",
+        "Post layout",
+        "Tablet layout"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Tablet layout",
+      "title": "Tablet split screen mode",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "false",
+      "dependency": "",
+      "existing_summary": "Same color as toolbar",
+      "help_treatment": "REVIEW_EXISTING_SUMMARY",
+      "key": "pref_colored_nav_bar",
+      "leaf_section": "Advanced appearance",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": null,
+          "key": "pref_colored_nav_bar",
+          "logical_kind": "stored_setting",
+          "resource": "pref_appearance_advanced_v2",
+          "root_referenced": false
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Theme & colors",
+      "page_intro": "Choose the app theme, color behavior, and night-mode presentation.",
+      "proposed_summary": "Same color as toolbar",
+      "root": "Appearance",
+      "screen_depth": 2,
+      "screen_path": [
+        "Appearance",
+        "Theme & colors",
+        "Advanced appearance"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Advanced appearance",
+      "title": "Colored navigation bar",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "true",
+      "dependency": "",
+      "existing_summary": "Same color as toolbar",
+      "help_treatment": "REVIEW_EXISTING_SUMMARY",
+      "key": "pref_colored_status_bar",
+      "leaf_section": "Advanced appearance",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": null,
+          "key": "pref_colored_status_bar",
+          "logical_kind": "stored_setting",
+          "resource": "pref_appearance_advanced_v2",
+          "root_referenced": false
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Theme & colors",
+      "page_intro": "Choose the app theme, color behavior, and night-mode presentation.",
+      "proposed_summary": "Same color as toolbar",
+      "root": "Appearance",
+      "screen_depth": 2,
+      "screen_path": [
+        "Appearance",
+        "Theme & colors",
+        "Advanced appearance"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Advanced appearance",
+      "title": "Colored status bar",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "OMIT_OR_ONE_LINE_ACTION_HINT",
+      "key": "pref_app_icon",
+      "leaf_section": "Personalization",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": null,
+          "key": "pref_app_icon",
+          "logical_kind": "action",
+          "resource": "pref_appearance_v2",
+          "root_referenced": false
+        }
+      ],
+      "logical_kind": "action",
+      "page": "Theme & colors",
+      "page_intro": "Choose the app theme, color behavior, and night-mode presentation.",
+      "proposed_summary": "",
+      "root": "Appearance",
+      "screen_depth": 2,
+      "screen_path": [
+        "Appearance",
+        "Theme & colors",
+        "Personalization"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "none_or_custom",
+      "subscreen": "Personalization",
+      "title": "App icon",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "0",
+      "dependency": "pref_dynamic_colors",
+      "existing_summary": "",
+      "help_treatment": "OMIT_OR_ONE_LINE_ACTION_HINT",
+      "key": "pref_theme",
+      "leaf_section": "Theme",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": null,
+          "key": "pref_theme",
+          "logical_kind": "action",
+          "resource": "pref_appearance_v2",
+          "root_referenced": false
+        }
+      ],
+      "logical_kind": "action",
+      "page": "Theme & colors",
+      "page_intro": "Choose the app theme, color behavior, and night-mode presentation.",
+      "proposed_summary": "",
+      "root": "Appearance",
+      "screen_depth": 2,
+      "screen_path": [
+        "Appearance",
+        "Theme & colors",
+        "Theme"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "none_or_custom",
+      "subscreen": "Theme",
+      "title": "Customize colors",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "1140",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE",
+      "key": "pref_theme_night_start_minutes",
+      "leaf_section": "Theme",
+      "legacy_route_count": 2,
+      "legacy_routes": [
+        {
+          "category": null,
+          "key": "pref_theme_night_start_minutes",
+          "logical_kind": "special_preference",
+          "resource": "pref_appearance_v2",
+          "root_referenced": false
+        },
+        {
+          "category": null,
+          "key": "pref_theme_night_start_minutes",
+          "logical_kind": "special_preference",
+          "resource": "pref_night_mode_v2",
+          "root_referenced": false
+        }
+      ],
+      "logical_kind": "special_preference",
+      "page": "Theme & colors",
+      "page_intro": "Choose the app theme, color behavior, and night-mode presentation.",
+      "proposed_summary": "",
+      "root": "Appearance",
+      "screen_depth": 2,
+      "screen_path": [
+        "Appearance",
+        "Theme & colors",
+        "Theme"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "none_or_custom",
+      "subscreen": "Theme",
+      "title": "Dark start time",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "8",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE",
+      "key": "pref_theme_night",
+      "leaf_section": "Theme",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": null,
+          "key": "pref_theme_night",
+          "logical_kind": "special_preference",
+          "resource": "pref_appearance_v2",
+          "root_referenced": false
+        }
+      ],
+      "logical_kind": "special_preference",
+      "page": "Theme & colors",
+      "page_intro": "Choose the app theme, color behavior, and night-mode presentation.",
+      "proposed_summary": "",
+      "root": "Appearance",
+      "screen_depth": 2,
+      "screen_path": [
+        "Appearance",
+        "Theme & colors",
+        "Theme"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "none_or_custom",
+      "subscreen": "Theme",
+      "title": "Dark theme",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "false",
+      "dependency": "",
+      "existing_summary": "Apply color palette from your system",
+      "help_treatment": "REVIEW_EXISTING_SUMMARY",
+      "key": "pref_dynamic_colors",
+      "leaf_section": "Theme",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": null,
+          "key": "pref_dynamic_colors",
+          "logical_kind": "stored_setting",
+          "resource": "pref_appearance_v2",
+          "root_referenced": false
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Theme & colors",
+      "page_intro": "Choose the app theme, color behavior, and night-mode presentation.",
+      "proposed_summary": "Apply color palette from your system",
+      "root": "Appearance",
+      "screen_depth": 2,
+      "screen_path": [
+        "Appearance",
+        "Theme & colors",
+        "Theme"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Theme",
+      "title": "Dynamic color",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "420",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE",
+      "key": "pref_theme_night_end_minutes",
+      "leaf_section": "Theme",
+      "legacy_route_count": 2,
+      "legacy_routes": [
+        {
+          "category": null,
+          "key": "pref_theme_night_end_minutes",
+          "logical_kind": "special_preference",
+          "resource": "pref_appearance_v2",
+          "root_referenced": false
+        },
+        {
+          "category": null,
+          "key": "pref_theme_night_end_minutes",
+          "logical_kind": "special_preference",
+          "resource": "pref_night_mode_v2",
+          "root_referenced": false
+        }
+      ],
+      "logical_kind": "special_preference",
+      "page": "Theme & colors",
+      "page_intro": "Choose the app theme, color behavior, and night-mode presentation.",
+      "proposed_summary": "",
+      "root": "Appearance",
+      "screen_depth": 2,
+      "screen_path": [
+        "Appearance",
+        "Theme & colors",
+        "Theme"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "none_or_custom",
+      "subscreen": "Theme",
+      "title": "Light start time",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "system",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE",
+      "key": "pref_theme_mode_type",
+      "leaf_section": "Theme",
+      "legacy_route_count": 2,
+      "legacy_routes": [
+        {
+          "category": null,
+          "key": "pref_theme_mode_type",
+          "logical_kind": "stored_setting",
+          "resource": "pref_appearance_v2",
+          "root_referenced": false
+        },
+        {
+          "category": null,
+          "key": "pref_theme_mode_type",
+          "logical_kind": "stored_setting",
+          "resource": "pref_night_mode_v2",
+          "root_referenced": false
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Theme & colors",
+      "page_intro": "Choose the app theme, color behavior, and night-mode presentation.",
+      "proposed_summary": "",
+      "root": "Appearance",
+      "screen_depth": 2,
+      "screen_path": [
+        "Appearance",
+        "Theme & colors",
+        "Theme"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "string",
+      "subscreen": "Theme",
+      "title": "Theme",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE",
+      "key": "pref_comments_font",
+      "leaf_section": "Comments",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Comments",
+          "key": "pref_comments_font",
+          "logical_kind": "special_preference",
+          "resource": "pref_fonts_v2",
+          "root_referenced": false
+        }
+      ],
+      "logical_kind": "special_preference",
+      "page": "Typography",
+      "page_intro": "Adjust text size and font presentation throughout Boost.",
+      "proposed_summary": "",
+      "root": "Appearance",
+      "screen_depth": 2,
+      "screen_path": [
+        "Appearance",
+        "Typography",
+        "Comments"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "none_or_custom",
+      "subscreen": "Comments",
+      "title": "Comments font",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "Medium",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE",
+      "key": "pref_font_size",
+      "leaf_section": "Comments",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Comments",
+          "key": "pref_font_size",
+          "logical_kind": "stored_setting",
+          "resource": "pref_fonts_v2",
+          "root_referenced": false
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Typography",
+      "page_intro": "Adjust text size and font presentation throughout Boost.",
+      "proposed_summary": "",
+      "root": "Appearance",
+      "screen_depth": 2,
+      "screen_path": [
+        "Appearance",
+        "Typography",
+        "Comments"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "string",
+      "subscreen": "Comments",
+      "title": "Comments text size",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE",
+      "key": "pref_title_font",
+      "leaf_section": "Posts",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Posts",
+          "key": "pref_title_font",
+          "logical_kind": "special_preference",
+          "resource": "pref_fonts_v2",
+          "root_referenced": false
+        }
+      ],
+      "logical_kind": "special_preference",
+      "page": "Typography",
+      "page_intro": "Adjust text size and font presentation throughout Boost.",
+      "proposed_summary": "",
+      "root": "Appearance",
+      "screen_depth": 2,
+      "screen_path": [
+        "Appearance",
+        "Typography",
+        "Posts"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "none_or_custom",
+      "subscreen": "Posts",
+      "title": "Title font",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "Medium",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE",
+      "key": "pref_font_size_title",
+      "leaf_section": "Posts",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Posts",
+          "key": "pref_font_size_title",
+          "logical_kind": "stored_setting",
+          "resource": "pref_fonts_v2",
+          "root_referenced": false
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Typography",
+      "page_intro": "Adjust text size and font presentation throughout Boost.",
+      "proposed_summary": "",
+      "root": "Appearance",
+      "screen_depth": 2,
+      "screen_path": [
+        "Appearance",
+        "Typography",
+        "Posts"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "string",
+      "subscreen": "Posts",
+      "title": "Title text size",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "",
+      "dependency": "",
+      "existing_summary": "Reset post and comment fonts to their default values.",
+      "help_treatment": "DIRECT_CONTROL_SUMMARY",
+      "key": "action:typography:restore_defaults",
+      "leaf_section": "Reset",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Reset",
+          "logical_kind": "direct_action",
+          "resource": "MorpheSettingsV4FontsFragment",
+          "root_referenced": false
+        }
+      ],
+      "logical_kind": "destructive_action",
+      "page": "Typography",
+      "page_intro": "Adjust text size and font presentation throughout Boost.",
+      "proposed_summary": "Reset post and comment fonts to their default values.",
+      "root": "Appearance",
+      "screen_depth": 2,
+      "screen_path": [
+        "Appearance",
+        "Typography",
+        "Reset"
+      ],
+      "source_type": "morphe_direct_ui",
+      "storage_type": "none",
+      "subscreen": "Reset",
+      "title": "Restore font defaults",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "false",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE",
+      "key": "pref_comments_buttons",
+      "leaf_section": "Comment actions",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Appearance",
+          "key": "pref_comments_buttons",
+          "logical_kind": "stored_setting",
+          "resource": "pref_comments_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Comments",
+      "page_intro": "Control comment display, actions, navigation, and thread behavior.",
+      "proposed_summary": "",
+      "root": "Reading & interaction",
+      "screen_depth": 2,
+      "screen_path": [
+        "Reading & interaction",
+        "Comments",
+        "Comment actions"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Comment actions",
+      "title": "Buttons always visible",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "35",
+      "dependency": "pref_swipe_back",
+      "existing_summary": "Dragging distance from edge as percentage of screen width to close and go back",
+      "help_treatment": "REVIEW_EXISTING_SUMMARY",
+      "key": "pref_swipe_threshold_percentage",
+      "leaf_section": "Comment actions",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Gestures",
+          "key": "pref_swipe_threshold_percentage",
+          "logical_kind": "stored_setting",
+          "resource": "pref_comments_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Comments",
+      "page_intro": "Control comment display, actions, navigation, and thread behavior.",
+      "proposed_summary": "Dragging distance from edge as percentage of screen width to close and go back",
+      "root": "Reading & interaction",
+      "screen_depth": 2,
+      "screen_path": [
+        "Reading & interaction",
+        "Comments",
+        "Comment actions"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "integer",
+      "subscreen": "Comment actions",
+      "title": "Distance threshold",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "false",
+      "dependency": "pref_comments_buttons",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE",
+      "key": "pref_comments_buttons_collapse_after_action",
+      "leaf_section": "Comment actions",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Appearance",
+          "key": "pref_comments_buttons_collapse_after_action",
+          "logical_kind": "stored_setting",
+          "resource": "pref_comments_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Comments",
+      "page_intro": "Control comment display, actions, navigation, and thread behavior.",
+      "proposed_summary": "",
+      "root": "Reading & interaction",
+      "screen_depth": 2,
+      "screen_path": [
+        "Reading & interaction",
+        "Comments",
+        "Comment actions"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Comment actions",
+      "title": "Hide buttons after voting/saving",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "true",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE",
+      "key": "pref_comments_button_save",
+      "leaf_section": "Comment actions",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Visible buttons",
+          "key": "pref_comments_button_save",
+          "logical_kind": "stored_setting",
+          "resource": "pref_comments_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Comments",
+      "page_intro": "Control comment display, actions, navigation, and thread behavior.",
+      "proposed_summary": "",
+      "root": "Reading & interaction",
+      "screen_depth": 2,
+      "screen_path": [
+        "Reading & interaction",
+        "Comments",
+        "Comment actions"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Comment actions",
+      "title": "Save",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "true",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE",
+      "key": "pref_comments_floating_button",
+      "leaf_section": "Comment actions",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Appearance",
+          "key": "pref_comments_floating_button",
+          "logical_kind": "stored_setting",
+          "resource": "pref_comments_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Comments",
+      "page_intro": "Control comment display, actions, navigation, and thread behavior.",
+      "proposed_summary": "",
+      "root": "Reading & interaction",
+      "screen_depth": 2,
+      "screen_path": [
+        "Reading & interaction",
+        "Comments",
+        "Comment actions"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Comment actions",
+      "title": "Show floating button",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "false",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE",
+      "key": "pref_info_post_upvote_percentage",
+      "leaf_section": "Comment actions",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Appearance",
+          "key": "pref_info_post_upvote_percentage",
+          "logical_kind": "stored_setting",
+          "resource": "pref_comments_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Comments",
+      "page_intro": "Control comment display, actions, navigation, and thread behavior.",
+      "proposed_summary": "",
+      "root": "Reading & interaction",
+      "screen_depth": 2,
+      "screen_path": [
+        "Reading & interaction",
+        "Comments",
+        "Comment actions"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Comment actions",
+      "title": "Show post upvote percentage",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "80",
+      "dependency": "pref_swipe_back",
+      "existing_summary": "Touch sensitivity to start the dragging. Higher means easier.",
+      "help_treatment": "REVIEW_EXISTING_SUMMARY",
+      "key": "pref_swipe_sensitivity_percentage",
+      "leaf_section": "Comment actions",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Gestures",
+          "key": "pref_swipe_sensitivity_percentage",
+          "logical_kind": "stored_setting",
+          "resource": "pref_comments_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Comments",
+      "page_intro": "Control comment display, actions, navigation, and thread behavior.",
+      "proposed_summary": "Touch sensitivity to start the dragging. Higher means easier.",
+      "root": "Reading & interaction",
+      "screen_depth": 2,
+      "screen_path": [
+        "Reading & interaction",
+        "Comments",
+        "Comment actions"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "integer",
+      "subscreen": "Comment actions",
+      "title": "Swipe sensitivity",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "true",
+      "dependency": "",
+      "existing_summary": "Swipe right to go back",
+      "help_treatment": "REVIEW_EXISTING_SUMMARY",
+      "key": "pref_swipe_back",
+      "leaf_section": "Comment actions",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Gestures",
+          "key": "pref_swipe_back",
+          "logical_kind": "stored_setting",
+          "resource": "pref_comments_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Comments",
+      "page_intro": "Control comment display, actions, navigation, and thread behavior.",
+      "proposed_summary": "Swipe right to go back",
+      "root": "Reading & interaction",
+      "screen_depth": 2,
+      "screen_path": [
+        "Reading & interaction",
+        "Comments",
+        "Comment actions"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Comment actions",
+      "title": "Swipe to close",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "1",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE",
+      "key": "pref_comments_button_parent",
+      "leaf_section": "Comment actions",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Visible buttons",
+          "key": "pref_comments_button_parent",
+          "logical_kind": "stored_setting",
+          "resource": "pref_comments_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Comments",
+      "page_intro": "Control comment display, actions, navigation, and thread behavior.",
+      "proposed_summary": "",
+      "root": "Reading & interaction",
+      "screen_depth": 2,
+      "screen_path": [
+        "Reading & interaction",
+        "Comments",
+        "Comment actions"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "string",
+      "subscreen": "Comment actions",
+      "title": "Up button",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "true",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE",
+      "key": "pref_comments_color_pattern",
+      "leaf_section": "Comment appearance",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Appearance",
+          "key": "pref_comments_color_pattern",
+          "logical_kind": "special_preference",
+          "resource": "pref_comments_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "special_preference",
+      "page": "Comments",
+      "page_intro": "Control comment display, actions, navigation, and thread behavior.",
+      "proposed_summary": "",
+      "root": "Reading & interaction",
+      "screen_depth": 2,
+      "screen_path": [
+        "Reading & interaction",
+        "Comments",
+        "Comment appearance"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "none_or_custom",
+      "subscreen": "Comment appearance",
+      "title": "Color pattern",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "true",
+      "dependency": "pref_comments_user_flair",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE",
+      "key": "pref_user_flair_emojis",
+      "leaf_section": "Comment appearance",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Flairs",
+          "key": "pref_user_flair_emojis",
+          "logical_kind": "stored_setting",
+          "resource": "pref_comments_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Comments",
+      "page_intro": "Control comment display, actions, navigation, and thread behavior.",
+      "proposed_summary": "",
+      "root": "Reading & interaction",
+      "screen_depth": 2,
+      "screen_path": [
+        "Reading & interaction",
+        "Comments",
+        "Comment appearance"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Comment appearance",
+      "title": "Show emojis",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "false",
+      "dependency": "pref_comments_user_flair",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE",
+      "key": "pref_user_flair_colors",
+      "leaf_section": "Comment appearance",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Flairs",
+          "key": "pref_user_flair_colors",
+          "logical_kind": "stored_setting",
+          "resource": "pref_comments_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Comments",
+      "page_intro": "Control comment display, actions, navigation, and thread behavior.",
+      "proposed_summary": "",
+      "root": "Reading & interaction",
+      "screen_depth": 2,
+      "screen_path": [
+        "Reading & interaction",
+        "Comments",
+        "Comment appearance"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Comment appearance",
+      "title": "Show flair colors",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "false",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE",
+      "key": "pref_comments_show_avatar",
+      "leaf_section": "Comment appearance",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Appearance",
+          "key": "pref_comments_show_avatar",
+          "logical_kind": "stored_setting",
+          "resource": "pref_comments_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Comments",
+      "page_intro": "Control comment display, actions, navigation, and thread behavior.",
+      "proposed_summary": "",
+      "root": "Reading & interaction",
+      "screen_depth": 2,
+      "screen_path": [
+        "Reading & interaction",
+        "Comments",
+        "Comment appearance"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Comment appearance",
+      "title": "Show user avatar",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "true",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE",
+      "key": "pref_comments_user_flair",
+      "leaf_section": "Comment appearance",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Flairs",
+          "key": "pref_comments_user_flair",
+          "logical_kind": "stored_setting",
+          "resource": "pref_comments_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Comments",
+      "page_intro": "Control comment display, actions, navigation, and thread behavior.",
+      "proposed_summary": "",
+      "root": "Reading & interaction",
+      "screen_depth": 2,
+      "screen_path": [
+        "Reading & interaction",
+        "Comments",
+        "Comment appearance"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Comment appearance",
+      "title": "Show user flair",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "true",
+      "dependency": "pref_show_awards_comments",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE",
+      "key": "pref_clickable_awards_comments",
+      "leaf_section": "Comment behavior",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Awards",
+          "key": "pref_clickable_awards_comments",
+          "logical_kind": "stored_setting",
+          "resource": "pref_comments_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Comments",
+      "page_intro": "Control comment display, actions, navigation, and thread behavior.",
+      "proposed_summary": "",
+      "root": "Reading & interaction",
+      "screen_depth": 2,
+      "screen_path": [
+        "Reading & interaction",
+        "Comments",
+        "Comment behavior"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Comment behavior",
+      "title": "Clickable awards",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "0",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE",
+      "key": "pref_default_comment_sorting",
+      "leaf_section": "Comment behavior",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": null,
+          "key": "pref_default_comment_sorting",
+          "logical_kind": "stored_setting",
+          "resource": "pref_comments_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Comments",
+      "page_intro": "Control comment display, actions, navigation, and thread behavior.",
+      "proposed_summary": "",
+      "root": "Reading & interaction",
+      "screen_depth": 2,
+      "screen_path": [
+        "Reading & interaction",
+        "Comments",
+        "Comment behavior"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "string",
+      "subscreen": "Comment behavior",
+      "title": "Default sort",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "true",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE",
+      "key": "pref_comments_highlight_mine",
+      "leaf_section": "Comment behavior",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Appearance",
+          "key": "pref_comments_highlight_mine",
+          "logical_kind": "stored_setting",
+          "resource": "pref_comments_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Comments",
+      "page_intro": "Control comment display, actions, navigation, and thread behavior.",
+      "proposed_summary": "",
+      "root": "Reading & interaction",
+      "screen_depth": 2,
+      "screen_path": [
+        "Reading & interaction",
+        "Comments",
+        "Comment behavior"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Comment behavior",
+      "title": "Highlight my username",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "1",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE",
+      "key": "pref_comments_image",
+      "leaf_section": "Comment behavior",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Appearance",
+          "key": "pref_comments_image",
+          "logical_kind": "stored_setting",
+          "resource": "pref_comments_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Comments",
+      "page_intro": "Control comment display, actions, navigation, and thread behavior.",
+      "proposed_summary": "",
+      "root": "Reading & interaction",
+      "screen_depth": 2,
+      "screen_path": [
+        "Reading & interaction",
+        "Comments",
+        "Comment behavior"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "string",
+      "subscreen": "Comment behavior",
+      "title": "Post media preview size",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "true",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE",
+      "key": "pref_show_awards_comments",
+      "leaf_section": "Comment behavior",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Awards",
+          "key": "pref_show_awards_comments",
+          "logical_kind": "stored_setting",
+          "resource": "pref_comments_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Comments",
+      "page_intro": "Control comment display, actions, navigation, and thread behavior.",
+      "proposed_summary": "",
+      "root": "Reading & interaction",
+      "screen_depth": 2,
+      "screen_path": [
+        "Reading & interaction",
+        "Comments",
+        "Comment behavior"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Comment behavior",
+      "title": "Show awards",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "true",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE",
+      "key": "pref_comments_clickable_username",
+      "leaf_section": "Comment behavior",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Behavior",
+          "key": "pref_comments_clickable_username",
+          "logical_kind": "stored_setting",
+          "resource": "pref_comments_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Comments",
+      "page_intro": "Control comment display, actions, navigation, and thread behavior.",
+      "proposed_summary": "",
+      "root": "Reading & interaction",
+      "screen_depth": 2,
+      "screen_path": [
+        "Reading & interaction",
+        "Comments",
+        "Comment behavior"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Comment behavior",
+      "title": "Tap username to view profile",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "true",
+      "dependency": "",
+      "existing_summary": "Use comment sort suggested by community or post",
+      "help_treatment": "REVIEW_EXISTING_SUMMARY",
+      "key": "pref_suggested_comment_sorting",
+      "leaf_section": "Comment behavior",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": null,
+          "key": "pref_suggested_comment_sorting",
+          "logical_kind": "stored_setting",
+          "resource": "pref_comments_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Comments",
+      "page_intro": "Control comment display, actions, navigation, and thread behavior.",
+      "proposed_summary": "Use comment sort suggested by community or post",
+      "root": "Reading & interaction",
+      "screen_depth": 2,
+      "screen_path": [
+        "Reading & interaction",
+        "Comments",
+        "Comment behavior"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Comment behavior",
+      "title": "Use suggested sort",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "false",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE",
+      "key": "pref_comments_scroll_animation",
+      "leaf_section": "Thread navigation",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Navigation",
+          "key": "pref_comments_scroll_animation",
+          "logical_kind": "stored_setting",
+          "resource": "pref_comments_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Comments",
+      "page_intro": "Control comment display, actions, navigation, and thread behavior.",
+      "proposed_summary": "",
+      "root": "Reading & interaction",
+      "screen_depth": 2,
+      "screen_path": [
+        "Reading & interaction",
+        "Comments",
+        "Thread navigation"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Thread navigation",
+      "title": "Animate navigation",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "false",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE",
+      "key": "pref_comments_click",
+      "leaf_section": "Thread navigation",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Behavior",
+          "key": "pref_comments_click",
+          "logical_kind": "stored_setting",
+          "resource": "pref_comments_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Comments",
+      "page_intro": "Control comment display, actions, navigation, and thread behavior.",
+      "proposed_summary": "",
+      "root": "Reading & interaction",
+      "screen_depth": 2,
+      "screen_path": [
+        "Reading & interaction",
+        "Comments",
+        "Thread navigation"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Thread navigation",
+      "title": "Click to collapse comment",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "false",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE",
+      "key": "pref_comments_collapse_automoderator",
+      "leaf_section": "Thread navigation",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Appearance",
+          "key": "pref_comments_collapse_automoderator",
+          "logical_kind": "stored_setting",
+          "resource": "pref_comments_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Comments",
+      "page_intro": "Control comment display, actions, navigation, and thread behavior.",
+      "proposed_summary": "",
+      "root": "Reading & interaction",
+      "screen_depth": 2,
+      "screen_path": [
+        "Reading & interaction",
+        "Comments",
+        "Thread navigation"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Thread navigation",
+      "title": "Collapse AutoModerator",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "false",
+      "dependency": "",
+      "existing_summary": "Crowd control, downvoted, deleted\u2026",
+      "help_treatment": "REVIEW_EXISTING_SUMMARY",
+      "key": "pref_comments_collapse_collapsed",
+      "leaf_section": "Thread navigation",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Appearance",
+          "key": "pref_comments_collapse_collapsed",
+          "logical_kind": "stored_setting",
+          "resource": "pref_comments_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Comments",
+      "page_intro": "Control comment display, actions, navigation, and thread behavior.",
+      "proposed_summary": "Crowd control, downvoted, deleted\u2026",
+      "root": "Reading & interaction",
+      "screen_depth": 2,
+      "screen_path": [
+        "Reading & interaction",
+        "Comments",
+        "Thread navigation"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Thread navigation",
+      "title": "Collapse disruptive comments",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "0",
+      "dependency": "pref_comments_highlight_new_comments",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE",
+      "key": "pref_comments_default_navigation",
+      "leaf_section": "Thread navigation",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Navigation",
+          "key": "pref_comments_default_navigation",
+          "logical_kind": "stored_setting",
+          "resource": "pref_comments_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Comments",
+      "page_intro": "Control comment display, actions, navigation, and thread behavior.",
+      "proposed_summary": "",
+      "root": "Reading & interaction",
+      "screen_depth": 2,
+      "screen_path": [
+        "Reading & interaction",
+        "Comments",
+        "Thread navigation"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "string",
+      "subscreen": "Thread navigation",
+      "title": "Default navigation mode",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "true",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE",
+      "key": "pref_comments_animation",
+      "leaf_section": "Thread navigation",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Behavior",
+          "key": "pref_comments_animation",
+          "logical_kind": "stored_setting",
+          "resource": "pref_comments_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Comments",
+      "page_intro": "Control comment display, actions, navigation, and thread behavior.",
+      "proposed_summary": "",
+      "root": "Reading & interaction",
+      "screen_depth": 2,
+      "screen_path": [
+        "Reading & interaction",
+        "Comments",
+        "Thread navigation"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Thread navigation",
+      "title": "Expand/collapse animation",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "false",
+      "dependency": "",
+      "existing_summary": "Show only comment header when collapsed",
+      "help_treatment": "REVIEW_EXISTING_SUMMARY",
+      "key": "pref_comments_full_collapse",
+      "leaf_section": "Thread navigation",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Behavior",
+          "key": "pref_comments_full_collapse",
+          "logical_kind": "stored_setting",
+          "resource": "pref_comments_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Comments",
+      "page_intro": "Control comment display, actions, navigation, and thread behavior.",
+      "proposed_summary": "Show only comment header when collapsed",
+      "root": "Reading & interaction",
+      "screen_depth": 2,
+      "screen_path": [
+        "Reading & interaction",
+        "Comments",
+        "Thread navigation"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Thread navigation",
+      "title": "Hide text of collapsed comments",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "true",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE",
+      "key": "pref_comments_highlight_new_comments",
+      "leaf_section": "Thread navigation",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Navigation",
+          "key": "pref_comments_highlight_new_comments",
+          "logical_kind": "stored_setting",
+          "resource": "pref_comments_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Comments",
+      "page_intro": "Control comment display, actions, navigation, and thread behavior.",
+      "proposed_summary": "",
+      "root": "Reading & interaction",
+      "screen_depth": 2,
+      "screen_path": [
+        "Reading & interaction",
+        "Comments",
+        "Thread navigation"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Thread navigation",
+      "title": "Highlight new comments",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "false",
+      "dependency": "",
+      "existing_summary": "Load top level comments with its replies collapsed",
+      "help_treatment": "REVIEW_EXISTING_SUMMARY",
+      "key": "pref_comments_load_collapsed",
+      "leaf_section": "Thread navigation",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Behavior",
+          "key": "pref_comments_load_collapsed",
+          "logical_kind": "stored_setting",
+          "resource": "pref_comments_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Comments",
+      "page_intro": "Control comment display, actions, navigation, and thread behavior.",
+      "proposed_summary": "Load top level comments with its replies collapsed",
+      "root": "Reading & interaction",
+      "screen_depth": 2,
+      "screen_path": [
+        "Reading & interaction",
+        "Comments",
+        "Thread navigation"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Thread navigation",
+      "title": "Load collapsed by default",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "false",
+      "dependency": "",
+      "existing_summary": "Jump between comments",
+      "help_treatment": "REVIEW_EXISTING_SUMMARY",
+      "key": "pref_comments_navigation_bar",
+      "leaf_section": "Thread navigation",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Appearance",
+          "key": "pref_comments_navigation_bar",
+          "logical_kind": "stored_setting",
+          "resource": "pref_comments_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Comments",
+      "page_intro": "Control comment display, actions, navigation, and thread behavior.",
+      "proposed_summary": "Jump between comments",
+      "root": "Reading & interaction",
+      "screen_depth": 2,
+      "screen_path": [
+        "Reading & interaction",
+        "Comments",
+        "Thread navigation"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Thread navigation",
+      "title": "Show navigation bar",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "0",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE",
+      "key": "pref_indent_style",
+      "leaf_section": "Thread navigation",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Appearance",
+          "key": "pref_indent_style",
+          "logical_kind": "stored_setting",
+          "resource": "pref_comments_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Comments",
+      "page_intro": "Control comment display, actions, navigation, and thread behavior.",
+      "proposed_summary": "",
+      "root": "Reading & interaction",
+      "screen_depth": 2,
+      "screen_path": [
+        "Reading & interaction",
+        "Comments",
+        "Thread navigation"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "string",
+      "subscreen": "Thread navigation",
+      "title": "Thread level indicator",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "false",
+      "dependency": "",
+      "existing_summary": "Use volume keys to go to next and previous comment",
+      "help_treatment": "REVIEW_EXISTING_SUMMARY",
+      "key": "pref_comments_volume_scroll",
+      "leaf_section": "Thread navigation",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Navigation",
+          "key": "pref_comments_volume_scroll",
+          "logical_kind": "stored_setting",
+          "resource": "pref_comments_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Comments",
+      "page_intro": "Control comment display, actions, navigation, and thread behavior.",
+      "proposed_summary": "Use volume keys to go to next and previous comment",
+      "root": "Reading & interaction",
+      "screen_depth": 2,
+      "screen_path": [
+        "Reading & interaction",
+        "Comments",
+        "Thread navigation"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Thread navigation",
+      "title": "Volume key navigation",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "",
+      "dependency": "",
+      "existing_summary": "View or delete drafts saved on reddit",
+      "help_treatment": "REVIEW_EXISTING_SUMMARY",
+      "key": "pref_manage_drafts",
+      "leaf_section": "Drafts",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Composing",
+          "key": "pref_manage_drafts",
+          "logical_kind": "action",
+          "resource": "pref_general_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "action",
+      "page": "Composing & drafts",
+      "page_intro": "Configure editors, draft storage, and uploaded composing media.",
+      "proposed_summary": "View or delete drafts saved on reddit",
+      "root": "Reading & interaction",
+      "screen_depth": 2,
+      "screen_path": [
+        "Reading & interaction",
+        "Composing & drafts",
+        "Drafts"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "none_or_custom",
+      "subscreen": "Drafts",
+      "title": "Post drafts",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "true",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE",
+      "key": "pref_drafts",
+      "leaf_section": "Drafts",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Composing",
+          "key": "pref_drafts",
+          "logical_kind": "stored_setting",
+          "resource": "pref_general_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Composing & drafts",
+      "page_intro": "Configure editors, draft storage, and uploaded composing media.",
+      "proposed_summary": "",
+      "root": "Reading & interaction",
+      "screen_depth": 2,
+      "screen_path": [
+        "Reading & interaction",
+        "Composing & drafts",
+        "Drafts"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Drafts",
+      "title": "Save drafts",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "false",
+      "dependency": "",
+      "existing_summary": "Disable to use quick reply dialog",
+      "help_treatment": "REVIEW_EXISTING_SUMMARY",
+      "key": "pref_use_advanced_editor",
+      "leaf_section": "Editor",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Composing",
+          "key": "pref_use_advanced_editor",
+          "logical_kind": "stored_setting",
+          "resource": "pref_general_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Composing & drafts",
+      "page_intro": "Configure editors, draft storage, and uploaded composing media.",
+      "proposed_summary": "Disable to use quick reply dialog",
+      "root": "Reading & interaction",
+      "screen_depth": 2,
+      "screen_path": [
+        "Reading & interaction",
+        "Composing & drafts",
+        "Editor"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Editor",
+      "title": "Advanced fullscreen editor",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "",
+      "dependency": "",
+      "existing_summary": "\"View or delete images you've uploaded to Imgur\"",
+      "help_treatment": "REVIEW_EXISTING_SUMMARY",
+      "key": "pref_imgur_uploads",
+      "leaf_section": "Uploads",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Composing",
+          "key": "pref_imgur_uploads",
+          "logical_kind": "action",
+          "resource": "pref_general_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "action",
+      "page": "Composing & drafts",
+      "page_intro": "Configure editors, draft storage, and uploaded composing media.",
+      "proposed_summary": "\"View or delete images you've uploaded to Imgur\"",
+      "root": "Reading & interaction",
+      "screen_depth": 2,
+      "screen_path": [
+        "Reading & interaction",
+        "Composing & drafts",
+        "Uploads"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "none_or_custom",
+      "subscreen": "Uploads",
+      "title": "Uploaded images",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "",
+      "dependency": "",
+      "existing_summary": "Manage your communities and custom feeds",
+      "help_treatment": "REVIEW_EXISTING_SUMMARY",
+      "key": "pref_edit_subscriptions",
+      "leaf_section": "Manage subscriptions",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Navigation",
+          "key": "pref_edit_subscriptions",
+          "logical_kind": "action",
+          "resource": "pref_general_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "action",
+      "page": "Feeds & subscriptions",
+      "page_intro": "Manage communities, custom feeds, and subscription-related behavior.",
+      "proposed_summary": "Manage your communities and custom feeds",
+      "root": "Reading & interaction",
+      "screen_depth": 2,
+      "screen_path": [
+        "Reading & interaction",
+        "Feeds & subscriptions",
+        "Manage subscriptions"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "none_or_custom",
+      "subscreen": "Manage subscriptions",
+      "title": "Subscriptions",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "OMIT_OR_ONE_LINE_ACTION_HINT",
+      "key": "pref_default_sort",
+      "leaf_section": "Feed behavior",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": null,
+          "key": "pref_default_sort",
+          "logical_kind": "action",
+          "resource": "pref_posts_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "action",
+      "page": "Posts",
+      "page_intro": "Choose how posts behave while browsing and reading.",
+      "proposed_summary": "",
+      "root": "Reading & interaction",
+      "screen_depth": 2,
+      "screen_path": [
+        "Reading & interaction",
+        "Posts",
+        "Feed behavior"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "none_or_custom",
+      "subscreen": "Feed behavior",
+      "title": "Default sort",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "false",
+      "dependency": "",
+      "existing_summary": "Each community will remember the last sort you selected for that community",
+      "help_treatment": "REVIEW_EXISTING_SUMMARY",
+      "key": "pref_sort_per_subscription",
+      "leaf_section": "Feed behavior",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": null,
+          "key": "pref_sort_per_subscription",
+          "logical_kind": "stored_setting",
+          "resource": "pref_posts_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Posts",
+      "page_intro": "Choose how posts behave while browsing and reading.",
+      "proposed_summary": "Each community will remember the last sort you selected for that community",
+      "root": "Reading & interaction",
+      "screen_depth": 2,
+      "screen_path": [
+        "Reading & interaction",
+        "Posts",
+        "Feed behavior"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Feed behavior",
+      "title": "Remember per community",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "OMIT_OR_ONE_LINE_ACTION_HINT",
+      "key": "pref_frontpage_sort",
+      "leaf_section": "Feed behavior",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": null,
+          "key": "pref_frontpage_sort",
+          "logical_kind": "action",
+          "resource": "pref_posts_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "action",
+      "page": "Posts",
+      "page_intro": "Choose how posts behave while browsing and reading.",
+      "proposed_summary": "",
+      "root": "Reading & interaction",
+      "screen_depth": 2,
+      "screen_path": [
+        "Reading & interaction",
+        "Posts",
+        "Feed behavior"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "none_or_custom",
+      "subscreen": "Feed behavior",
+      "title": "Sort Home posts by",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "true",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE",
+      "key": "pref_post_show_comments_button",
+      "leaf_section": "Post actions",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Visible buttons",
+          "key": "pref_post_show_comments_button",
+          "logical_kind": "stored_setting",
+          "resource": "pref_posts_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Posts",
+      "page_intro": "Choose how posts behave while browsing and reading.",
+      "proposed_summary": "",
+      "root": "Reading & interaction",
+      "screen_depth": 2,
+      "screen_path": [
+        "Reading & interaction",
+        "Posts",
+        "Post actions"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Post actions",
+      "title": "Comments",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "false",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE",
+      "key": "pref_show_hide",
+      "leaf_section": "Post actions",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Visible buttons",
+          "key": "pref_show_hide",
+          "logical_kind": "stored_setting",
+          "resource": "pref_posts_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Posts",
+      "page_intro": "Choose how posts behave while browsing and reading.",
+      "proposed_summary": "",
+      "root": "Reading & interaction",
+      "screen_depth": 2,
+      "screen_path": [
+        "Reading & interaction",
+        "Posts",
+        "Post actions"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Post actions",
+      "title": "Hide",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "",
+      "dependency": "pref_sort_per_subscription",
+      "existing_summary": "",
+      "help_treatment": "OMIT_OR_ONE_LINE_ACTION_HINT",
+      "key": "pref_sort_per_sub",
+      "leaf_section": "Post actions",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": null,
+          "key": "pref_sort_per_sub",
+          "logical_kind": "action",
+          "resource": "pref_posts_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "action",
+      "page": "Posts",
+      "page_intro": "Choose how posts behave while browsing and reading.",
+      "proposed_summary": "",
+      "root": "Reading & interaction",
+      "screen_depth": 2,
+      "screen_path": [
+        "Reading & interaction",
+        "Posts",
+        "Post actions"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "none_or_custom",
+      "subscreen": "Post actions",
+      "title": "Manage saved sorts",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "false",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE",
+      "key": "pref_show_read",
+      "leaf_section": "Post actions",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Visible buttons",
+          "key": "pref_show_read",
+          "logical_kind": "stored_setting",
+          "resource": "pref_posts_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Posts",
+      "page_intro": "Choose how posts behave while browsing and reading.",
+      "proposed_summary": "",
+      "root": "Reading & interaction",
+      "screen_depth": 2,
+      "screen_path": [
+        "Reading & interaction",
+        "Posts",
+        "Post actions"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Post actions",
+      "title": "Mark read",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "true",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE",
+      "key": "pref_post_show_open_button",
+      "leaf_section": "Post actions",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Visible buttons",
+          "key": "pref_post_show_open_button",
+          "logical_kind": "stored_setting",
+          "resource": "pref_posts_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Posts",
+      "page_intro": "Choose how posts behave while browsing and reading.",
+      "proposed_summary": "",
+      "root": "Reading & interaction",
+      "screen_depth": 2,
+      "screen_path": [
+        "Reading & interaction",
+        "Posts",
+        "Post actions"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Post actions",
+      "title": "Open in external app",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "false",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE",
+      "key": "pref_post_show_share_button",
+      "leaf_section": "Post actions",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Visible buttons",
+          "key": "pref_post_show_share_button",
+          "logical_kind": "stored_setting",
+          "resource": "pref_posts_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Posts",
+      "page_intro": "Choose how posts behave while browsing and reading.",
+      "proposed_summary": "",
+      "root": "Reading & interaction",
+      "screen_depth": 2,
+      "screen_path": [
+        "Reading & interaction",
+        "Posts",
+        "Post actions"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Post actions",
+      "title": "Share",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "true",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE",
+      "key": "pref_posts_floating_button",
+      "leaf_section": "Post actions",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Post info",
+          "key": "pref_posts_floating_button",
+          "logical_kind": "stored_setting",
+          "resource": "pref_posts_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Posts",
+      "page_intro": "Choose how posts behave while browsing and reading.",
+      "proposed_summary": "",
+      "root": "Reading & interaction",
+      "screen_depth": 2,
+      "screen_path": [
+        "Reading & interaction",
+        "Posts",
+        "Post actions"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Post actions",
+      "title": "Show floating button",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "false",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE",
+      "key": "pref_upvote_on_save",
+      "leaf_section": "Post actions",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Links",
+          "key": "pref_upvote_on_save",
+          "logical_kind": "stored_setting",
+          "resource": "pref_general_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Posts",
+      "page_intro": "Choose how posts behave while browsing and reading.",
+      "proposed_summary": "",
+      "root": "Reading & interaction",
+      "screen_depth": 2,
+      "screen_path": [
+        "Reading & interaction",
+        "Posts",
+        "Post actions"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Post actions",
+      "title": "Upvote on save",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "true",
+      "dependency": "pref_show_awards_posts",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE",
+      "key": "pref_clickable_awards_posts",
+      "leaf_section": "Post behavior",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Awards",
+          "key": "pref_clickable_awards_posts",
+          "logical_kind": "stored_setting",
+          "resource": "pref_posts_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Posts",
+      "page_intro": "Choose how posts behave while browsing and reading.",
+      "proposed_summary": "",
+      "root": "Reading & interaction",
+      "screen_depth": 2,
+      "screen_path": [
+        "Reading & interaction",
+        "Posts",
+        "Post behavior"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Post behavior",
+      "title": "Clickable awards",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "false",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE",
+      "key": "pref_info_username",
+      "leaf_section": "Post behavior",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Post info",
+          "key": "pref_info_username",
+          "logical_kind": "stored_setting",
+          "resource": "pref_posts_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Posts",
+      "page_intro": "Choose how posts behave while browsing and reading.",
+      "proposed_summary": "",
+      "root": "Reading & interaction",
+      "screen_depth": 2,
+      "screen_path": [
+        "Reading & interaction",
+        "Posts",
+        "Post behavior"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Post behavior",
+      "title": "Show author",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "true",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE",
+      "key": "pref_show_awards_posts",
+      "leaf_section": "Post behavior",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Awards",
+          "key": "pref_show_awards_posts",
+          "logical_kind": "stored_setting",
+          "resource": "pref_posts_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Posts",
+      "page_intro": "Choose how posts behave while browsing and reading.",
+      "proposed_summary": "",
+      "root": "Reading & interaction",
+      "screen_depth": 2,
+      "screen_path": [
+        "Reading & interaction",
+        "Posts",
+        "Post behavior"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Post behavior",
+      "title": "Show awards",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "true",
+      "dependency": "pref_info_post_flair",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE",
+      "key": "pref_flair_emojis",
+      "leaf_section": "Post behavior",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Flairs",
+          "key": "pref_flair_emojis",
+          "logical_kind": "stored_setting",
+          "resource": "pref_posts_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Posts",
+      "page_intro": "Choose how posts behave while browsing and reading.",
+      "proposed_summary": "",
+      "root": "Reading & interaction",
+      "screen_depth": 2,
+      "screen_path": [
+        "Reading & interaction",
+        "Posts",
+        "Post behavior"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Post behavior",
+      "title": "Show emojis",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "true",
+      "dependency": "pref_info_post_flair",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE",
+      "key": "pref_flair_colors",
+      "leaf_section": "Post behavior",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Flairs",
+          "key": "pref_flair_colors",
+          "logical_kind": "stored_setting",
+          "resource": "pref_posts_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Posts",
+      "page_intro": "Choose how posts behave while browsing and reading.",
+      "proposed_summary": "",
+      "root": "Reading & interaction",
+      "screen_depth": 2,
+      "screen_path": [
+        "Reading & interaction",
+        "Posts",
+        "Post behavior"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Post behavior",
+      "title": "Show flair colors",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "true",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE",
+      "key": "pref_info_post_flair",
+      "leaf_section": "Post behavior",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Flairs",
+          "key": "pref_info_post_flair",
+          "logical_kind": "stored_setting",
+          "resource": "pref_posts_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Posts",
+      "page_intro": "Choose how posts behave while browsing and reading.",
+      "proposed_summary": "",
+      "root": "Reading & interaction",
+      "screen_depth": 2,
+      "screen_path": [
+        "Reading & interaction",
+        "Posts",
+        "Post behavior"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Post behavior",
+      "title": "Show post flair",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "true",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE",
+      "key": "pref_post_clickable_subreddit",
+      "leaf_section": "Post behavior",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Post info",
+          "key": "pref_post_clickable_subreddit",
+          "logical_kind": "stored_setting",
+          "resource": "pref_posts_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Posts",
+      "page_intro": "Choose how posts behave while browsing and reading.",
+      "proposed_summary": "",
+      "root": "Reading & interaction",
+      "screen_depth": 2,
+      "screen_path": [
+        "Reading & interaction",
+        "Posts",
+        "Post behavior"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Post behavior",
+      "title": "Tap community to visit",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "false",
+      "dependency": "pref_info_post_flair",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE",
+      "key": "pref_flair_clickable",
+      "leaf_section": "Post behavior",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Flairs",
+          "key": "pref_flair_clickable",
+          "logical_kind": "stored_setting",
+          "resource": "pref_posts_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Posts",
+      "page_intro": "Choose how posts behave while browsing and reading.",
+      "proposed_summary": "",
+      "root": "Reading & interaction",
+      "screen_depth": 2,
+      "screen_path": [
+        "Reading & interaction",
+        "Posts",
+        "Post behavior"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Post behavior",
+      "title": "Tap flair to search",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "true",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE",
+      "key": "pref_post_clickable_username",
+      "leaf_section": "Post behavior",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Post info",
+          "key": "pref_post_clickable_username",
+          "logical_kind": "stored_setting",
+          "resource": "pref_posts_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Posts",
+      "page_intro": "Choose how posts behave while browsing and reading.",
+      "proposed_summary": "",
+      "root": "Reading & interaction",
+      "screen_depth": 2,
+      "screen_path": [
+        "Reading & interaction",
+        "Posts",
+        "Post behavior"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Post behavior",
+      "title": "Tap username to view profile",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "",
+      "dependency": "",
+      "existing_summary": "Sync read posts between devices with synccit.com",
+      "help_treatment": "REVIEW_EXISTING_SUMMARY+PROGRESSIVE_DISCLOSURE",
+      "key": "synncit_config",
+      "leaf_section": "Reading state",
+      "legacy_route_count": 2,
+      "legacy_routes": [
+        {
+          "category": "Mark as read",
+          "key": "synncit_config",
+          "logical_kind": "action",
+          "resource": "pref_posts_v2",
+          "root_referenced": true
+        },
+        {
+          "category": "Mark as read",
+          "key": "synncit_config",
+          "logical_kind": "action",
+          "resource": "pref_privacy_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "action",
+      "page": "Posts",
+      "page_intro": "Choose how posts behave while browsing and reading.",
+      "proposed_summary": "Sync read posts between devices with synccit.com",
+      "root": "Reading & interaction",
+      "screen_depth": 2,
+      "screen_path": [
+        "Reading & interaction",
+        "Posts",
+        "Reading state"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "none_or_custom",
+      "subscreen": "Reading state",
+      "title": "Configure Synccit",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "false",
+      "dependency": "pref_mark_read",
+      "existing_summary": "Post images will be dimmed when marked as read",
+      "help_treatment": "REVIEW_EXISTING_SUMMARY",
+      "key": "pref_mark_read_dim_images",
+      "leaf_section": "Reading state",
+      "legacy_route_count": 2,
+      "legacy_routes": [
+        {
+          "category": "Mark as read",
+          "key": "pref_mark_read_dim_images",
+          "logical_kind": "stored_setting",
+          "resource": "pref_posts_v2",
+          "root_referenced": true
+        },
+        {
+          "category": "Mark as read",
+          "key": "pref_mark_read_dim_images",
+          "logical_kind": "stored_setting",
+          "resource": "pref_privacy_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Posts",
+      "page_intro": "Choose how posts behave while browsing and reading.",
+      "proposed_summary": "Post images will be dimmed when marked as read",
+      "root": "Reading & interaction",
+      "screen_depth": 2,
+      "screen_path": [
+        "Reading & interaction",
+        "Posts",
+        "Reading state"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Reading state",
+      "title": "Dim images in read posts",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "false",
+      "dependency": "pref_mark_read",
+      "existing_summary": "Pressing \\\"Hide read\\\" will move read posts on screen to Profile->Hidden (requires login)",
+      "help_treatment": "REVIEW_EXISTING_SUMMARY",
+      "key": "pref_hide_read_permanently",
+      "leaf_section": "Reading state",
+      "legacy_route_count": 2,
+      "legacy_routes": [
+        {
+          "category": "Mark as read",
+          "key": "pref_hide_read_permanently",
+          "logical_kind": "stored_setting",
+          "resource": "pref_posts_v2",
+          "root_referenced": true
+        },
+        {
+          "category": "Mark as read",
+          "key": "pref_hide_read_permanently",
+          "logical_kind": "stored_setting",
+          "resource": "pref_privacy_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Posts",
+      "page_intro": "Choose how posts behave while browsing and reading.",
+      "proposed_summary": "Pressing \\\"Hide read\\\" will move read posts on screen to Profile->Hidden (requires login)",
+      "root": "Reading & interaction",
+      "screen_depth": 2,
+      "screen_path": [
+        "Reading & interaction",
+        "Posts",
+        "Reading state"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Reading state",
+      "title": "Hide read permanently",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "false",
+      "dependency": "pref_mark_read",
+      "existing_summary": "Post will be marked as read when it leaves the screen",
+      "help_treatment": "REVIEW_EXISTING_SUMMARY",
+      "key": "pref_mark_read_on_scroll",
+      "leaf_section": "Reading state",
+      "legacy_route_count": 2,
+      "legacy_routes": [
+        {
+          "category": "Mark as read",
+          "key": "pref_mark_read_on_scroll",
+          "logical_kind": "stored_setting",
+          "resource": "pref_posts_v2",
+          "root_referenced": true
+        },
+        {
+          "category": "Mark as read",
+          "key": "pref_mark_read_on_scroll",
+          "logical_kind": "stored_setting",
+          "resource": "pref_privacy_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Posts",
+      "page_intro": "Choose how posts behave while browsing and reading.",
+      "proposed_summary": "Post will be marked as read when it leaves the screen",
+      "root": "Reading & interaction",
+      "screen_depth": 2,
+      "screen_path": [
+        "Reading & interaction",
+        "Posts",
+        "Reading state"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Reading state",
+      "title": "Mark as read on scroll",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "true",
+      "dependency": "",
+      "existing_summary": "Clicking on a post will mark as read",
+      "help_treatment": "REVIEW_EXISTING_SUMMARY",
+      "key": "pref_mark_read",
+      "leaf_section": "Reading state",
+      "legacy_route_count": 2,
+      "legacy_routes": [
+        {
+          "category": "Mark as read",
+          "key": "pref_mark_read",
+          "logical_kind": "stored_setting",
+          "resource": "pref_posts_v2",
+          "root_referenced": true
+        },
+        {
+          "category": "Mark as read",
+          "key": "pref_mark_read",
+          "logical_kind": "stored_setting",
+          "resource": "pref_privacy_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Posts",
+      "page_intro": "Choose how posts behave while browsing and reading.",
+      "proposed_summary": "Clicking on a post will mark as read",
+      "root": "Reading & interaction",
+      "screen_depth": 2,
+      "screen_path": [
+        "Reading & interaction",
+        "Posts",
+        "Reading state"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Reading state",
+      "title": "Mark posts as read",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "false",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE",
+      "key": "pref_history_delete_read",
+      "leaf_section": "Reading state",
+      "legacy_route_count": 2,
+      "legacy_routes": [
+        {
+          "category": "Mark as read",
+          "key": "pref_history_delete_read",
+          "logical_kind": "special_preference",
+          "resource": "pref_posts_v2",
+          "root_referenced": true
+        },
+        {
+          "category": "Mark as read",
+          "key": "pref_history_delete_read",
+          "logical_kind": "special_preference",
+          "resource": "pref_privacy_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "special_preference",
+      "page": "Posts",
+      "page_intro": "Choose how posts behave while browsing and reading.",
+      "proposed_summary": "",
+      "root": "Reading & interaction",
+      "screen_depth": 2,
+      "screen_path": [
+        "Reading & interaction",
+        "Posts",
+        "Reading state"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "none_or_custom",
+      "subscreen": "Reading state",
+      "title": "Reset read posts",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "false",
+      "dependency": "pref_load_nsfw_images",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE",
+      "key": "pref_blur_nsfw_images",
+      "leaf_section": "Filter behavior",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "More options",
+          "key": "pref_blur_nsfw_images",
+          "logical_kind": "stored_setting",
+          "resource": "pref_filters_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Search & filters",
+      "page_intro": "Configure search entry, search behavior, and content filtering.",
+      "proposed_summary": "",
+      "root": "Reading & interaction",
+      "screen_depth": 3,
+      "screen_path": [
+        "Reading & interaction",
+        "Search & filters",
+        "Content filters",
+        "Filter behavior"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Filter behavior",
+      "title": "Blur images in NSFW posts",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "false",
+      "dependency": "pref_nsfw",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE",
+      "key": "pref_load_nsfw_images",
+      "leaf_section": "Filter behavior",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "More options",
+          "key": "pref_load_nsfw_images",
+          "logical_kind": "stored_setting",
+          "resource": "pref_filters_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Search & filters",
+      "page_intro": "Configure search entry, search behavior, and content filtering.",
+      "proposed_summary": "",
+      "root": "Reading & interaction",
+      "screen_depth": 3,
+      "screen_path": [
+        "Reading & interaction",
+        "Search & filters",
+        "Content filters",
+        "Filter behavior"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Filter behavior",
+      "title": "Show images in NSFW posts",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "false",
+      "dependency": "",
+      "existing_summary": "Show content labeled Not Safe For Work",
+      "help_treatment": "REVIEW_EXISTING_SUMMARY",
+      "key": "pref_nsfw",
+      "leaf_section": "Filter behavior",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "More options",
+          "key": "pref_nsfw",
+          "logical_kind": "stored_setting",
+          "resource": "pref_filters_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Search & filters",
+      "page_intro": "Configure search entry, search behavior, and content filtering.",
+      "proposed_summary": "Show content labeled Not Safe For Work",
+      "root": "Reading & interaction",
+      "screen_depth": 3,
+      "screen_path": [
+        "Reading & interaction",
+        "Search & filters",
+        "Content filters",
+        "Filter behavior"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Filter behavior",
+      "title": "Show NSFW",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "",
+      "dependency": "",
+      "existing_summary": "Hide posts from these communities. Use * wildcards to group communities (\\\"ask*\\\" hides AskReddit, AskScience\u2026)",
+      "help_treatment": "REVIEW_EXISTING_SUMMARY",
+      "key": "pref_filter_subreddit",
+      "leaf_section": "Muted content",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Muting options",
+          "key": "pref_filter_subreddit",
+          "logical_kind": "special_preference",
+          "resource": "pref_filters_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "special_preference",
+      "page": "Search & filters",
+      "page_intro": "Configure search entry, search behavior, and content filtering.",
+      "proposed_summary": "Hide posts from these communities. Use * wildcards to group communities (\\\"ask*\\\" hides AskReddit, AskScience\u2026)",
+      "root": "Reading & interaction",
+      "screen_depth": 3,
+      "screen_path": [
+        "Reading & interaction",
+        "Search & filters",
+        "Content filters",
+        "Muted content"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "none_or_custom",
+      "subscreen": "Muting options",
+      "title": "Communities",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "",
+      "dependency": "",
+      "existing_summary": "Hide posts from these domains",
+      "help_treatment": "REVIEW_EXISTING_SUMMARY",
+      "key": "pref_filter_domain",
+      "leaf_section": "Muted content",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Muting options",
+          "key": "pref_filter_domain",
+          "logical_kind": "special_preference",
+          "resource": "pref_filters_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "special_preference",
+      "page": "Search & filters",
+      "page_intro": "Configure search entry, search behavior, and content filtering.",
+      "proposed_summary": "Hide posts from these domains",
+      "root": "Reading & interaction",
+      "screen_depth": 3,
+      "screen_path": [
+        "Reading & interaction",
+        "Search & filters",
+        "Content filters",
+        "Muted content"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "none_or_custom",
+      "subscreen": "Muting options",
+      "title": "Domains",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "",
+      "dependency": "",
+      "existing_summary": "Hide posts with these flairs. Use * wildcards to group flairs (\\\"*meme\\\" hides meme, wholesomememe\u2026)",
+      "help_treatment": "REVIEW_EXISTING_SUMMARY",
+      "key": "pref_filter_flair",
+      "leaf_section": "Muted content",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Muting options",
+          "key": "pref_filter_flair",
+          "logical_kind": "special_preference",
+          "resource": "pref_filters_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "special_preference",
+      "page": "Search & filters",
+      "page_intro": "Configure search entry, search behavior, and content filtering.",
+      "proposed_summary": "Hide posts with these flairs. Use * wildcards to group flairs (\\\"*meme\\\" hides meme, wholesomememe\u2026)",
+      "root": "Reading & interaction",
+      "screen_depth": 3,
+      "screen_path": [
+        "Reading & interaction",
+        "Search & filters",
+        "Content filters",
+        "Muted content"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "none_or_custom",
+      "subscreen": "Muting options",
+      "title": "Flairs",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "",
+      "dependency": "",
+      "existing_summary": "Hide posts from these users",
+      "help_treatment": "REVIEW_EXISTING_SUMMARY",
+      "key": "pref_filter_username",
+      "leaf_section": "Muted content",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Muting options",
+          "key": "pref_filter_username",
+          "logical_kind": "special_preference",
+          "resource": "pref_filters_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "special_preference",
+      "page": "Search & filters",
+      "page_intro": "Configure search entry, search behavior, and content filtering.",
+      "proposed_summary": "Hide posts from these users",
+      "root": "Reading & interaction",
+      "screen_depth": 3,
+      "screen_path": [
+        "Reading & interaction",
+        "Search & filters",
+        "Content filters",
+        "Muted content"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "none_or_custom",
+      "subscreen": "Muting options",
+      "title": "Users",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "",
+      "dependency": "",
+      "existing_summary": "Hide posts containing words in title",
+      "help_treatment": "REVIEW_EXISTING_SUMMARY",
+      "key": "pref_filter_keyword",
+      "leaf_section": "Muted content",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Muting options",
+          "key": "pref_filter_keyword",
+          "logical_kind": "special_preference",
+          "resource": "pref_filters_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "special_preference",
+      "page": "Search & filters",
+      "page_intro": "Configure search entry, search behavior, and content filtering.",
+      "proposed_summary": "Hide posts containing words in title",
+      "root": "Reading & interaction",
+      "screen_depth": 3,
+      "screen_path": [
+        "Reading & interaction",
+        "Search & filters",
+        "Content filters",
+        "Muted content"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "none_or_custom",
+      "subscreen": "Muting options",
+      "title": "Words",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "true",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE",
+      "key": "pref_album",
+      "leaf_section": "Post matching",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Show posts with",
+          "key": "pref_album",
+          "logical_kind": "stored_setting",
+          "resource": "pref_filters_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Search & filters",
+      "page_intro": "Configure search entry, search behavior, and content filtering.",
+      "proposed_summary": "",
+      "root": "Reading & interaction",
+      "screen_depth": 3,
+      "screen_path": [
+        "Reading & interaction",
+        "Search & filters",
+        "Content filters",
+        "Post matching"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Show posts with",
+      "title": "Albums",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "true",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE",
+      "key": "pref_gif",
+      "leaf_section": "Post matching",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Show posts with",
+          "key": "pref_gif",
+          "logical_kind": "stored_setting",
+          "resource": "pref_filters_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Search & filters",
+      "page_intro": "Configure search entry, search behavior, and content filtering.",
+      "proposed_summary": "",
+      "root": "Reading & interaction",
+      "screen_depth": 3,
+      "screen_path": [
+        "Reading & interaction",
+        "Search & filters",
+        "Content filters",
+        "Post matching"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Show posts with",
+      "title": "Gifs",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "true",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "OMIT_SELF_EXPLANATORY",
+      "key": "pref_image",
+      "leaf_section": "Post matching",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Show posts with",
+          "key": "pref_image",
+          "logical_kind": "stored_setting",
+          "resource": "pref_filters_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Search & filters",
+      "page_intro": "Configure search entry, search behavior, and content filtering.",
+      "proposed_summary": "",
+      "root": "Reading & interaction",
+      "screen_depth": 3,
+      "screen_path": [
+        "Reading & interaction",
+        "Search & filters",
+        "Content filters",
+        "Post matching"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Show posts with",
+      "title": "Images",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "true",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE",
+      "key": "pref_link",
+      "leaf_section": "Post matching",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Show posts with",
+          "key": "pref_link",
+          "logical_kind": "stored_setting",
+          "resource": "pref_filters_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Search & filters",
+      "page_intro": "Configure search entry, search behavior, and content filtering.",
+      "proposed_summary": "",
+      "root": "Reading & interaction",
+      "screen_depth": 3,
+      "screen_path": [
+        "Reading & interaction",
+        "Search & filters",
+        "Content filters",
+        "Post matching"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Show posts with",
+      "title": "Links",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "true",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE",
+      "key": "pref_self",
+      "leaf_section": "Post matching",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Show posts with",
+          "key": "pref_self",
+          "logical_kind": "stored_setting",
+          "resource": "pref_filters_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Search & filters",
+      "page_intro": "Configure search entry, search behavior, and content filtering.",
+      "proposed_summary": "",
+      "root": "Reading & interaction",
+      "screen_depth": 3,
+      "screen_path": [
+        "Reading & interaction",
+        "Search & filters",
+        "Content filters",
+        "Post matching"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Show posts with",
+      "title": "Text",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "true",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "OMIT_SELF_EXPLANATORY",
+      "key": "pref_video",
+      "leaf_section": "Post matching",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Show posts with",
+          "key": "pref_video",
+          "logical_kind": "stored_setting",
+          "resource": "pref_filters_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Search & filters",
+      "page_intro": "Configure search entry, search behavior, and content filtering.",
+      "proposed_summary": "",
+      "root": "Reading & interaction",
+      "screen_depth": 3,
+      "screen_path": [
+        "Reading & interaction",
+        "Search & filters",
+        "Content filters",
+        "Post matching"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Show posts with",
+      "title": "Videos",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "OMIT_OR_ONE_LINE_ACTION_HINT",
+      "key": "pref_search_advanced_help",
+      "leaf_section": "Advanced search",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Advanced search",
+          "key": "pref_search_advanced_help",
+          "logical_kind": "action",
+          "resource": "pref_search_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "action",
+      "page": "Search & filters",
+      "page_intro": "Configure search entry, search behavior, and content filtering.",
+      "proposed_summary": "",
+      "root": "Reading & interaction",
+      "screen_depth": 3,
+      "screen_path": [
+        "Reading & interaction",
+        "Search & filters",
+        "Search",
+        "Advanced search"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "none_or_custom",
+      "subscreen": "Advanced search",
+      "title": "Field search help",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "5",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE",
+      "key": "pref_default_search_period",
+      "leaf_section": "Search behavior",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": null,
+          "key": "pref_default_search_period",
+          "logical_kind": "stored_setting",
+          "resource": "pref_search_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Search & filters",
+      "page_intro": "Configure search entry, search behavior, and content filtering.",
+      "proposed_summary": "",
+      "root": "Reading & interaction",
+      "screen_depth": 3,
+      "screen_path": [
+        "Reading & interaction",
+        "Search & filters",
+        "Search",
+        "Search behavior"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "string",
+      "subscreen": "Search behavior",
+      "title": "Default period",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "0",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE",
+      "key": "pref_default_search_sorting",
+      "leaf_section": "Search behavior",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": null,
+          "key": "pref_default_search_sorting",
+          "logical_kind": "stored_setting",
+          "resource": "pref_search_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Search & filters",
+      "page_intro": "Configure search entry, search behavior, and content filtering.",
+      "proposed_summary": "",
+      "root": "Reading & interaction",
+      "screen_depth": 3,
+      "screen_path": [
+        "Reading & interaction",
+        "Search & filters",
+        "Search",
+        "Search behavior"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "string",
+      "subscreen": "Search behavior",
+      "title": "Default sort",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "false",
+      "dependency": "",
+      "existing_summary": "Focus the search field and show the keyboard immediately. When disabled, tap Search again to start typing.",
+      "help_treatment": "REVIEW_EXISTING_SUMMARY",
+      "key": "morphe_boost_search_open_keyboard_on_entry",
+      "leaf_section": "Search behavior",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Search",
+          "key": "morphe_boost_search_open_keyboard_on_entry",
+          "logical_kind": "morphe_user_setting",
+          "resource": "morphe_boost_settings_skeleton",
+          "root_referenced": false
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Search & filters",
+      "page_intro": "Configure search entry, search behavior, and content filtering.",
+      "proposed_summary": "Focus the search field and show the keyboard immediately. When disabled, tap Search again to start typing.",
+      "root": "Reading & interaction",
+      "screen_depth": 3,
+      "screen_path": [
+        "Reading & interaction",
+        "Search & filters",
+        "Search",
+        "Search behavior"
+      ],
+      "source_type": "morphe_embedded_xml",
+      "storage_type": "boolean",
+      "subscreen": "Search behavior",
+      "title": "Open keyboard when entering Search",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "OMIT_OR_ONE_LINE_ACTION_HINT",
+      "key": "pref_saved_searches",
+      "leaf_section": "Suggestions",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Suggestions",
+          "key": "pref_saved_searches",
+          "logical_kind": "action",
+          "resource": "pref_search_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "action",
+      "page": "Search & filters",
+      "page_intro": "Configure search entry, search behavior, and content filtering.",
+      "proposed_summary": "",
+      "root": "Reading & interaction",
+      "screen_depth": 3,
+      "screen_path": [
+        "Reading & interaction",
+        "Search & filters",
+        "Search",
+        "Suggestions"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "none_or_custom",
+      "subscreen": "Suggestions",
+      "title": "Saved searches",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "true",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE",
+      "key": "pref_search_show_random",
+      "leaf_section": "Suggestions",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Suggestions",
+          "key": "pref_search_show_random",
+          "logical_kind": "stored_setting",
+          "resource": "pref_search_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Search & filters",
+      "page_intro": "Configure search entry, search behavior, and content filtering.",
+      "proposed_summary": "",
+      "root": "Reading & interaction",
+      "screen_depth": 3,
+      "screen_path": [
+        "Reading & interaction",
+        "Search & filters",
+        "Search",
+        "Suggestions"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Suggestions",
+      "title": "Show random",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "true",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE",
+      "key": "pref_search_show_random_nsfw",
+      "leaf_section": "Suggestions",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Suggestions",
+          "key": "pref_search_show_random_nsfw",
+          "logical_kind": "stored_setting",
+          "resource": "pref_search_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Search & filters",
+      "page_intro": "Configure search entry, search behavior, and content filtering.",
+      "proposed_summary": "",
+      "root": "Reading & interaction",
+      "screen_depth": 3,
+      "screen_path": [
+        "Reading & interaction",
+        "Search & filters",
+        "Search",
+        "Suggestions"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Suggestions",
+      "title": "Show random NSFW",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "false",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE",
+      "key": "pref_search_show_trending",
+      "leaf_section": "Suggestions",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Suggestions",
+          "key": "pref_search_show_trending",
+          "logical_kind": "stored_setting",
+          "resource": "pref_search_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Search & filters",
+      "page_intro": "Configure search entry, search behavior, and content filtering.",
+      "proposed_summary": "",
+      "root": "Reading & interaction",
+      "screen_depth": 3,
+      "screen_path": [
+        "Reading & interaction",
+        "Search & filters",
+        "Search",
+        "Suggestions"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Suggestions",
+      "title": "Show trending communities",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "false",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE",
+      "key": "pref_search_show_trending_searches",
+      "leaf_section": "Suggestions",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Suggestions",
+          "key": "pref_search_show_trending_searches",
+          "logical_kind": "stored_setting",
+          "resource": "pref_search_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Search & filters",
+      "page_intro": "Configure search entry, search behavior, and content filtering.",
+      "proposed_summary": "",
+      "root": "Reading & interaction",
+      "screen_depth": 3,
+      "screen_path": [
+        "Reading & interaction",
+        "Search & filters",
+        "Search",
+        "Suggestions"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Suggestions",
+      "title": "Show trending today",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "true",
+      "dependency": "",
+      "existing_summary": "Show confirmation dialog before exiting",
+      "help_treatment": "REVIEW_EXISTING_SUMMARY",
+      "key": "pref_ask_exit",
+      "leaf_section": "Back & exit",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Exit confirmation",
+          "key": "pref_ask_exit",
+          "logical_kind": "stored_setting",
+          "resource": "pref_general_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Navigation & gestures",
+      "page_intro": "Choose how you move around Boost and which shortcuts are available.",
+      "proposed_summary": "Show confirmation dialog before exiting",
+      "root": "Navigation",
+      "screen_depth": 1,
+      "screen_path": [
+        "Navigation",
+        "Back & exit"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Back & exit",
+      "title": "Confirm exit",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "true",
+      "dependency": "pref_ask_exit",
+      "existing_summary": "Tap back button twice to exit",
+      "help_treatment": "REVIEW_EXISTING_SUMMARY",
+      "key": "pref_double_exit",
+      "leaf_section": "Back & exit",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Exit confirmation",
+          "key": "pref_double_exit",
+          "logical_kind": "stored_setting",
+          "resource": "pref_general_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Navigation & gestures",
+      "page_intro": "Choose how you move around Boost and which shortcuts are available.",
+      "proposed_summary": "Tap back button twice to exit",
+      "root": "Navigation",
+      "screen_depth": 1,
+      "screen_path": [
+        "Navigation",
+        "Back & exit"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Back & exit",
+      "title": "Double tap to exit",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "true",
+      "dependency": "pref_bottom_navigation",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE",
+      "key": "pref_bottom_navigation_hide_on_scroll",
+      "leaf_section": "Bottom navigation",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": null,
+          "key": "pref_bottom_navigation_hide_on_scroll",
+          "logical_kind": "stored_setting",
+          "resource": "pref_bottom_navigation_v2",
+          "root_referenced": false
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Navigation & gestures",
+      "page_intro": "Choose how you move around Boost and which shortcuts are available.",
+      "proposed_summary": "",
+      "root": "Navigation",
+      "screen_depth": 1,
+      "screen_path": [
+        "Navigation",
+        "Bottom navigation"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Bottom navigation",
+      "title": "Hide on scroll",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "false",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE",
+      "key": "pref_bottom_navigation",
+      "leaf_section": "Bottom navigation",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": null,
+          "key": "pref_bottom_navigation",
+          "logical_kind": "stored_setting",
+          "resource": "pref_bottom_navigation_v2",
+          "root_referenced": false
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Navigation & gestures",
+      "page_intro": "Choose how you move around Boost and which shortcuts are available.",
+      "proposed_summary": "",
+      "root": "Navigation",
+      "screen_depth": 1,
+      "screen_path": [
+        "Navigation",
+        "Bottom navigation"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Bottom navigation",
+      "title": "Show bottom navigation",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "true",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE+PROGRESSIVE_DISCLOSURE",
+      "key": "pref_accounts_show_avatar",
+      "leaf_section": "Account switcher",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Account switcher",
+          "key": "pref_accounts_show_avatar",
+          "logical_kind": "stored_setting",
+          "resource": "pref_drawer_v2",
+          "root_referenced": false
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Navigation & gestures",
+      "page_intro": "Choose how you move around Boost and which shortcuts are available.",
+      "proposed_summary": "",
+      "root": "Navigation",
+      "screen_depth": 2,
+      "screen_path": [
+        "Navigation",
+        "Navigation drawer",
+        "Account switcher"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Account switcher",
+      "title": "Show avatar",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "true",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE+PROGRESSIVE_DISCLOSURE",
+      "key": "pref_accounts_show_username",
+      "leaf_section": "Account switcher",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Account switcher",
+          "key": "pref_accounts_show_username",
+          "logical_kind": "stored_setting",
+          "resource": "pref_drawer_v2",
+          "root_referenced": false
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Navigation & gestures",
+      "page_intro": "Choose how you move around Boost and which shortcuts are available.",
+      "proposed_summary": "",
+      "root": "Navigation",
+      "screen_depth": 2,
+      "screen_path": [
+        "Navigation",
+        "Navigation drawer",
+        "Account switcher"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Account switcher",
+      "title": "Show username",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "false",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "OMIT_SELF_EXPLANATORY",
+      "key": "pref_drawer_show_drafts",
+      "leaf_section": "Account & tools",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Items to show",
+          "key": "pref_drawer_show_drafts",
+          "logical_kind": "stored_setting",
+          "resource": "pref_drawer_v2",
+          "root_referenced": false
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Navigation & gestures",
+      "page_intro": "Choose how you move around Boost and which shortcuts are available.",
+      "proposed_summary": "",
+      "root": "Navigation",
+      "screen_depth": 2,
+      "screen_path": [
+        "Navigation",
+        "Navigation drawer",
+        "Account & tools"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Account & tools",
+      "title": "Drafts",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "true",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "OMIT_SELF_EXPLANATORY",
+      "key": "pref_drawer_show_history",
+      "leaf_section": "Feeds & library",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Items to show",
+          "key": "pref_drawer_show_history",
+          "logical_kind": "stored_setting",
+          "resource": "pref_drawer_v2",
+          "root_referenced": false
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Navigation & gestures",
+      "page_intro": "Choose how you move around Boost and which shortcuts are available.",
+      "proposed_summary": "",
+      "root": "Navigation",
+      "screen_depth": 2,
+      "screen_path": [
+        "Navigation",
+        "Navigation drawer",
+        "Feeds & library"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Feeds & library",
+      "title": "History",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "true",
+      "dependency": "",
+      "existing_summary": "Posts from subscripions",
+      "help_treatment": "REVIEW_EXISTING_SUMMARY",
+      "key": "pref_drawer_show_frontpage",
+      "leaf_section": "Feeds & library",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Items to show",
+          "key": "pref_drawer_show_frontpage",
+          "logical_kind": "stored_setting",
+          "resource": "pref_drawer_v2",
+          "root_referenced": false
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Navigation & gestures",
+      "page_intro": "Choose how you move around Boost and which shortcuts are available.",
+      "proposed_summary": "Posts from subscripions",
+      "root": "Navigation",
+      "screen_depth": 2,
+      "screen_path": [
+        "Navigation",
+        "Navigation drawer",
+        "Feeds & library"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Feeds & library",
+      "title": "Home feed",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "true",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "OMIT_SELF_EXPLANATORY",
+      "key": "pref_drawer_show_inbox",
+      "leaf_section": "Account & tools",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Items to show",
+          "key": "pref_drawer_show_inbox",
+          "logical_kind": "stored_setting",
+          "resource": "pref_drawer_v2",
+          "root_referenced": false
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Navigation & gestures",
+      "page_intro": "Choose how you move around Boost and which shortcuts are available.",
+      "proposed_summary": "",
+      "root": "Navigation",
+      "screen_depth": 2,
+      "screen_path": [
+        "Navigation",
+        "Navigation drawer",
+        "Account & tools"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Account & tools",
+      "title": "Inbox",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "true",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "OMIT_SELF_EXPLANATORY",
+      "key": "pref_drawer_show_mod",
+      "leaf_section": "Account & tools",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Items to show",
+          "key": "pref_drawer_show_mod",
+          "logical_kind": "stored_setting",
+          "resource": "pref_drawer_v2",
+          "root_referenced": false
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Navigation & gestures",
+      "page_intro": "Choose how you move around Boost and which shortcuts are available.",
+      "proposed_summary": "",
+      "root": "Navigation",
+      "screen_depth": 2,
+      "screen_path": [
+        "Navigation",
+        "Navigation drawer",
+        "Account & tools"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Account & tools",
+      "title": "Moderation",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "true",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "OMIT_SELF_EXPLANATORY",
+      "key": "pref_drawer_show_popular",
+      "leaf_section": "Feeds & library",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Items to show",
+          "key": "pref_drawer_show_popular",
+          "logical_kind": "stored_setting",
+          "resource": "pref_drawer_v2",
+          "root_referenced": false
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Navigation & gestures",
+      "page_intro": "Choose how you move around Boost and which shortcuts are available.",
+      "proposed_summary": "",
+      "root": "Navigation",
+      "screen_depth": 2,
+      "screen_path": [
+        "Navigation",
+        "Navigation drawer",
+        "Feeds & library"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Feeds & library",
+      "title": "Popular",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "true",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "OMIT_SELF_EXPLANATORY",
+      "key": "pref_drawer_show_profile",
+      "leaf_section": "Account & tools",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Items to show",
+          "key": "pref_drawer_show_profile",
+          "logical_kind": "stored_setting",
+          "resource": "pref_drawer_v2",
+          "root_referenced": false
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Navigation & gestures",
+      "page_intro": "Choose how you move around Boost and which shortcuts are available.",
+      "proposed_summary": "",
+      "root": "Navigation",
+      "screen_depth": 2,
+      "screen_path": [
+        "Navigation",
+        "Navigation drawer",
+        "Account & tools"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Account & tools",
+      "title": "Profile",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "true",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "OMIT_SELF_EXPLANATORY",
+      "key": "pref_drawer_show_saved",
+      "leaf_section": "Feeds & library",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Items to show",
+          "key": "pref_drawer_show_saved",
+          "logical_kind": "stored_setting",
+          "resource": "pref_drawer_v2",
+          "root_referenced": false
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Navigation & gestures",
+      "page_intro": "Choose how you move around Boost and which shortcuts are available.",
+      "proposed_summary": "",
+      "root": "Navigation",
+      "screen_depth": 2,
+      "screen_path": [
+        "Navigation",
+        "Navigation drawer",
+        "Feeds & library"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Feeds & library",
+      "title": "Saved",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "true",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "OMIT_SELF_EXPLANATORY",
+      "key": "pref_drawer_show_search_generic",
+      "leaf_section": "Account & tools",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Items to show",
+          "key": "pref_drawer_show_search_generic",
+          "logical_kind": "stored_setting",
+          "resource": "pref_drawer_v2",
+          "root_referenced": false
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Navigation & gestures",
+      "page_intro": "Choose how you move around Boost and which shortcuts are available.",
+      "proposed_summary": "",
+      "root": "Navigation",
+      "screen_depth": 2,
+      "screen_path": [
+        "Navigation",
+        "Navigation drawer",
+        "Account & tools"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Account & tools",
+      "title": "Search",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "true",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "OMIT_SELF_EXPLANATORY",
+      "key": "pref_drawer_show_all",
+      "leaf_section": "Feeds & library",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Items to show",
+          "key": "pref_drawer_show_all",
+          "logical_kind": "stored_setting",
+          "resource": "pref_drawer_v2",
+          "root_referenced": false
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Navigation & gestures",
+      "page_intro": "Choose how you move around Boost and which shortcuts are available.",
+      "proposed_summary": "",
+      "root": "Navigation",
+      "screen_depth": 2,
+      "screen_path": [
+        "Navigation",
+        "Navigation drawer",
+        "Feeds & library"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Feeds & library",
+      "title": "All",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "true",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE",
+      "key": "pref_drawer_show_friends",
+      "leaf_section": "Account & tools",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Items to show",
+          "key": "pref_drawer_show_friends",
+          "logical_kind": "stored_setting",
+          "resource": "pref_drawer_v2",
+          "root_referenced": false
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Navigation & gestures",
+      "page_intro": "Choose how you move around Boost and which shortcuts are available.",
+      "proposed_summary": "",
+      "root": "Navigation",
+      "screen_depth": 2,
+      "screen_path": [
+        "Navigation",
+        "Navigation drawer",
+        "Account & tools"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Account & tools",
+      "title": "Friends",
+      "v5_visibility": "WITHHELD_RUNTIME_UNAVAILABLE",
+      "v5_visibility_reason": "Static implementation exists, but the Friends destination was not proven to return functional Reddit data at runtime."
+    },
+    {
+      "default_value": "true",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE",
+      "key": "pref_drawer_sticky_settings",
+      "leaf_section": "Drawer behavior",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Items to show",
+          "key": "pref_drawer_sticky_settings",
+          "logical_kind": "stored_setting",
+          "resource": "pref_drawer_v2",
+          "root_referenced": false
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Navigation & gestures",
+      "page_intro": "Choose how you move around Boost and which shortcuts are available.",
+      "proposed_summary": "",
+      "root": "Navigation",
+      "screen_depth": 2,
+      "screen_path": [
+        "Navigation",
+        "Navigation drawer",
+        "Drawer behavior"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Drawer behavior",
+      "title": "Sticky Settings",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "false",
+      "dependency": "",
+      "existing_summary": "Open menu from the opposite edge",
+      "help_treatment": "REVIEW_EXISTING_SUMMARY",
+      "key": "pref_drawer_end",
+      "leaf_section": "Drawer behavior",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "General",
+          "key": "pref_drawer_end",
+          "logical_kind": "stored_setting",
+          "resource": "pref_drawer_v2",
+          "root_referenced": false
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Navigation & gestures",
+      "page_intro": "Choose how you move around Boost and which shortcuts are available.",
+      "proposed_summary": "Open menu from the opposite edge",
+      "root": "Navigation",
+      "screen_depth": 2,
+      "screen_path": [
+        "Navigation",
+        "Navigation drawer",
+        "Drawer behavior"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Drawer behavior",
+      "title": "Switch side",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "false",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE",
+      "key": "pref_drawer_show_go_to_subreddit",
+      "leaf_section": "Go-to shortcuts",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Items to show",
+          "key": "pref_drawer_show_go_to_subreddit",
+          "logical_kind": "stored_setting",
+          "resource": "pref_drawer_v2",
+          "root_referenced": false
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Navigation & gestures",
+      "page_intro": "Choose how you move around Boost and which shortcuts are available.",
+      "proposed_summary": "",
+      "root": "Navigation",
+      "screen_depth": 2,
+      "screen_path": [
+        "Navigation",
+        "Navigation drawer",
+        "Go-to shortcuts"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Go-to shortcuts",
+      "title": "Go to community",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "true",
+      "dependency": "",
+      "existing_summary": "Including Community, user or random (Long press to go to community)",
+      "help_treatment": "REVIEW_EXISTING_SUMMARY",
+      "key": "pref_drawer_show_go_to",
+      "leaf_section": "Go-to shortcuts",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Items to show",
+          "key": "pref_drawer_show_go_to",
+          "logical_kind": "stored_setting",
+          "resource": "pref_drawer_v2",
+          "root_referenced": false
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Navigation & gestures",
+      "page_intro": "Choose how you move around Boost and which shortcuts are available.",
+      "proposed_summary": "Including Community, user or random (Long press to go to community)",
+      "root": "Navigation",
+      "screen_depth": 2,
+      "screen_path": [
+        "Navigation",
+        "Navigation drawer",
+        "Go-to shortcuts"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Go-to shortcuts",
+      "title": "Go to dropdown",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "false",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE",
+      "key": "pref_drawer_show_go_to_user",
+      "leaf_section": "Go-to shortcuts",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Items to show",
+          "key": "pref_drawer_show_go_to_user",
+          "logical_kind": "stored_setting",
+          "resource": "pref_drawer_v2",
+          "root_referenced": false
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Navigation & gestures",
+      "page_intro": "Choose how you move around Boost and which shortcuts are available.",
+      "proposed_summary": "",
+      "root": "Navigation",
+      "screen_depth": 2,
+      "screen_path": [
+        "Navigation",
+        "Navigation drawer",
+        "Go-to shortcuts"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Go-to shortcuts",
+      "title": "Go to user",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "false",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "OMIT_SELF_EXPLANATORY",
+      "key": "pref_drawer_show_blur_switch",
+      "leaf_section": "Quick toggles",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Items to show",
+          "key": "pref_drawer_show_blur_switch",
+          "logical_kind": "stored_setting",
+          "resource": "pref_drawer_v2",
+          "root_referenced": false
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Navigation & gestures",
+      "page_intro": "Choose how you move around Boost and which shortcuts are available.",
+      "proposed_summary": "",
+      "root": "Navigation",
+      "screen_depth": 2,
+      "screen_path": [
+        "Navigation",
+        "Navigation drawer",
+        "Quick toggles"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Quick toggles",
+      "title": "Blur NSFW",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "false",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "OMIT_SELF_EXPLANATORY",
+      "key": "pref_drawer_show_night_mode",
+      "leaf_section": "Quick toggles",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Items to show",
+          "key": "pref_drawer_show_night_mode",
+          "logical_kind": "stored_setting",
+          "resource": "pref_drawer_v2",
+          "root_referenced": false
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Navigation & gestures",
+      "page_intro": "Choose how you move around Boost and which shortcuts are available.",
+      "proposed_summary": "",
+      "root": "Navigation",
+      "screen_depth": 2,
+      "screen_path": [
+        "Navigation",
+        "Navigation drawer",
+        "Quick toggles"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Quick toggles",
+      "title": "Dark mode",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "false",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "OMIT_SELF_EXPLANATORY",
+      "key": "pref_drawer_show_nsfw_switch",
+      "leaf_section": "Quick toggles",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Items to show",
+          "key": "pref_drawer_show_nsfw_switch",
+          "logical_kind": "stored_setting",
+          "resource": "pref_drawer_v2",
+          "root_referenced": false
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Navigation & gestures",
+      "page_intro": "Choose how you move around Boost and which shortcuts are available.",
+      "proposed_summary": "",
+      "root": "Navigation",
+      "screen_depth": 2,
+      "screen_path": [
+        "Navigation",
+        "Navigation drawer",
+        "Quick toggles"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Quick toggles",
+      "title": "Show NSFW",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "true",
+      "dependency": "",
+      "existing_summary": "Default feed. To set any community, go to Subscriptions list and select \\\"Set as default\\\"",
+      "help_treatment": "REVIEW_EXISTING_SUMMARY",
+      "key": "pref_drawer_show_home",
+      "leaf_section": "Feeds & library",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Items to show",
+          "key": "pref_drawer_show_home",
+          "logical_kind": "stored_setting",
+          "resource": "pref_drawer_v2",
+          "root_referenced": false
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Navigation & gestures",
+      "page_intro": "Choose how you move around Boost and which shortcuts are available.",
+      "proposed_summary": "Default feed. To set any community, go to Subscriptions list and select \\\"Set as default\\\"",
+      "root": "Navigation",
+      "screen_depth": 2,
+      "screen_path": [
+        "Navigation",
+        "Navigation drawer",
+        "Feeds & library"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Feeds & library",
+      "title": "Home",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "true",
+      "dependency": "pref_subscriptions_drawer",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE",
+      "key": "pref_subscriptions_drawer_show_icon",
+      "leaf_section": "Subscriptions",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Subscriptions list",
+          "key": "pref_subscriptions_drawer_show_icon",
+          "logical_kind": "stored_setting",
+          "resource": "pref_drawer_v2",
+          "root_referenced": false
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Navigation & gestures",
+      "page_intro": "Choose how you move around Boost and which shortcuts are available.",
+      "proposed_summary": "",
+      "root": "Navigation",
+      "screen_depth": 2,
+      "screen_path": [
+        "Navigation",
+        "Navigation drawer",
+        "Subscriptions"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Subscriptions",
+      "title": "Show icons",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "true",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE",
+      "key": "pref_subscriptions_drawer",
+      "leaf_section": "Subscriptions",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Subscriptions list",
+          "key": "pref_subscriptions_drawer",
+          "logical_kind": "stored_setting",
+          "resource": "pref_drawer_v2",
+          "root_referenced": false
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Navigation & gestures",
+      "page_intro": "Choose how you move around Boost and which shortcuts are available.",
+      "proposed_summary": "",
+      "root": "Navigation",
+      "screen_depth": 2,
+      "screen_path": [
+        "Navigation",
+        "Navigation drawer",
+        "Subscriptions"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Subscriptions",
+      "title": "Show in menu",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "false",
+      "dependency": "pref_subscriptions_drawer",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE",
+      "key": "pref_subscriptions_only_casual",
+      "leaf_section": "Subscriptions",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Subscriptions list",
+          "key": "pref_subscriptions_only_casual",
+          "logical_kind": "stored_setting",
+          "resource": "pref_drawer_v2",
+          "root_referenced": false
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Navigation & gestures",
+      "page_intro": "Choose how you move around Boost and which shortcuts are available.",
+      "proposed_summary": "",
+      "root": "Navigation",
+      "screen_depth": 2,
+      "screen_path": [
+        "Navigation",
+        "Navigation drawer",
+        "Subscriptions"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Subscriptions",
+      "title": "Show only favorites",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "true",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE",
+      "key": "pref_toolbar",
+      "leaf_section": "Toolbar",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": null,
+          "key": "pref_toolbar",
+          "logical_kind": "stored_setting",
+          "resource": "pref_toolbar_v2",
+          "root_referenced": false
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Navigation & gestures",
+      "page_intro": "Choose how you move around Boost and which shortcuts are available.",
+      "proposed_summary": "",
+      "root": "Navigation",
+      "screen_depth": 1,
+      "screen_path": [
+        "Navigation",
+        "Toolbar"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Toolbar",
+      "title": "Hide on scroll",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "1",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE",
+      "key": "pref_toolbar_main_action",
+      "leaf_section": "Toolbar",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": null,
+          "key": "pref_toolbar_main_action",
+          "logical_kind": "stored_setting",
+          "resource": "pref_toolbar_v2",
+          "root_referenced": false
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Navigation & gestures",
+      "page_intro": "Choose how you move around Boost and which shortcuts are available.",
+      "proposed_summary": "",
+      "root": "Navigation",
+      "screen_depth": 1,
+      "screen_path": [
+        "Navigation",
+        "Toolbar"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "string",
+      "subscreen": "Toolbar",
+      "title": "Main action",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "false",
+      "dependency": "",
+      "existing_summary": "Organize downloaded media into community folders",
+      "help_treatment": "REVIEW_EXISTING_SUMMARY+PROGRESSIVE_DISCLOSURE",
+      "key": "pref_download_folder_per_subreddit",
+      "leaf_section": "Download folders",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": null,
+          "key": "pref_download_folder_per_subreddit",
+          "logical_kind": "stored_setting",
+          "resource": "pref_downloads_v2",
+          "root_referenced": false
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Downloads & cache",
+      "page_intro": "Manage download locations and downloaded media behavior.",
+      "proposed_summary": "Organize downloaded media into community folders",
+      "root": "Media",
+      "screen_depth": 2,
+      "screen_path": [
+        "Media",
+        "Downloads & cache",
+        "Download folders"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Download folders",
+      "title": "Community subfolders",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "",
+      "dependency": "",
+      "existing_summary": "Choose the default folder used for downloaded media.",
+      "help_treatment": "DIRECT_CONTROL_SUMMARY",
+      "key": "pref_download_folder_default",
+      "leaf_section": "Download folders",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Download folders",
+          "logical_kind": "direct_action_state",
+          "resource": "MorpheSettingsV4DownloadsFragment",
+          "root_referenced": false
+        }
+      ],
+      "logical_kind": "action_state",
+      "page": "Downloads & cache",
+      "page_intro": "Manage download locations and downloaded media behavior.",
+      "proposed_summary": "Choose the default folder used for downloaded media.",
+      "root": "Media",
+      "screen_depth": 2,
+      "screen_path": [
+        "Media",
+        "Downloads & cache",
+        "Download folders"
+      ],
+      "source_type": "boost_direct_ui",
+      "storage_type": "string",
+      "subscreen": "Download folders",
+      "title": "Default folder",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "",
+      "dependency": "",
+      "existing_summary": "Choose the folder used for downloaded GIFs.",
+      "help_treatment": "DIRECT_CONTROL_SUMMARY",
+      "key": "pref_download_folder_gif",
+      "leaf_section": "Download folders",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Download folders",
+          "logical_kind": "direct_action_state",
+          "resource": "MorpheSettingsV4DownloadsFragment",
+          "root_referenced": false
+        }
+      ],
+      "logical_kind": "action_state",
+      "page": "Downloads & cache",
+      "page_intro": "Manage download locations and downloaded media behavior.",
+      "proposed_summary": "Choose the folder used for downloaded GIFs.",
+      "root": "Media",
+      "screen_depth": 2,
+      "screen_path": [
+        "Media",
+        "Downloads & cache",
+        "Download folders"
+      ],
+      "source_type": "boost_direct_ui",
+      "storage_type": "string",
+      "subscreen": "Download folders",
+      "title": "GIFs",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "",
+      "dependency": "",
+      "existing_summary": "Choose the folder used for downloaded images.",
+      "help_treatment": "DIRECT_CONTROL_SUMMARY",
+      "key": "pref_download_folder_img",
+      "leaf_section": "Download folders",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Download folders",
+          "logical_kind": "direct_action_state",
+          "resource": "MorpheSettingsV4DownloadsFragment",
+          "root_referenced": false
+        }
+      ],
+      "logical_kind": "action_state",
+      "page": "Downloads & cache",
+      "page_intro": "Manage download locations and downloaded media behavior.",
+      "proposed_summary": "Choose the folder used for downloaded images.",
+      "root": "Media",
+      "screen_depth": 2,
+      "screen_path": [
+        "Media",
+        "Downloads & cache",
+        "Download folders"
+      ],
+      "source_type": "boost_direct_ui",
+      "storage_type": "string",
+      "subscreen": "Download folders",
+      "title": "Images",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "",
+      "dependency": "",
+      "existing_summary": "Choose the folder used for downloaded videos.",
+      "help_treatment": "DIRECT_CONTROL_SUMMARY",
+      "key": "pref_download_folder_mp4",
+      "leaf_section": "Download folders",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Download folders",
+          "logical_kind": "direct_action_state",
+          "resource": "MorpheSettingsV4DownloadsFragment",
+          "root_referenced": false
+        }
+      ],
+      "logical_kind": "action_state",
+      "page": "Downloads & cache",
+      "page_intro": "Manage download locations and downloaded media behavior.",
+      "proposed_summary": "Choose the folder used for downloaded videos.",
+      "root": "Media",
+      "screen_depth": 2,
+      "screen_path": [
+        "Media",
+        "Downloads & cache",
+        "Download folders"
+      ],
+      "source_type": "boost_direct_ui",
+      "storage_type": "string",
+      "subscreen": "Download folders",
+      "title": "Videos",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "glide",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE",
+      "key": "pref_image_loader",
+      "leaf_section": "Native image behavior",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Image viewer",
+          "key": "pref_image_loader",
+          "logical_kind": "stored_setting",
+          "resource": "pref_media_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Images, GIFs & previews",
+      "page_intro": "Configure media previews, image behavior, and tap actions.",
+      "proposed_summary": "",
+      "root": "Media",
+      "screen_depth": 2,
+      "screen_path": [
+        "Media",
+        "Images, GIFs & previews",
+        "Native image behavior"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "string",
+      "subscreen": "Native image behavior",
+      "title": "Image loader",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "false",
+      "dependency": "",
+      "existing_summary": "Load images with deep zoom by default",
+      "help_treatment": "REVIEW_EXISTING_SUMMARY",
+      "key": "pref_images_deepzoom",
+      "leaf_section": "Native image behavior",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Image viewer",
+          "key": "pref_images_deepzoom",
+          "logical_kind": "stored_setting",
+          "resource": "pref_media_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Images, GIFs & previews",
+      "page_intro": "Configure media previews, image behavior, and tap actions.",
+      "proposed_summary": "Load images with deep zoom by default",
+      "root": "Media",
+      "screen_depth": 2,
+      "screen_path": [
+        "Media",
+        "Images, GIFs & previews",
+        "Native image behavior"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Native image behavior",
+      "title": "Load HQ images",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "false",
+      "dependency": "pref_images_deepzoom",
+      "existing_summary": "Fit smallest dimension to screen size",
+      "help_treatment": "REVIEW_EXISTING_SUMMARY",
+      "key": "pref_images_fit",
+      "leaf_section": "Native image behavior",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Image viewer",
+          "key": "pref_images_fit",
+          "logical_kind": "stored_setting",
+          "resource": "pref_media_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Images, GIFs & previews",
+      "page_intro": "Configure media previews, image behavior, and tap actions.",
+      "proposed_summary": "Fit smallest dimension to screen size",
+      "root": "Media",
+      "screen_depth": 2,
+      "screen_path": [
+        "Media",
+        "Images, GIFs & previews",
+        "Native image behavior"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Native image behavior",
+      "title": "Load zoomed in",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "true",
+      "dependency": "",
+      "existing_summary": "Swipe or fling content to close viewer",
+      "help_treatment": "REVIEW_EXISTING_SUMMARY",
+      "key": "pref_swipe_up_to_dismiss_image",
+      "leaf_section": "Native image behavior",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Interface",
+          "key": "pref_swipe_up_to_dismiss_image",
+          "logical_kind": "stored_setting",
+          "resource": "pref_media_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Images, GIFs & previews",
+      "page_intro": "Configure media previews, image behavior, and tap actions.",
+      "proposed_summary": "Swipe or fling content to close viewer",
+      "root": "Media",
+      "screen_depth": 2,
+      "screen_path": [
+        "Media",
+        "Images, GIFs & previews",
+        "Native image behavior"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Native image behavior",
+      "title": "Swipe to dismiss",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "vertical",
+      "dependency": "pref_swipe_up_to_dismiss_image",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE",
+      "key": "pref_swipe_dismiss_direction_mode_image",
+      "leaf_section": "Native image behavior",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Interface",
+          "key": "pref_swipe_dismiss_direction_mode_image",
+          "logical_kind": "stored_setting",
+          "resource": "pref_media_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Images, GIFs & previews",
+      "page_intro": "Configure media previews, image behavior, and tap actions.",
+      "proposed_summary": "",
+      "root": "Media",
+      "screen_depth": 2,
+      "screen_path": [
+        "Media",
+        "Images, GIFs & previews",
+        "Native image behavior"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "string",
+      "subscreen": "Native image behavior",
+      "title": "Swipe to dismiss direction",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "true",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE",
+      "key": "pref_tap_to_dismiss_image",
+      "leaf_section": "Native image behavior",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Interface",
+          "key": "pref_tap_to_dismiss_image",
+          "logical_kind": "stored_setting",
+          "resource": "pref_media_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Images, GIFs & previews",
+      "page_intro": "Configure media previews, image behavior, and tap actions.",
+      "proposed_summary": "",
+      "root": "Media",
+      "screen_depth": 2,
+      "screen_path": [
+        "Media",
+        "Images, GIFs & previews",
+        "Native image behavior"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Native image behavior",
+      "title": "Tap to dismiss",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "image_viewer",
+      "dependency": "",
+      "existing_summary": "Image viewer",
+      "help_treatment": "REVIEW_EXISTING_SUMMARY",
+      "key": "morphe_boost_direct_reddit_gif_tap_action",
+      "leaf_section": "Open behavior",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Open behavior",
+          "key": "morphe_boost_direct_reddit_gif_tap_action",
+          "logical_kind": "morphe_user_setting",
+          "resource": "morphe_boost_settings_skeleton",
+          "root_referenced": false
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Images, GIFs & previews",
+      "page_intro": "Configure media previews, image behavior, and tap actions.",
+      "proposed_summary": "Image viewer",
+      "root": "Media",
+      "screen_depth": 2,
+      "screen_path": [
+        "Media",
+        "Images, GIFs & previews",
+        "Open behavior"
+      ],
+      "source_type": "morphe_embedded_xml",
+      "storage_type": "string",
+      "subscreen": "Open behavior",
+      "title": "Direct Reddit GIF tap action",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "video_viewer",
+      "dependency": "",
+      "existing_summary": "Video viewer",
+      "help_treatment": "REVIEW_EXISTING_SUMMARY",
+      "key": "morphe_boost_giphy_preview_tap_action",
+      "leaf_section": "Open behavior",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Open behavior",
+          "key": "morphe_boost_giphy_preview_tap_action",
+          "logical_kind": "morphe_user_setting",
+          "resource": "morphe_boost_settings_skeleton",
+          "root_referenced": false
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Images, GIFs & previews",
+      "page_intro": "Configure media previews, image behavior, and tap actions.",
+      "proposed_summary": "Video viewer",
+      "root": "Media",
+      "screen_depth": 2,
+      "screen_path": [
+        "Media",
+        "Images, GIFs & previews",
+        "Open behavior"
+      ],
+      "source_type": "morphe_embedded_xml",
+      "storage_type": "string",
+      "subscreen": "Open behavior",
+      "title": "Giphy preview tap action",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "image_viewer",
+      "dependency": "",
+      "existing_summary": "Image viewer",
+      "help_treatment": "REVIEW_EXISTING_SUMMARY",
+      "key": "morphe_boost_static_preview_tap_action",
+      "leaf_section": "Open behavior",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Open behavior",
+          "key": "morphe_boost_static_preview_tap_action",
+          "logical_kind": "morphe_user_setting",
+          "resource": "morphe_boost_settings_skeleton",
+          "root_referenced": false
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Images, GIFs & previews",
+      "page_intro": "Configure media previews, image behavior, and tap actions.",
+      "proposed_summary": "Image viewer",
+      "root": "Media",
+      "screen_depth": 2,
+      "screen_path": [
+        "Media",
+        "Images, GIFs & previews",
+        "Open behavior"
+      ],
+      "source_type": "morphe_embedded_xml",
+      "storage_type": "string",
+      "subscreen": "Open behavior",
+      "title": "Static preview tap action",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "true",
+      "dependency": "",
+      "existing_summary": "Show supported media previews directly in comments.",
+      "help_treatment": "REVIEW_EXISTING_SUMMARY",
+      "key": "morphe_boost_inline_media_previews_enabled",
+      "leaf_section": "Preview behavior",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Media previews",
+          "key": "morphe_boost_inline_media_previews_enabled",
+          "logical_kind": "morphe_user_setting",
+          "resource": "morphe_boost_settings_skeleton",
+          "root_referenced": false
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Images, GIFs & previews",
+      "page_intro": "Configure media previews, image behavior, and tap actions.",
+      "proposed_summary": "Show supported media previews directly in comments.",
+      "root": "Media",
+      "screen_depth": 2,
+      "screen_path": [
+        "Media",
+        "Images, GIFs & previews",
+        "Preview behavior"
+      ],
+      "source_type": "morphe_embedded_xml",
+      "storage_type": "boolean",
+      "subscreen": "Preview behavior",
+      "title": "Enable inline media previews",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "false",
+      "dependency": "",
+      "existing_summary": "Keep the original link text visible with the preview.",
+      "help_treatment": "REVIEW_EXISTING_SUMMARY",
+      "key": "morphe_boost_inline_media_preview_show_source_text",
+      "leaf_section": "Preview behavior",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Media previews",
+          "key": "morphe_boost_inline_media_preview_show_source_text",
+          "logical_kind": "morphe_user_setting",
+          "resource": "morphe_boost_settings_skeleton",
+          "root_referenced": false
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Images, GIFs & previews",
+      "page_intro": "Configure media previews, image behavior, and tap actions.",
+      "proposed_summary": "Keep the original link text visible with the preview.",
+      "root": "Media",
+      "screen_depth": 2,
+      "screen_path": [
+        "Media",
+        "Images, GIFs & previews",
+        "Preview behavior"
+      ],
+      "source_type": "morphe_embedded_xml",
+      "storage_type": "boolean",
+      "subscreen": "Preview behavior",
+      "title": "Show source text with preview",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "center",
+      "dependency": "",
+      "existing_summary": "Center",
+      "help_treatment": "REVIEW_EXISTING_SUMMARY",
+      "key": "morphe_boost_inline_media_preview_alignment",
+      "leaf_section": "Preview layout",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Media previews",
+          "key": "morphe_boost_inline_media_preview_alignment",
+          "logical_kind": "morphe_user_setting",
+          "resource": "morphe_boost_settings_skeleton",
+          "root_referenced": false
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Images, GIFs & previews",
+      "page_intro": "Configure media previews, image behavior, and tap actions.",
+      "proposed_summary": "Center",
+      "root": "Media",
+      "screen_depth": 2,
+      "screen_path": [
+        "Media",
+        "Images, GIFs & previews",
+        "Preview layout"
+      ],
+      "source_type": "morphe_embedded_xml",
+      "storage_type": "string",
+      "subscreen": "Preview layout",
+      "title": "Preview alignment",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "balanced",
+      "dependency": "",
+      "existing_summary": "Balanced",
+      "help_treatment": "REVIEW_EXISTING_SUMMARY",
+      "key": "morphe_boost_inline_media_preview_size",
+      "leaf_section": "Preview layout",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Media previews",
+          "key": "morphe_boost_inline_media_preview_size",
+          "logical_kind": "morphe_user_setting",
+          "resource": "morphe_boost_settings_skeleton",
+          "root_referenced": false
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Images, GIFs & previews",
+      "page_intro": "Configure media previews, image behavior, and tap actions.",
+      "proposed_summary": "Balanced",
+      "root": "Media",
+      "screen_depth": 2,
+      "screen_path": [
+        "Media",
+        "Images, GIFs & previews",
+        "Preview layout"
+      ],
+      "source_type": "morphe_embedded_xml",
+      "storage_type": "string",
+      "subscreen": "Preview layout",
+      "title": "Preview size",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "0",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE",
+      "key": "pref_browser",
+      "leaf_section": "Browser",
+      "legacy_route_count": 2,
+      "legacy_routes": [
+        {
+          "category": "Links",
+          "key": "pref_browser",
+          "logical_kind": "stored_setting",
+          "resource": "pref_general_v2",
+          "root_referenced": true
+        },
+        {
+          "category": null,
+          "key": "pref_browser",
+          "logical_kind": "stored_setting",
+          "resource": "pref_links_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Links & browser",
+      "page_intro": "Choose how links open and which browser behavior Boost uses.",
+      "proposed_summary": "",
+      "root": "Media",
+      "screen_depth": 2,
+      "screen_path": [
+        "Media",
+        "Links & browser",
+        "Browser"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "string",
+      "subscreen": "Browser",
+      "title": "Default browser",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "",
+      "dependency": "",
+      "existing_summary": "Domains that will always open in external app",
+      "help_treatment": "REVIEW_EXISTING_SUMMARY",
+      "key": "pref_domain_exceptions",
+      "leaf_section": "Link handling",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": null,
+          "key": "pref_domain_exceptions",
+          "logical_kind": "special_preference",
+          "resource": "pref_links_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "special_preference",
+      "page": "Links & browser",
+      "page_intro": "Choose how links open and which browser behavior Boost uses.",
+      "proposed_summary": "Domains that will always open in external app",
+      "root": "Media",
+      "screen_depth": 2,
+      "screen_path": [
+        "Media",
+        "Links & browser",
+        "Link handling"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "none_or_custom",
+      "subscreen": "Link handling",
+      "title": "Domain exceptions",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "true",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE",
+      "key": "pref_link_album",
+      "leaf_section": "Links to open in app",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Links to open in app",
+          "key": "pref_link_album",
+          "logical_kind": "stored_setting",
+          "resource": "pref_links_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Links & browser",
+      "page_intro": "Choose how links open and which browser behavior Boost uses.",
+      "proposed_summary": "",
+      "root": "Media",
+      "screen_depth": 2,
+      "screen_path": [
+        "Media",
+        "Links & browser",
+        "Links to open in app"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Links to open in app",
+      "title": "Albums",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "true",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE",
+      "key": "pref_link_deviant",
+      "leaf_section": "Links to open in app",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Links to open in app",
+          "key": "pref_link_deviant",
+          "logical_kind": "stored_setting",
+          "resource": "pref_links_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Links & browser",
+      "page_intro": "Choose how links open and which browser behavior Boost uses.",
+      "proposed_summary": "",
+      "root": "Media",
+      "screen_depth": 2,
+      "screen_path": [
+        "Media",
+        "Links & browser",
+        "Links to open in app"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Links to open in app",
+      "title": "Deviant Art",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "true",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE",
+      "key": "pref_link_gif",
+      "leaf_section": "Links to open in app",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Links to open in app",
+          "key": "pref_link_gif",
+          "logical_kind": "stored_setting",
+          "resource": "pref_links_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Links & browser",
+      "page_intro": "Choose how links open and which browser behavior Boost uses.",
+      "proposed_summary": "",
+      "root": "Media",
+      "screen_depth": 2,
+      "screen_path": [
+        "Media",
+        "Links & browser",
+        "Links to open in app"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Links to open in app",
+      "title": "Gifs",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "true",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "OMIT_SELF_EXPLANATORY",
+      "key": "pref_link_image",
+      "leaf_section": "Links to open in app",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Links to open in app",
+          "key": "pref_link_image",
+          "logical_kind": "stored_setting",
+          "resource": "pref_links_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Links & browser",
+      "page_intro": "Choose how links open and which browser behavior Boost uses.",
+      "proposed_summary": "",
+      "root": "Media",
+      "screen_depth": 2,
+      "screen_path": [
+        "Media",
+        "Links & browser",
+        "Links to open in app"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Links to open in app",
+      "title": "Images",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "true",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE",
+      "key": "pref_link_neatclip",
+      "leaf_section": "Links to open in app",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Links to open in app",
+          "key": "pref_link_neatclip",
+          "logical_kind": "stored_setting",
+          "resource": "pref_links_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Links & browser",
+      "page_intro": "Choose how links open and which browser behavior Boost uses.",
+      "proposed_summary": "",
+      "root": "Media",
+      "screen_depth": 2,
+      "screen_path": [
+        "Media",
+        "Links & browser",
+        "Links to open in app"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Links to open in app",
+      "title": "NeatClip",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "true",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE",
+      "key": "pref_link_vreddit",
+      "leaf_section": "Links to open in app",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Links to open in app",
+          "key": "pref_link_vreddit",
+          "logical_kind": "stored_setting",
+          "resource": "pref_links_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Links & browser",
+      "page_intro": "Choose how links open and which browser behavior Boost uses.",
+      "proposed_summary": "",
+      "root": "Media",
+      "screen_depth": 2,
+      "screen_path": [
+        "Media",
+        "Links & browser",
+        "Links to open in app"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Links to open in app",
+      "title": "Reddit videos",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "true",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE",
+      "key": "pref_link_streamable",
+      "leaf_section": "Links to open in app",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Links to open in app",
+          "key": "pref_link_streamable",
+          "logical_kind": "stored_setting",
+          "resource": "pref_links_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Links & browser",
+      "page_intro": "Choose how links open and which browser behavior Boost uses.",
+      "proposed_summary": "",
+      "root": "Media",
+      "screen_depth": 2,
+      "screen_path": [
+        "Media",
+        "Links & browser",
+        "Links to open in app"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Links to open in app",
+      "title": "Streamable",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "true",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE",
+      "key": "pref_link_xkcd",
+      "leaf_section": "Links to open in app",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Links to open in app",
+          "key": "pref_link_xkcd",
+          "logical_kind": "stored_setting",
+          "resource": "pref_links_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Links & browser",
+      "page_intro": "Choose how links open and which browser behavior Boost uses.",
+      "proposed_summary": "",
+      "root": "Media",
+      "screen_depth": 2,
+      "screen_path": [
+        "Media",
+        "Links & browser",
+        "Links to open in app"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Links to open in app",
+      "title": "XKCD",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "true",
+      "dependency": "",
+      "existing_summary": "Disable to open with external app",
+      "help_treatment": "REVIEW_EXISTING_SUMMARY",
+      "key": "pref_link_video",
+      "leaf_section": "Video links",
+      "legacy_route_count": 2,
+      "legacy_routes": [
+        {
+          "category": "Links",
+          "key": "pref_link_video",
+          "logical_kind": "stored_setting",
+          "resource": "pref_general_v2",
+          "root_referenced": true
+        },
+        {
+          "category": "Links to open in app",
+          "key": "pref_link_video",
+          "logical_kind": "stored_setting",
+          "resource": "pref_links_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Links & browser",
+      "page_intro": "Choose how links open and which browser behavior Boost uses.",
+      "proposed_summary": "Disable to open with external app",
+      "root": "Media",
+      "screen_depth": 2,
+      "screen_path": [
+        "Media",
+        "Links & browser",
+        "Video links"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Video links",
+      "title": "Internal Youtube player",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "false",
+      "dependency": "",
+      "existing_summary": "Start videos muted by default",
+      "help_treatment": "REVIEW_EXISTING_SUMMARY",
+      "key": "pref_video_audio_start_muted",
+      "leaf_section": "Audio",
+      "legacy_route_count": 2,
+      "legacy_routes": [
+        {
+          "category": "Links",
+          "key": "pref_video_audio_start_muted",
+          "logical_kind": "stored_setting",
+          "resource": "pref_general_v2",
+          "root_referenced": true
+        },
+        {
+          "category": "Video viewer",
+          "key": "pref_video_audio_start_muted",
+          "logical_kind": "stored_setting",
+          "resource": "pref_media_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Playback & autoplay",
+      "page_intro": "Control video, audio, autoplay, and player behavior.",
+      "proposed_summary": "Start videos muted by default",
+      "root": "Media",
+      "screen_depth": 2,
+      "screen_path": [
+        "Media",
+        "Playback & autoplay",
+        "Audio"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Audio",
+      "title": "Mute audio",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "1",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE+PROGRESSIVE_DISCLOSURE",
+      "key": "pref_autoplay_cards",
+      "leaf_section": "Autoplay",
+      "legacy_route_count": 2,
+      "legacy_routes": [
+        {
+          "category": "Videos",
+          "key": "pref_autoplay_cards",
+          "logical_kind": "stored_setting",
+          "resource": "pref_data_v2",
+          "root_referenced": true
+        },
+        {
+          "category": "Links",
+          "key": "pref_autoplay_cards",
+          "logical_kind": "stored_setting",
+          "resource": "pref_general_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Playback & autoplay",
+      "page_intro": "Control video, audio, autoplay, and player behavior.",
+      "proposed_summary": "",
+      "root": "Media",
+      "screen_depth": 2,
+      "screen_path": [
+        "Media",
+        "Playback & autoplay",
+        "Autoplay"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "string",
+      "subscreen": "Autoplay",
+      "title": "Autoplay videos",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "boost",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE",
+      "key": "pref_media_viewer",
+      "leaf_section": "Media behavior",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Interface",
+          "key": "pref_media_viewer",
+          "logical_kind": "stored_setting",
+          "resource": "pref_media_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Playback & autoplay",
+      "page_intro": "Control video, audio, autoplay, and player behavior.",
+      "proposed_summary": "",
+      "root": "Media",
+      "screen_depth": 2,
+      "screen_path": [
+        "Media",
+        "Playback & autoplay",
+        "Media behavior"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "string",
+      "subscreen": "Media behavior",
+      "title": "Media viewer",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "show",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE",
+      "key": "pref_media_overlay_visibility",
+      "leaf_section": "Media behavior",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Interface",
+          "key": "pref_media_overlay_visibility",
+          "logical_kind": "stored_setting",
+          "resource": "pref_media_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Playback & autoplay",
+      "page_intro": "Control video, audio, autoplay, and player behavior.",
+      "proposed_summary": "",
+      "root": "Media",
+      "screen_depth": 2,
+      "screen_path": [
+        "Media",
+        "Playback & autoplay",
+        "Media behavior"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "string",
+      "subscreen": "Media behavior",
+      "title": "Overlay elements",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "false",
+      "dependency": "",
+      "existing_summary": "Tap outside video to close (If enabled, vertical videos will be played horizontally)",
+      "help_treatment": "REVIEW_EXISTING_SUMMARY",
+      "key": "pref_tap_to_dismiss_youtube_videos",
+      "leaf_section": "Playback & autoplay",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Youtube",
+          "key": "pref_tap_to_dismiss_youtube_videos",
+          "logical_kind": "stored_setting",
+          "resource": "pref_media_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Playback & autoplay",
+      "page_intro": "Control video, audio, autoplay, and player behavior.",
+      "proposed_summary": "Tap outside video to close (If enabled, vertical videos will be played horizontally)",
+      "root": "Media",
+      "screen_depth": 2,
+      "screen_path": [
+        "Media",
+        "Playback & autoplay",
+        "Playback & autoplay"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Playback & autoplay",
+      "title": "Tap to dismiss Youtube",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "0",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE",
+      "key": "pref_video_player",
+      "leaf_section": "Playback & autoplay",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Video viewer",
+          "key": "pref_video_player",
+          "logical_kind": "stored_setting",
+          "resource": "pref_media_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Playback & autoplay",
+      "page_intro": "Control video, audio, autoplay, and player behavior.",
+      "proposed_summary": "",
+      "root": "Media",
+      "screen_depth": 2,
+      "screen_path": [
+        "Media",
+        "Playback & autoplay",
+        "Playback & autoplay"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "string",
+      "subscreen": "Playback & autoplay",
+      "title": "Video player",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "false",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE",
+      "key": "pref_all_delete",
+      "leaf_section": "History",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "History",
+          "key": "pref_all_delete",
+          "logical_kind": "special_preference",
+          "resource": "pref_privacy_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "special_preference",
+      "page": "History, privacy & recovery",
+      "page_intro": "Manage history, privacy, and supported archive recovery.",
+      "proposed_summary": "",
+      "root": "Notifications & account",
+      "screen_depth": 2,
+      "screen_path": [
+        "Notifications & account",
+        "History, privacy & recovery",
+        "History"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "none_or_custom",
+      "subscreen": "History",
+      "title": "Clear all history",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "false",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE",
+      "key": "pref_history_delete",
+      "leaf_section": "History",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "History",
+          "key": "pref_history_delete",
+          "logical_kind": "special_preference",
+          "resource": "pref_privacy_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "special_preference",
+      "page": "History, privacy & recovery",
+      "page_intro": "Manage history, privacy, and supported archive recovery.",
+      "proposed_summary": "",
+      "root": "Notifications & account",
+      "screen_depth": 2,
+      "screen_path": [
+        "Notifications & account",
+        "History, privacy & recovery",
+        "History"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "none_or_custom",
+      "subscreen": "History",
+      "title": "Clear community history",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "false",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE",
+      "key": "pref_recent_posts_delete",
+      "leaf_section": "History",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "History",
+          "key": "pref_recent_posts_delete",
+          "logical_kind": "special_preference",
+          "resource": "pref_privacy_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "special_preference",
+      "page": "History, privacy & recovery",
+      "page_intro": "Manage history, privacy, and supported archive recovery.",
+      "proposed_summary": "",
+      "root": "Notifications & account",
+      "screen_depth": 2,
+      "screen_path": [
+        "Notifications & account",
+        "History, privacy & recovery",
+        "History"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "none_or_custom",
+      "subscreen": "History",
+      "title": "Clear post history",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "false",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE",
+      "key": "pref_searches_delete",
+      "leaf_section": "History",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "History",
+          "key": "pref_searches_delete",
+          "logical_kind": "special_preference",
+          "resource": "pref_privacy_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "special_preference",
+      "page": "History, privacy & recovery",
+      "page_intro": "Manage history, privacy, and supported archive recovery.",
+      "proposed_summary": "",
+      "root": "Notifications & account",
+      "screen_depth": 2,
+      "screen_path": [
+        "Notifications & account",
+        "History, privacy & recovery",
+        "History"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "none_or_custom",
+      "subscreen": "History",
+      "title": "Clear search history",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "true",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE",
+      "key": "pref_recent_posts_save_nsfw",
+      "leaf_section": "History",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "History",
+          "key": "pref_recent_posts_save_nsfw",
+          "logical_kind": "stored_setting",
+          "resource": "pref_privacy_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "History, privacy & recovery",
+      "page_intro": "Manage history, privacy, and supported archive recovery.",
+      "proposed_summary": "",
+      "root": "Notifications & account",
+      "screen_depth": 2,
+      "screen_path": [
+        "Notifications & account",
+        "History, privacy & recovery",
+        "History"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "History",
+      "title": "Include NSFW posts",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "true",
+      "dependency": "",
+      "existing_summary": "Visited communities show in autocomplete fields",
+      "help_treatment": "REVIEW_EXISTING_SUMMARY",
+      "key": "pref_history_save",
+      "leaf_section": "History",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "History",
+          "key": "pref_history_save",
+          "logical_kind": "stored_setting",
+          "resource": "pref_privacy_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "History, privacy & recovery",
+      "page_intro": "Manage history, privacy, and supported archive recovery.",
+      "proposed_summary": "Visited communities show in autocomplete fields",
+      "root": "Notifications & account",
+      "screen_depth": 2,
+      "screen_path": [
+        "Notifications & account",
+        "History, privacy & recovery",
+        "History"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "History",
+      "title": "Save recent communities",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "true",
+      "dependency": "",
+      "existing_summary": "Visited posts show in History screen",
+      "help_treatment": "REVIEW_EXISTING_SUMMARY",
+      "key": "pref_recent_posts_save",
+      "leaf_section": "History",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "History",
+          "key": "pref_recent_posts_save",
+          "logical_kind": "stored_setting",
+          "resource": "pref_privacy_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "History, privacy & recovery",
+      "page_intro": "Manage history, privacy, and supported archive recovery.",
+      "proposed_summary": "Visited posts show in History screen",
+      "root": "Notifications & account",
+      "screen_depth": 2,
+      "screen_path": [
+        "Notifications & account",
+        "History, privacy & recovery",
+        "History"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "History",
+      "title": "Save recent posts",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "true",
+      "dependency": "",
+      "existing_summary": "Recent searches are cleared on exit",
+      "help_treatment": "REVIEW_EXISTING_SUMMARY",
+      "key": "pref_search_history_save",
+      "leaf_section": "History",
+      "legacy_route_count": 2,
+      "legacy_routes": [
+        {
+          "category": "History",
+          "key": "pref_search_history_save",
+          "logical_kind": "stored_setting",
+          "resource": "pref_privacy_v2",
+          "root_referenced": true
+        },
+        {
+          "category": "Suggestions",
+          "key": "pref_search_history_save",
+          "logical_kind": "stored_setting",
+          "resource": "pref_search_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "History, privacy & recovery",
+      "page_intro": "Manage history, privacy, and supported archive recovery.",
+      "proposed_summary": "Recent searches are cleared on exit",
+      "root": "Notifications & account",
+      "screen_depth": 2,
+      "screen_path": [
+        "Notifications & account",
+        "History, privacy & recovery",
+        "History"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "History",
+      "title": "Show recent searches",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "false",
+      "dependency": "",
+      "existing_summary": "Try to restore supported missing Imgur media from archive sources. Disabled by default.",
+      "help_treatment": "REVIEW_EXISTING_SUMMARY+PROGRESSIVE_DISCLOSURE",
+      "key": "morphe_boost_imgur_undelete_enabled",
+      "leaf_section": "Recovery & archives",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Recovery & archives",
+          "key": "morphe_boost_imgur_undelete_enabled",
+          "logical_kind": "morphe_user_setting",
+          "resource": "morphe_boost_settings_skeleton",
+          "root_referenced": false
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "History, privacy & recovery",
+      "page_intro": "Manage history, privacy, and supported archive recovery.",
+      "proposed_summary": "Try to restore supported missing Imgur media from archive sources. Disabled by default.",
+      "root": "Notifications & account",
+      "screen_depth": 2,
+      "screen_path": [
+        "Notifications & account",
+        "History, privacy & recovery",
+        "Recovery & archives"
+      ],
+      "source_type": "morphe_embedded_xml",
+      "storage_type": "boolean",
+      "subscreen": "Recovery & archives",
+      "title": "Automatically undelete Imgur images",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "false",
+      "dependency": "",
+      "existing_summary": "Try to restore supported deleted Reddit posts/comments from archive sources. Disabled by default to keep normal browsing stable.",
+      "help_treatment": "REVIEW_EXISTING_SUMMARY+PROGRESSIVE_DISCLOSURE",
+      "key": "morphe_boost_reddit_undelete_enabled",
+      "leaf_section": "Recovery & archives",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Recovery & archives",
+          "key": "morphe_boost_reddit_undelete_enabled",
+          "logical_kind": "morphe_user_setting",
+          "resource": "morphe_boost_settings_skeleton",
+          "root_referenced": false
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "History, privacy & recovery",
+      "page_intro": "Manage history, privacy, and supported archive recovery.",
+      "proposed_summary": "Try to restore supported deleted Reddit posts/comments from archive sources. Disabled by default to keep normal browsing stable.",
+      "root": "Notifications & account",
+      "screen_depth": 2,
+      "screen_path": [
+        "Notifications & account",
+        "History, privacy & recovery",
+        "Recovery & archives"
+      ],
+      "source_type": "morphe_embedded_xml",
+      "storage_type": "boolean",
+      "subscreen": "Recovery & archives",
+      "title": "Automatically undelete Reddit content",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "true",
+      "dependency": "pref_check_messages_push",
+      "existing_summary": "Show only Boost notification",
+      "help_treatment": "REVIEW_EXISTING_SUMMARY+PROGRESSIVE_DISCLOSURE",
+      "key": "pref_check_messages_push_clear",
+      "leaf_section": "Advanced",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Advanced",
+          "key": "pref_check_messages_push_clear",
+          "logical_kind": "stored_setting",
+          "resource": "pref_messages_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Notifications & inbox",
+      "page_intro": "Control notifications, messages, and inbox behavior.",
+      "proposed_summary": "Show only Boost notification",
+      "root": "Notifications & account",
+      "screen_depth": 2,
+      "screen_path": [
+        "Notifications & account",
+        "Notifications & inbox",
+        "Advanced"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Advanced",
+      "title": "Clear source notification",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "false",
+      "dependency": "pref_check_messages",
+      "existing_summary": "Requires the reddit app to be installed. Boost will show its own notifications when a push notification from reddit is received. Make sure your account is added to the reddit app and notifications are enabled",
+      "help_treatment": "REVIEW_EXISTING_SUMMARY+PROGRESSIVE_DISCLOSURE",
+      "key": "pref_check_messages_push",
+      "leaf_section": "Advanced",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Advanced",
+          "key": "pref_check_messages_push",
+          "logical_kind": "stored_setting",
+          "resource": "pref_messages_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Notifications & inbox",
+      "page_intro": "Control notifications, messages, and inbox behavior.",
+      "proposed_summary": "Requires the reddit app to be installed. Boost will show its own notifications when a push notification from reddit is received. Make sure your account is added to the reddit app and notifications are enabled",
+      "root": "Notifications & account",
+      "screen_depth": 2,
+      "screen_path": [
+        "Notifications & account",
+        "Notifications & inbox",
+        "Advanced"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Advanced",
+      "title": "Reddit push",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "60",
+      "dependency": "pref_check_messages",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE",
+      "key": "pref_check_messages_interval",
+      "leaf_section": "Notifications",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": null,
+          "key": "pref_check_messages_interval",
+          "logical_kind": "stored_setting",
+          "resource": "pref_messages_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Notifications & inbox",
+      "page_intro": "Control notifications, messages, and inbox behavior.",
+      "proposed_summary": "",
+      "root": "Notifications & account",
+      "screen_depth": 2,
+      "screen_path": [
+        "Notifications & account",
+        "Notifications & inbox",
+        "Notifications"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "string",
+      "subscreen": "Notifications",
+      "title": "Check interval",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "true",
+      "dependency": "pref_check_messages",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE",
+      "key": "pref_check_modmail",
+      "leaf_section": "Notifications",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": null,
+          "key": "pref_check_modmail",
+          "logical_kind": "stored_setting",
+          "resource": "pref_messages_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Notifications & inbox",
+      "page_intro": "Control notifications, messages, and inbox behavior.",
+      "proposed_summary": "",
+      "root": "Notifications & account",
+      "screen_depth": 2,
+      "screen_path": [
+        "Notifications & account",
+        "Notifications & inbox",
+        "Notifications"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Notifications",
+      "title": "Check moderator mail",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "true",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE+PROGRESSIVE_DISCLOSURE",
+      "key": "pref_check_messages",
+      "leaf_section": "Notifications",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": null,
+          "key": "pref_check_messages",
+          "logical_kind": "stored_setting",
+          "resource": "pref_messages_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Notifications & inbox",
+      "page_intro": "Control notifications, messages, and inbox behavior.",
+      "proposed_summary": "",
+      "root": "Notifications & account",
+      "screen_depth": 2,
+      "screen_path": [
+        "Notifications & account",
+        "Notifications & inbox",
+        "Notifications"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Notifications",
+      "title": "Check notifications",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "",
+      "dependency": "",
+      "existing_summary": "Open system notification settings",
+      "help_treatment": "REVIEW_EXISTING_SUMMARY+PROGRESSIVE_DISCLOSURE",
+      "key": "pref_notifications_configure",
+      "leaf_section": "Notifications",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": null,
+          "key": "pref_notifications_configure",
+          "logical_kind": "action",
+          "resource": "pref_messages_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "action",
+      "page": "Notifications & inbox",
+      "page_intro": "Control notifications, messages, and inbox behavior.",
+      "proposed_summary": "Open system notification settings",
+      "root": "Notifications & account",
+      "screen_depth": 2,
+      "screen_path": [
+        "Notifications & account",
+        "Notifications & inbox",
+        "Notifications"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "none_or_custom",
+      "subscreen": "Notifications",
+      "title": "Configure notifications",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "",
+      "dependency": "",
+      "existing_summary": "Version",
+      "help_treatment": "REVIEW_EXISTING_SUMMARY",
+      "key": "about_version",
+      "leaf_section": "About Boost",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": null,
+          "key": "about_version",
+          "logical_kind": "action",
+          "resource": "pref_about_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "action",
+      "page": "About & support",
+      "page_intro": "View app information, legal information, and support actions.",
+      "proposed_summary": "Version",
+      "root": "Data & app",
+      "screen_depth": 2,
+      "screen_path": [
+        "Data & app",
+        "About & support",
+        "About Boost"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "none_or_custom",
+      "subscreen": "About Boost",
+      "title": "Changelog",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "",
+      "dependency": "",
+      "existing_summary": "Rate it in Google Play",
+      "help_treatment": "REVIEW_EXISTING_SUMMARY",
+      "key": "rate_app",
+      "leaf_section": "About Boost",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": null,
+          "key": "rate_app",
+          "logical_kind": "action",
+          "resource": "pref_about_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "action",
+      "page": "About & support",
+      "page_intro": "View app information, legal information, and support actions.",
+      "proposed_summary": "Rate it in Google Play",
+      "root": "Data & app",
+      "screen_depth": 2,
+      "screen_path": [
+        "Data & app",
+        "About & support",
+        "About Boost"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "none_or_custom",
+      "subscreen": "About Boost",
+      "title": "Do you like this app?",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "",
+      "dependency": "",
+      "existing_summary": "r/BoostForReddit",
+      "help_treatment": "REVIEW_EXISTING_SUMMARY",
+      "key": "about_subreddit",
+      "leaf_section": "About Boost",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": null,
+          "key": "about_subreddit",
+          "logical_kind": "action",
+          "resource": "pref_about_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "action",
+      "page": "About & support",
+      "page_intro": "View app information, legal information, and support actions.",
+      "proposed_summary": "r/BoostForReddit",
+      "root": "Data & app",
+      "screen_depth": 2,
+      "screen_path": [
+        "Data & app",
+        "About & support",
+        "About Boost"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "none_or_custom",
+      "subscreen": "About Boost",
+      "title": "Feedback and support",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "OMIT_OR_ONE_LINE_ACTION_HINT",
+      "key": "about_faq",
+      "leaf_section": "About Boost",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": null,
+          "key": "about_faq",
+          "logical_kind": "action",
+          "resource": "pref_about_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "action",
+      "page": "About & support",
+      "page_intro": "View app information, legal information, and support actions.",
+      "proposed_summary": "",
+      "root": "Data & app",
+      "screen_depth": 2,
+      "screen_path": [
+        "Data & app",
+        "About & support",
+        "About Boost"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "none_or_custom",
+      "subscreen": "About Boost",
+      "title": "Help/FAQ",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "",
+      "dependency": "",
+      "existing_summary": "Give Boost some love!",
+      "help_treatment": "REVIEW_EXISTING_SUMMARY",
+      "key": "support_launch",
+      "leaf_section": "About Boost",
+      "legacy_route_count": 2,
+      "legacy_routes": [
+        {
+          "category": null,
+          "key": "support_launch",
+          "logical_kind": "action",
+          "resource": "pref_about_v2",
+          "root_referenced": true
+        },
+        {
+          "category": null,
+          "key": "support_launch",
+          "logical_kind": "action",
+          "resource": "pref_headers_v2",
+          "root_referenced": false
+        }
+      ],
+      "logical_kind": "action",
+      "page": "About & support",
+      "page_intro": "View app information, legal information, and support actions.",
+      "proposed_summary": "Give Boost some love!",
+      "root": "Data & app",
+      "screen_depth": 2,
+      "screen_path": [
+        "Data & app",
+        "About & support",
+        "About Boost"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "none_or_custom",
+      "subscreen": "About Boost",
+      "title": "Launch the rocket",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "OMIT_OR_ONE_LINE_ACTION_HINT",
+      "key": "licenses_preference",
+      "leaf_section": "About Boost",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": null,
+          "key": "licenses_preference",
+          "logical_kind": "action",
+          "resource": "pref_about_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "action",
+      "page": "About & support",
+      "page_intro": "View app information, legal information, and support actions.",
+      "proposed_summary": "",
+      "root": "Data & app",
+      "screen_depth": 2,
+      "screen_path": [
+        "Data & app",
+        "About & support",
+        "About Boost"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "none_or_custom",
+      "subscreen": "About Boost",
+      "title": "Licenses",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "",
+      "dependency": "",
+      "existing_summary": "mayayo.dev@gmail.com",
+      "help_treatment": "REVIEW_EXISTING_SUMMARY",
+      "key": "contact_dev_key",
+      "leaf_section": "Author",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Author",
+          "key": "contact_dev_key",
+          "logical_kind": "action",
+          "resource": "pref_about_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "action",
+      "page": "About & support",
+      "page_intro": "View app information, legal information, and support actions.",
+      "proposed_summary": "mayayo.dev@gmail.com",
+      "root": "Data & app",
+      "screen_depth": 2,
+      "screen_path": [
+        "Data & app",
+        "About & support",
+        "Author"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "none_or_custom",
+      "subscreen": "Author",
+      "title": "Email",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "",
+      "dependency": "",
+      "existing_summary": "u/rmayayo",
+      "help_treatment": "REVIEW_EXISTING_SUMMARY",
+      "key": "about_reddit",
+      "leaf_section": "Author",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Author",
+          "key": "about_reddit",
+          "logical_kind": "action",
+          "resource": "pref_about_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "action",
+      "page": "About & support",
+      "page_intro": "View app information, legal information, and support actions.",
+      "proposed_summary": "u/rmayayo",
+      "root": "Data & app",
+      "screen_depth": 2,
+      "screen_path": [
+        "Data & app",
+        "About & support",
+        "Author"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "none_or_custom",
+      "subscreen": "Author",
+      "title": "reddit",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "",
+      "dependency": "",
+      "existing_summary": "@rmayayo",
+      "help_treatment": "REVIEW_EXISTING_SUMMARY",
+      "key": "about_twitter",
+      "leaf_section": "Author",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Author",
+          "key": "about_twitter",
+          "logical_kind": "action",
+          "resource": "pref_about_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "action",
+      "page": "About & support",
+      "page_intro": "View app information, legal information, and support actions.",
+      "proposed_summary": "@rmayayo",
+      "root": "Data & app",
+      "screen_depth": 2,
+      "screen_path": [
+        "Data & app",
+        "About & support",
+        "Author"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "none_or_custom",
+      "subscreen": "Author",
+      "title": "Twitter",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "OMIT_OR_ONE_LINE_ACTION_HINT+PROGRESSIVE_DISCLOSURE",
+      "key": "privacy_policy",
+      "leaf_section": "Privacy",
+      "legacy_route_count": 2,
+      "legacy_routes": [
+        {
+          "category": "Privacy",
+          "key": "privacy_policy",
+          "logical_kind": "action",
+          "resource": "pref_about_v2",
+          "root_referenced": true
+        },
+        {
+          "category": null,
+          "key": "privacy_policy",
+          "logical_kind": "action",
+          "resource": "pref_headers_v2",
+          "root_referenced": false
+        }
+      ],
+      "logical_kind": "action",
+      "page": "About & support",
+      "page_intro": "View app information, legal information, and support actions.",
+      "proposed_summary": "",
+      "root": "Data & app",
+      "screen_depth": 2,
+      "screen_path": [
+        "Data & app",
+        "About & support",
+        "Privacy"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "none_or_custom",
+      "subscreen": "Privacy",
+      "title": "Privacy policy",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "false",
+      "dependency": "",
+      "existing_summary": "For users in the European Union",
+      "help_treatment": "REVIEW_EXISTING_SUMMARY",
+      "key": "pref_gdpr_revoke",
+      "leaf_section": "Privacy",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Privacy",
+          "key": "pref_gdpr_revoke",
+          "logical_kind": "special_preference",
+          "resource": "pref_about_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "special_preference",
+      "page": "About & support",
+      "page_intro": "View app information, legal information, and support actions.",
+      "proposed_summary": "For users in the European Union",
+      "root": "Data & app",
+      "screen_depth": 2,
+      "screen_path": [
+        "Data & app",
+        "About & support",
+        "Privacy"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "none_or_custom",
+      "subscreen": "Privacy",
+      "title": "Revoke GDPR consent",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "true",
+      "dependency": "",
+      "existing_summary": "Automatically send usage statistics and crash reports to help us improve Boost for reddit",
+      "help_treatment": "REVIEW_EXISTING_SUMMARY",
+      "key": "pref_statistics",
+      "leaf_section": "Privacy",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Privacy",
+          "key": "pref_statistics",
+          "logical_kind": "stored_setting",
+          "resource": "pref_about_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "About & support",
+      "page_intro": "View app information, legal information, and support actions.",
+      "proposed_summary": "Automatically send usage statistics and crash reports to help us improve Boost for reddit",
+      "root": "Data & app",
+      "screen_depth": 2,
+      "screen_path": [
+        "Data & app",
+        "About & support",
+        "Privacy"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Privacy",
+      "title": "Send statistics",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "true",
+      "dependency": "",
+      "existing_summary": "Crop community icon into a circular shape. Recommended if your launcher uses round icons",
+      "help_treatment": "REVIEW_EXISTING_SUMMARY",
+      "key": "pref_shortcut_icon_crop",
+      "leaf_section": "Community shortcuts",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Community shortcuts",
+          "key": "pref_shortcut_icon_crop",
+          "logical_kind": "stored_setting",
+          "resource": "pref_misc_v2",
+          "root_referenced": false
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "App behavior & compatibility",
+      "page_intro": "Manage app-wide compatibility options and remaining global behavior.",
+      "proposed_summary": "Crop community icon into a circular shape. Recommended if your launcher uses round icons",
+      "root": "Data & app",
+      "screen_depth": 2,
+      "screen_path": [
+        "Data & app",
+        "App behavior & compatibility",
+        "Community shortcuts"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Community shortcuts",
+      "title": "Crop community icon",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "3",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE+PROGRESSIVE_DISCLOSURE",
+      "key": "pref_autoplay_swipe",
+      "leaf_section": "Compatibility & legacy",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Legacy features",
+          "key": "pref_autoplay_swipe",
+          "logical_kind": "stored_setting",
+          "resource": "pref_misc_v2",
+          "root_referenced": false
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "App behavior & compatibility",
+      "page_intro": "Manage app-wide compatibility options and remaining global behavior.",
+      "proposed_summary": "",
+      "root": "Data & app",
+      "screen_depth": 2,
+      "screen_path": [
+        "Data & app",
+        "App behavior & compatibility",
+        "Compatibility & legacy"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "string",
+      "subscreen": "Compatibility & legacy",
+      "title": "Autoplay videos in Swipe view",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "true",
+      "dependency": "",
+      "existing_summary": "Color tags in images indicating the link type",
+      "help_treatment": "REVIEW_EXISTING_SUMMARY",
+      "key": "pref_info_color_indicators",
+      "leaf_section": "Compatibility & legacy",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Legacy features",
+          "key": "pref_info_color_indicators",
+          "logical_kind": "stored_setting",
+          "resource": "pref_misc_v2",
+          "root_referenced": false
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "App behavior & compatibility",
+      "page_intro": "Manage app-wide compatibility options and remaining global behavior.",
+      "proposed_summary": "Color tags in images indicating the link type",
+      "root": "Data & app",
+      "screen_depth": 2,
+      "screen_path": [
+        "Data & app",
+        "App behavior & compatibility",
+        "Compatibility & legacy"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Compatibility & legacy",
+      "title": "Colored link type indicators",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "false",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE",
+      "key": "pref_go_to_sub_dialog",
+      "leaf_section": "Compatibility & legacy",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Legacy features",
+          "key": "pref_go_to_sub_dialog",
+          "logical_kind": "stored_setting",
+          "resource": "pref_misc_v2",
+          "root_referenced": false
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "App behavior & compatibility",
+      "page_intro": "Manage app-wide compatibility options and remaining global behavior.",
+      "proposed_summary": "",
+      "root": "Data & app",
+      "screen_depth": 2,
+      "screen_path": [
+        "Data & app",
+        "App behavior & compatibility",
+        "Compatibility & legacy"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Compatibility & legacy",
+      "title": "Go to community in a dialog",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "false",
+      "dependency": "",
+      "existing_summary": "Show image preview above post title",
+      "help_treatment": "REVIEW_EXISTING_SUMMARY",
+      "key": "pref_cards_preview_top",
+      "leaf_section": "Compatibility & legacy",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Legacy features",
+          "key": "pref_cards_preview_top",
+          "logical_kind": "stored_setting",
+          "resource": "pref_misc_v2",
+          "root_referenced": false
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "App behavior & compatibility",
+      "page_intro": "Manage app-wide compatibility options and remaining global behavior.",
+      "proposed_summary": "Show image preview above post title",
+      "root": "Data & app",
+      "screen_depth": 2,
+      "screen_path": [
+        "Data & app",
+        "App behavior & compatibility",
+        "Compatibility & legacy"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Compatibility & legacy",
+      "title": "Previews on top",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "true",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE",
+      "key": "pref_info_post_shorten_score",
+      "leaf_section": "Compatibility & legacy",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Legacy features",
+          "key": "pref_info_post_shorten_score",
+          "logical_kind": "stored_setting",
+          "resource": "pref_misc_v2",
+          "root_referenced": false
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "App behavior & compatibility",
+      "page_intro": "Manage app-wide compatibility options and remaining global behavior.",
+      "proposed_summary": "",
+      "root": "Data & app",
+      "screen_depth": 2,
+      "screen_path": [
+        "Data & app",
+        "App behavior & compatibility",
+        "Compatibility & legacy"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Compatibility & legacy",
+      "title": "Shorten score",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "false",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE",
+      "key": "pref_send_floating_button",
+      "leaf_section": "Compatibility & legacy",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Legacy features",
+          "key": "pref_send_floating_button",
+          "logical_kind": "stored_setting",
+          "resource": "pref_misc_v2",
+          "root_referenced": false
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "App behavior & compatibility",
+      "page_intro": "Manage app-wide compatibility options and remaining global behavior.",
+      "proposed_summary": "",
+      "root": "Data & app",
+      "screen_depth": 2,
+      "screen_path": [
+        "Data & app",
+        "App behavior & compatibility",
+        "Compatibility & legacy"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Compatibility & legacy",
+      "title": "Show floating send button",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "true",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE",
+      "key": "pref_info_post_self_image",
+      "leaf_section": "Compatibility & legacy",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Legacy features",
+          "key": "pref_info_post_self_image",
+          "logical_kind": "stored_setting",
+          "resource": "pref_misc_v2",
+          "root_referenced": false
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "App behavior & compatibility",
+      "page_intro": "Manage app-wide compatibility options and remaining global behavior.",
+      "proposed_summary": "",
+      "root": "Data & app",
+      "screen_depth": 2,
+      "screen_path": [
+        "Data & app",
+        "App behavior & compatibility",
+        "Compatibility & legacy"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Compatibility & legacy",
+      "title": "Show images from text posts",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "true",
+      "dependency": "",
+      "existing_summary": "Own posts and moderator",
+      "help_treatment": "REVIEW_EXISTING_SUMMARY",
+      "key": "pref_info_post_view_count",
+      "leaf_section": "Compatibility & legacy",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Legacy features",
+          "key": "pref_info_post_view_count",
+          "logical_kind": "stored_setting",
+          "resource": "pref_misc_v2",
+          "root_referenced": false
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "App behavior & compatibility",
+      "page_intro": "Manage app-wide compatibility options and remaining global behavior.",
+      "proposed_summary": "Own posts and moderator",
+      "root": "Data & app",
+      "screen_depth": 2,
+      "screen_path": [
+        "Data & app",
+        "App behavior & compatibility",
+        "Compatibility & legacy"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Compatibility & legacy",
+      "title": "Show view count",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "false",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE",
+      "key": "pref_toolbar_dropdown",
+      "leaf_section": "Compatibility & legacy",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Legacy features",
+          "key": "pref_toolbar_dropdown",
+          "logical_kind": "stored_setting",
+          "resource": "pref_misc_v2",
+          "root_referenced": false
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "App behavior & compatibility",
+      "page_intro": "Manage app-wide compatibility options and remaining global behavior.",
+      "proposed_summary": "",
+      "root": "Data & app",
+      "screen_depth": 2,
+      "screen_path": [
+        "Data & app",
+        "App behavior & compatibility",
+        "Compatibility & legacy"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Compatibility & legacy",
+      "title": "Subscriptions dropdown in toolbar",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "true",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE",
+      "key": "pref_toolbar_tap_to_go",
+      "leaf_section": "Compatibility & legacy",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Legacy features",
+          "key": "pref_toolbar_tap_to_go",
+          "logical_kind": "stored_setting",
+          "resource": "pref_misc_v2",
+          "root_referenced": false
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "App behavior & compatibility",
+      "page_intro": "Manage app-wide compatibility options and remaining global behavior.",
+      "proposed_summary": "",
+      "root": "Data & app",
+      "screen_depth": 2,
+      "screen_path": [
+        "Data & app",
+        "App behavior & compatibility",
+        "Compatibility & legacy"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Compatibility & legacy",
+      "title": "Tap toolbar to show subs",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "false",
+      "dependency": "",
+      "existing_summary": "Community and post info below title, no icon",
+      "help_treatment": "REVIEW_EXISTING_SUMMARY",
+      "key": "pref_cards_legacy",
+      "leaf_section": "Compatibility & legacy",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Legacy features",
+          "key": "pref_cards_legacy",
+          "logical_kind": "stored_setting",
+          "resource": "pref_misc_v2",
+          "root_referenced": false
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "App behavior & compatibility",
+      "page_intro": "Manage app-wide compatibility options and remaining global behavior.",
+      "proposed_summary": "Community and post info below title, no icon",
+      "root": "Data & app",
+      "screen_depth": 2,
+      "screen_path": [
+        "Data & app",
+        "App behavior & compatibility",
+        "Compatibility & legacy"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Compatibility & legacy",
+      "title": "Use legacy cards layout",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "0",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE",
+      "key": "pref_ad_format",
+      "leaf_section": "Other app behavior",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Misc",
+          "key": "pref_ad_format",
+          "logical_kind": "stored_setting",
+          "resource": "pref_misc_v2",
+          "root_referenced": false
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "App behavior & compatibility",
+      "page_intro": "Manage app-wide compatibility options and remaining global behavior.",
+      "proposed_summary": "",
+      "root": "Data & app",
+      "screen_depth": 2,
+      "screen_path": [
+        "Data & app",
+        "App behavior & compatibility",
+        "Other app behavior"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "string",
+      "subscreen": "Other app behavior",
+      "title": "Preferred Ad format",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "OMIT_OR_ONE_LINE_ACTION_HINT",
+      "key": "reset_tips",
+      "leaf_section": "Other app behavior",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Misc",
+          "key": "reset_tips",
+          "logical_kind": "action",
+          "resource": "pref_misc_v2",
+          "root_referenced": false
+        }
+      ],
+      "logical_kind": "action",
+      "page": "App behavior & compatibility",
+      "page_intro": "Manage app-wide compatibility options and remaining global behavior.",
+      "proposed_summary": "",
+      "root": "Data & app",
+      "screen_depth": 2,
+      "screen_path": [
+        "Data & app",
+        "App behavior & compatibility",
+        "Other app behavior"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "none_or_custom",
+      "subscreen": "Other app behavior",
+      "title": "Reset tips",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "true",
+      "dependency": "",
+      "existing_summary": "Use Morphe's modern task-based settings. Reopen Settings to apply.",
+      "help_treatment": "REVIEW_EXISTING_SUMMARY",
+      "key": "morphe_boost_settings_v4_enabled",
+      "leaf_section": "Settings presentation",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Settings",
+          "key": "morphe_boost_settings_v4_enabled",
+          "logical_kind": "morphe_user_setting",
+          "resource": "morphe_boost_settings_skeleton",
+          "root_referenced": false
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Settings experience",
+      "page_intro": "Choose which Settings presentation Boost uses.",
+      "proposed_summary": "Use Morphe's modern task-based settings. Reopen Settings to apply.",
+      "root": "Data & app",
+      "screen_depth": 2,
+      "screen_path": [
+        "Data & app",
+        "Settings experience",
+        "Settings presentation"
+      ],
+      "source_type": "morphe_embedded_xml",
+      "storage_type": "boolean",
+      "subscreen": "Settings presentation",
+      "title": "Material settings",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "",
+      "dependency": "",
+      "existing_summary": "Delete images and videos from cache",
+      "help_treatment": "REVIEW_EXISTING_SUMMARY+PROGRESSIVE_DISCLOSURE",
+      "key": "pref_cache_current_size",
+      "leaf_section": "Cache",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Cache",
+          "key": "pref_cache_current_size",
+          "logical_kind": "action",
+          "resource": "pref_data_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "action",
+      "page": "Storage & bandwidth",
+      "page_intro": "Control data usage, caching, and bandwidth-sensitive behavior.",
+      "proposed_summary": "Delete images and videos from cache",
+      "root": "Data & app",
+      "screen_depth": 2,
+      "screen_path": [
+        "Data & app",
+        "Storage & bandwidth",
+        "Cache"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "none_or_custom",
+      "subscreen": "Cache",
+      "title": "Clear cache",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "128",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE+PROGRESSIVE_DISCLOSURE",
+      "key": "pref_cache_max_size",
+      "leaf_section": "Cache",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Cache",
+          "key": "pref_cache_max_size",
+          "logical_kind": "stored_setting",
+          "resource": "pref_data_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Storage & bandwidth",
+      "page_intro": "Control data usage, caching, and bandwidth-sensitive behavior.",
+      "proposed_summary": "",
+      "root": "Data & app",
+      "screen_depth": 2,
+      "screen_path": [
+        "Data & app",
+        "Storage & bandwidth",
+        "Cache"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "string",
+      "subscreen": "Cache",
+      "title": "Maximum cache size",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "true",
+      "dependency": "",
+      "existing_summary": "Load lower-size media",
+      "help_treatment": "REVIEW_EXISTING_SUMMARY+PROGRESSIVE_DISCLOSURE",
+      "key": "pref_reduce_mobile",
+      "leaf_section": "Data saver",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Data saver",
+          "key": "pref_reduce_mobile",
+          "logical_kind": "stored_setting",
+          "resource": "pref_data_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Storage & bandwidth",
+      "page_intro": "Control data usage, caching, and bandwidth-sensitive behavior.",
+      "proposed_summary": "Load lower-size media",
+      "root": "Data & app",
+      "screen_depth": 2,
+      "screen_path": [
+        "Data & app",
+        "Storage & bandwidth",
+        "Data saver"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Data saver",
+      "title": "Mobile data saver",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "false",
+      "dependency": "",
+      "existing_summary": "Load lower-size media",
+      "help_treatment": "REVIEW_EXISTING_SUMMARY+PROGRESSIVE_DISCLOSURE",
+      "key": "pref_reduce_wifi",
+      "leaf_section": "Data saver",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Data saver",
+          "key": "pref_reduce_wifi",
+          "logical_kind": "stored_setting",
+          "resource": "pref_data_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Storage & bandwidth",
+      "page_intro": "Control data usage, caching, and bandwidth-sensitive behavior.",
+      "proposed_summary": "Load lower-size media",
+      "root": "Data & app",
+      "screen_depth": 2,
+      "screen_path": [
+        "Data & app",
+        "Storage & bandwidth",
+        "Data saver"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "boolean",
+      "subscreen": "Data saver",
+      "title": "Wifi data saver",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "",
+      "dependency": "",
+      "existing_summary": "Change download folder location",
+      "help_treatment": "REVIEW_EXISTING_SUMMARY+PROGRESSIVE_DISCLOSURE",
+      "key": "pref_download_folders",
+      "leaf_section": "Data usage",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": null,
+          "key": "pref_download_folders",
+          "logical_kind": "action",
+          "resource": "pref_data_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "action",
+      "page": "Storage & bandwidth",
+      "page_intro": "Control data usage, caching, and bandwidth-sensitive behavior.",
+      "proposed_summary": "Change download folder location",
+      "root": "Data & app",
+      "screen_depth": 2,
+      "screen_path": [
+        "Data & app",
+        "Storage & bandwidth",
+        "Data usage"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "none_or_custom",
+      "subscreen": "Data usage",
+      "title": "Configure downloads",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "0",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE",
+      "key": "pref_load_images",
+      "leaf_section": "Images",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Images",
+          "key": "pref_load_images",
+          "logical_kind": "stored_setting",
+          "resource": "pref_data_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Storage & bandwidth",
+      "page_intro": "Control data usage, caching, and bandwidth-sensitive behavior.",
+      "proposed_summary": "",
+      "root": "Data & app",
+      "screen_depth": 2,
+      "screen_path": [
+        "Data & app",
+        "Storage & bandwidth",
+        "Images"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "string",
+      "subscreen": "Images",
+      "title": "Load images",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "1080",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE+PROGRESSIVE_DISCLOSURE",
+      "key": "pref_video_quality_max",
+      "leaf_section": "Videos",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Videos",
+          "key": "pref_video_quality_max",
+          "logical_kind": "stored_setting",
+          "resource": "pref_data_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Storage & bandwidth",
+      "page_intro": "Control data usage, caching, and bandwidth-sensitive behavior.",
+      "proposed_summary": "",
+      "root": "Data & app",
+      "screen_depth": 2,
+      "screen_path": [
+        "Data & app",
+        "Storage & bandwidth",
+        "Videos"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "string",
+      "subscreen": "Videos",
+      "title": "Maximum quality",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "480",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE+PROGRESSIVE_DISCLOSURE",
+      "key": "pref_video_quality_min",
+      "leaf_section": "Videos",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Videos",
+          "key": "pref_video_quality_min",
+          "logical_kind": "stored_setting",
+          "resource": "pref_data_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Storage & bandwidth",
+      "page_intro": "Control data usage, caching, and bandwidth-sensitive behavior.",
+      "proposed_summary": "",
+      "root": "Data & app",
+      "screen_depth": 2,
+      "screen_path": [
+        "Data & app",
+        "Storage & bandwidth",
+        "Videos"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "string",
+      "subscreen": "Videos",
+      "title": "Minimum quality",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "0",
+      "dependency": "",
+      "existing_summary": "",
+      "help_treatment": "WRITE_ONE_SHORT_SENTENCE+PROGRESSIVE_DISCLOSURE",
+      "key": "pref_video_quality",
+      "leaf_section": "Videos",
+      "legacy_route_count": 1,
+      "legacy_routes": [
+        {
+          "category": "Videos",
+          "key": "pref_video_quality",
+          "logical_kind": "stored_setting",
+          "resource": "pref_data_v2",
+          "root_referenced": true
+        }
+      ],
+      "logical_kind": "stored_setting",
+      "page": "Storage & bandwidth",
+      "page_intro": "Control data usage, caching, and bandwidth-sensitive behavior.",
+      "proposed_summary": "",
+      "root": "Data & app",
+      "screen_depth": 2,
+      "screen_path": [
+        "Data & app",
+        "Storage & bandwidth",
+        "Videos"
+      ],
+      "source_type": "boost_xml",
+      "storage_type": "string",
+      "subscreen": "Videos",
+      "title": "Video quality",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    }
+  ],
+  "root_order": [
+    "Morphe",
+    "Appearance",
+    "Reading & interaction",
+    "Navigation",
+    "Media",
+    "Notifications & account",
+    "Data & app"
+  ],
+  "root_overview_shell": {
+    "classic_fallback_location": "root_only",
+    "count": 1,
+    "status_required": "COMPLETE"
+  },
+  "schema": 1,
+  "screen_edge_count": 98,
+  "screen_node_count": 105,
+  "screens": [
+    {
+      "child_count": 0,
+      "control_count": 0,
+      "depth": 0,
+      "max_children_contract": "",
+      "path": "Morphe",
+      "role": "root_group",
+      "root": "Morphe",
+      "task_page": "",
+      "title": "Morphe"
+    },
+    {
+      "child_count": 5,
+      "control_count": 0,
+      "depth": 0,
+      "max_children_contract": "",
+      "path": "Appearance",
+      "role": "root_group",
+      "root": "Appearance",
+      "task_page": "",
+      "title": "Appearance"
+    },
+    {
+      "child_count": 1,
+      "control_count": 0,
+      "depth": 1,
+      "max_children_contract": 5,
+      "path": "Appearance / Community header",
+      "role": "task_page",
+      "root": "Appearance",
+      "task_page": "Community header",
+      "title": "Community header"
+    },
+    {
+      "child_count": 1,
+      "control_count": 0,
+      "depth": 1,
+      "max_children_contract": 5,
+      "path": "Appearance / Display & motion",
+      "role": "task_page",
+      "root": "Appearance",
+      "task_page": "Display & motion",
+      "title": "Display & motion"
+    },
+    {
+      "child_count": 4,
+      "control_count": 0,
+      "depth": 1,
+      "max_children_contract": 5,
+      "path": "Appearance / Post layout",
+      "role": "task_page",
+      "root": "Appearance",
+      "task_page": "Post layout",
+      "title": "Post layout"
+    },
+    {
+      "child_count": 3,
+      "control_count": 0,
+      "depth": 1,
+      "max_children_contract": 5,
+      "path": "Appearance / Theme & colors",
+      "role": "task_page",
+      "root": "Appearance",
+      "task_page": "Theme & colors",
+      "title": "Theme & colors"
+    },
+    {
+      "child_count": 3,
+      "control_count": 0,
+      "depth": 1,
+      "max_children_contract": 5,
+      "path": "Appearance / Typography",
+      "role": "task_page",
+      "root": "Appearance",
+      "task_page": "Typography",
+      "title": "Typography"
+    },
+    {
+      "child_count": 0,
+      "control_count": 3,
+      "depth": 2,
+      "max_children_contract": 0,
+      "path": "Appearance / Community header / Community header",
+      "role": "leaf_section",
+      "root": "Appearance",
+      "task_page": "Community header",
+      "title": "Community header"
+    },
+    {
+      "child_count": 0,
+      "control_count": 1,
+      "depth": 2,
+      "max_children_contract": 0,
+      "path": "Appearance / Display & motion / Display performance",
+      "role": "leaf_section",
+      "root": "Appearance",
+      "task_page": "Display & motion",
+      "title": "Display performance"
+    },
+    {
+      "child_count": 0,
+      "control_count": 8,
+      "depth": 2,
+      "max_children_contract": 0,
+      "path": "Appearance / Post layout / Cards",
+      "role": "leaf_section",
+      "root": "Appearance",
+      "task_page": "Post layout",
+      "title": "Cards"
+    },
+    {
+      "child_count": 2,
+      "control_count": 0,
+      "depth": 2,
+      "max_children_contract": 6,
+      "path": "Appearance / Post layout / Compact layouts",
+      "role": "intermediate_page",
+      "root": "Appearance",
+      "task_page": "Post layout",
+      "title": "Compact layouts"
+    },
+    {
+      "child_count": 2,
+      "control_count": 0,
+      "depth": 2,
+      "max_children_contract": 6,
+      "path": "Appearance / Post layout / Layout & saved views",
+      "role": "intermediate_page",
+      "root": "Appearance",
+      "task_page": "Post layout",
+      "title": "Layout & saved views"
+    },
+    {
+      "child_count": 0,
+      "control_count": 1,
+      "depth": 2,
+      "max_children_contract": 0,
+      "path": "Appearance / Post layout / Tablet layout",
+      "role": "leaf_section",
+      "root": "Appearance",
+      "task_page": "Post layout",
+      "title": "Tablet layout"
+    },
+    {
+      "child_count": 0,
+      "control_count": 2,
+      "depth": 2,
+      "max_children_contract": 0,
+      "path": "Appearance / Theme & colors / Advanced appearance",
+      "role": "leaf_section",
+      "root": "Appearance",
+      "task_page": "Theme & colors",
+      "title": "Advanced appearance"
+    },
+    {
+      "child_count": 0,
+      "control_count": 1,
+      "depth": 2,
+      "max_children_contract": 0,
+      "path": "Appearance / Theme & colors / Personalization",
+      "role": "leaf_section",
+      "root": "Appearance",
+      "task_page": "Theme & colors",
+      "title": "Personalization"
+    },
+    {
+      "child_count": 0,
+      "control_count": 6,
+      "depth": 2,
+      "max_children_contract": 0,
+      "path": "Appearance / Theme & colors / Theme",
+      "role": "leaf_section",
+      "root": "Appearance",
+      "task_page": "Theme & colors",
+      "title": "Theme"
+    },
+    {
+      "child_count": 0,
+      "control_count": 2,
+      "depth": 2,
+      "max_children_contract": 0,
+      "path": "Appearance / Typography / Comments",
+      "role": "leaf_section",
+      "root": "Appearance",
+      "task_page": "Typography",
+      "title": "Comments"
+    },
+    {
+      "child_count": 0,
+      "control_count": 2,
+      "depth": 2,
+      "max_children_contract": 0,
+      "path": "Appearance / Typography / Posts",
+      "role": "leaf_section",
+      "root": "Appearance",
+      "task_page": "Typography",
+      "title": "Posts"
+    },
+    {
+      "child_count": 0,
+      "control_count": 1,
+      "depth": 2,
+      "max_children_contract": 0,
+      "path": "Appearance / Typography / Reset",
+      "role": "leaf_section",
+      "root": "Appearance",
+      "task_page": "Typography",
+      "title": "Reset"
+    },
+    {
+      "child_count": 0,
+      "control_count": 1,
+      "depth": 3,
+      "max_children_contract": 0,
+      "path": "Appearance / Post layout / Compact layouts / Dense",
+      "role": "leaf_section",
+      "root": "Appearance",
+      "task_page": "Post layout",
+      "title": "Dense"
+    },
+    {
+      "child_count": 0,
+      "control_count": 4,
+      "depth": 3,
+      "max_children_contract": 0,
+      "path": "Appearance / Post layout / Compact layouts / Small cards",
+      "role": "leaf_section",
+      "root": "Appearance",
+      "task_page": "Post layout",
+      "title": "Small cards"
+    },
+    {
+      "child_count": 0,
+      "control_count": 5,
+      "depth": 3,
+      "max_children_contract": 0,
+      "path": "Appearance / Post layout / Layout & saved views / Post layout",
+      "role": "leaf_section",
+      "root": "Appearance",
+      "task_page": "Post layout",
+      "title": "Post layout"
+    },
+    {
+      "child_count": 0,
+      "control_count": 2,
+      "depth": 3,
+      "max_children_contract": 0,
+      "path": "Appearance / Post layout / Layout & saved views / Saved community views",
+      "role": "leaf_section",
+      "root": "Appearance",
+      "task_page": "Post layout",
+      "title": "Saved community views"
+    },
+    {
+      "child_count": 5,
+      "control_count": 0,
+      "depth": 0,
+      "max_children_contract": "",
+      "path": "Reading & interaction",
+      "role": "root_group",
+      "root": "Reading & interaction",
+      "task_page": "",
+      "title": "Reading & interaction"
+    },
+    {
+      "child_count": 4,
+      "control_count": 0,
+      "depth": 1,
+      "max_children_contract": 5,
+      "path": "Reading & interaction / Comments",
+      "role": "task_page",
+      "root": "Reading & interaction",
+      "task_page": "Comments",
+      "title": "Comments"
+    },
+    {
+      "child_count": 3,
+      "control_count": 0,
+      "depth": 1,
+      "max_children_contract": 5,
+      "path": "Reading & interaction / Composing & drafts",
+      "role": "task_page",
+      "root": "Reading & interaction",
+      "task_page": "Composing & drafts",
+      "title": "Composing & drafts"
+    },
+    {
+      "child_count": 1,
+      "control_count": 0,
+      "depth": 1,
+      "max_children_contract": 5,
+      "path": "Reading & interaction / Feeds & subscriptions",
+      "role": "task_page",
+      "root": "Reading & interaction",
+      "task_page": "Feeds & subscriptions",
+      "title": "Feeds & subscriptions"
+    },
+    {
+      "child_count": 4,
+      "control_count": 0,
+      "depth": 1,
+      "max_children_contract": 5,
+      "path": "Reading & interaction / Posts",
+      "role": "task_page",
+      "root": "Reading & interaction",
+      "task_page": "Posts",
+      "title": "Posts"
+    },
+    {
+      "child_count": 2,
+      "control_count": 0,
+      "depth": 1,
+      "max_children_contract": 5,
+      "path": "Reading & interaction / Search & filters",
+      "role": "task_page",
+      "root": "Reading & interaction",
+      "task_page": "Search & filters",
+      "title": "Search & filters"
+    },
+    {
+      "child_count": 0,
+      "control_count": 9,
+      "depth": 2,
+      "max_children_contract": 0,
+      "path": "Reading & interaction / Comments / Comment actions",
+      "role": "leaf_section",
+      "root": "Reading & interaction",
+      "task_page": "Comments",
+      "title": "Comment actions"
+    },
+    {
+      "child_count": 0,
+      "control_count": 5,
+      "depth": 2,
+      "max_children_contract": 0,
+      "path": "Reading & interaction / Comments / Comment appearance",
+      "role": "leaf_section",
+      "root": "Reading & interaction",
+      "task_page": "Comments",
+      "title": "Comment appearance"
+    },
+    {
+      "child_count": 0,
+      "control_count": 7,
+      "depth": 2,
+      "max_children_contract": 0,
+      "path": "Reading & interaction / Comments / Comment behavior",
+      "role": "leaf_section",
+      "root": "Reading & interaction",
+      "task_page": "Comments",
+      "title": "Comment behavior"
+    },
+    {
+      "child_count": 0,
+      "control_count": 12,
+      "depth": 2,
+      "max_children_contract": 0,
+      "path": "Reading & interaction / Comments / Thread navigation",
+      "role": "leaf_section",
+      "root": "Reading & interaction",
+      "task_page": "Comments",
+      "title": "Thread navigation"
+    },
+    {
+      "child_count": 0,
+      "control_count": 2,
+      "depth": 2,
+      "max_children_contract": 0,
+      "path": "Reading & interaction / Composing & drafts / Drafts",
+      "role": "leaf_section",
+      "root": "Reading & interaction",
+      "task_page": "Composing & drafts",
+      "title": "Drafts"
+    },
+    {
+      "child_count": 0,
+      "control_count": 1,
+      "depth": 2,
+      "max_children_contract": 0,
+      "path": "Reading & interaction / Composing & drafts / Editor",
+      "role": "leaf_section",
+      "root": "Reading & interaction",
+      "task_page": "Composing & drafts",
+      "title": "Editor"
+    },
+    {
+      "child_count": 0,
+      "control_count": 1,
+      "depth": 2,
+      "max_children_contract": 0,
+      "path": "Reading & interaction / Composing & drafts / Uploads",
+      "role": "leaf_section",
+      "root": "Reading & interaction",
+      "task_page": "Composing & drafts",
+      "title": "Uploads"
+    },
+    {
+      "child_count": 0,
+      "control_count": 1,
+      "depth": 2,
+      "max_children_contract": 0,
+      "path": "Reading & interaction / Feeds & subscriptions / Manage subscriptions",
+      "role": "leaf_section",
+      "root": "Reading & interaction",
+      "task_page": "Feeds & subscriptions",
+      "title": "Manage subscriptions"
+    },
+    {
+      "child_count": 0,
+      "control_count": 3,
+      "depth": 2,
+      "max_children_contract": 0,
+      "path": "Reading & interaction / Posts / Feed behavior",
+      "role": "leaf_section",
+      "root": "Reading & interaction",
+      "task_page": "Posts",
+      "title": "Feed behavior"
+    },
+    {
+      "child_count": 0,
+      "control_count": 8,
+      "depth": 2,
+      "max_children_contract": 0,
+      "path": "Reading & interaction / Posts / Post actions",
+      "role": "leaf_section",
+      "root": "Reading & interaction",
+      "task_page": "Posts",
+      "title": "Post actions"
+    },
+    {
+      "child_count": 0,
+      "control_count": 9,
+      "depth": 2,
+      "max_children_contract": 0,
+      "path": "Reading & interaction / Posts / Post behavior",
+      "role": "leaf_section",
+      "root": "Reading & interaction",
+      "task_page": "Posts",
+      "title": "Post behavior"
+    },
+    {
+      "child_count": 0,
+      "control_count": 6,
+      "depth": 2,
+      "max_children_contract": 0,
+      "path": "Reading & interaction / Posts / Reading state",
+      "role": "leaf_section",
+      "root": "Reading & interaction",
+      "task_page": "Posts",
+      "title": "Reading state"
+    },
+    {
+      "child_count": 3,
+      "control_count": 0,
+      "depth": 2,
+      "max_children_contract": 6,
+      "path": "Reading & interaction / Search & filters / Content filters",
+      "role": "intermediate_page",
+      "root": "Reading & interaction",
+      "task_page": "Search & filters",
+      "title": "Content filters"
+    },
+    {
+      "child_count": 3,
+      "control_count": 0,
+      "depth": 2,
+      "max_children_contract": 6,
+      "path": "Reading & interaction / Search & filters / Search",
+      "role": "intermediate_page",
+      "root": "Reading & interaction",
+      "task_page": "Search & filters",
+      "title": "Search"
+    },
+    {
+      "child_count": 0,
+      "control_count": 3,
+      "depth": 3,
+      "max_children_contract": 0,
+      "path": "Reading & interaction / Search & filters / Content filters / Filter behavior",
+      "role": "leaf_section",
+      "root": "Reading & interaction",
+      "task_page": "Search & filters",
+      "title": "Filter behavior"
+    },
+    {
+      "child_count": 0,
+      "control_count": 5,
+      "depth": 3,
+      "max_children_contract": 0,
+      "path": "Reading & interaction / Search & filters / Content filters / Muted content",
+      "role": "leaf_section",
+      "root": "Reading & interaction",
+      "task_page": "Search & filters",
+      "title": "Muted content"
+    },
+    {
+      "child_count": 0,
+      "control_count": 6,
+      "depth": 3,
+      "max_children_contract": 0,
+      "path": "Reading & interaction / Search & filters / Content filters / Post matching",
+      "role": "leaf_section",
+      "root": "Reading & interaction",
+      "task_page": "Search & filters",
+      "title": "Post matching"
+    },
+    {
+      "child_count": 0,
+      "control_count": 1,
+      "depth": 3,
+      "max_children_contract": 0,
+      "path": "Reading & interaction / Search & filters / Search / Advanced search",
+      "role": "leaf_section",
+      "root": "Reading & interaction",
+      "task_page": "Search & filters",
+      "title": "Advanced search"
+    },
+    {
+      "child_count": 0,
+      "control_count": 3,
+      "depth": 3,
+      "max_children_contract": 0,
+      "path": "Reading & interaction / Search & filters / Search / Search behavior",
+      "role": "leaf_section",
+      "root": "Reading & interaction",
+      "task_page": "Search & filters",
+      "title": "Search behavior"
+    },
+    {
+      "child_count": 0,
+      "control_count": 5,
+      "depth": 3,
+      "max_children_contract": 0,
+      "path": "Reading & interaction / Search & filters / Search / Suggestions",
+      "role": "leaf_section",
+      "root": "Reading & interaction",
+      "task_page": "Search & filters",
+      "title": "Suggestions"
+    },
+    {
+      "child_count": 4,
+      "control_count": 0,
+      "depth": 0,
+      "max_children_contract": "",
+      "path": "Navigation",
+      "role": "root_group",
+      "root": "Navigation",
+      "task_page": "",
+      "title": "Navigation"
+    },
+    {
+      "child_count": 0,
+      "control_count": 2,
+      "depth": 1,
+      "max_children_contract": 0,
+      "path": "Navigation / Back & exit",
+      "role": "leaf_section",
+      "root": "Navigation",
+      "task_page": "Navigation & gestures",
+      "title": "Back & exit"
+    },
+    {
+      "child_count": 0,
+      "control_count": 2,
+      "depth": 1,
+      "max_children_contract": 0,
+      "path": "Navigation / Bottom navigation",
+      "role": "leaf_section",
+      "root": "Navigation",
+      "task_page": "Navigation & gestures",
+      "title": "Bottom navigation"
+    },
+    {
+      "child_count": 7,
+      "control_count": 0,
+      "depth": 1,
+      "max_children_contract": 7,
+      "path": "Navigation / Navigation drawer",
+      "role": "intermediate_page",
+      "root": "Navigation",
+      "task_page": "Navigation & gestures",
+      "title": "Navigation drawer"
+    },
+    {
+      "child_count": 0,
+      "control_count": 2,
+      "depth": 1,
+      "max_children_contract": 0,
+      "path": "Navigation / Toolbar",
+      "role": "leaf_section",
+      "root": "Navigation",
+      "task_page": "Navigation & gestures",
+      "title": "Toolbar"
+    },
+    {
+      "child_count": 0,
+      "control_count": 6,
+      "depth": 2,
+      "max_children_contract": 0,
+      "path": "Navigation / Navigation drawer / Account & tools",
+      "role": "leaf_section",
+      "root": "Navigation",
+      "task_page": "Navigation & gestures",
+      "title": "Account & tools"
+    },
+    {
+      "child_count": 0,
+      "control_count": 2,
+      "depth": 2,
+      "max_children_contract": 0,
+      "path": "Navigation / Navigation drawer / Account switcher",
+      "role": "leaf_section",
+      "root": "Navigation",
+      "task_page": "Navigation & gestures",
+      "title": "Account switcher"
+    },
+    {
+      "child_count": 0,
+      "control_count": 3,
+      "depth": 2,
+      "max_children_contract": 0,
+      "path": "Navigation / Navigation drawer / Drawer behavior",
+      "role": "leaf_section",
+      "root": "Navigation",
+      "task_page": "Navigation & gestures",
+      "title": "Drawer behavior"
+    },
+    {
+      "child_count": 0,
+      "control_count": 6,
+      "depth": 2,
+      "max_children_contract": 0,
+      "path": "Navigation / Navigation drawer / Feeds & library",
+      "role": "leaf_section",
+      "root": "Navigation",
+      "task_page": "Navigation & gestures",
+      "title": "Feeds & library"
+    },
+    {
+      "child_count": 0,
+      "control_count": 3,
+      "depth": 2,
+      "max_children_contract": 0,
+      "path": "Navigation / Navigation drawer / Go-to shortcuts",
+      "role": "leaf_section",
+      "root": "Navigation",
+      "task_page": "Navigation & gestures",
+      "title": "Go-to shortcuts"
+    },
+    {
+      "child_count": 0,
+      "control_count": 3,
+      "depth": 2,
+      "max_children_contract": 0,
+      "path": "Navigation / Navigation drawer / Quick toggles",
+      "role": "leaf_section",
+      "root": "Navigation",
+      "task_page": "Navigation & gestures",
+      "title": "Quick toggles"
+    },
+    {
+      "child_count": 0,
+      "control_count": 3,
+      "depth": 2,
+      "max_children_contract": 0,
+      "path": "Navigation / Navigation drawer / Subscriptions",
+      "role": "leaf_section",
+      "root": "Navigation",
+      "task_page": "Navigation & gestures",
+      "title": "Subscriptions"
+    },
+    {
+      "child_count": 4,
+      "control_count": 0,
+      "depth": 0,
+      "max_children_contract": "",
+      "path": "Media",
+      "role": "root_group",
+      "root": "Media",
+      "task_page": "",
+      "title": "Media"
+    },
+    {
+      "child_count": 1,
+      "control_count": 0,
+      "depth": 1,
+      "max_children_contract": 5,
+      "path": "Media / Downloads & cache",
+      "role": "task_page",
+      "root": "Media",
+      "task_page": "Downloads & cache",
+      "title": "Downloads & cache"
+    },
+    {
+      "child_count": 4,
+      "control_count": 0,
+      "depth": 1,
+      "max_children_contract": 5,
+      "path": "Media / Images, GIFs & previews",
+      "role": "task_page",
+      "root": "Media",
+      "task_page": "Images, GIFs & previews",
+      "title": "Images, GIFs & previews"
+    },
+    {
+      "child_count": 4,
+      "control_count": 0,
+      "depth": 1,
+      "max_children_contract": 5,
+      "path": "Media / Links & browser",
+      "role": "task_page",
+      "root": "Media",
+      "task_page": "Links & browser",
+      "title": "Links & browser"
+    },
+    {
+      "child_count": 4,
+      "control_count": 0,
+      "depth": 1,
+      "max_children_contract": 5,
+      "path": "Media / Playback & autoplay",
+      "role": "task_page",
+      "root": "Media",
+      "task_page": "Playback & autoplay",
+      "title": "Playback & autoplay"
+    },
+    {
+      "child_count": 0,
+      "control_count": 5,
+      "depth": 2,
+      "max_children_contract": 0,
+      "path": "Media / Downloads & cache / Download folders",
+      "role": "leaf_section",
+      "root": "Media",
+      "task_page": "Downloads & cache",
+      "title": "Download folders"
+    },
+    {
+      "child_count": 0,
+      "control_count": 6,
+      "depth": 2,
+      "max_children_contract": 0,
+      "path": "Media / Images, GIFs & previews / Native image behavior",
+      "role": "leaf_section",
+      "root": "Media",
+      "task_page": "Images, GIFs & previews",
+      "title": "Native image behavior"
+    },
+    {
+      "child_count": 0,
+      "control_count": 3,
+      "depth": 2,
+      "max_children_contract": 0,
+      "path": "Media / Images, GIFs & previews / Open behavior",
+      "role": "leaf_section",
+      "root": "Media",
+      "task_page": "Images, GIFs & previews",
+      "title": "Open behavior"
+    },
+    {
+      "child_count": 0,
+      "control_count": 2,
+      "depth": 2,
+      "max_children_contract": 0,
+      "path": "Media / Images, GIFs & previews / Preview behavior",
+      "role": "leaf_section",
+      "root": "Media",
+      "task_page": "Images, GIFs & previews",
+      "title": "Preview behavior"
+    },
+    {
+      "child_count": 0,
+      "control_count": 2,
+      "depth": 2,
+      "max_children_contract": 0,
+      "path": "Media / Images, GIFs & previews / Preview layout",
+      "role": "leaf_section",
+      "root": "Media",
+      "task_page": "Images, GIFs & previews",
+      "title": "Preview layout"
+    },
+    {
+      "child_count": 0,
+      "control_count": 1,
+      "depth": 2,
+      "max_children_contract": 0,
+      "path": "Media / Links & browser / Browser",
+      "role": "leaf_section",
+      "root": "Media",
+      "task_page": "Links & browser",
+      "title": "Browser"
+    },
+    {
+      "child_count": 0,
+      "control_count": 2,
+      "depth": 2,
+      "max_children_contract": 0,
+      "path": "Media / Links & browser / Link handling",
+      "role": "leaf_section",
+      "root": "Media",
+      "task_page": "Links & browser",
+      "title": "Link handling"
+    },
+    {
+      "child_count": 0,
+      "control_count": 8,
+      "depth": 2,
+      "max_children_contract": 0,
+      "path": "Media / Links & browser / Links to open in app",
+      "role": "leaf_section",
+      "root": "Media",
+      "task_page": "Links & browser",
+      "title": "Links to open in app"
+    },
+    {
+      "child_count": 0,
+      "control_count": 1,
+      "depth": 2,
+      "max_children_contract": 0,
+      "path": "Media / Links & browser / Video links",
+      "role": "leaf_section",
+      "root": "Media",
+      "task_page": "Links & browser",
+      "title": "Video links"
+    },
+    {
+      "child_count": 0,
+      "control_count": 1,
+      "depth": 2,
+      "max_children_contract": 0,
+      "path": "Media / Playback & autoplay / Audio",
+      "role": "leaf_section",
+      "root": "Media",
+      "task_page": "Playback & autoplay",
+      "title": "Audio"
+    },
+    {
+      "child_count": 0,
+      "control_count": 1,
+      "depth": 2,
+      "max_children_contract": 0,
+      "path": "Media / Playback & autoplay / Autoplay",
+      "role": "leaf_section",
+      "root": "Media",
+      "task_page": "Playback & autoplay",
+      "title": "Autoplay"
+    },
+    {
+      "child_count": 0,
+      "control_count": 2,
+      "depth": 2,
+      "max_children_contract": 0,
+      "path": "Media / Playback & autoplay / Media behavior",
+      "role": "leaf_section",
+      "root": "Media",
+      "task_page": "Playback & autoplay",
+      "title": "Media behavior"
+    },
+    {
+      "child_count": 0,
+      "control_count": 2,
+      "depth": 2,
+      "max_children_contract": 0,
+      "path": "Media / Playback & autoplay / Playback & autoplay",
+      "role": "leaf_section",
+      "root": "Media",
+      "task_page": "Playback & autoplay",
+      "title": "Playback & autoplay"
+    },
+    {
+      "child_count": 3,
+      "control_count": 0,
+      "depth": 0,
+      "max_children_contract": "",
+      "path": "Notifications & account",
+      "role": "root_group",
+      "root": "Notifications & account",
+      "task_page": "",
+      "title": "Notifications & account"
+    },
+    {
+      "child_count": 2,
+      "control_count": 0,
+      "depth": 1,
+      "max_children_contract": 5,
+      "path": "Notifications & account / History, privacy & recovery",
+      "role": "task_page",
+      "root": "Notifications & account",
+      "task_page": "History, privacy & recovery",
+      "title": "History, privacy & recovery"
+    },
+    {
+      "child_count": 2,
+      "control_count": 0,
+      "depth": 1,
+      "max_children_contract": 5,
+      "path": "Notifications & account / Notifications & inbox",
+      "role": "task_page",
+      "root": "Notifications & account",
+      "task_page": "Notifications & inbox",
+      "title": "Notifications & inbox"
+    },
+    {
+      "child_count": 0,
+      "control_count": 0,
+      "depth": 1,
+      "max_children_contract": 5,
+      "path": "Notifications & account / Reddit account",
+      "role": "task_page",
+      "root": "Notifications & account",
+      "task_page": "Reddit account",
+      "title": "Reddit account"
+    },
+    {
+      "child_count": 0,
+      "control_count": 8,
+      "depth": 2,
+      "max_children_contract": 0,
+      "path": "Notifications & account / History, privacy & recovery / History",
+      "role": "leaf_section",
+      "root": "Notifications & account",
+      "task_page": "History, privacy & recovery",
+      "title": "History"
+    },
+    {
+      "child_count": 0,
+      "control_count": 2,
+      "depth": 2,
+      "max_children_contract": 0,
+      "path": "Notifications & account / History, privacy & recovery / Recovery & archives",
+      "role": "leaf_section",
+      "root": "Notifications & account",
+      "task_page": "History, privacy & recovery",
+      "title": "Recovery & archives"
+    },
+    {
+      "child_count": 0,
+      "control_count": 2,
+      "depth": 2,
+      "max_children_contract": 0,
+      "path": "Notifications & account / Notifications & inbox / Advanced",
+      "role": "leaf_section",
+      "root": "Notifications & account",
+      "task_page": "Notifications & inbox",
+      "title": "Advanced"
+    },
+    {
+      "child_count": 0,
+      "control_count": 4,
+      "depth": 2,
+      "max_children_contract": 0,
+      "path": "Notifications & account / Notifications & inbox / Notifications",
+      "role": "leaf_section",
+      "root": "Notifications & account",
+      "task_page": "Notifications & inbox",
+      "title": "Notifications"
+    },
+    {
+      "child_count": 5,
+      "control_count": 0,
+      "depth": 0,
+      "max_children_contract": "",
+      "path": "Data & app",
+      "role": "root_group",
+      "root": "Data & app",
+      "task_page": "",
+      "title": "Data & app"
+    },
+    {
+      "child_count": 3,
+      "control_count": 0,
+      "depth": 1,
+      "max_children_contract": 5,
+      "path": "Data & app / About & support",
+      "role": "task_page",
+      "root": "Data & app",
+      "task_page": "About & support",
+      "title": "About & support"
+    },
+    {
+      "child_count": 3,
+      "control_count": 0,
+      "depth": 1,
+      "max_children_contract": 5,
+      "path": "Data & app / App behavior & compatibility",
+      "role": "task_page",
+      "root": "Data & app",
+      "task_page": "App behavior & compatibility",
+      "title": "App behavior & compatibility"
+    },
+    {
+      "child_count": 0,
+      "control_count": 0,
+      "depth": 1,
+      "max_children_contract": 5,
+      "path": "Data & app / Backup & restore",
+      "role": "task_page",
+      "root": "Data & app",
+      "task_page": "Backup & restore",
+      "title": "Backup & restore"
+    },
+    {
+      "child_count": 1,
+      "control_count": 0,
+      "depth": 1,
+      "max_children_contract": 5,
+      "path": "Data & app / Settings experience",
+      "role": "task_page",
+      "root": "Data & app",
+      "task_page": "Settings experience",
+      "title": "Settings experience"
+    },
+    {
+      "child_count": 5,
+      "control_count": 0,
+      "depth": 1,
+      "max_children_contract": 5,
+      "path": "Data & app / Storage & bandwidth",
+      "role": "task_page",
+      "root": "Data & app",
+      "task_page": "Storage & bandwidth",
+      "title": "Storage & bandwidth"
+    },
+    {
+      "child_count": 0,
+      "control_count": 8,
+      "depth": 2,
+      "max_children_contract": 0,
+      "path": "Data & app / About & support / About Boost",
+      "role": "leaf_section",
+      "root": "Data & app",
+      "task_page": "About & support",
+      "title": "About Boost"
+    },
+    {
+      "child_count": 0,
+      "control_count": 3,
+      "depth": 2,
+      "max_children_contract": 0,
+      "path": "Data & app / About & support / Author",
+      "role": "leaf_section",
+      "root": "Data & app",
+      "task_page": "About & support",
+      "title": "Author"
+    },
+    {
+      "child_count": 0,
+      "control_count": 3,
+      "depth": 2,
+      "max_children_contract": 0,
+      "path": "Data & app / About & support / Privacy",
+      "role": "leaf_section",
+      "root": "Data & app",
+      "task_page": "About & support",
+      "title": "Privacy"
+    },
+    {
+      "child_count": 0,
+      "control_count": 1,
+      "depth": 2,
+      "max_children_contract": 0,
+      "path": "Data & app / App behavior & compatibility / Community shortcuts",
+      "role": "leaf_section",
+      "root": "Data & app",
+      "task_page": "App behavior & compatibility",
+      "title": "Community shortcuts"
+    },
+    {
+      "child_count": 0,
+      "control_count": 11,
+      "depth": 2,
+      "max_children_contract": 0,
+      "path": "Data & app / App behavior & compatibility / Compatibility & legacy",
+      "role": "leaf_section",
+      "root": "Data & app",
+      "task_page": "App behavior & compatibility",
+      "title": "Compatibility & legacy"
+    },
+    {
+      "child_count": 0,
+      "control_count": 2,
+      "depth": 2,
+      "max_children_contract": 0,
+      "path": "Data & app / App behavior & compatibility / Other app behavior",
+      "role": "leaf_section",
+      "root": "Data & app",
+      "task_page": "App behavior & compatibility",
+      "title": "Other app behavior"
+    },
+    {
+      "child_count": 0,
+      "control_count": 1,
+      "depth": 2,
+      "max_children_contract": 0,
+      "path": "Data & app / Settings experience / Settings presentation",
+      "role": "leaf_section",
+      "root": "Data & app",
+      "task_page": "Settings experience",
+      "title": "Settings presentation"
+    },
+    {
+      "child_count": 0,
+      "control_count": 2,
+      "depth": 2,
+      "max_children_contract": 0,
+      "path": "Data & app / Storage & bandwidth / Cache",
+      "role": "leaf_section",
+      "root": "Data & app",
+      "task_page": "Storage & bandwidth",
+      "title": "Cache"
+    },
+    {
+      "child_count": 0,
+      "control_count": 2,
+      "depth": 2,
+      "max_children_contract": 0,
+      "path": "Data & app / Storage & bandwidth / Data saver",
+      "role": "leaf_section",
+      "root": "Data & app",
+      "task_page": "Storage & bandwidth",
+      "title": "Data saver"
+    },
+    {
+      "child_count": 0,
+      "control_count": 1,
+      "depth": 2,
+      "max_children_contract": 0,
+      "path": "Data & app / Storage & bandwidth / Data usage",
+      "role": "leaf_section",
+      "root": "Data & app",
+      "task_page": "Storage & bandwidth",
+      "title": "Data usage"
+    },
+    {
+      "child_count": 0,
+      "control_count": 1,
+      "depth": 2,
+      "max_children_contract": 0,
+      "path": "Data & app / Storage & bandwidth / Images",
+      "role": "leaf_section",
+      "root": "Data & app",
+      "task_page": "Storage & bandwidth",
+      "title": "Images"
+    },
+    {
+      "child_count": 0,
+      "control_count": 3,
+      "depth": 2,
+      "max_children_contract": 0,
+      "path": "Data & app / Storage & bandwidth / Videos",
+      "role": "leaf_section",
+      "root": "Data & app",
+      "task_page": "Storage & bandwidth",
+      "title": "Videos"
+    }
+  ],
+  "semantic_revision": {
+    "classification_corrections": [
+      {
+        "action": "MOVE",
+        "from_path": "Appearance / Community header / Community header",
+        "key": "buy_pro",
+        "reason": "A purchase/support action is unrelated to community-header presentation.",
+        "title": "Boost PRO",
+        "to_path": "Data & app / About & support / About Boost"
+      },
+      {
+        "action": "MOVE",
+        "from_path": "Appearance / Community header / Community header",
+        "key": "remove_ads",
+        "reason": "A purchase/support action belongs with app support and product information, not community-header controls.",
+        "title": "Remove ads",
+        "to_path": "Data & app / About & support / About Boost"
+      },
+      {
+        "action": "MOVE",
+        "from_path": "Appearance / Theme & colors / Theme",
+        "key": "pref_app_icon",
+        "reason": "Launcher-icon selection is personalization, not theme-mode or color behavior.",
+        "title": "App icon",
+        "to_path": "Appearance / Theme & colors / Personalization"
+      },
+      {
+        "action": "MOVE",
+        "from_path": "Appearance / Post layout / Swipe",
+        "key": "pref_load_readability",
+        "reason": "Loading a text preview for external links is link/content handling, not post-layout presentation.",
+        "title": "Preview external links",
+        "to_path": "Media / Links & browser / Link handling"
+      },
+      {
+        "action": "MOVE",
+        "from_path": "Appearance / Post layout / Swipe",
+        "key": "pref_lock_sidebar",
+        "reason": "Disabling the sidebar swipe gesture is navigation-drawer behavior, not appearance.",
+        "title": "Lock sidebar",
+        "to_path": "Navigation / Navigation drawer / Drawer behavior"
+      }
+    ],
+    "hierarchy_flattening": [
+      {
+        "action": "REMOVE_REDUNDANT_SINGLE_TASK_WRAPPER",
+        "from_path": "Navigation / Navigation & gestures",
+        "reason": "The Navigation root contained only one task destination, adding a click without adding information.",
+        "result": "The Navigation root renders the Navigation & gestures destinations directly."
+      },
+      {
+        "action": "REMOVE_REDUNDANT_SINGLE_TASK_WRAPPER",
+        "from_path": "Morphe / Patch features",
+        "reason": "The Morphe root contained only one task destination, adding a click without adding information and implying an incomplete patch catalog.",
+        "result": "The Morphe root renders the 12 configurable Morphe feature references directly."
+      }
+    ],
+    "principles": [
+      "task-based placement",
+      "one visible control per user action",
+      "route aliases are graph metadata rather than duplicate controls",
+      "empty leaf screens are removed",
+      "single-task root wrappers are flattened into their root page"
+    ],
+    "route_alias_removals": [
+      {
+        "key": "action:appearance:app_icon",
+        "reason": "Route-only Morphe alias duplicates canonical XML action `pref_app_icon`; V5 should render one App icon destination.",
+        "replacement_key": "pref_app_icon",
+        "title": "App icon"
+      },
+      {
+        "key": "action:post_layout:manage_saved_views",
+        "reason": "Route-only Morphe alias duplicates canonical XML action `pref_view_per_sub`; V5 should render one destination.",
+        "replacement_key": "pref_view_per_sub",
+        "title": "Manage saved views"
+      }
+    ],
+    "schema": 2,
+    "supersedes_contract_sha256": "627f8850c2d8051fe03b3a07accb512f5392d6d54b1c708bf25e328e0112cac3",
+    "revision": "V4",
+    "original_v1_contract_sha256": "30745994dd0aec9f8c5d9b118dfaaee26d4522c5ca6d55a01da27a97961896f7"
+  },
+  "target": "Morphe Settings V5 semantically corrected complete tree",
+  "visible_item_target": 247,
+  "withheld_controls": [
+    {
+      "key": "pref_drawer_show_friends",
+      "reason": "Static implementation exists, but the Friends destination was not proven to return functional Reddit data at runtime.",
+      "required_resolution": "runtime destination validation before exposure",
+      "target_path": "Navigation / Navigation drawer / Account & tools"
+    }
+  ],
+  "withheld_item_target": 1,
+  "morphe_configurable_feature_reference_count": 12
+}

--- a/tools/contracts/boost-settings-v5-data-app-wave-v1.json
+++ b/tools/contracts/boost-settings-v5-data-app-wave-v1.json
@@ -1,0 +1,566 @@
+{
+  "binding_capture": {
+    "archive_sha256": "3b5f170322d956db8c0898943d0532aab871f7546cf041c9611ea749b42f5a3d",
+    "base_apk_sha256": "a68c22d632a5dd1f446c3759a171c7dbb9edab2afc3c2f87e39323f198606742",
+    "source_mpp_sha256": "600904a3d9639e198adcf9bab6d17ab6cbb3fd07e3a53694fc756b85d1be9934",
+    "special_handler_archive_sha256": "d2fe10c466530ef6168af9108728f8d3fcf4cdbe81d68f855dd730cb7bac41d7",
+    "v5_contract_sha256": "f1d6a9ac6c27f71eec61b300e5f36d0785d831fde14cb982450e21b3ae238682"
+  },
+  "issue": 121,
+  "items": [
+    {
+      "default_value": "",
+      "dependency": "",
+      "key": "buy_pro",
+      "logical_kind": "action",
+      "page_id": "v5/data_and_app/about_and_support/about_boost",
+      "storage_type": "none_or_custom",
+      "title": "Boost PRO"
+    },
+    {
+      "default_value": "",
+      "dependency": "",
+      "key": "remove_ads",
+      "logical_kind": "action",
+      "page_id": "v5/data_and_app/about_and_support/about_boost",
+      "storage_type": "none_or_custom",
+      "title": "Remove ads"
+    },
+    {
+      "default_value": "",
+      "dependency": "",
+      "key": "about_version",
+      "logical_kind": "action",
+      "page_id": "v5/data_and_app/about_and_support/about_boost",
+      "storage_type": "none_or_custom",
+      "title": "Changelog"
+    },
+    {
+      "default_value": "",
+      "dependency": "",
+      "key": "rate_app",
+      "logical_kind": "action",
+      "page_id": "v5/data_and_app/about_and_support/about_boost",
+      "storage_type": "none_or_custom",
+      "title": "Do you like this app?"
+    },
+    {
+      "default_value": "",
+      "dependency": "",
+      "key": "about_subreddit",
+      "logical_kind": "action",
+      "page_id": "v5/data_and_app/about_and_support/about_boost",
+      "storage_type": "none_or_custom",
+      "title": "Feedback and support"
+    },
+    {
+      "default_value": "",
+      "dependency": "",
+      "key": "about_faq",
+      "logical_kind": "action",
+      "page_id": "v5/data_and_app/about_and_support/about_boost",
+      "storage_type": "none_or_custom",
+      "title": "Help/FAQ"
+    },
+    {
+      "default_value": "",
+      "dependency": "",
+      "key": "support_launch",
+      "logical_kind": "action",
+      "page_id": "v5/data_and_app/about_and_support/about_boost",
+      "storage_type": "none_or_custom",
+      "title": "Launch the rocket"
+    },
+    {
+      "default_value": "",
+      "dependency": "",
+      "key": "licenses_preference",
+      "logical_kind": "action",
+      "page_id": "v5/data_and_app/about_and_support/about_boost",
+      "storage_type": "none_or_custom",
+      "title": "Licenses"
+    },
+    {
+      "default_value": "",
+      "dependency": "",
+      "key": "contact_dev_key",
+      "logical_kind": "action",
+      "page_id": "v5/data_and_app/about_and_support/author",
+      "storage_type": "none_or_custom",
+      "title": "Email"
+    },
+    {
+      "default_value": "",
+      "dependency": "",
+      "key": "about_reddit",
+      "logical_kind": "action",
+      "page_id": "v5/data_and_app/about_and_support/author",
+      "storage_type": "none_or_custom",
+      "title": "reddit"
+    },
+    {
+      "default_value": "",
+      "dependency": "",
+      "key": "about_twitter",
+      "logical_kind": "action",
+      "page_id": "v5/data_and_app/about_and_support/author",
+      "storage_type": "none_or_custom",
+      "title": "Twitter"
+    },
+    {
+      "default_value": "",
+      "dependency": "",
+      "key": "privacy_policy",
+      "logical_kind": "action",
+      "page_id": "v5/data_and_app/about_and_support/privacy",
+      "storage_type": "none_or_custom",
+      "title": "Privacy policy"
+    },
+    {
+      "default_value": "false",
+      "dependency": "",
+      "key": "pref_gdpr_revoke",
+      "logical_kind": "special_preference",
+      "page_id": "v5/data_and_app/about_and_support/privacy",
+      "storage_type": "none_or_custom",
+      "title": "Revoke GDPR consent"
+    },
+    {
+      "default_value": "true",
+      "dependency": "",
+      "key": "pref_statistics",
+      "logical_kind": "stored_setting",
+      "page_id": "v5/data_and_app/about_and_support/privacy",
+      "storage_type": "boolean",
+      "title": "Send statistics"
+    },
+    {
+      "default_value": "true",
+      "dependency": "",
+      "key": "pref_shortcut_icon_crop",
+      "logical_kind": "stored_setting",
+      "page_id": "v5/data_and_app/app_behavior_and_compatibility/community_shortcuts",
+      "storage_type": "boolean",
+      "title": "Crop community icon"
+    },
+    {
+      "default_value": "3",
+      "dependency": "",
+      "key": "pref_autoplay_swipe",
+      "logical_kind": "stored_setting",
+      "page_id": "v5/data_and_app/app_behavior_and_compatibility/compatibility_and_legacy",
+      "storage_type": "string",
+      "title": "Autoplay videos in Swipe view"
+    },
+    {
+      "default_value": "true",
+      "dependency": "",
+      "key": "pref_info_color_indicators",
+      "logical_kind": "stored_setting",
+      "page_id": "v5/data_and_app/app_behavior_and_compatibility/compatibility_and_legacy",
+      "storage_type": "boolean",
+      "title": "Colored link type indicators"
+    },
+    {
+      "default_value": "false",
+      "dependency": "",
+      "key": "pref_go_to_sub_dialog",
+      "logical_kind": "stored_setting",
+      "page_id": "v5/data_and_app/app_behavior_and_compatibility/compatibility_and_legacy",
+      "storage_type": "boolean",
+      "title": "Go to community in a dialog"
+    },
+    {
+      "default_value": "false",
+      "dependency": "",
+      "key": "pref_cards_preview_top",
+      "logical_kind": "stored_setting",
+      "page_id": "v5/data_and_app/app_behavior_and_compatibility/compatibility_and_legacy",
+      "storage_type": "boolean",
+      "title": "Previews on top"
+    },
+    {
+      "default_value": "true",
+      "dependency": "",
+      "key": "pref_info_post_shorten_score",
+      "logical_kind": "stored_setting",
+      "page_id": "v5/data_and_app/app_behavior_and_compatibility/compatibility_and_legacy",
+      "storage_type": "boolean",
+      "title": "Shorten score"
+    },
+    {
+      "default_value": "false",
+      "dependency": "",
+      "key": "pref_send_floating_button",
+      "logical_kind": "stored_setting",
+      "page_id": "v5/data_and_app/app_behavior_and_compatibility/compatibility_and_legacy",
+      "storage_type": "boolean",
+      "title": "Show floating send button"
+    },
+    {
+      "default_value": "true",
+      "dependency": "",
+      "key": "pref_info_post_self_image",
+      "logical_kind": "stored_setting",
+      "page_id": "v5/data_and_app/app_behavior_and_compatibility/compatibility_and_legacy",
+      "storage_type": "boolean",
+      "title": "Show images from text posts"
+    },
+    {
+      "default_value": "true",
+      "dependency": "",
+      "key": "pref_info_post_view_count",
+      "logical_kind": "stored_setting",
+      "page_id": "v5/data_and_app/app_behavior_and_compatibility/compatibility_and_legacy",
+      "storage_type": "boolean",
+      "title": "Show view count"
+    },
+    {
+      "default_value": "false",
+      "dependency": "",
+      "key": "pref_toolbar_dropdown",
+      "logical_kind": "stored_setting",
+      "page_id": "v5/data_and_app/app_behavior_and_compatibility/compatibility_and_legacy",
+      "storage_type": "boolean",
+      "title": "Subscriptions dropdown in toolbar"
+    },
+    {
+      "default_value": "true",
+      "dependency": "",
+      "key": "pref_toolbar_tap_to_go",
+      "logical_kind": "stored_setting",
+      "page_id": "v5/data_and_app/app_behavior_and_compatibility/compatibility_and_legacy",
+      "storage_type": "boolean",
+      "title": "Tap toolbar to show subs"
+    },
+    {
+      "default_value": "false",
+      "dependency": "",
+      "key": "pref_cards_legacy",
+      "logical_kind": "stored_setting",
+      "page_id": "v5/data_and_app/app_behavior_and_compatibility/compatibility_and_legacy",
+      "storage_type": "boolean",
+      "title": "Use legacy cards layout"
+    },
+    {
+      "default_value": "0",
+      "dependency": "",
+      "key": "pref_ad_format",
+      "logical_kind": "stored_setting",
+      "page_id": "v5/data_and_app/app_behavior_and_compatibility/other_app_behavior",
+      "storage_type": "string",
+      "title": "Preferred Ad format"
+    },
+    {
+      "default_value": "",
+      "dependency": "",
+      "key": "reset_tips",
+      "logical_kind": "action",
+      "page_id": "v5/data_and_app/app_behavior_and_compatibility/other_app_behavior",
+      "storage_type": "none_or_custom",
+      "title": "Reset tips"
+    },
+    {
+      "default_value": "true",
+      "dependency": "",
+      "key": "morphe_boost_settings_v4_enabled",
+      "logical_kind": "stored_setting",
+      "page_id": "v5/data_and_app/settings_experience/settings_presentation",
+      "storage_type": "boolean",
+      "title": "Material settings"
+    },
+    {
+      "default_value": "",
+      "dependency": "",
+      "key": "pref_cache_current_size",
+      "logical_kind": "action",
+      "page_id": "v5/data_and_app/storage_and_bandwidth/cache",
+      "storage_type": "none_or_custom",
+      "title": "Clear cache"
+    },
+    {
+      "default_value": "128",
+      "dependency": "",
+      "key": "pref_cache_max_size",
+      "logical_kind": "stored_setting",
+      "page_id": "v5/data_and_app/storage_and_bandwidth/cache",
+      "storage_type": "string",
+      "title": "Maximum cache size"
+    },
+    {
+      "default_value": "true",
+      "dependency": "",
+      "key": "pref_reduce_mobile",
+      "logical_kind": "stored_setting",
+      "page_id": "v5/data_and_app/storage_and_bandwidth/data_saver",
+      "storage_type": "boolean",
+      "title": "Mobile data saver"
+    },
+    {
+      "default_value": "false",
+      "dependency": "",
+      "key": "pref_reduce_wifi",
+      "logical_kind": "stored_setting",
+      "page_id": "v5/data_and_app/storage_and_bandwidth/data_saver",
+      "storage_type": "boolean",
+      "title": "Wifi data saver"
+    },
+    {
+      "default_value": "",
+      "dependency": "",
+      "key": "pref_download_folders",
+      "logical_kind": "action",
+      "page_id": "v5/data_and_app/storage_and_bandwidth/data_usage",
+      "storage_type": "none_or_custom",
+      "title": "Configure downloads"
+    },
+    {
+      "default_value": "0",
+      "dependency": "",
+      "key": "pref_load_images",
+      "logical_kind": "stored_setting",
+      "page_id": "v5/data_and_app/storage_and_bandwidth/images",
+      "storage_type": "string",
+      "title": "Load images"
+    },
+    {
+      "default_value": "1080",
+      "dependency": "",
+      "key": "pref_video_quality_max",
+      "logical_kind": "stored_setting",
+      "page_id": "v5/data_and_app/storage_and_bandwidth/videos",
+      "storage_type": "string",
+      "title": "Maximum quality"
+    },
+    {
+      "default_value": "480",
+      "dependency": "",
+      "key": "pref_video_quality_min",
+      "logical_kind": "stored_setting",
+      "page_id": "v5/data_and_app/storage_and_bandwidth/videos",
+      "storage_type": "string",
+      "title": "Minimum quality"
+    },
+    {
+      "default_value": "0",
+      "dependency": "",
+      "key": "pref_video_quality",
+      "logical_kind": "stored_setting",
+      "page_id": "v5/data_and_app/storage_and_bandwidth/videos",
+      "storage_type": "string",
+      "title": "Video quality"
+    }
+  ],
+  "root": "Data & app",
+  "schema": 1,
+  "screens": [
+    {
+      "child_count": 5,
+      "control_count": 0,
+      "page_id": "v5/data_and_app",
+      "path": "Data & app",
+      "renderer": "MorpheSettingsV5DataAppFragment",
+      "role": "root_group",
+      "title": "Data & app"
+    },
+    {
+      "child_count": 3,
+      "control_count": 0,
+      "page_id": "v5/data_and_app/about_and_support",
+      "path": "Data & app / About & support",
+      "renderer": "MorpheSettingsV5DataAppFragment",
+      "role": "task_page",
+      "title": "About & support"
+    },
+    {
+      "child_count": 3,
+      "control_count": 0,
+      "page_id": "v5/data_and_app/app_behavior_and_compatibility",
+      "path": "Data & app / App behavior & compatibility",
+      "renderer": "MorpheSettingsV5DataAppFragment",
+      "role": "task_page",
+      "title": "App behavior & compatibility"
+    },
+    {
+      "child_count": 0,
+      "control_count": 0,
+      "page_id": "v5/data_and_app/backup_and_restore",
+      "path": "Data & app / Backup & restore",
+      "renderer": "MorpheSettingsV5BackupRestoreFragment",
+      "role": "task_page",
+      "title": "Backup & restore"
+    },
+    {
+      "child_count": 1,
+      "control_count": 0,
+      "page_id": "v5/data_and_app/settings_experience",
+      "path": "Data & app / Settings experience",
+      "renderer": "MorpheSettingsV5DataAppFragment",
+      "role": "task_page",
+      "title": "Settings experience"
+    },
+    {
+      "child_count": 5,
+      "control_count": 0,
+      "page_id": "v5/data_and_app/storage_and_bandwidth",
+      "path": "Data & app / Storage & bandwidth",
+      "renderer": "MorpheSettingsV5DataAppFragment",
+      "role": "task_page",
+      "title": "Storage & bandwidth"
+    },
+    {
+      "child_count": 0,
+      "control_count": 8,
+      "page_id": "v5/data_and_app/about_and_support/about_boost",
+      "path": "Data & app / About & support / About Boost",
+      "renderer": "MorpheSettingsV5DataAppLeafFragment",
+      "role": "leaf_section",
+      "title": "About Boost"
+    },
+    {
+      "child_count": 0,
+      "control_count": 3,
+      "page_id": "v5/data_and_app/about_and_support/author",
+      "path": "Data & app / About & support / Author",
+      "renderer": "MorpheSettingsV5DataAppLeafFragment",
+      "role": "leaf_section",
+      "title": "Author"
+    },
+    {
+      "child_count": 0,
+      "control_count": 3,
+      "page_id": "v5/data_and_app/about_and_support/privacy",
+      "path": "Data & app / About & support / Privacy",
+      "renderer": "MorpheSettingsV5DataAppLeafFragment",
+      "role": "leaf_section",
+      "title": "Privacy"
+    },
+    {
+      "child_count": 0,
+      "control_count": 1,
+      "page_id": "v5/data_and_app/app_behavior_and_compatibility/community_shortcuts",
+      "path": "Data & app / App behavior & compatibility / Community shortcuts",
+      "renderer": "MorpheSettingsV5DataAppLeafFragment",
+      "role": "leaf_section",
+      "title": "Community shortcuts"
+    },
+    {
+      "child_count": 0,
+      "control_count": 11,
+      "page_id": "v5/data_and_app/app_behavior_and_compatibility/compatibility_and_legacy",
+      "path": "Data & app / App behavior & compatibility / Compatibility & legacy",
+      "renderer": "MorpheSettingsV5DataAppLeafFragment",
+      "role": "leaf_section",
+      "title": "Compatibility & legacy"
+    },
+    {
+      "child_count": 0,
+      "control_count": 2,
+      "page_id": "v5/data_and_app/app_behavior_and_compatibility/other_app_behavior",
+      "path": "Data & app / App behavior & compatibility / Other app behavior",
+      "renderer": "MorpheSettingsV5DataAppLeafFragment",
+      "role": "leaf_section",
+      "title": "Other app behavior"
+    },
+    {
+      "child_count": 0,
+      "control_count": 1,
+      "page_id": "v5/data_and_app/settings_experience/settings_presentation",
+      "path": "Data & app / Settings experience / Settings presentation",
+      "renderer": "MorpheSettingsV5DataAppLeafFragment",
+      "role": "leaf_section",
+      "title": "Settings presentation"
+    },
+    {
+      "child_count": 0,
+      "control_count": 2,
+      "page_id": "v5/data_and_app/storage_and_bandwidth/cache",
+      "path": "Data & app / Storage & bandwidth / Cache",
+      "renderer": "MorpheSettingsV5DataAppLeafFragment",
+      "role": "leaf_section",
+      "title": "Cache"
+    },
+    {
+      "child_count": 0,
+      "control_count": 2,
+      "page_id": "v5/data_and_app/storage_and_bandwidth/data_saver",
+      "path": "Data & app / Storage & bandwidth / Data saver",
+      "renderer": "MorpheSettingsV5DataAppLeafFragment",
+      "role": "leaf_section",
+      "title": "Data saver"
+    },
+    {
+      "child_count": 0,
+      "control_count": 1,
+      "page_id": "v5/data_and_app/storage_and_bandwidth/data_usage",
+      "path": "Data & app / Storage & bandwidth / Data usage",
+      "renderer": "MorpheSettingsV5DataAppLeafFragment",
+      "role": "leaf_section",
+      "title": "Data usage"
+    },
+    {
+      "child_count": 0,
+      "control_count": 1,
+      "page_id": "v5/data_and_app/storage_and_bandwidth/images",
+      "path": "Data & app / Storage & bandwidth / Images",
+      "renderer": "MorpheSettingsV5DataAppLeafFragment",
+      "role": "leaf_section",
+      "title": "Images"
+    },
+    {
+      "child_count": 0,
+      "control_count": 3,
+      "page_id": "v5/data_and_app/storage_and_bandwidth/videos",
+      "path": "Data & app / Storage & bandwidth / Videos",
+      "renderer": "MorpheSettingsV5DataAppLeafFragment",
+      "role": "leaf_section",
+      "title": "Videos"
+    }
+  ],
+  "special_handlers": {
+    "backup_route": [
+      "v5/data_and_app/backup_and_restore"
+    ],
+    "privacy": [
+      "pref_gdpr_revoke"
+    ],
+    "purchase_and_ads": [
+      "buy_pro",
+      "remove_ads"
+    ],
+    "storage": [
+      "pref_cache_current_size",
+      "pref_cache_max_size",
+      "pref_download_folders"
+    ],
+    "support": [
+      "about_version",
+      "rate_app",
+      "about_subreddit",
+      "about_faq",
+      "support_launch",
+      "licenses_preference",
+      "contact_dev_key",
+      "about_reddit",
+      "about_twitter",
+      "privacy_policy",
+      "reset_tips"
+    ],
+    "video_quality_state": [
+      "pref_video_quality",
+      "pref_video_quality_min",
+      "pref_video_quality_max",
+      "pref_reduce_mobile",
+      "pref_reduce_wifi"
+    ]
+  },
+  "targets": {
+    "action_count": 15,
+    "dependency_count": 0,
+    "screen_count": 18,
+    "special_preference_count": 1,
+    "stored_setting_count": 22,
+    "visible_item_count": 38,
+    "zero_control_route_count": 1
+  }
+}

--- a/tools/contracts/boost-settings-v5-font-preview-v1.json
+++ b/tools/contracts/boost-settings-v5-font-preview-v1.json
@@ -1,0 +1,25 @@
+{
+  "canonical_keys": [
+    "pref_title_font",
+    "pref_comments_font"
+  ],
+  "font_option_count": 13,
+  "issue": 121,
+  "requirements": {
+    "canonical_storage_preserved": true,
+    "current_value_summary_renders_selected_typeface": true,
+    "picker_rows_render_candidate_typeface": true,
+    "preference_key_changes": 0,
+    "radio_selection_preserved": true,
+    "readable_font_name_preserved": true,
+    "route_changes": 0
+  },
+  "schema": 1,
+  "scope": "hidden_v5_appearance_typography_font_picker",
+  "source_evidence": {
+    "boost_preference_class": "com.rubenmayayo.reddit.ui.preferences.v2.custom.FontDropDownPreference",
+    "boost_typeface_resolver": "id.b.v0().p4(Context,String)",
+    "entry_array": "font_options",
+    "value_array": "font_values"
+  }
+}

--- a/tools/contracts/boost-settings-v5-media-wave-v1.json
+++ b/tools/contracts/boost-settings-v5-media-wave-v1.json
@@ -1,0 +1,524 @@
+{
+  "binding_capture": {
+    "archive_sha256": "12e3a8ac2604dec833bbb3d223316e1afc8eddd1aebd40e9518bd6f42c0618ca",
+    "base_apk_sha256": "a68c22d632a5dd1f446c3759a171c7dbb9edab2afc3c2f87e39323f198606742",
+    "source_mpp_sha256": "765bfd3c15487e5021f9e7979cd1aabee600363217beda9a381ff29545fb6280",
+    "v5_contract_sha256": "4c8e081069d7444938c3ff5ad0e451bb3b16183592114a6b8adf77cd1208d3f7"
+  },
+  "dependencies": {
+    "pref_images_fit": "pref_images_deepzoom",
+    "pref_swipe_dismiss_direction_mode_image": "pref_swipe_up_to_dismiss_image"
+  },
+  "issue": 121,
+  "items": [
+    {
+      "default_value": "false",
+      "dependency": "",
+      "key": "pref_load_readability",
+      "logical_kind": "stored_setting",
+      "page_id": "v5/media/links_and_browser/link_handling",
+      "storage_type": "boolean",
+      "title": "Preview external links"
+    },
+    {
+      "default_value": "false",
+      "dependency": "",
+      "key": "pref_download_folder_per_subreddit",
+      "logical_kind": "stored_setting",
+      "page_id": "v5/media/downloads_and_cache/download_folders",
+      "storage_type": "boolean",
+      "title": "Community subfolders"
+    },
+    {
+      "default_value": "",
+      "dependency": "",
+      "key": "pref_download_folder_default",
+      "logical_kind": "action_state",
+      "page_id": "v5/media/downloads_and_cache/download_folders",
+      "storage_type": "string",
+      "title": "Default folder"
+    },
+    {
+      "default_value": "",
+      "dependency": "",
+      "key": "pref_download_folder_gif",
+      "logical_kind": "action_state",
+      "page_id": "v5/media/downloads_and_cache/download_folders",
+      "storage_type": "string",
+      "title": "GIFs"
+    },
+    {
+      "default_value": "",
+      "dependency": "",
+      "key": "pref_download_folder_img",
+      "logical_kind": "action_state",
+      "page_id": "v5/media/downloads_and_cache/download_folders",
+      "storage_type": "string",
+      "title": "Images"
+    },
+    {
+      "default_value": "",
+      "dependency": "",
+      "key": "pref_download_folder_mp4",
+      "logical_kind": "action_state",
+      "page_id": "v5/media/downloads_and_cache/download_folders",
+      "storage_type": "string",
+      "title": "Videos"
+    },
+    {
+      "default_value": "glide",
+      "dependency": "",
+      "key": "pref_image_loader",
+      "logical_kind": "stored_setting",
+      "page_id": "v5/media/images_gifs_and_previews/native_image_behavior",
+      "storage_type": "string",
+      "title": "Image loader"
+    },
+    {
+      "default_value": "false",
+      "dependency": "",
+      "key": "pref_images_deepzoom",
+      "logical_kind": "stored_setting",
+      "page_id": "v5/media/images_gifs_and_previews/native_image_behavior",
+      "storage_type": "boolean",
+      "title": "Load HQ images"
+    },
+    {
+      "default_value": "false",
+      "dependency": "pref_images_deepzoom",
+      "key": "pref_images_fit",
+      "logical_kind": "stored_setting",
+      "page_id": "v5/media/images_gifs_and_previews/native_image_behavior",
+      "storage_type": "boolean",
+      "title": "Load zoomed in"
+    },
+    {
+      "default_value": "true",
+      "dependency": "",
+      "key": "pref_swipe_up_to_dismiss_image",
+      "logical_kind": "stored_setting",
+      "page_id": "v5/media/images_gifs_and_previews/native_image_behavior",
+      "storage_type": "boolean",
+      "title": "Swipe to dismiss"
+    },
+    {
+      "default_value": "vertical",
+      "dependency": "pref_swipe_up_to_dismiss_image",
+      "key": "pref_swipe_dismiss_direction_mode_image",
+      "logical_kind": "stored_setting",
+      "page_id": "v5/media/images_gifs_and_previews/native_image_behavior",
+      "storage_type": "string",
+      "title": "Swipe to dismiss direction"
+    },
+    {
+      "default_value": "true",
+      "dependency": "",
+      "key": "pref_tap_to_dismiss_image",
+      "logical_kind": "stored_setting",
+      "page_id": "v5/media/images_gifs_and_previews/native_image_behavior",
+      "storage_type": "boolean",
+      "title": "Tap to dismiss"
+    },
+    {
+      "default_value": "image_viewer",
+      "dependency": "",
+      "key": "morphe_boost_direct_reddit_gif_tap_action",
+      "logical_kind": "stored_setting",
+      "page_id": "v5/media/images_gifs_and_previews/open_behavior",
+      "storage_type": "string",
+      "title": "Direct Reddit GIF tap action"
+    },
+    {
+      "default_value": "video_viewer",
+      "dependency": "",
+      "key": "morphe_boost_giphy_preview_tap_action",
+      "logical_kind": "stored_setting",
+      "page_id": "v5/media/images_gifs_and_previews/open_behavior",
+      "storage_type": "string",
+      "title": "Giphy preview tap action"
+    },
+    {
+      "default_value": "image_viewer",
+      "dependency": "",
+      "key": "morphe_boost_static_preview_tap_action",
+      "logical_kind": "stored_setting",
+      "page_id": "v5/media/images_gifs_and_previews/open_behavior",
+      "storage_type": "string",
+      "title": "Static preview tap action"
+    },
+    {
+      "default_value": "true",
+      "dependency": "",
+      "key": "morphe_boost_inline_media_previews_enabled",
+      "logical_kind": "stored_setting",
+      "page_id": "v5/media/images_gifs_and_previews/preview_behavior",
+      "storage_type": "boolean",
+      "title": "Enable inline media previews"
+    },
+    {
+      "default_value": "false",
+      "dependency": "",
+      "key": "morphe_boost_inline_media_preview_show_source_text",
+      "logical_kind": "stored_setting",
+      "page_id": "v5/media/images_gifs_and_previews/preview_behavior",
+      "storage_type": "boolean",
+      "title": "Show source text with preview"
+    },
+    {
+      "default_value": "center",
+      "dependency": "",
+      "key": "morphe_boost_inline_media_preview_alignment",
+      "logical_kind": "stored_setting",
+      "page_id": "v5/media/images_gifs_and_previews/preview_layout",
+      "storage_type": "string",
+      "title": "Preview alignment"
+    },
+    {
+      "default_value": "balanced",
+      "dependency": "",
+      "key": "morphe_boost_inline_media_preview_size",
+      "logical_kind": "stored_setting",
+      "page_id": "v5/media/images_gifs_and_previews/preview_layout",
+      "storage_type": "string",
+      "title": "Preview size"
+    },
+    {
+      "default_value": "0",
+      "dependency": "",
+      "key": "pref_browser",
+      "logical_kind": "stored_setting",
+      "page_id": "v5/media/links_and_browser/browser",
+      "storage_type": "string",
+      "title": "Default browser"
+    },
+    {
+      "default_value": "",
+      "dependency": "",
+      "key": "pref_domain_exceptions",
+      "logical_kind": "special_preference",
+      "page_id": "v5/media/links_and_browser/link_handling",
+      "storage_type": "none_or_custom",
+      "title": "Domain exceptions"
+    },
+    {
+      "default_value": "true",
+      "dependency": "",
+      "key": "pref_link_album",
+      "logical_kind": "stored_setting",
+      "page_id": "v5/media/links_and_browser/links_to_open_in_app",
+      "storage_type": "boolean",
+      "title": "Albums"
+    },
+    {
+      "default_value": "true",
+      "dependency": "",
+      "key": "pref_link_deviant",
+      "logical_kind": "stored_setting",
+      "page_id": "v5/media/links_and_browser/links_to_open_in_app",
+      "storage_type": "boolean",
+      "title": "Deviant Art"
+    },
+    {
+      "default_value": "true",
+      "dependency": "",
+      "key": "pref_link_gif",
+      "logical_kind": "stored_setting",
+      "page_id": "v5/media/links_and_browser/links_to_open_in_app",
+      "storage_type": "boolean",
+      "title": "Gifs"
+    },
+    {
+      "default_value": "true",
+      "dependency": "",
+      "key": "pref_link_image",
+      "logical_kind": "stored_setting",
+      "page_id": "v5/media/links_and_browser/links_to_open_in_app",
+      "storage_type": "boolean",
+      "title": "Images"
+    },
+    {
+      "default_value": "true",
+      "dependency": "",
+      "key": "pref_link_neatclip",
+      "logical_kind": "stored_setting",
+      "page_id": "v5/media/links_and_browser/links_to_open_in_app",
+      "storage_type": "boolean",
+      "title": "NeatClip"
+    },
+    {
+      "default_value": "true",
+      "dependency": "",
+      "key": "pref_link_vreddit",
+      "logical_kind": "stored_setting",
+      "page_id": "v5/media/links_and_browser/links_to_open_in_app",
+      "storage_type": "boolean",
+      "title": "Reddit videos"
+    },
+    {
+      "default_value": "true",
+      "dependency": "",
+      "key": "pref_link_streamable",
+      "logical_kind": "stored_setting",
+      "page_id": "v5/media/links_and_browser/links_to_open_in_app",
+      "storage_type": "boolean",
+      "title": "Streamable"
+    },
+    {
+      "default_value": "true",
+      "dependency": "",
+      "key": "pref_link_xkcd",
+      "logical_kind": "stored_setting",
+      "page_id": "v5/media/links_and_browser/links_to_open_in_app",
+      "storage_type": "boolean",
+      "title": "XKCD"
+    },
+    {
+      "default_value": "true",
+      "dependency": "",
+      "key": "pref_link_video",
+      "logical_kind": "stored_setting",
+      "page_id": "v5/media/links_and_browser/video_links",
+      "storage_type": "boolean",
+      "title": "Internal Youtube player"
+    },
+    {
+      "default_value": "false",
+      "dependency": "",
+      "key": "pref_video_audio_start_muted",
+      "logical_kind": "stored_setting",
+      "page_id": "v5/media/playback_and_autoplay/audio",
+      "storage_type": "boolean",
+      "title": "Mute audio"
+    },
+    {
+      "default_value": "1",
+      "dependency": "",
+      "key": "pref_autoplay_cards",
+      "logical_kind": "stored_setting",
+      "page_id": "v5/media/playback_and_autoplay/autoplay",
+      "storage_type": "string",
+      "title": "Autoplay videos"
+    },
+    {
+      "default_value": "boost",
+      "dependency": "",
+      "key": "pref_media_viewer",
+      "logical_kind": "stored_setting",
+      "page_id": "v5/media/playback_and_autoplay/media_behavior",
+      "storage_type": "string",
+      "title": "Media viewer"
+    },
+    {
+      "default_value": "show",
+      "dependency": "",
+      "key": "pref_media_overlay_visibility",
+      "logical_kind": "stored_setting",
+      "page_id": "v5/media/playback_and_autoplay/media_behavior",
+      "storage_type": "string",
+      "title": "Overlay elements"
+    },
+    {
+      "default_value": "false",
+      "dependency": "",
+      "key": "pref_tap_to_dismiss_youtube_videos",
+      "logical_kind": "stored_setting",
+      "page_id": "v5/media/playback_and_autoplay/playback_and_autoplay",
+      "storage_type": "boolean",
+      "title": "Tap to dismiss Youtube"
+    },
+    {
+      "default_value": "0",
+      "dependency": "",
+      "key": "pref_video_player",
+      "logical_kind": "stored_setting",
+      "page_id": "v5/media/playback_and_autoplay/playback_and_autoplay",
+      "storage_type": "string",
+      "title": "Video player"
+    }
+  ],
+  "schema": 1,
+  "screens": [
+    {
+      "child_count": 4,
+      "control_count": 0,
+      "page_id": "v5/media",
+      "renderer": "MorpheSettingsV5MediaFragment",
+      "role": "root_group",
+      "title": "Media"
+    },
+    {
+      "child_count": 1,
+      "control_count": 0,
+      "page_id": "v5/media/downloads_and_cache",
+      "renderer": "MorpheSettingsV5MediaFragment",
+      "role": "task_page",
+      "title": "Downloads & cache"
+    },
+    {
+      "child_count": 4,
+      "control_count": 0,
+      "page_id": "v5/media/images_gifs_and_previews",
+      "renderer": "MorpheSettingsV5MediaFragment",
+      "role": "task_page",
+      "title": "Images, GIFs & previews"
+    },
+    {
+      "child_count": 4,
+      "control_count": 0,
+      "page_id": "v5/media/links_and_browser",
+      "renderer": "MorpheSettingsV5MediaFragment",
+      "role": "task_page",
+      "title": "Links & browser"
+    },
+    {
+      "child_count": 4,
+      "control_count": 0,
+      "page_id": "v5/media/playback_and_autoplay",
+      "renderer": "MorpheSettingsV5MediaFragment",
+      "role": "task_page",
+      "title": "Playback & autoplay"
+    },
+    {
+      "child_count": 0,
+      "control_count": 5,
+      "page_id": "v5/media/downloads_and_cache/download_folders",
+      "renderer": "MorpheSettingsV5MediaDownloadFoldersFragment",
+      "role": "leaf_section",
+      "title": "Download folders"
+    },
+    {
+      "child_count": 0,
+      "control_count": 6,
+      "page_id": "v5/media/images_gifs_and_previews/native_image_behavior",
+      "renderer": "MorpheSettingsV5MediaLeafFragment",
+      "role": "leaf_section",
+      "title": "Native image behavior"
+    },
+    {
+      "child_count": 0,
+      "control_count": 3,
+      "page_id": "v5/media/images_gifs_and_previews/open_behavior",
+      "renderer": "MorpheSettingsV5MediaLeafFragment",
+      "role": "leaf_section",
+      "title": "Open behavior"
+    },
+    {
+      "child_count": 0,
+      "control_count": 2,
+      "page_id": "v5/media/images_gifs_and_previews/preview_behavior",
+      "renderer": "MorpheSettingsV5MediaLeafFragment",
+      "role": "leaf_section",
+      "title": "Preview behavior"
+    },
+    {
+      "child_count": 0,
+      "control_count": 2,
+      "page_id": "v5/media/images_gifs_and_previews/preview_layout",
+      "renderer": "MorpheSettingsV5MediaLeafFragment",
+      "role": "leaf_section",
+      "title": "Preview layout"
+    },
+    {
+      "child_count": 0,
+      "control_count": 1,
+      "page_id": "v5/media/links_and_browser/browser",
+      "renderer": "MorpheSettingsV5MediaLeafFragment",
+      "role": "leaf_section",
+      "title": "Browser"
+    },
+    {
+      "child_count": 0,
+      "control_count": 2,
+      "page_id": "v5/media/links_and_browser/link_handling",
+      "renderer": "MorpheSettingsV5MediaLeafFragment",
+      "role": "leaf_section",
+      "title": "Link handling"
+    },
+    {
+      "child_count": 0,
+      "control_count": 8,
+      "page_id": "v5/media/links_and_browser/links_to_open_in_app",
+      "renderer": "MorpheSettingsV5MediaLeafFragment",
+      "role": "leaf_section",
+      "title": "Links to open in app"
+    },
+    {
+      "child_count": 0,
+      "control_count": 1,
+      "page_id": "v5/media/links_and_browser/video_links",
+      "renderer": "MorpheSettingsV5MediaLeafFragment",
+      "role": "leaf_section",
+      "title": "Video links"
+    },
+    {
+      "child_count": 0,
+      "control_count": 1,
+      "page_id": "v5/media/playback_and_autoplay/audio",
+      "renderer": "MorpheSettingsV5MediaLeafFragment",
+      "role": "leaf_section",
+      "title": "Audio"
+    },
+    {
+      "child_count": 0,
+      "control_count": 1,
+      "page_id": "v5/media/playback_and_autoplay/autoplay",
+      "renderer": "MorpheSettingsV5MediaLeafFragment",
+      "role": "leaf_section",
+      "title": "Autoplay"
+    },
+    {
+      "child_count": 0,
+      "control_count": 2,
+      "page_id": "v5/media/playback_and_autoplay/media_behavior",
+      "renderer": "MorpheSettingsV5MediaLeafFragment",
+      "role": "leaf_section",
+      "title": "Media behavior"
+    },
+    {
+      "child_count": 0,
+      "control_count": 2,
+      "page_id": "v5/media/playback_and_autoplay/playback_and_autoplay",
+      "renderer": "MorpheSettingsV5MediaLeafFragment",
+      "role": "leaf_section",
+      "title": "Playback & autoplay"
+    }
+  ],
+  "source_files": [
+    "MorpheSettingsV5Registry.java",
+    "MorpheSettingsV5Navigation.java",
+    "MorpheSettingsV5MediaFragment.java",
+    "MorpheSettingsV5MediaLeafFragment.java",
+    "MorpheSettingsV5MediaMetadata.java",
+    "MorpheSettingsV5MediaDownloadFoldersFragment.java",
+    "MorpheSettingsV5XmlPreferenceFragment.java",
+    "MorpheSettingsV5Search.java"
+  ],
+  "special_handlers": {
+    "download_folder_actions": [
+      "pref_download_folder_default",
+      "pref_download_folder_img",
+      "pref_download_folder_mp4",
+      "pref_download_folder_gif"
+    ],
+    "filter_preferences": [
+      "pref_domain_exceptions"
+    ],
+    "morphe_choice_controls": [
+      "morphe_boost_direct_reddit_gif_tap_action",
+      "morphe_boost_giphy_preview_tap_action",
+      "morphe_boost_static_preview_tap_action",
+      "morphe_boost_inline_media_preview_alignment",
+      "morphe_boost_inline_media_preview_size"
+    ]
+  },
+  "target": {
+    "legacy_routes": 0,
+    "max_controls_per_leaf": 8,
+    "placeholder_pages": 0,
+    "screen_nodes": 18,
+    "visible_by_default": false,
+    "visible_items": 36,
+    "withheld_items": 0
+  },
+  "wave": "Media"
+}

--- a/tools/contracts/boost-settings-v5-navigation-wave-v1.json
+++ b/tools/contracts/boost-settings-v5-navigation-wave-v1.json
@@ -1,0 +1,492 @@
+{
+  "binding_capture": {
+    "archive_sha256": "38d6836a42121090affca2016b95da80383e20898195e61abae8f6ffe4ea96b1",
+    "base_apk_sha256": "a68c22d632a5dd1f446c3759a171c7dbb9edab2afc3c2f87e39323f198606742",
+    "source_mpp_sha256": "1121fe81f01f6bd7701948ac825f49d4e9873baee4bd0f229ab14307d7abc4f3",
+    "v5_contract_sha256": "4c8e081069d7444938c3ff5ad0e451bb3b16183592114a6b8adf77cd1208d3f7"
+  },
+  "dependencies": {
+    "pref_bottom_navigation_hide_on_scroll": "pref_bottom_navigation",
+    "pref_double_exit": "pref_ask_exit",
+    "pref_subscriptions_drawer_show_icon": "pref_subscriptions_drawer",
+    "pref_subscriptions_only_casual": "pref_subscriptions_drawer"
+  },
+  "issue": 121,
+  "items": [
+    {
+      "default_value": "false",
+      "dependency": "",
+      "key": "pref_lock_sidebar",
+      "logical_kind": "stored_setting",
+      "page_id": "v5/navigation/navigation_drawer/drawer_behavior",
+      "storage_type": "boolean",
+      "title": "Lock sidebar",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "true",
+      "dependency": "",
+      "key": "pref_ask_exit",
+      "logical_kind": "stored_setting",
+      "page_id": "v5/navigation/back_and_exit",
+      "storage_type": "boolean",
+      "title": "Confirm exit",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "true",
+      "dependency": "pref_ask_exit",
+      "key": "pref_double_exit",
+      "logical_kind": "stored_setting",
+      "page_id": "v5/navigation/back_and_exit",
+      "storage_type": "boolean",
+      "title": "Double tap to exit",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "true",
+      "dependency": "pref_bottom_navigation",
+      "key": "pref_bottom_navigation_hide_on_scroll",
+      "logical_kind": "stored_setting",
+      "page_id": "v5/navigation/bottom_navigation",
+      "storage_type": "boolean",
+      "title": "Hide on scroll",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "false",
+      "dependency": "",
+      "key": "pref_bottom_navigation",
+      "logical_kind": "stored_setting",
+      "page_id": "v5/navigation/bottom_navigation",
+      "storage_type": "boolean",
+      "title": "Show bottom navigation",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "true",
+      "dependency": "",
+      "key": "pref_accounts_show_avatar",
+      "logical_kind": "stored_setting",
+      "page_id": "v5/navigation/navigation_drawer/account_switcher",
+      "storage_type": "boolean",
+      "title": "Show avatar",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "true",
+      "dependency": "",
+      "key": "pref_accounts_show_username",
+      "logical_kind": "stored_setting",
+      "page_id": "v5/navigation/navigation_drawer/account_switcher",
+      "storage_type": "boolean",
+      "title": "Show username",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "false",
+      "dependency": "",
+      "key": "pref_drawer_show_drafts",
+      "logical_kind": "stored_setting",
+      "page_id": "v5/navigation/navigation_drawer/account_and_tools",
+      "storage_type": "boolean",
+      "title": "Drafts",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "true",
+      "dependency": "",
+      "key": "pref_drawer_show_history",
+      "logical_kind": "stored_setting",
+      "page_id": "v5/navigation/navigation_drawer/feeds_and_library",
+      "storage_type": "boolean",
+      "title": "History",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "true",
+      "dependency": "",
+      "key": "pref_drawer_show_frontpage",
+      "logical_kind": "stored_setting",
+      "page_id": "v5/navigation/navigation_drawer/feeds_and_library",
+      "storage_type": "boolean",
+      "title": "Home feed",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "true",
+      "dependency": "",
+      "key": "pref_drawer_show_inbox",
+      "logical_kind": "stored_setting",
+      "page_id": "v5/navigation/navigation_drawer/account_and_tools",
+      "storage_type": "boolean",
+      "title": "Inbox",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "true",
+      "dependency": "",
+      "key": "pref_drawer_show_mod",
+      "logical_kind": "stored_setting",
+      "page_id": "v5/navigation/navigation_drawer/account_and_tools",
+      "storage_type": "boolean",
+      "title": "Moderation",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "true",
+      "dependency": "",
+      "key": "pref_drawer_show_popular",
+      "logical_kind": "stored_setting",
+      "page_id": "v5/navigation/navigation_drawer/feeds_and_library",
+      "storage_type": "boolean",
+      "title": "Popular",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "true",
+      "dependency": "",
+      "key": "pref_drawer_show_profile",
+      "logical_kind": "stored_setting",
+      "page_id": "v5/navigation/navigation_drawer/account_and_tools",
+      "storage_type": "boolean",
+      "title": "Profile",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "true",
+      "dependency": "",
+      "key": "pref_drawer_show_saved",
+      "logical_kind": "stored_setting",
+      "page_id": "v5/navigation/navigation_drawer/feeds_and_library",
+      "storage_type": "boolean",
+      "title": "Saved",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "true",
+      "dependency": "",
+      "key": "pref_drawer_show_search_generic",
+      "logical_kind": "stored_setting",
+      "page_id": "v5/navigation/navigation_drawer/account_and_tools",
+      "storage_type": "boolean",
+      "title": "Search",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "true",
+      "dependency": "",
+      "key": "pref_drawer_show_all",
+      "logical_kind": "stored_setting",
+      "page_id": "v5/navigation/navigation_drawer/feeds_and_library",
+      "storage_type": "boolean",
+      "title": "All",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "true",
+      "dependency": "",
+      "key": "pref_drawer_show_friends",
+      "logical_kind": "stored_setting",
+      "page_id": "v5/navigation/navigation_drawer/account_and_tools",
+      "storage_type": "boolean",
+      "title": "Friends",
+      "v5_visibility": "WITHHELD_RUNTIME_UNAVAILABLE",
+      "v5_visibility_reason": "Static implementation exists, but the Friends destination was not proven to return functional Reddit data at runtime."
+    },
+    {
+      "default_value": "true",
+      "dependency": "",
+      "key": "pref_drawer_sticky_settings",
+      "logical_kind": "stored_setting",
+      "page_id": "v5/navigation/navigation_drawer/drawer_behavior",
+      "storage_type": "boolean",
+      "title": "Sticky Settings",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "false",
+      "dependency": "",
+      "key": "pref_drawer_end",
+      "logical_kind": "stored_setting",
+      "page_id": "v5/navigation/navigation_drawer/drawer_behavior",
+      "storage_type": "boolean",
+      "title": "Switch side",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "false",
+      "dependency": "",
+      "key": "pref_drawer_show_go_to_subreddit",
+      "logical_kind": "stored_setting",
+      "page_id": "v5/navigation/navigation_drawer/go_to_shortcuts",
+      "storage_type": "boolean",
+      "title": "Go to community",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "true",
+      "dependency": "",
+      "key": "pref_drawer_show_go_to",
+      "logical_kind": "stored_setting",
+      "page_id": "v5/navigation/navigation_drawer/go_to_shortcuts",
+      "storage_type": "boolean",
+      "title": "Go to dropdown",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "false",
+      "dependency": "",
+      "key": "pref_drawer_show_go_to_user",
+      "logical_kind": "stored_setting",
+      "page_id": "v5/navigation/navigation_drawer/go_to_shortcuts",
+      "storage_type": "boolean",
+      "title": "Go to user",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "false",
+      "dependency": "",
+      "key": "pref_drawer_show_blur_switch",
+      "logical_kind": "stored_setting",
+      "page_id": "v5/navigation/navigation_drawer/quick_toggles",
+      "storage_type": "boolean",
+      "title": "Blur NSFW",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "false",
+      "dependency": "",
+      "key": "pref_drawer_show_night_mode",
+      "logical_kind": "stored_setting",
+      "page_id": "v5/navigation/navigation_drawer/quick_toggles",
+      "storage_type": "boolean",
+      "title": "Dark mode",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "false",
+      "dependency": "",
+      "key": "pref_drawer_show_nsfw_switch",
+      "logical_kind": "stored_setting",
+      "page_id": "v5/navigation/navigation_drawer/quick_toggles",
+      "storage_type": "boolean",
+      "title": "Show NSFW",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "true",
+      "dependency": "",
+      "key": "pref_drawer_show_home",
+      "logical_kind": "stored_setting",
+      "page_id": "v5/navigation/navigation_drawer/feeds_and_library",
+      "storage_type": "boolean",
+      "title": "Home",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "true",
+      "dependency": "pref_subscriptions_drawer",
+      "key": "pref_subscriptions_drawer_show_icon",
+      "logical_kind": "stored_setting",
+      "page_id": "v5/navigation/navigation_drawer/subscriptions",
+      "storage_type": "boolean",
+      "title": "Show icons",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "true",
+      "dependency": "",
+      "key": "pref_subscriptions_drawer",
+      "logical_kind": "stored_setting",
+      "page_id": "v5/navigation/navigation_drawer/subscriptions",
+      "storage_type": "boolean",
+      "title": "Show in menu",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "false",
+      "dependency": "pref_subscriptions_drawer",
+      "key": "pref_subscriptions_only_casual",
+      "logical_kind": "stored_setting",
+      "page_id": "v5/navigation/navigation_drawer/subscriptions",
+      "storage_type": "boolean",
+      "title": "Show only favorites",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "true",
+      "dependency": "",
+      "key": "pref_toolbar",
+      "logical_kind": "stored_setting",
+      "page_id": "v5/navigation/toolbar",
+      "storage_type": "boolean",
+      "title": "Hide on scroll",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    },
+    {
+      "default_value": "1",
+      "dependency": "",
+      "key": "pref_toolbar_main_action",
+      "logical_kind": "stored_setting",
+      "page_id": "v5/navigation/toolbar",
+      "storage_type": "string",
+      "title": "Main action",
+      "v5_visibility": "VISIBLE",
+      "v5_visibility_reason": ""
+    }
+  ],
+  "schema": 1,
+  "screens": [
+    {
+      "child_count": 4,
+      "control_count": 0,
+      "page_id": "v5/navigation",
+      "renderer": "MorpheSettingsV5NavigationFragment",
+      "role": "root_group",
+      "title": "Navigation & gestures"
+    },
+    {
+      "child_count": 0,
+      "control_count": 2,
+      "page_id": "v5/navigation/back_and_exit",
+      "renderer": "MorpheSettingsV5NavigationLeafFragment",
+      "role": "leaf_section",
+      "title": "Back & exit"
+    },
+    {
+      "child_count": 0,
+      "control_count": 2,
+      "page_id": "v5/navigation/bottom_navigation",
+      "renderer": "MorpheSettingsV5NavigationLeafFragment",
+      "role": "leaf_section",
+      "title": "Bottom navigation"
+    },
+    {
+      "child_count": 7,
+      "control_count": 0,
+      "page_id": "v5/navigation/navigation_drawer",
+      "renderer": "MorpheSettingsV5NavigationFragment",
+      "role": "intermediate_page",
+      "title": "Navigation drawer"
+    },
+    {
+      "child_count": 0,
+      "control_count": 2,
+      "page_id": "v5/navigation/toolbar",
+      "renderer": "MorpheSettingsV5NavigationLeafFragment",
+      "role": "leaf_section",
+      "title": "Toolbar"
+    },
+    {
+      "child_count": 0,
+      "control_count": 6,
+      "page_id": "v5/navigation/navigation_drawer/account_and_tools",
+      "renderer": "MorpheSettingsV5NavigationLeafFragment",
+      "role": "leaf_section",
+      "title": "Account & tools"
+    },
+    {
+      "child_count": 0,
+      "control_count": 2,
+      "page_id": "v5/navigation/navigation_drawer/account_switcher",
+      "renderer": "MorpheSettingsV5NavigationLeafFragment",
+      "role": "leaf_section",
+      "title": "Account switcher"
+    },
+    {
+      "child_count": 0,
+      "control_count": 3,
+      "page_id": "v5/navigation/navigation_drawer/drawer_behavior",
+      "renderer": "MorpheSettingsV5NavigationLeafFragment",
+      "role": "leaf_section",
+      "title": "Drawer behavior"
+    },
+    {
+      "child_count": 0,
+      "control_count": 6,
+      "page_id": "v5/navigation/navigation_drawer/feeds_and_library",
+      "renderer": "MorpheSettingsV5NavigationLeafFragment",
+      "role": "leaf_section",
+      "title": "Feeds & library"
+    },
+    {
+      "child_count": 0,
+      "control_count": 3,
+      "page_id": "v5/navigation/navigation_drawer/go_to_shortcuts",
+      "renderer": "MorpheSettingsV5NavigationLeafFragment",
+      "role": "leaf_section",
+      "title": "Go-to shortcuts"
+    },
+    {
+      "child_count": 0,
+      "control_count": 3,
+      "page_id": "v5/navigation/navigation_drawer/quick_toggles",
+      "renderer": "MorpheSettingsV5NavigationLeafFragment",
+      "role": "leaf_section",
+      "title": "Quick toggles"
+    },
+    {
+      "child_count": 0,
+      "control_count": 3,
+      "page_id": "v5/navigation/navigation_drawer/subscriptions",
+      "renderer": "MorpheSettingsV5NavigationLeafFragment",
+      "role": "leaf_section",
+      "title": "Subscriptions"
+    }
+  ],
+  "source_files": [
+    "MorpheSettingsV5Registry.java",
+    "MorpheSettingsV5Navigation.java",
+    "MorpheSettingsV5NavigationFragment.java",
+    "MorpheSettingsV5NavigationLeafFragment.java",
+    "MorpheSettingsV5NavigationMetadata.java",
+    "MorpheSettingsV5XmlPreferenceFragment.java",
+    "MorpheSettingsV5Search.java"
+  ],
+  "special_handlers": {
+    "withheld_runtime_unavailable": [
+      "pref_drawer_show_friends"
+    ]
+  },
+  "target": {
+    "legacy_routes": 0,
+    "max_controls_per_leaf": 6,
+    "placeholder_pages": 0,
+    "screen_nodes": 12,
+    "visible_by_default": false,
+    "visible_items": 31,
+    "withheld_items": 1
+  },
+  "wave": "Navigation"
+}

--- a/tools/contracts/boost-settings-v5-notifications-account-wave-v1.json
+++ b/tools/contracts/boost-settings-v5-notifications-account-wave-v1.json
@@ -1,0 +1,271 @@
+{
+  "binding_capture": {
+    "archive_sha256": "38fe3cb8f3a276cbc15dcc4aa3d564c357c09060765a778ff3c773cf251a0c3b",
+    "base_apk_sha256": "a68c22d632a5dd1f446c3759a171c7dbb9edab2afc3c2f87e39323f198606742",
+    "source_mpp_sha256": "f5912189364f1c672c25a18fdda04fda99fdcd61edb6aebbadf2cedb0e086158",
+    "v5_contract_sha256": "4c8e081069d7444938c3ff5ad0e451bb3b16183592114a6b8adf77cd1208d3f7"
+  },
+  "dependencies": {
+    "pref_check_messages_interval": "pref_check_messages",
+    "pref_check_messages_push": "pref_check_messages",
+    "pref_check_messages_push_clear": "pref_check_messages_push",
+    "pref_check_modmail": "pref_check_messages"
+  },
+  "issue": 121,
+  "items": [
+    {
+      "default_value": "false",
+      "dependency": "",
+      "key": "pref_all_delete",
+      "logical_kind": "special_preference",
+      "page_id": "v5/notifications_and_account/history_privacy_and_recovery/history",
+      "storage_type": "none_or_custom",
+      "title": "Clear all history"
+    },
+    {
+      "default_value": "false",
+      "dependency": "",
+      "key": "pref_history_delete",
+      "logical_kind": "special_preference",
+      "page_id": "v5/notifications_and_account/history_privacy_and_recovery/history",
+      "storage_type": "none_or_custom",
+      "title": "Clear community history"
+    },
+    {
+      "default_value": "false",
+      "dependency": "",
+      "key": "pref_recent_posts_delete",
+      "logical_kind": "special_preference",
+      "page_id": "v5/notifications_and_account/history_privacy_and_recovery/history",
+      "storage_type": "none_or_custom",
+      "title": "Clear post history"
+    },
+    {
+      "default_value": "false",
+      "dependency": "",
+      "key": "pref_searches_delete",
+      "logical_kind": "special_preference",
+      "page_id": "v5/notifications_and_account/history_privacy_and_recovery/history",
+      "storage_type": "none_or_custom",
+      "title": "Clear search history"
+    },
+    {
+      "default_value": "true",
+      "dependency": "",
+      "key": "pref_recent_posts_save_nsfw",
+      "logical_kind": "stored_setting",
+      "page_id": "v5/notifications_and_account/history_privacy_and_recovery/history",
+      "storage_type": "boolean",
+      "title": "Include NSFW posts"
+    },
+    {
+      "default_value": "true",
+      "dependency": "",
+      "key": "pref_history_save",
+      "logical_kind": "stored_setting",
+      "page_id": "v5/notifications_and_account/history_privacy_and_recovery/history",
+      "storage_type": "boolean",
+      "title": "Save recent communities"
+    },
+    {
+      "default_value": "true",
+      "dependency": "",
+      "key": "pref_recent_posts_save",
+      "logical_kind": "stored_setting",
+      "page_id": "v5/notifications_and_account/history_privacy_and_recovery/history",
+      "storage_type": "boolean",
+      "title": "Save recent posts"
+    },
+    {
+      "default_value": "true",
+      "dependency": "",
+      "key": "pref_search_history_save",
+      "logical_kind": "stored_setting",
+      "page_id": "v5/notifications_and_account/history_privacy_and_recovery/history",
+      "storage_type": "boolean",
+      "title": "Show recent searches"
+    },
+    {
+      "default_value": "false",
+      "dependency": "",
+      "key": "morphe_boost_imgur_undelete_enabled",
+      "logical_kind": "stored_setting",
+      "page_id": "v5/notifications_and_account/history_privacy_and_recovery/recovery_and_archives",
+      "storage_type": "boolean",
+      "title": "Automatically undelete Imgur images"
+    },
+    {
+      "default_value": "false",
+      "dependency": "",
+      "key": "morphe_boost_reddit_undelete_enabled",
+      "logical_kind": "stored_setting",
+      "page_id": "v5/notifications_and_account/history_privacy_and_recovery/recovery_and_archives",
+      "storage_type": "boolean",
+      "title": "Automatically undelete Reddit content"
+    },
+    {
+      "default_value": "true",
+      "dependency": "pref_check_messages_push",
+      "key": "pref_check_messages_push_clear",
+      "logical_kind": "stored_setting",
+      "page_id": "v5/notifications_and_account/notifications_and_inbox/advanced",
+      "storage_type": "boolean",
+      "title": "Clear source notification"
+    },
+    {
+      "default_value": "false",
+      "dependency": "pref_check_messages",
+      "key": "pref_check_messages_push",
+      "logical_kind": "stored_setting",
+      "page_id": "v5/notifications_and_account/notifications_and_inbox/advanced",
+      "storage_type": "boolean",
+      "title": "Reddit push"
+    },
+    {
+      "default_value": "60",
+      "dependency": "pref_check_messages",
+      "key": "pref_check_messages_interval",
+      "logical_kind": "stored_setting",
+      "page_id": "v5/notifications_and_account/notifications_and_inbox/notifications",
+      "storage_type": "string",
+      "title": "Check interval"
+    },
+    {
+      "default_value": "true",
+      "dependency": "pref_check_messages",
+      "key": "pref_check_modmail",
+      "logical_kind": "stored_setting",
+      "page_id": "v5/notifications_and_account/notifications_and_inbox/notifications",
+      "storage_type": "boolean",
+      "title": "Check moderator mail"
+    },
+    {
+      "default_value": "true",
+      "dependency": "",
+      "key": "pref_check_messages",
+      "logical_kind": "stored_setting",
+      "page_id": "v5/notifications_and_account/notifications_and_inbox/notifications",
+      "storage_type": "boolean",
+      "title": "Check notifications"
+    },
+    {
+      "default_value": "",
+      "dependency": "",
+      "key": "pref_notifications_configure",
+      "logical_kind": "action",
+      "page_id": "v5/notifications_and_account/notifications_and_inbox/notifications",
+      "storage_type": "none_or_custom",
+      "title": "Configure notifications"
+    }
+  ],
+  "schema": 1,
+  "screens": [
+    {
+      "child_count": 3,
+      "control_count": 0,
+      "page_id": "v5/notifications_and_account",
+      "renderer": "MorpheSettingsV5NotificationsAccountFragment",
+      "role": "root_group",
+      "title": "Notifications & account"
+    },
+    {
+      "child_count": 2,
+      "control_count": 0,
+      "page_id": "v5/notifications_and_account/history_privacy_and_recovery",
+      "renderer": "MorpheSettingsV5NotificationsAccountFragment",
+      "role": "task_page",
+      "title": "History, privacy & recovery"
+    },
+    {
+      "child_count": 2,
+      "control_count": 0,
+      "page_id": "v5/notifications_and_account/notifications_and_inbox",
+      "renderer": "MorpheSettingsV5NotificationsAccountFragment",
+      "role": "task_page",
+      "title": "Notifications & inbox"
+    },
+    {
+      "child_count": 0,
+      "control_count": 0,
+      "page_id": "v5/notifications_and_account/reddit_account",
+      "renderer": "MorpheSettingsV5RedditAccountFragment",
+      "role": "task_page",
+      "title": "Reddit account"
+    },
+    {
+      "child_count": 0,
+      "control_count": 8,
+      "page_id": "v5/notifications_and_account/history_privacy_and_recovery/history",
+      "renderer": "MorpheSettingsV5NotificationsAccountLeafFragment",
+      "role": "leaf_section",
+      "title": "History"
+    },
+    {
+      "child_count": 0,
+      "control_count": 2,
+      "page_id": "v5/notifications_and_account/history_privacy_and_recovery/recovery_and_archives",
+      "renderer": "MorpheSettingsV5NotificationsAccountLeafFragment",
+      "role": "leaf_section",
+      "title": "Recovery & archives"
+    },
+    {
+      "child_count": 0,
+      "control_count": 2,
+      "page_id": "v5/notifications_and_account/notifications_and_inbox/advanced",
+      "renderer": "MorpheSettingsV5NotificationsAccountLeafFragment",
+      "role": "leaf_section",
+      "title": "Advanced"
+    },
+    {
+      "child_count": 0,
+      "control_count": 4,
+      "page_id": "v5/notifications_and_account/notifications_and_inbox/notifications",
+      "renderer": "MorpheSettingsV5NotificationsAccountLeafFragment",
+      "role": "leaf_section",
+      "title": "Notifications"
+    }
+  ],
+  "source_files": [
+    "MorpheSettingsV5Registry.java",
+    "MorpheSettingsV5Navigation.java",
+    "MorpheSettingsV5NotificationsAccountFragment.java",
+    "MorpheSettingsV5NotificationsAccountLeafFragment.java",
+    "MorpheSettingsV5NotificationsAccountMetadata.java",
+    "MorpheSettingsV5RedditAccountFragment.java",
+    "MorpheSettingsV5XmlPreferenceFragment.java",
+    "MorpheSettingsV5Search.java"
+  ],
+  "special_handlers": {
+    "hidden_canonical_controls": [
+      "pref_search_history_save",
+      "pref_searches_delete"
+    ],
+    "history_delete_actions": [
+      "pref_all_delete",
+      "pref_history_delete",
+      "pref_recent_posts_delete",
+      "pref_searches_delete"
+    ],
+    "notification_configuration_action": [
+      "pref_notifications_configure"
+    ],
+    "notification_side_effects": [
+      "pref_check_messages",
+      "pref_check_messages_interval",
+      "pref_check_messages_push"
+    ],
+    "reddit_account_status_page": [
+      "v5/notifications_and_account/reddit_account"
+    ]
+  },
+  "target": {
+    "legacy_routes": 0,
+    "max_controls_per_leaf": 8,
+    "placeholder_pages": 0,
+    "screen_nodes": 8,
+    "visible_by_default": false,
+    "visible_items": 16,
+    "withheld_items": 0
+  },
+  "wave": "Notifications & account"
+}

--- a/tools/contracts/boost-settings-v5-reading-wave-v1.json
+++ b/tools/contracts/boost-settings-v5-reading-wave-v1.json
@@ -1,0 +1,1065 @@
+{
+  "binding_capture": {
+    "archive_sha256": "3a6fd1ae8faef9ba369e9162926e6b4a054c81a3e194bcd502150d04ed50e594",
+    "base_apk_sha256": "a68c22d632a5dd1f446c3759a171c7dbb9edab2afc3c2f87e39323f198606742",
+    "source_mpp_sha256": "a860dc7e6845b23fe557d4c8aeb06c02486b91f49b5d75d8dd852f2e18123a0f",
+    "v5_contract_sha256": "4c8e081069d7444938c3ff5ad0e451bb3b16183592114a6b8adf77cd1208d3f7"
+  },
+  "dependencies": {
+    "pref_blur_nsfw_images": "pref_load_nsfw_images",
+    "pref_clickable_awards_comments": "pref_show_awards_comments",
+    "pref_clickable_awards_posts": "pref_show_awards_posts",
+    "pref_comments_buttons_collapse_after_action": "pref_comments_buttons",
+    "pref_comments_default_navigation": "pref_comments_highlight_new_comments",
+    "pref_flair_clickable": "pref_info_post_flair",
+    "pref_flair_colors": "pref_info_post_flair",
+    "pref_flair_emojis": "pref_info_post_flair",
+    "pref_hide_read_permanently": "pref_mark_read",
+    "pref_load_nsfw_images": "pref_nsfw",
+    "pref_mark_read_dim_images": "pref_mark_read",
+    "pref_mark_read_on_scroll": "pref_mark_read",
+    "pref_sort_per_sub": "pref_sort_per_subscription",
+    "pref_swipe_sensitivity_percentage": "pref_swipe_back",
+    "pref_swipe_threshold_percentage": "pref_swipe_back",
+    "pref_user_flair_colors": "pref_comments_user_flair",
+    "pref_user_flair_emojis": "pref_comments_user_flair"
+  },
+  "issue": 121,
+  "items": [
+    {
+      "default_value": "false",
+      "dependency": "",
+      "key": "pref_comments_buttons",
+      "logical_kind": "stored_setting",
+      "page_id": "v5/reading_and_interaction/comments/comment_actions",
+      "storage_type": "boolean",
+      "title": "Buttons always visible"
+    },
+    {
+      "default_value": "35",
+      "dependency": "pref_swipe_back",
+      "key": "pref_swipe_threshold_percentage",
+      "logical_kind": "stored_setting",
+      "page_id": "v5/reading_and_interaction/comments/comment_actions",
+      "storage_type": "integer",
+      "title": "Distance threshold"
+    },
+    {
+      "default_value": "false",
+      "dependency": "pref_comments_buttons",
+      "key": "pref_comments_buttons_collapse_after_action",
+      "logical_kind": "stored_setting",
+      "page_id": "v5/reading_and_interaction/comments/comment_actions",
+      "storage_type": "boolean",
+      "title": "Hide buttons after voting/saving"
+    },
+    {
+      "default_value": "true",
+      "dependency": "",
+      "key": "pref_comments_button_save",
+      "logical_kind": "stored_setting",
+      "page_id": "v5/reading_and_interaction/comments/comment_actions",
+      "storage_type": "boolean",
+      "title": "Save"
+    },
+    {
+      "default_value": "true",
+      "dependency": "",
+      "key": "pref_comments_floating_button",
+      "logical_kind": "stored_setting",
+      "page_id": "v5/reading_and_interaction/comments/comment_actions",
+      "storage_type": "boolean",
+      "title": "Show floating button"
+    },
+    {
+      "default_value": "false",
+      "dependency": "",
+      "key": "pref_info_post_upvote_percentage",
+      "logical_kind": "stored_setting",
+      "page_id": "v5/reading_and_interaction/comments/comment_actions",
+      "storage_type": "boolean",
+      "title": "Show post upvote percentage"
+    },
+    {
+      "default_value": "80",
+      "dependency": "pref_swipe_back",
+      "key": "pref_swipe_sensitivity_percentage",
+      "logical_kind": "stored_setting",
+      "page_id": "v5/reading_and_interaction/comments/comment_actions",
+      "storage_type": "integer",
+      "title": "Swipe sensitivity"
+    },
+    {
+      "default_value": "true",
+      "dependency": "",
+      "key": "pref_swipe_back",
+      "logical_kind": "stored_setting",
+      "page_id": "v5/reading_and_interaction/comments/comment_actions",
+      "storage_type": "boolean",
+      "title": "Swipe to close"
+    },
+    {
+      "default_value": "1",
+      "dependency": "",
+      "key": "pref_comments_button_parent",
+      "logical_kind": "stored_setting",
+      "page_id": "v5/reading_and_interaction/comments/comment_actions",
+      "storage_type": "string",
+      "title": "Up button"
+    },
+    {
+      "default_value": "true",
+      "dependency": "",
+      "key": "pref_comments_color_pattern",
+      "logical_kind": "special_preference",
+      "page_id": "v5/reading_and_interaction/comments/comment_appearance",
+      "storage_type": "none_or_custom",
+      "title": "Color pattern"
+    },
+    {
+      "default_value": "true",
+      "dependency": "pref_comments_user_flair",
+      "key": "pref_user_flair_emojis",
+      "logical_kind": "stored_setting",
+      "page_id": "v5/reading_and_interaction/comments/comment_appearance",
+      "storage_type": "boolean",
+      "title": "Show emojis"
+    },
+    {
+      "default_value": "false",
+      "dependency": "pref_comments_user_flair",
+      "key": "pref_user_flair_colors",
+      "logical_kind": "stored_setting",
+      "page_id": "v5/reading_and_interaction/comments/comment_appearance",
+      "storage_type": "boolean",
+      "title": "Show flair colors"
+    },
+    {
+      "default_value": "false",
+      "dependency": "",
+      "key": "pref_comments_show_avatar",
+      "logical_kind": "stored_setting",
+      "page_id": "v5/reading_and_interaction/comments/comment_appearance",
+      "storage_type": "boolean",
+      "title": "Show user avatar"
+    },
+    {
+      "default_value": "true",
+      "dependency": "",
+      "key": "pref_comments_user_flair",
+      "logical_kind": "stored_setting",
+      "page_id": "v5/reading_and_interaction/comments/comment_appearance",
+      "storage_type": "boolean",
+      "title": "Show user flair"
+    },
+    {
+      "default_value": "true",
+      "dependency": "pref_show_awards_comments",
+      "key": "pref_clickable_awards_comments",
+      "logical_kind": "stored_setting",
+      "page_id": "v5/reading_and_interaction/comments/comment_behavior",
+      "storage_type": "boolean",
+      "title": "Clickable awards"
+    },
+    {
+      "default_value": "0",
+      "dependency": "",
+      "key": "pref_default_comment_sorting",
+      "logical_kind": "stored_setting",
+      "page_id": "v5/reading_and_interaction/comments/comment_behavior",
+      "storage_type": "string",
+      "title": "Default sort"
+    },
+    {
+      "default_value": "true",
+      "dependency": "",
+      "key": "pref_comments_highlight_mine",
+      "logical_kind": "stored_setting",
+      "page_id": "v5/reading_and_interaction/comments/comment_behavior",
+      "storage_type": "boolean",
+      "title": "Highlight my username"
+    },
+    {
+      "default_value": "1",
+      "dependency": "",
+      "key": "pref_comments_image",
+      "logical_kind": "stored_setting",
+      "page_id": "v5/reading_and_interaction/comments/comment_behavior",
+      "storage_type": "string",
+      "title": "Post media preview size"
+    },
+    {
+      "default_value": "true",
+      "dependency": "",
+      "key": "pref_show_awards_comments",
+      "logical_kind": "stored_setting",
+      "page_id": "v5/reading_and_interaction/comments/comment_behavior",
+      "storage_type": "boolean",
+      "title": "Show awards"
+    },
+    {
+      "default_value": "true",
+      "dependency": "",
+      "key": "pref_comments_clickable_username",
+      "logical_kind": "stored_setting",
+      "page_id": "v5/reading_and_interaction/comments/comment_behavior",
+      "storage_type": "boolean",
+      "title": "Tap username to view profile"
+    },
+    {
+      "default_value": "true",
+      "dependency": "",
+      "key": "pref_suggested_comment_sorting",
+      "logical_kind": "stored_setting",
+      "page_id": "v5/reading_and_interaction/comments/comment_behavior",
+      "storage_type": "boolean",
+      "title": "Use suggested sort"
+    },
+    {
+      "default_value": "false",
+      "dependency": "",
+      "key": "pref_comments_scroll_animation",
+      "logical_kind": "stored_setting",
+      "page_id": "v5/reading_and_interaction/comments/thread_navigation",
+      "storage_type": "boolean",
+      "title": "Animate navigation"
+    },
+    {
+      "default_value": "false",
+      "dependency": "",
+      "key": "pref_comments_click",
+      "logical_kind": "stored_setting",
+      "page_id": "v5/reading_and_interaction/comments/thread_navigation",
+      "storage_type": "boolean",
+      "title": "Click to collapse comment"
+    },
+    {
+      "default_value": "false",
+      "dependency": "",
+      "key": "pref_comments_collapse_automoderator",
+      "logical_kind": "stored_setting",
+      "page_id": "v5/reading_and_interaction/comments/thread_navigation",
+      "storage_type": "boolean",
+      "title": "Collapse AutoModerator"
+    },
+    {
+      "default_value": "false",
+      "dependency": "",
+      "key": "pref_comments_collapse_collapsed",
+      "logical_kind": "stored_setting",
+      "page_id": "v5/reading_and_interaction/comments/thread_navigation",
+      "storage_type": "boolean",
+      "title": "Collapse disruptive comments"
+    },
+    {
+      "default_value": "0",
+      "dependency": "pref_comments_highlight_new_comments",
+      "key": "pref_comments_default_navigation",
+      "logical_kind": "stored_setting",
+      "page_id": "v5/reading_and_interaction/comments/thread_navigation",
+      "storage_type": "string",
+      "title": "Default navigation mode"
+    },
+    {
+      "default_value": "true",
+      "dependency": "",
+      "key": "pref_comments_animation",
+      "logical_kind": "stored_setting",
+      "page_id": "v5/reading_and_interaction/comments/thread_navigation",
+      "storage_type": "boolean",
+      "title": "Expand/collapse animation"
+    },
+    {
+      "default_value": "false",
+      "dependency": "",
+      "key": "pref_comments_full_collapse",
+      "logical_kind": "stored_setting",
+      "page_id": "v5/reading_and_interaction/comments/thread_navigation",
+      "storage_type": "boolean",
+      "title": "Hide text of collapsed comments"
+    },
+    {
+      "default_value": "true",
+      "dependency": "",
+      "key": "pref_comments_highlight_new_comments",
+      "logical_kind": "stored_setting",
+      "page_id": "v5/reading_and_interaction/comments/thread_navigation",
+      "storage_type": "boolean",
+      "title": "Highlight new comments"
+    },
+    {
+      "default_value": "false",
+      "dependency": "",
+      "key": "pref_comments_load_collapsed",
+      "logical_kind": "stored_setting",
+      "page_id": "v5/reading_and_interaction/comments/thread_navigation",
+      "storage_type": "boolean",
+      "title": "Load collapsed by default"
+    },
+    {
+      "default_value": "false",
+      "dependency": "",
+      "key": "pref_comments_navigation_bar",
+      "logical_kind": "stored_setting",
+      "page_id": "v5/reading_and_interaction/comments/thread_navigation",
+      "storage_type": "boolean",
+      "title": "Show navigation bar"
+    },
+    {
+      "default_value": "0",
+      "dependency": "",
+      "key": "pref_indent_style",
+      "logical_kind": "stored_setting",
+      "page_id": "v5/reading_and_interaction/comments/thread_navigation",
+      "storage_type": "string",
+      "title": "Thread level indicator"
+    },
+    {
+      "default_value": "false",
+      "dependency": "",
+      "key": "pref_comments_volume_scroll",
+      "logical_kind": "stored_setting",
+      "page_id": "v5/reading_and_interaction/comments/thread_navigation",
+      "storage_type": "boolean",
+      "title": "Volume key navigation"
+    },
+    {
+      "default_value": "",
+      "dependency": "",
+      "key": "pref_manage_drafts",
+      "logical_kind": "action",
+      "page_id": "v5/reading_and_interaction/composing_and_drafts/drafts",
+      "storage_type": "none_or_custom",
+      "title": "Post drafts"
+    },
+    {
+      "default_value": "true",
+      "dependency": "",
+      "key": "pref_drafts",
+      "logical_kind": "stored_setting",
+      "page_id": "v5/reading_and_interaction/composing_and_drafts/drafts",
+      "storage_type": "boolean",
+      "title": "Save drafts"
+    },
+    {
+      "default_value": "false",
+      "dependency": "",
+      "key": "pref_use_advanced_editor",
+      "logical_kind": "stored_setting",
+      "page_id": "v5/reading_and_interaction/composing_and_drafts/editor",
+      "storage_type": "boolean",
+      "title": "Advanced fullscreen editor"
+    },
+    {
+      "default_value": "",
+      "dependency": "",
+      "key": "pref_imgur_uploads",
+      "logical_kind": "action",
+      "page_id": "v5/reading_and_interaction/composing_and_drafts/uploads",
+      "storage_type": "none_or_custom",
+      "title": "Uploaded images"
+    },
+    {
+      "default_value": "",
+      "dependency": "",
+      "key": "pref_edit_subscriptions",
+      "logical_kind": "action",
+      "page_id": "v5/reading_and_interaction/feeds_and_subscriptions/manage_subscriptions",
+      "storage_type": "none_or_custom",
+      "title": "Subscriptions"
+    },
+    {
+      "default_value": "",
+      "dependency": "",
+      "key": "pref_default_sort",
+      "logical_kind": "action",
+      "page_id": "v5/reading_and_interaction/posts/feed_behavior",
+      "storage_type": "none_or_custom",
+      "title": "Default sort"
+    },
+    {
+      "default_value": "false",
+      "dependency": "",
+      "key": "pref_sort_per_subscription",
+      "logical_kind": "stored_setting",
+      "page_id": "v5/reading_and_interaction/posts/feed_behavior",
+      "storage_type": "boolean",
+      "title": "Remember per community"
+    },
+    {
+      "default_value": "",
+      "dependency": "",
+      "key": "pref_frontpage_sort",
+      "logical_kind": "action",
+      "page_id": "v5/reading_and_interaction/posts/feed_behavior",
+      "storage_type": "none_or_custom",
+      "title": "Sort Home posts by"
+    },
+    {
+      "default_value": "true",
+      "dependency": "",
+      "key": "pref_post_show_comments_button",
+      "logical_kind": "stored_setting",
+      "page_id": "v5/reading_and_interaction/posts/post_actions",
+      "storage_type": "boolean",
+      "title": "Comments"
+    },
+    {
+      "default_value": "false",
+      "dependency": "",
+      "key": "pref_show_hide",
+      "logical_kind": "stored_setting",
+      "page_id": "v5/reading_and_interaction/posts/post_actions",
+      "storage_type": "boolean",
+      "title": "Hide"
+    },
+    {
+      "default_value": "",
+      "dependency": "pref_sort_per_subscription",
+      "key": "pref_sort_per_sub",
+      "logical_kind": "action",
+      "page_id": "v5/reading_and_interaction/posts/post_actions",
+      "storage_type": "none_or_custom",
+      "title": "Manage saved sorts"
+    },
+    {
+      "default_value": "false",
+      "dependency": "",
+      "key": "pref_show_read",
+      "logical_kind": "stored_setting",
+      "page_id": "v5/reading_and_interaction/posts/post_actions",
+      "storage_type": "boolean",
+      "title": "Mark read"
+    },
+    {
+      "default_value": "true",
+      "dependency": "",
+      "key": "pref_post_show_open_button",
+      "logical_kind": "stored_setting",
+      "page_id": "v5/reading_and_interaction/posts/post_actions",
+      "storage_type": "boolean",
+      "title": "Open in external app"
+    },
+    {
+      "default_value": "false",
+      "dependency": "",
+      "key": "pref_post_show_share_button",
+      "logical_kind": "stored_setting",
+      "page_id": "v5/reading_and_interaction/posts/post_actions",
+      "storage_type": "boolean",
+      "title": "Share"
+    },
+    {
+      "default_value": "true",
+      "dependency": "",
+      "key": "pref_posts_floating_button",
+      "logical_kind": "stored_setting",
+      "page_id": "v5/reading_and_interaction/posts/post_actions",
+      "storage_type": "boolean",
+      "title": "Show floating button"
+    },
+    {
+      "default_value": "false",
+      "dependency": "",
+      "key": "pref_upvote_on_save",
+      "logical_kind": "stored_setting",
+      "page_id": "v5/reading_and_interaction/posts/post_actions",
+      "storage_type": "boolean",
+      "title": "Upvote on save"
+    },
+    {
+      "default_value": "true",
+      "dependency": "pref_show_awards_posts",
+      "key": "pref_clickable_awards_posts",
+      "logical_kind": "stored_setting",
+      "page_id": "v5/reading_and_interaction/posts/post_behavior",
+      "storage_type": "boolean",
+      "title": "Clickable awards"
+    },
+    {
+      "default_value": "false",
+      "dependency": "",
+      "key": "pref_info_username",
+      "logical_kind": "stored_setting",
+      "page_id": "v5/reading_and_interaction/posts/post_behavior",
+      "storage_type": "boolean",
+      "title": "Show author"
+    },
+    {
+      "default_value": "true",
+      "dependency": "",
+      "key": "pref_show_awards_posts",
+      "logical_kind": "stored_setting",
+      "page_id": "v5/reading_and_interaction/posts/post_behavior",
+      "storage_type": "boolean",
+      "title": "Show awards"
+    },
+    {
+      "default_value": "true",
+      "dependency": "pref_info_post_flair",
+      "key": "pref_flair_emojis",
+      "logical_kind": "stored_setting",
+      "page_id": "v5/reading_and_interaction/posts/post_behavior",
+      "storage_type": "boolean",
+      "title": "Show emojis"
+    },
+    {
+      "default_value": "true",
+      "dependency": "pref_info_post_flair",
+      "key": "pref_flair_colors",
+      "logical_kind": "stored_setting",
+      "page_id": "v5/reading_and_interaction/posts/post_behavior",
+      "storage_type": "boolean",
+      "title": "Show flair colors"
+    },
+    {
+      "default_value": "true",
+      "dependency": "",
+      "key": "pref_info_post_flair",
+      "logical_kind": "stored_setting",
+      "page_id": "v5/reading_and_interaction/posts/post_behavior",
+      "storage_type": "boolean",
+      "title": "Show post flair"
+    },
+    {
+      "default_value": "true",
+      "dependency": "",
+      "key": "pref_post_clickable_subreddit",
+      "logical_kind": "stored_setting",
+      "page_id": "v5/reading_and_interaction/posts/post_behavior",
+      "storage_type": "boolean",
+      "title": "Tap community to visit"
+    },
+    {
+      "default_value": "false",
+      "dependency": "pref_info_post_flair",
+      "key": "pref_flair_clickable",
+      "logical_kind": "stored_setting",
+      "page_id": "v5/reading_and_interaction/posts/post_behavior",
+      "storage_type": "boolean",
+      "title": "Tap flair to search"
+    },
+    {
+      "default_value": "true",
+      "dependency": "",
+      "key": "pref_post_clickable_username",
+      "logical_kind": "stored_setting",
+      "page_id": "v5/reading_and_interaction/posts/post_behavior",
+      "storage_type": "boolean",
+      "title": "Tap username to view profile"
+    },
+    {
+      "default_value": "",
+      "dependency": "",
+      "key": "synncit_config",
+      "logical_kind": "action",
+      "page_id": "v5/reading_and_interaction/posts/reading_state",
+      "storage_type": "none_or_custom",
+      "title": "Configure Synccit"
+    },
+    {
+      "default_value": "false",
+      "dependency": "pref_mark_read",
+      "key": "pref_mark_read_dim_images",
+      "logical_kind": "stored_setting",
+      "page_id": "v5/reading_and_interaction/posts/reading_state",
+      "storage_type": "boolean",
+      "title": "Dim images in read posts"
+    },
+    {
+      "default_value": "false",
+      "dependency": "pref_mark_read",
+      "key": "pref_hide_read_permanently",
+      "logical_kind": "stored_setting",
+      "page_id": "v5/reading_and_interaction/posts/reading_state",
+      "storage_type": "boolean",
+      "title": "Hide read permanently"
+    },
+    {
+      "default_value": "false",
+      "dependency": "pref_mark_read",
+      "key": "pref_mark_read_on_scroll",
+      "logical_kind": "stored_setting",
+      "page_id": "v5/reading_and_interaction/posts/reading_state",
+      "storage_type": "boolean",
+      "title": "Mark as read on scroll"
+    },
+    {
+      "default_value": "true",
+      "dependency": "",
+      "key": "pref_mark_read",
+      "logical_kind": "stored_setting",
+      "page_id": "v5/reading_and_interaction/posts/reading_state",
+      "storage_type": "boolean",
+      "title": "Mark posts as read"
+    },
+    {
+      "default_value": "false",
+      "dependency": "",
+      "key": "pref_history_delete_read",
+      "logical_kind": "special_preference",
+      "page_id": "v5/reading_and_interaction/posts/reading_state",
+      "storage_type": "none_or_custom",
+      "title": "Reset read posts"
+    },
+    {
+      "default_value": "false",
+      "dependency": "pref_load_nsfw_images",
+      "key": "pref_blur_nsfw_images",
+      "logical_kind": "stored_setting",
+      "page_id": "v5/reading_and_interaction/search_and_filters/content_filters/filter_behavior",
+      "storage_type": "boolean",
+      "title": "Blur images in NSFW posts"
+    },
+    {
+      "default_value": "false",
+      "dependency": "pref_nsfw",
+      "key": "pref_load_nsfw_images",
+      "logical_kind": "stored_setting",
+      "page_id": "v5/reading_and_interaction/search_and_filters/content_filters/filter_behavior",
+      "storage_type": "boolean",
+      "title": "Show images in NSFW posts"
+    },
+    {
+      "default_value": "false",
+      "dependency": "",
+      "key": "pref_nsfw",
+      "logical_kind": "stored_setting",
+      "page_id": "v5/reading_and_interaction/search_and_filters/content_filters/filter_behavior",
+      "storage_type": "boolean",
+      "title": "Show NSFW"
+    },
+    {
+      "default_value": "",
+      "dependency": "",
+      "key": "pref_filter_subreddit",
+      "logical_kind": "special_preference",
+      "page_id": "v5/reading_and_interaction/search_and_filters/content_filters/muted_content",
+      "storage_type": "none_or_custom",
+      "title": "Communities"
+    },
+    {
+      "default_value": "",
+      "dependency": "",
+      "key": "pref_filter_domain",
+      "logical_kind": "special_preference",
+      "page_id": "v5/reading_and_interaction/search_and_filters/content_filters/muted_content",
+      "storage_type": "none_or_custom",
+      "title": "Domains"
+    },
+    {
+      "default_value": "",
+      "dependency": "",
+      "key": "pref_filter_flair",
+      "logical_kind": "special_preference",
+      "page_id": "v5/reading_and_interaction/search_and_filters/content_filters/muted_content",
+      "storage_type": "none_or_custom",
+      "title": "Flairs"
+    },
+    {
+      "default_value": "",
+      "dependency": "",
+      "key": "pref_filter_username",
+      "logical_kind": "special_preference",
+      "page_id": "v5/reading_and_interaction/search_and_filters/content_filters/muted_content",
+      "storage_type": "none_or_custom",
+      "title": "Users"
+    },
+    {
+      "default_value": "",
+      "dependency": "",
+      "key": "pref_filter_keyword",
+      "logical_kind": "special_preference",
+      "page_id": "v5/reading_and_interaction/search_and_filters/content_filters/muted_content",
+      "storage_type": "none_or_custom",
+      "title": "Words"
+    },
+    {
+      "default_value": "true",
+      "dependency": "",
+      "key": "pref_album",
+      "logical_kind": "stored_setting",
+      "page_id": "v5/reading_and_interaction/search_and_filters/content_filters/post_matching",
+      "storage_type": "boolean",
+      "title": "Albums"
+    },
+    {
+      "default_value": "true",
+      "dependency": "",
+      "key": "pref_gif",
+      "logical_kind": "stored_setting",
+      "page_id": "v5/reading_and_interaction/search_and_filters/content_filters/post_matching",
+      "storage_type": "boolean",
+      "title": "Gifs"
+    },
+    {
+      "default_value": "true",
+      "dependency": "",
+      "key": "pref_image",
+      "logical_kind": "stored_setting",
+      "page_id": "v5/reading_and_interaction/search_and_filters/content_filters/post_matching",
+      "storage_type": "boolean",
+      "title": "Images"
+    },
+    {
+      "default_value": "true",
+      "dependency": "",
+      "key": "pref_link",
+      "logical_kind": "stored_setting",
+      "page_id": "v5/reading_and_interaction/search_and_filters/content_filters/post_matching",
+      "storage_type": "boolean",
+      "title": "Links"
+    },
+    {
+      "default_value": "true",
+      "dependency": "",
+      "key": "pref_self",
+      "logical_kind": "stored_setting",
+      "page_id": "v5/reading_and_interaction/search_and_filters/content_filters/post_matching",
+      "storage_type": "boolean",
+      "title": "Text"
+    },
+    {
+      "default_value": "true",
+      "dependency": "",
+      "key": "pref_video",
+      "logical_kind": "stored_setting",
+      "page_id": "v5/reading_and_interaction/search_and_filters/content_filters/post_matching",
+      "storage_type": "boolean",
+      "title": "Videos"
+    },
+    {
+      "default_value": "",
+      "dependency": "",
+      "key": "pref_search_advanced_help",
+      "logical_kind": "action",
+      "page_id": "v5/reading_and_interaction/search_and_filters/search/advanced_search",
+      "storage_type": "none_or_custom",
+      "title": "Field search help"
+    },
+    {
+      "default_value": "5",
+      "dependency": "",
+      "key": "pref_default_search_period",
+      "logical_kind": "stored_setting",
+      "page_id": "v5/reading_and_interaction/search_and_filters/search/search_behavior",
+      "storage_type": "string",
+      "title": "Default period"
+    },
+    {
+      "default_value": "0",
+      "dependency": "",
+      "key": "pref_default_search_sorting",
+      "logical_kind": "stored_setting",
+      "page_id": "v5/reading_and_interaction/search_and_filters/search/search_behavior",
+      "storage_type": "string",
+      "title": "Default sort"
+    },
+    {
+      "default_value": "false",
+      "dependency": "",
+      "key": "morphe_boost_search_open_keyboard_on_entry",
+      "logical_kind": "stored_setting",
+      "page_id": "v5/reading_and_interaction/search_and_filters/search/search_behavior",
+      "storage_type": "boolean",
+      "title": "Open keyboard when entering Search"
+    },
+    {
+      "default_value": "",
+      "dependency": "",
+      "key": "pref_saved_searches",
+      "logical_kind": "action",
+      "page_id": "v5/reading_and_interaction/search_and_filters/search/suggestions",
+      "storage_type": "none_or_custom",
+      "title": "Saved searches"
+    },
+    {
+      "default_value": "true",
+      "dependency": "",
+      "key": "pref_search_show_random",
+      "logical_kind": "stored_setting",
+      "page_id": "v5/reading_and_interaction/search_and_filters/search/suggestions",
+      "storage_type": "boolean",
+      "title": "Show random"
+    },
+    {
+      "default_value": "true",
+      "dependency": "",
+      "key": "pref_search_show_random_nsfw",
+      "logical_kind": "stored_setting",
+      "page_id": "v5/reading_and_interaction/search_and_filters/search/suggestions",
+      "storage_type": "boolean",
+      "title": "Show random NSFW"
+    },
+    {
+      "default_value": "false",
+      "dependency": "",
+      "key": "pref_search_show_trending",
+      "logical_kind": "stored_setting",
+      "page_id": "v5/reading_and_interaction/search_and_filters/search/suggestions",
+      "storage_type": "boolean",
+      "title": "Show trending communities"
+    },
+    {
+      "default_value": "false",
+      "dependency": "",
+      "key": "pref_search_show_trending_searches",
+      "logical_kind": "stored_setting",
+      "page_id": "v5/reading_and_interaction/search_and_filters/search/suggestions",
+      "storage_type": "boolean",
+      "title": "Show trending today"
+    }
+  ],
+  "runtime_gate": "not_authorized_until_static_build_and_dev_only_audit",
+  "schema": 1,
+  "screens": [
+    {
+      "child_count": 5,
+      "control_count": 0,
+      "page_id": "v5/reading_and_interaction",
+      "path": "Reading & interaction",
+      "role": "root_group"
+    },
+    {
+      "child_count": 4,
+      "control_count": 0,
+      "page_id": "v5/reading_and_interaction/comments",
+      "path": "Reading & interaction / Comments",
+      "role": "task_page"
+    },
+    {
+      "child_count": 3,
+      "control_count": 0,
+      "page_id": "v5/reading_and_interaction/composing_and_drafts",
+      "path": "Reading & interaction / Composing & drafts",
+      "role": "task_page"
+    },
+    {
+      "child_count": 1,
+      "control_count": 0,
+      "page_id": "v5/reading_and_interaction/feeds_and_subscriptions",
+      "path": "Reading & interaction / Feeds & subscriptions",
+      "role": "task_page"
+    },
+    {
+      "child_count": 4,
+      "control_count": 0,
+      "page_id": "v5/reading_and_interaction/posts",
+      "path": "Reading & interaction / Posts",
+      "role": "task_page"
+    },
+    {
+      "child_count": 2,
+      "control_count": 0,
+      "page_id": "v5/reading_and_interaction/search_and_filters",
+      "path": "Reading & interaction / Search & filters",
+      "role": "task_page"
+    },
+    {
+      "child_count": 0,
+      "control_count": 9,
+      "page_id": "v5/reading_and_interaction/comments/comment_actions",
+      "path": "Reading & interaction / Comments / Comment actions",
+      "role": "leaf_section"
+    },
+    {
+      "child_count": 0,
+      "control_count": 5,
+      "page_id": "v5/reading_and_interaction/comments/comment_appearance",
+      "path": "Reading & interaction / Comments / Comment appearance",
+      "role": "leaf_section"
+    },
+    {
+      "child_count": 0,
+      "control_count": 7,
+      "page_id": "v5/reading_and_interaction/comments/comment_behavior",
+      "path": "Reading & interaction / Comments / Comment behavior",
+      "role": "leaf_section"
+    },
+    {
+      "child_count": 0,
+      "control_count": 12,
+      "page_id": "v5/reading_and_interaction/comments/thread_navigation",
+      "path": "Reading & interaction / Comments / Thread navigation",
+      "role": "leaf_section"
+    },
+    {
+      "child_count": 0,
+      "control_count": 2,
+      "page_id": "v5/reading_and_interaction/composing_and_drafts/drafts",
+      "path": "Reading & interaction / Composing & drafts / Drafts",
+      "role": "leaf_section"
+    },
+    {
+      "child_count": 0,
+      "control_count": 1,
+      "page_id": "v5/reading_and_interaction/composing_and_drafts/editor",
+      "path": "Reading & interaction / Composing & drafts / Editor",
+      "role": "leaf_section"
+    },
+    {
+      "child_count": 0,
+      "control_count": 1,
+      "page_id": "v5/reading_and_interaction/composing_and_drafts/uploads",
+      "path": "Reading & interaction / Composing & drafts / Uploads",
+      "role": "leaf_section"
+    },
+    {
+      "child_count": 0,
+      "control_count": 1,
+      "page_id": "v5/reading_and_interaction/feeds_and_subscriptions/manage_subscriptions",
+      "path": "Reading & interaction / Feeds & subscriptions / Manage subscriptions",
+      "role": "leaf_section"
+    },
+    {
+      "child_count": 0,
+      "control_count": 3,
+      "page_id": "v5/reading_and_interaction/posts/feed_behavior",
+      "path": "Reading & interaction / Posts / Feed behavior",
+      "role": "leaf_section"
+    },
+    {
+      "child_count": 0,
+      "control_count": 8,
+      "page_id": "v5/reading_and_interaction/posts/post_actions",
+      "path": "Reading & interaction / Posts / Post actions",
+      "role": "leaf_section"
+    },
+    {
+      "child_count": 0,
+      "control_count": 9,
+      "page_id": "v5/reading_and_interaction/posts/post_behavior",
+      "path": "Reading & interaction / Posts / Post behavior",
+      "role": "leaf_section"
+    },
+    {
+      "child_count": 0,
+      "control_count": 6,
+      "page_id": "v5/reading_and_interaction/posts/reading_state",
+      "path": "Reading & interaction / Posts / Reading state",
+      "role": "leaf_section"
+    },
+    {
+      "child_count": 3,
+      "control_count": 0,
+      "page_id": "v5/reading_and_interaction/search_and_filters/content_filters",
+      "path": "Reading & interaction / Search & filters / Content filters",
+      "role": "intermediate_page"
+    },
+    {
+      "child_count": 3,
+      "control_count": 0,
+      "page_id": "v5/reading_and_interaction/search_and_filters/search",
+      "path": "Reading & interaction / Search & filters / Search",
+      "role": "intermediate_page"
+    },
+    {
+      "child_count": 0,
+      "control_count": 3,
+      "page_id": "v5/reading_and_interaction/search_and_filters/content_filters/filter_behavior",
+      "path": "Reading & interaction / Search & filters / Content filters / Filter behavior",
+      "role": "leaf_section"
+    },
+    {
+      "child_count": 0,
+      "control_count": 5,
+      "page_id": "v5/reading_and_interaction/search_and_filters/content_filters/muted_content",
+      "path": "Reading & interaction / Search & filters / Content filters / Muted content",
+      "role": "leaf_section"
+    },
+    {
+      "child_count": 0,
+      "control_count": 6,
+      "page_id": "v5/reading_and_interaction/search_and_filters/content_filters/post_matching",
+      "path": "Reading & interaction / Search & filters / Content filters / Post matching",
+      "role": "leaf_section"
+    },
+    {
+      "child_count": 0,
+      "control_count": 1,
+      "page_id": "v5/reading_and_interaction/search_and_filters/search/advanced_search",
+      "path": "Reading & interaction / Search & filters / Search / Advanced search",
+      "role": "leaf_section"
+    },
+    {
+      "child_count": 0,
+      "control_count": 3,
+      "page_id": "v5/reading_and_interaction/search_and_filters/search/search_behavior",
+      "path": "Reading & interaction / Search & filters / Search / Search behavior",
+      "role": "leaf_section"
+    },
+    {
+      "child_count": 0,
+      "control_count": 5,
+      "page_id": "v5/reading_and_interaction/search_and_filters/search/suggestions",
+      "path": "Reading & interaction / Search & filters / Search / Suggestions",
+      "role": "leaf_section"
+    }
+  ],
+  "source_files": [
+    "MorpheSettingsV5Registry.java",
+    "MorpheSettingsV5Navigation.java",
+    "MorpheSettingsV5AppearanceFragment.java",
+    "MorpheSettingsV5ReadingFragment.java",
+    "MorpheSettingsV5ReadingLeafFragment.java",
+    "MorpheSettingsV5ReadingMetadata.java",
+    "MorpheSettingsV5XmlPreferenceFragment.java",
+    "MorpheSettingsV5Search.java"
+  ],
+  "special_handlers": {
+    "actions": [
+      "pref_manage_drafts",
+      "pref_imgur_uploads",
+      "pref_edit_subscriptions",
+      "pref_default_sort",
+      "pref_frontpage_sort",
+      "pref_sort_per_sub",
+      "synncit_config",
+      "pref_search_advanced_help",
+      "pref_saved_searches"
+    ],
+    "choices": [
+      "pref_comments_button_parent",
+      "pref_default_comment_sorting",
+      "pref_comments_image",
+      "pref_comments_default_navigation",
+      "pref_indent_style",
+      "pref_default_search_period",
+      "pref_default_search_sorting"
+    ],
+    "color_pattern": [
+      "pref_comments_color_pattern"
+    ],
+    "delete_read": [
+      "pref_history_delete_read"
+    ],
+    "filter_editors": [
+      "pref_filter_subreddit",
+      "pref_filter_domain",
+      "pref_filter_flair",
+      "pref_filter_username",
+      "pref_filter_keyword"
+    ],
+    "seekbars": [
+      "pref_swipe_threshold_percentage",
+      "pref_swipe_sensitivity_percentage"
+    ],
+    "side_effects": [
+      "pref_search_show_trending_searches"
+    ],
+    "source_owned": [
+      "morphe_boost_search_open_keyboard_on_entry"
+    ]
+  },
+  "status": "HIDDEN_COMPLETE_WAVE_STATIC_TARGET",
+  "target": {
+    "legacy_routes": 0,
+    "max_controls_per_leaf": 12,
+    "placeholder_pages": 0,
+    "screen_nodes": 26,
+    "visible_by_default": false,
+    "visible_items": 87,
+    "withheld_items": 0
+  },
+  "wave": "Reading & interaction"
+}

--- a/tools/contracts/boost-settings-v5-root-overview-wave-v1.json
+++ b/tools/contracts/boost-settings-v5-root-overview-wave-v1.json
@@ -1,0 +1,88 @@
+{
+  "activation_state": {
+    "activation_performed": false,
+    "root_classic_fallback_location": "root_only",
+    "v5_visible_by_default": false
+  },
+  "configurable_feature_reference_keys": [
+    "morphe_boost_inline_media_previews_enabled",
+    "morphe_boost_inline_media_preview_size",
+    "morphe_boost_inline_media_preview_alignment",
+    "morphe_boost_inline_media_preview_show_source_text",
+    "morphe_boost_direct_reddit_gif_tap_action",
+    "morphe_boost_giphy_preview_tap_action",
+    "morphe_boost_static_preview_tap_action",
+    "morphe_boost_search_open_keyboard_on_entry",
+    "morphe_boost_prefer_high_refresh_rate",
+    "morphe_boost_reddit_undelete_enabled",
+    "morphe_boost_imgur_undelete_enabled",
+    "morphe_boost_settings_v4_enabled"
+  ],
+  "issue": 121,
+  "root": "Morphe",
+  "root_destinations": [
+    {
+      "page_id": "v5/morphe",
+      "title": "Morphe"
+    },
+    {
+      "page_id": "v5/appearance",
+      "title": "Appearance"
+    },
+    {
+      "page_id": "v5/reading_and_interaction",
+      "title": "Reading & interaction"
+    },
+    {
+      "page_id": "v5/navigation",
+      "title": "Navigation & gestures"
+    },
+    {
+      "page_id": "v5/media",
+      "title": "Media"
+    },
+    {
+      "page_id": "v5/notifications_and_account",
+      "title": "Notifications & account"
+    },
+    {
+      "page_id": "v5/data_and_app",
+      "title": "Data & app"
+    }
+  ],
+  "schema": 1,
+  "semantic_revision": {
+    "revision": "V4",
+    "removed_page_id": "v5/morphe/patch_features",
+    "removed_path": "Morphe / Patch features",
+    "result": "Morphe renders its 12 configurable feature references directly"
+  },
+  "screens": [
+    {
+      "child_count": 0,
+      "configurable_reference_count": 12,
+      "control_count": 0,
+      "page_id": "v5/morphe",
+      "path": "Morphe",
+      "renderer": "MorpheSettingsV5MorpheFragment",
+      "role": "root_group",
+      "title": "Morphe"
+    }
+  ],
+  "targets": {
+    "classic_fallback_count": 1,
+    "configurable_feature_reference_count": 12,
+    "root_destination_count": 7,
+    "root_group_count": 1,
+    "root_overview_shell_count": 1,
+    "screen_count": 1,
+    "task_page_count": 0,
+    "visible_item_count": 0,
+    "withheld_item_count": 0
+  },
+  "v5_contract": {
+    "path": "tools/contracts/boost-settings-v5-completeness-v2.json",
+    "sha256": "f1d6a9ac6c27f71eec61b300e5f36d0785d831fde14cb982450e21b3ae238682"
+  },
+  "wave": "root_overview_morphe_flatten_and_classic_fallback"
+}

--- a/tools/contracts/boost-settings-v5-runtime-validation-v1.json
+++ b/tools/contracts/boost-settings-v5-runtime-validation-v1.json
@@ -1,0 +1,106 @@
+{
+  "activation": {
+    "entry_fragment": "app.morphe.extension.boostforreddit.settings.MorpheSettingsV5RootFragment",
+    "material_settings_false_route": "classic",
+    "material_settings_true_route": "v5",
+    "normal_settings_launch_fragment_override": false,
+    "v5_visible_by_default": true
+  },
+  "artifacts": [
+    {
+      "filename": "summary.txt",
+      "role": "classic_summary",
+      "sha256": "5e70eb6d6d80ec554dc4e95b3571d943f4e6474bc244fa3413b3f4617abc7518"
+    },
+    {
+      "filename": "logcat-focused.txt",
+      "role": "classic_logcat",
+      "sha256": "a1bcef39b8bd78224346d67db71065d5e877b60cf57ee65017af40321272f0b0"
+    },
+    {
+      "filename": "final_classic-final.png",
+      "role": "classic_screenshot",
+      "sha256": "f3922444fbc502687d77732ba813fdb82d73172ae6d4a0e77868e8231a5de1b2"
+    },
+    {
+      "filename": "summary.txt",
+      "role": "root7_summary",
+      "sha256": "d2dd33eda197b86e2c22f2be5271b474c6487c18f573d74fb57f23bd56e801bc"
+    },
+    {
+      "filename": "runtime-plan.tsv",
+      "role": "root7_plan",
+      "sha256": "6bf95e4d25eabd6130fe24265298eea49c76bf1085589c6f5c23934da6f91768"
+    },
+    {
+      "filename": "logcat-focused.txt",
+      "role": "root7_logcat",
+      "sha256": "1d8320075dc02b84dbcc6401e037c3c2c6cee5ea5cdc99af84e27f8bd9f3c441"
+    },
+    {
+      "filename": "final_root-final.png",
+      "role": "root7_screenshot",
+      "sha256": "23a3930a38e41decbfaa0034455286c5143c1fcaf94bf30686e148d318be0095"
+    },
+    {
+      "filename": "summary.txt",
+      "role": "visible_summary",
+      "sha256": "f8f8b66b9dd6ce3f7138c1512a003c64a4555a315c3e94e32bb82082e9f197bf"
+    },
+    {
+      "filename": "logcat-focused.txt",
+      "role": "visible_logcat",
+      "sha256": "02fcf7139c6812a73c1f8f70affcf227114c2742b8e9c47d34d9de32b40c59f5"
+    },
+    {
+      "filename": "v5-visible-root.png",
+      "role": "visible_screenshot",
+      "sha256": "b5721785d101e99432c19c51302048f4707482eaf1e6c49fd5d6444af142fe2c"
+    }
+  ],
+  "build": {
+    "activated_dev_apk_sha256": "ff8a34987283a5ed1aeb98a5621986784f548ba5c2bb1de9aa3cfa5ef83847ae",
+    "activated_mpp_sha256": "0c52634ea6519c720896624e3f13706efa29c15d2c36d2d8f6fa88df0b1cc7cb",
+    "android_release": "17",
+    "android_sdk": 37,
+    "device": "oriole",
+    "model": "Pixel 6"
+  },
+  "coverage": {
+    "classic_fallback_runtime": {
+      "covered": 1,
+      "target": 1
+    },
+    "morphe_configurable_controls": {
+      "covered": 12,
+      "target": 12
+    },
+    "root_destinations_back": {
+      "covered": 7,
+      "target": 7
+    },
+    "root_destinations_click": {
+      "covered": 7,
+      "target": 7
+    },
+    "root_destinations_render": {
+      "covered": 7,
+      "target": 7
+    },
+    "visible_root_labels": {
+      "covered": 8,
+      "target": 8
+    }
+  },
+  "issue": 121,
+  "safety": {
+    "critical_settings_exception_count": 0,
+    "normal_boost_untouched": true,
+    "relevant_fatal_count": 0,
+    "setting_value_mutations_by_harness": false
+  },
+  "schema_version": 1,
+  "semantic_revision": "V4",
+  "validated_at": "2026-07-26T03:10:16+02:00",
+  "validation_state": "complete"
+}


### PR DESCRIPTION
## Summary

Implements the complete task-based Settings V5 hierarchy for Boost and activates it for the Material settings route.

- adds seven top-level groups: Morphe, Appearance, Reading & interaction, Navigation & gestures, Media, Notifications & account, and Data & app
- flattens Morphe controls into the Morphe root
- adds global Settings search coverage
- preserves an explicit classic Boost Settings fallback
- keeps historical implementation-wave contracts immutable
- records final activation state and runtime evidence in separate activation checks

## Validation

- 7/7 root destinations clicked, rendered, and returned correctly
- 8/8 visible root labels verified
- 12/12 configurable Morphe controls verified
- classic fallback runtime coverage: 1/1
- relevant fatal count: 0
- critical Settings exception count: 0
- normal Boost install remained untouched
- final activation checkers: 3/3 pass
- historical content-wave checker identity: 6/6
- `:patches:buildAndroid` passed
- MPP SHA-256 remained `0c52634ea6519c720896624e3f13706efa29c15d2c36d2d8f6fa88df0b1cc7cb`

## Commit

`c1ba1b12ae2d1fa7f3269d22236c88530bba35fe`

Refs #121
