### PR TITLE
fix(boost): repair malformed parenthesized links

### DIFF
--- a/extensions/boostforreddit/src/main/java/app/morphe/extension/boostforreddit/codeblock/CodeBlockHtmlNormalizer.java
+++ b/extensions/boostforreddit/src/main/java/app/morphe/extension/boostforreddit/codeblock/CodeBlockHtmlNormalizer.java
@@ -10,7 +10,8 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 public final class CodeBlockHtmlNormalizer {
-    public static final String MARKER = "MORPHE_CODEBLOCK_HTML_NORMALIZER_V6_RAW_HTML_MALFORMED_CODE_CLOSE";
+    public static final String MARKER = "MORPHE_CODEBLOCK_HTML_NORMALIZER_V7_MALFORMED_PARENTHESIZED_LINKS";
+    public static final String V6_MARKER = "MORPHE_CODEBLOCK_HTML_NORMALIZER_V6_RAW_HTML_MALFORMED_CODE_CLOSE";
     public static final String PREVIOUS_MARKER = "MORPHE_CODEBLOCK_HTML_NORMALIZER_V4_FENCED_SELFTEXT_ACTUAL_SHAPE";
     public static final String V3_MARKER = "MORPHE_CODEBLOCK_HTML_NORMALIZER_V3_FENCED_SELFTEXT";
     public static final String V2_MARKER = "MORPHE_CODEBLOCK_HTML_NORMALIZER_V2_SEGMENTED";
@@ -23,6 +24,9 @@ public final class CodeBlockHtmlNormalizer {
     private static final Pattern CODE_PATTERN =
             Pattern.compile("(?is)<code>(.*?)</code>");
 
+    private static final Pattern MALFORMED_PARENTHESIZED_LINK_PATTERN =
+            Pattern.compile("(?i)<a href=\"(https?://[^\"]+)\">(https?://[^<]+)</a>(#[^<\\s)]+)\\)");
+
     private CodeBlockHtmlNormalizer() {
     }
 
@@ -32,6 +36,11 @@ public final class CodeBlockHtmlNormalizer {
         }
 
         try {
+            String malformedLinks = normalizeMalformedParenthesizedLinks(html);
+            if (malformedLinks != null) {
+                html = malformedLinks;
+            }
+
             String plainTextFenced = normalizePlainTextFencedCodeBlocks(html);
             if (plainTextFenced != null) {
                 return plainTextFenced;
@@ -62,6 +71,57 @@ public final class CodeBlockHtmlNormalizer {
     }
 
 
+
+    private static String normalizeMalformedParenthesizedLinks(String html) {
+        Matcher matcher = MALFORMED_PARENTHESIZED_LINK_PATTERN.matcher(html);
+        StringBuffer out = new StringBuffer();
+        boolean changed = false;
+
+        while (matcher.find()) {
+            String href = matcher.group(1);
+            String visibleUrl = matcher.group(2);
+            String duplicatedFragment = matcher.group(3);
+
+            if (!visibleUrl.startsWith(href)) {
+                matcher.appendReplacement(out, Matcher.quoteReplacement(matcher.group(0)));
+                continue;
+            }
+
+            String visibleSuffix = visibleUrl.substring(href.length());
+            boolean exactRedditShape = visibleSuffix.equals(")" + duplicatedFragment);
+            boolean hrefMissingExactlyOneCloseParen =
+                    countCharacter(href, '(') == countCharacter(href, ')') + 1;
+            boolean visibleUrlParenthesesBalanced =
+                    countCharacter(visibleUrl, '(') == countCharacter(visibleUrl, ')');
+
+            if (!exactRedditShape
+                    || !hrefMissingExactlyOneCloseParen
+                    || !visibleUrlParenthesesBalanced) {
+                matcher.appendReplacement(out, Matcher.quoteReplacement(matcher.group(0)));
+                continue;
+            }
+
+            String replacement =
+                    "<a href=\"" + visibleUrl + "\">" + visibleUrl + "</a>";
+            matcher.appendReplacement(out, Matcher.quoteReplacement(replacement));
+            changed = true;
+        }
+
+        matcher.appendTail(out);
+        return changed ? out.toString() : null;
+    }
+
+    private static int countCharacter(String value, char needle) {
+        int count = 0;
+
+        for (int i = 0; i < value.length(); i++) {
+            if (value.charAt(i) == needle) {
+                count++;
+            }
+        }
+
+        return count;
+    }
 
     private static String normalizeActualRawHtmlMalformedCodeBlock(String html) {
         if (html == null || html.indexOf(FENCE) < 0) {

--- a/patches-list.json
+++ b/patches-list.json
@@ -688,7 +688,7 @@
     },
     {
       "name": "Fix Boost code block rendering",
-      "description": "Preserves Reddit code blocks by normalizing multiline <code> HTML and malformed fenced selftext to Boost's native <pre> renderer path.",
+      "description": "Preserves Reddit code blocks and repairs malformed legacy HTML links with parenthesized URLs before Boost renders them.",
       "default": true,
       "dependencies": [
         "BytecodePatch"

--- a/patches/src/main/kotlin/app/morphe/patches/reddit/customclients/boostforreddit/fix/codeblock/FixCodeBlockRenderingPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/reddit/customclients/boostforreddit/fix/codeblock/FixCodeBlockRenderingPatch.kt
@@ -17,7 +17,7 @@ private const val CODEBLOCK_NORMALIZER_DESCRIPTOR =
 @Suppress("unused")
 val fixCodeBlockRenderingPatch = bytecodePatch(
     name = "Fix Boost code block rendering",
-    description = "Preserves Reddit code blocks by normalizing multiline <code> HTML and malformed fenced selftext to Boost\'s native <pre> renderer path.",
+    description = "Preserves Reddit code blocks and repairs malformed legacy HTML links with parenthesized URLs before Boost renders them.",
     default = true
 ) {
     dependsOn(sharedExtensionPatch)

--- a/tools/check-boost-html-normalizer-contract.sh
+++ b/tools/check-boost-html-normalizer-contract.sh
@@ -1,0 +1,155 @@
+#!/usr/bin/env bash
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SOURCE="$ROOT/extensions/boostforreddit/src/main/java/app/morphe/extension/boostforreddit/codeblock/CodeBlockHtmlNormalizer.java"
+TMP="$(mktemp -d)"
+FAIL=0
+
+cleanup() {
+    rm -rf "$TMP"
+}
+trap cleanup EXIT
+
+fail() {
+    printf 'FAIL=%s\n' "$*"
+    FAIL=1
+}
+
+printf 'CONTRACT=BOOST_HTML_NORMALIZER_V7\n'
+
+if ! command -v javac >/dev/null 2>&1; then
+    fail "JAVAC_NOT_FOUND"
+fi
+
+if [ ! -f "$SOURCE" ]; then
+    fail "NORMALIZER_SOURCE_NOT_FOUND"
+fi
+
+if [ "$FAIL" -eq 0 ]; then
+    grep -Fq 'MORPHE_CODEBLOCK_HTML_NORMALIZER_V7_MALFORMED_PARENTHESIZED_LINKS' "$SOURCE" ||
+        fail "V7_MARKER_MISSING"
+    grep -Fq 'normalizeMalformedParenthesizedLinks' "$SOURCE" ||
+        fail "V7_NORMALIZER_METHOD_MISSING"
+fi
+
+if [ "$FAIL" -eq 0 ]; then
+    cat > "$TMP/CodeBlockHtmlNormalizerContract.java" <<'JAVA'
+import app.morphe.extension.boostforreddit.codeblock.CodeBlockHtmlNormalizer;
+
+public final class CodeBlockHtmlNormalizerContract {
+    private static void assertEquals(String name, String expected, String actual) {
+        if (!expected.equals(actual)) {
+            throw new AssertionError(
+                    name + "\nEXPECTED=" + expected + "\nACTUAL=" + actual
+            );
+        }
+        System.out.println("PASS=" + name);
+    }
+
+    private static void assertContains(String name, String needle, String actual) {
+        if (!actual.contains(needle)) {
+            throw new AssertionError(
+                    name + "\nNEEDLE=" + needle + "\nACTUAL=" + actual
+            );
+        }
+        System.out.println("PASS=" + name);
+    }
+
+    public static void main(String[] args) {
+        String malformed =
+                "<p>ref: <a href=\"https://betawiki.net/wiki/Windows_XP_build_2474_(main\">"
+                + "https://betawiki.net/wiki/Windows_XP_build_2474_(main)#Login_screen"
+                + "</a>#Login_screen) and the gif can be found in the gallery.</p>";
+        String repaired =
+                "<p>ref: <a href=\"https://betawiki.net/wiki/Windows_XP_build_2474_(main)#Login_screen\">"
+                + "https://betawiki.net/wiki/Windows_XP_build_2474_(main)#Login_screen"
+                + "</a> and the gif can be found in the gallery.</p>";
+
+        assertEquals(
+                "ISSUE125_EXACT_REPRO_REPAIRED",
+                repaired,
+                CodeBlockHtmlNormalizer.normalize(malformed)
+        );
+        assertEquals(
+                "ISSUE125_REPAIR_IDEMPOTENT",
+                repaired,
+                CodeBlockHtmlNormalizer.normalize(repaired)
+        );
+
+        String mismatchedFragment =
+                "<p><a href=\"https://example.com/a(b\">https://example.com/a(b)#one</a>#two)</p>";
+        assertEquals(
+                "MISMATCHED_FRAGMENT_UNCHANGED",
+                mismatchedFragment,
+                CodeBlockHtmlNormalizer.normalize(mismatchedFragment)
+        );
+
+        String nonUrlLabel =
+                "<p><a href=\"https://example.com/a(b\">article</a>#one)</p>";
+        assertEquals(
+                "NON_URL_LABEL_UNCHANGED",
+                nonUrlLabel,
+                CodeBlockHtmlNormalizer.normalize(nonUrlLabel)
+        );
+
+        String balancedHrefWithResidue =
+                "<p><a href=\"https://example.com/a(b)#one\">"
+                + "https://example.com/a(b)#one</a>#one)</p>";
+        assertEquals(
+                "BALANCED_HREF_WITH_RESIDUE_UNCHANGED",
+                balancedHrefWithResidue,
+                CodeBlockHtmlNormalizer.normalize(balancedHrefWithResidue)
+        );
+
+        String relativeLink =
+                "<p><a href=\"/wiki/a(b\">/wiki/a(b)#one</a>#one)</p>";
+        assertEquals(
+                "RELATIVE_LINK_UNCHANGED",
+                relativeLink,
+                CodeBlockHtmlNormalizer.normalize(relativeLink)
+        );
+
+        String cleanPre = "<pre><code>line</code></pre>";
+        assertEquals(
+                "CLEAN_PRE_UNCHANGED",
+                cleanPre,
+                CodeBlockHtmlNormalizer.normalize(cleanPre)
+        );
+
+        String legacyMultilineCode = "<p>before <code>line1\nline2</code> after</p>";
+        assertContains(
+                "EXISTING_MULTILINE_CODE_PATH_PRESERVED",
+                "<pre><code>line1\nline2</code></pre>",
+                CodeBlockHtmlNormalizer.normalize(legacyMultilineCode)
+        );
+
+        if (!"MORPHE_CODEBLOCK_HTML_NORMALIZER_V7_MALFORMED_PARENTHESIZED_LINKS"
+                .equals(CodeBlockHtmlNormalizer.MARKER)) {
+            throw new AssertionError("V7_MARKER_VALUE_MISMATCH");
+        }
+        System.out.println("PASS=V7_MARKER_VALUE");
+        System.out.println("RESULT=BOOST_HTML_NORMALIZER_V7_CONTRACT_PASS");
+    }
+}
+JAVA
+
+    mkdir -p "$TMP/classes"
+
+    javac -encoding UTF-8 -d "$TMP/classes" \
+        "$SOURCE" \
+        "$TMP/CodeBlockHtmlNormalizerContract.java" ||
+        fail "CONTRACT_JAVAC_FAILED"
+fi
+
+if [ "$FAIL" -eq 0 ]; then
+    java -cp "$TMP/classes" CodeBlockHtmlNormalizerContract ||
+        fail "CONTRACT_RUNTIME_FAILED"
+fi
+
+if [ "$FAIL" -eq 0 ]; then
+    printf 'RESULT=BOOST_HTML_NORMALIZER_V7_CONTRACT_PASS\n'
+else
+    printf 'RESULT=BOOST_HTML_NORMALIZER_V7_CONTRACT_FAIL\n'
+fi
+
+exit "$FAIL"


### PR DESCRIPTION
## Summary

Repair malformed Reddit legacy HTML for parenthesized URLs when Reddit truncates the anchor `href` but leaves the complete URL in the visible anchor text and appends a duplicated fragment residue after `</a>`.

The normalizer repairs only the exact fail-closed shape observed in Issue #125:

- visible URL starts with the truncated `href`;
- the missing portion is exactly one closing parenthesis followed by the duplicated fragment;
- the `href` is missing exactly one closing parenthesis;
- the visible URL has balanced parentheses.

All other links are left unchanged.

## Changes

- Extend `CodeBlockHtmlNormalizer` with malformed parenthesized-link normalization.
- Preserve the previous V6 marker and add `MORPHE_CODEBLOCK_HTML_NORMALIZER_V7_MALFORMED_PARENTHESIZED_LINKS`.
- Update the patch description to cover malformed legacy HTML links.
- Add a standalone Java contract covering the exact repro, idempotence, negative controls, clean `<pre>` content, and the existing multiline code-block path.

## Validation

- `BOOST_HTML_NORMALIZER_V7_CONTRACT_PASS`
- `./gradlew :patches:buildAndroid --offline --no-daemon` — PASS
- MPP structure — `classes.dex` and `extensions/boostforreddit.mpe` present
- Bytecode safety gate — PASS (`FINDING_COUNT=0`)
- DEV package — `com.rubenmayayo.reddit.dev`
- DEV install — PASS on Pixel 6 / Android 17
- Runtime rendering — complete URL displayed without duplicated `#Login_screen)` residue
- Runtime navigation — tapping the link opens the complete Betawiki URL at the `#Login_screen` fragment

Commit under validation: `6989eebef1f0287c8cbeab51e3b7d0ea29c2fa38`.

Closes #125
