### PR TITLE
chore(release): prepare Morphe patch bundle 1.4.96

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Changelog
 
 <!-- MORPHE_MANAGER_CHANGELOG_START -->
+## [1.4.96](https://github.com/brealorg/breal-morphe-patches/compare/morphe-patches-95...morphe-patches-96) (2026-07-26)
+
+* **Boost for Reddit:** Features
+
+- Add task-based Material Settings V5 navigation with global search and a classic fallback.
+
 ## [1.4.95](https://github.com/brealorg/breal-morphe-patches/compare/morphe-patches-94...morphe-patches-95) (2026-07-25)
 
 * **Boost for Reddit:** Bug Fixes

--- a/README.md
+++ b/README.md
@@ -72,14 +72,14 @@ The repository shorthand shown at the top is the preferred Manager setup. Raw
 
 | Field | Value |
 |---|---|
-| Version | `1.4.95` |
-| Release tag | `morphe-patches-95` |
-| Asset | `patches-1.4.95.mpp` |
-| SHA256 | `5c998b8bc159c4ab8fbb077a72bf1b758285b9512ffab76eead0a63c077eb7bd` |
+| Version | `1.4.96` |
+| Release tag | `morphe-patches-96` |
+| Asset | `patches-1.4.96.mpp` |
+| SHA256 | `1a94a3d39f269f53852cd38aa30fd5c11140b59779677980a576eb47e00932d5` |
 | Manager JSON | `https://raw.githubusercontent.com/brealorg/breal-morphe-patches/main/patches-bundle.json` |
-| Download URL | `https://github.com/brealorg/breal-morphe-patches/releases/download/morphe-patches-95/patches-1.4.95.mpp` |
+| Download URL | `https://github.com/brealorg/breal-morphe-patches/releases/download/morphe-patches-96/patches-1.4.96.mpp` |
 
-SHA256: `5c998b8bc159c4ab8fbb077a72bf1b758285b9512ffab76eead0a63c077eb7bd`
+SHA256: `1a94a3d39f269f53852cd38aa30fd5c11140b59779677980a576eb47e00932d5`
 ## What this bundle does
 
 The current bundle is focused on practical hotfixes for tested app versions, especially Boost for Reddit behavior on newer Android versions.
@@ -126,7 +126,7 @@ Included Imgur patches:
 ### Patches list
 
 <!-- PATCHES_START -->
-> **Patch source version:** `1.4.95` • `main` • 52 unique patches • 104 package entries
+> **Patch source version:** `1.4.96` • `main` • 52 unique patches • 104 package entries
 
 <details>
 <summary><strong>Boost for Reddit</strong> • 43 patches</summary>
@@ -145,7 +145,7 @@ Included Imgur patches:
 | [Animate media in Boost gallery previews](#animate-media-in-boost-gallery-previews) | Autoplays selected Reddit gallery GIF and video media while preserving Boost's poster, data preferences, and full-screen media route. |  |
 | [Automatically undelete Imgur images](#automatically-undelete-imgur-images) |  |  |
 | [Automatically undelete Reddit content](#automatically-undelete-reddit-content) |  |  |
-| [Boost Morphe settings](#boost-morphe-settings) | Adds dedicated Morphe settings and Morphe-owned Material-style Settings v4 pages with a classic fallback. |  |
+| [Boost Morphe settings](#boost-morphe-settings) | Adds dedicated Morphe settings and task-based Material Settings V5 navigation with global search and a classic fallback. |  |
 | [Boost search default discovery](#boost-search-default-discovery) | Starts Boost search on an instant cached active-subreddit landing with Reddit-native labels. |  |
 | [Custom Synccit URL](#custom-synccit-url) | Allows Boost to use a custom self-hosted Synccit API endpoint. | • Synccit API URL |
 | [Disable ads](#disable-ads) |  |  |
@@ -539,16 +539,16 @@ Compatibility with other app versions is not guaranteed.
 
 ## Verification
 
-Release `1.4.95` is prepared and locally verified with:
+Release `1.4.96` is prepared and locally verified with:
 
-- Release tag `morphe-patches-95`.
+- Release tag `morphe-patches-96`.
 - Local built MPP SHA256 matching README.
-`5c998b8bc159c4ab8fbb077a72bf1b758285b9512ffab76eead0a63c077eb7bd`
-- `patches-bundle.json` returning version `1.4.95`.
-- `patches-bundle.json` pointing to the `morphe-patches-95` asset.
+`1a94a3d39f269f53852cd38aa30fd5c11140b59779677980a576eb47e00932d5`
+- `patches-bundle.json` returning version `1.4.96`.
+- `patches-bundle.json` pointing to the `morphe-patches-96` asset.
 - Expected release asset:
-`patches-1.4.95.mpp`
-- `5c998b8bc159c4ab8fbb077a72bf1b758285b9512ffab76eead0a63c077eb7bd  patches-1.4.95.mpp`
+`patches-1.4.96.mpp`
+- `1a94a3d39f269f53852cd38aa30fd5c11140b59779677980a576eb47e00932d5  patches-1.4.96.mpp`
 
 ## Development notes
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,4 +3,4 @@ org.gradle.jvmargs = -Xms512M -Xmx2048M
 org.gradle.parallel = true
 android.useAndroidX = true
 kotlin.code.style = official
-version = 1.4.95
+version = 1.4.96

--- a/patches-bundle.json
+++ b/patches-bundle.json
@@ -1,7 +1,7 @@
 {
-  "created_at": "2026-07-25T16:51:02",
-  "description": "Bug Fixes\n\n- Keep the correct Boost bottom-navigation destination selected after returning with Android Back.\n",
-  "download_url": "https://github.com/brealorg/breal-morphe-patches/releases/download/morphe-patches-95/patches-1.4.95.mpp",
-  "signature_download_url": "https://github.com/brealorg/breal-morphe-patches/releases/download/morphe-patches-95/patches-1.4.95.mpp.asc",
-  "version": "1.4.95"
+  "created_at": "2026-07-26T11:15:04",
+  "description": "Features\n\n- Add task-based Material Settings V5 navigation with global search and a classic fallback.\n",
+  "download_url": "https://github.com/brealorg/breal-morphe-patches/releases/download/morphe-patches-96/patches-1.4.96.mpp",
+  "signature_download_url": "https://github.com/brealorg/breal-morphe-patches/releases/download/morphe-patches-96/patches-1.4.96.mpp.asc",
+  "version": "1.4.96"
 }

--- a/patches-list.json
+++ b/patches-list.json
@@ -1,6 +1,6 @@
 {
   "NOTE": "Do NOT manually edit this file. This file is automatically updated when semantic release (release.yml) runs. Manually editing this file can break your releases and break third party tools that use this file.",
-  "version": "1.4.95",
+  "version": "1.4.96",
   "patches": [
     {
       "name": "Add Boost Search bottom navigation",
@@ -147,7 +147,7 @@
     },
     {
       "name": "Boost Morphe settings",
-      "description": "Adds dedicated Morphe settings and Morphe-owned Material-style Settings v4 pages with a classic fallback.",
+      "description": "Adds dedicated Morphe settings and task-based Material Settings V5 navigation with global search and a classic fallback.",
       "default": false,
       "dependencies": [
         "BytecodePatch",

--- a/patches/src/main/kotlin/app/morphe/patches/reddit/customclients/boostforreddit/misc/settings/BoostMorpheSettingsSkeletonPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/reddit/customclients/boostforreddit/misc/settings/BoostMorpheSettingsSkeletonPatch.kt
@@ -487,7 +487,7 @@ private val boostMorpheSettingsResourcesPatch = resourcePatch(
 @Suppress("unused")
 val boostMorpheSettingsSkeletonPatch = bytecodePatch(
     name = "Boost Morphe settings",
-    description = "Adds dedicated Morphe settings and Morphe-owned Material-style Settings v4 pages with a classic fallback.",
+    description = "Adds dedicated Morphe settings and task-based Material Settings V5 navigation with global search and a classic fallback.",
     default = false,
 ) {
     dependsOn(sharedExtensionPatch, boostMorpheSettingsResourcesPatch)


### PR DESCRIPTION
## Summary

Prepares protected-main metadata and the reproducible release artifact for Morphe patch bundle 1.4.96.

## User-visible Boost change

- Add task-based Material Settings V5 navigation with global search and a classic fallback.

Addresses #121.

## Release identity

- Version: `1.4.96`
- Tag: `morphe-patches-96`
- Asset: `patches-1.4.96.mpp`
- Expected SHA-256: `1a94a3d39f269f53852cd38aa30fd5c11140b59779677980a576eb47e00932d5`

## Validation

- Settings V5 static and activation contracts: PASS
- DEV runtime validation: PASS
- all project contracts: PASS
- canonical release preparation gate: PASS
- post-commit release feed smoke: PASS
- three byte-identical Android MPP builds: PASS
- MPP required-entry structure: PASS
- generated Manager feed: PASS
- detached signature verification: PASS
- release metadata limited to five expected files

This PR prepares release metadata only. Publication and Issue #121 closeout occur after merge.
