### PR TITLE
fix(release): recognize protected-main Actions token

### DIFF
--- a/docs/release-state.md
+++ b/docs/release-state.md
@@ -116,6 +116,16 @@ missing phases:
 7. draft publication;
 8. final authoritative remote verification.
 
+The exact `workflow_dispatch` run of `.github/workflows/release.yml` on `main`
+uses GitHub's repository-scoped App installation token with explicit
+`contents: write`. In that context only, the controller binds authorization to
+the exact repository, event, branch, workflow ref, and dispatch SHA. The
+collaborator-oriented `permissions.push` field returned in repository
+metadata is not treated as authoritative for that installation token. Actual
+release-listing and mutation API responses remain authoritative. Every other
+caller retains the existing `permissions.push=true` gate so draft-release
+visibility must be established before mutation.
+
 Existing matching state is a no-op. An existing tag at another commit,
 duplicate or mismatching assets, an unexpected digest, or divergent refs cause
 `INCONSISTENT_ABORT`. The controller never force-moves a tag and never uploads

--- a/docs/release-state.md
+++ b/docs/release-state.md
@@ -119,7 +119,7 @@ missing phases:
 The exact `workflow_dispatch` run of `.github/workflows/release.yml` on `main`
 uses GitHub's repository-scoped App installation token with explicit
 `contents: write`. In that context only, the controller binds authorization to
-the exact repository, event, branch, workflow ref, and dispatch SHA. The
+the exact repository, event, branch, workflow ref, dispatch SHA, and workflow SHA. The
 collaborator-oriented `permissions.push` field returned in repository
 metadata is not treated as authoritative for that installation token. Actual
 release-listing and mutation API responses remain authoritative. Every other

--- a/scripts/releasectl.py
+++ b/scripts/releasectl.py
@@ -1944,6 +1944,8 @@ def _is_protected_main_actions_release_context(
             active_environment.get("GITHUB_REF_NAME") == "main",
             active_environment.get("GITHUB_SHA") == identity.release_commit,
             active_environment.get("GITHUB_WORKFLOW_REF") == expected_workflow_ref,
+            active_environment.get("GITHUB_WORKFLOW_SHA")
+            == identity.release_commit,
         )
     )
 

--- a/scripts/releasectl.py
+++ b/scripts/releasectl.py
@@ -22,7 +22,7 @@ import subprocess
 import sys
 import tempfile
 import zipfile
-from typing import Any, Protocol, Sequence
+from typing import Any, Mapping, Protocol, Sequence
 
 
 _SHA1_RE = re.compile(r"^[0-9a-f]{40}$")
@@ -1914,6 +1914,40 @@ def _github_api_get_args(endpoint: str, *, paginate: bool = False) -> tuple[str,
     return tuple(args)
 
 
+def _is_protected_main_actions_release_context(
+    repository: str,
+    identity: ReleaseIdentity,
+    *,
+    environment: Mapping[str, str] | None = None,
+) -> bool:
+    """Recognize only the repository's exact protected-main release workflow.
+
+    GitHub's ``GITHUB_TOKEN`` is a GitHub App installation token. Repository
+    metadata can therefore report the collaborator-oriented ``permissions.push``
+    field as false even when the workflow job has explicit ``contents: write``.
+    The exception is intentionally bound to the exact release workflow, event,
+    repository, branch, dispatch commit, and workflow commit.
+    """
+
+    active_environment = os.environ if environment is None else environment
+    expected_workflow_ref = (
+        f"{repository}/.github/workflows/release.yml@refs/heads/main"
+    )
+
+    return all(
+        (
+            active_environment.get("GITHUB_ACTIONS") == "true",
+            active_environment.get("GITHUB_EVENT_NAME") == "workflow_dispatch",
+            active_environment.get("GITHUB_REPOSITORY", "").casefold()
+            == repository.casefold(),
+            active_environment.get("GITHUB_REF") == "refs/heads/main",
+            active_environment.get("GITHUB_REF_NAME") == "main",
+            active_environment.get("GITHUB_SHA") == identity.release_commit,
+            active_environment.get("GITHUB_WORKFLOW_REF") == expected_workflow_ref,
+        )
+    )
+
+
 def _parse_repository_access(
     stdout: str,
     repository: str,
@@ -1944,11 +1978,6 @@ def _parse_repository_access(
         errors.append("GitHub repository metadata permissions.push must be boolean")
         return None
 
-    if not can_push:
-        errors.append(
-            "authenticated GitHub viewer lacks push permission; draft release "
-            "visibility cannot be guaranteed"
-        )
     return can_push
 
 
@@ -1957,6 +1986,7 @@ def observe_github_release(
     identity: ReleaseIdentity,
     *,
     runner: GhRunner | None = None,
+    environment: Mapping[str, str] | None = None,
 ) -> GitHubReleaseObservationResult:
     """Observe GitHub Release metadata using a read-only REST API listing.
 
@@ -1989,6 +2019,11 @@ def observe_github_release(
     errors: list[str] = []
     warnings: list[str] = []
 
+    protected_main_actions_context = (
+        _is_protected_main_actions_release_context(
+            normalized_repository, identity, environment=environment
+        )
+    )
     repository_result = active_runner.run(
         _github_api_get_args(f"repos/{normalized_repository}")
     )
@@ -2012,7 +2047,12 @@ def observe_github_release(
         normalized_repository,
         errors=errors,
     )
-    if errors or viewer_can_push is not True:
+    if viewer_can_push is False and not protected_main_actions_context:
+        errors.append(
+            "authenticated GitHub viewer lacks push permission; draft release "
+            "visibility cannot be guaranteed"
+        )
+    if errors or viewer_can_push is None:
         return GitHubReleaseObservationResult(
             repository=normalized_repository,
             viewer_can_push=viewer_can_push,
@@ -2028,13 +2068,19 @@ def observe_github_release(
             warnings=tuple(warnings),
         )
 
+    if viewer_can_push is False:
+        warnings.append(
+            "repository metadata permissions.push is not authoritative for the "
+            "exact protected-main GitHub Actions installation-token context"
+        )
+
     endpoint = f"repos/{normalized_repository}/releases?per_page=100"
     result = active_runner.run(_github_api_get_args(endpoint, paginate=True))
 
     if result.returncode != 0:
         return GitHubReleaseObservationResult(
             repository=normalized_repository,
-            viewer_can_push=True,
+            viewer_can_push=viewer_can_push,
             github=GitHubReleaseObservations(),
             release_id=None,
             is_immutable=None,
@@ -2044,6 +2090,7 @@ def observe_github_release(
             signature_asset_ids=(),
             observations_complete=False,
             errors=(_gh_error("GitHub release listing", result),),
+            warnings=tuple(warnings),
         )
 
     releases = _parse_release_pages(result.stdout, errors=errors)
@@ -2065,7 +2112,7 @@ def observe_github_release(
     if errors or len(matches) > 1:
         return GitHubReleaseObservationResult(
             repository=normalized_repository,
-            viewer_can_push=True,
+            viewer_can_push=viewer_can_push,
             github=GitHubReleaseObservations(),
             release_id=None,
             is_immutable=None,
@@ -2081,7 +2128,7 @@ def observe_github_release(
     if not matches:
         return GitHubReleaseObservationResult(
             repository=normalized_repository,
-            viewer_can_push=True,
+            viewer_can_push=viewer_can_push,
             github=GitHubReleaseObservations(),
             release_id=None,
             is_immutable=None,
@@ -2091,7 +2138,7 @@ def observe_github_release(
             signature_asset_ids=(),
             observations_complete=True,
             errors=(),
-            warnings=(),
+            warnings=tuple(warnings),
         )
 
     parsed = _validate_matching_release(
@@ -2102,7 +2149,7 @@ def observe_github_release(
     )
     return GitHubReleaseObservationResult(
         repository=normalized_repository,
-        viewer_can_push=True,
+        viewer_can_push=viewer_can_push,
         github=parsed.github,
         release_id=parsed.release_id,
         is_immutable=parsed.is_immutable,

--- a/tests/release/test_releasectl_github_release.py
+++ b/tests/release/test_releasectl_github_release.py
@@ -43,6 +43,21 @@ def identity() -> ReleaseIdentity:
     )
 
 
+def protected_main_environment() -> dict[str, str]:
+    release_commit = identity().release_commit
+    return {
+        "GITHUB_ACTIONS": "true",
+        "GITHUB_EVENT_NAME": "workflow_dispatch",
+        "GITHUB_REPOSITORY": REPOSITORY,
+        "GITHUB_REF": "refs/heads/main",
+        "GITHUB_REF_NAME": "main",
+        "GITHUB_SHA": release_commit,
+        "GITHUB_WORKFLOW_REF": (
+            f"{REPOSITORY}/.github/workflows/release.yml@refs/heads/main"
+        ),
+    }
+
+
 def asset(
     asset_id: int,
     name: str,
@@ -147,8 +162,15 @@ class RejectingRunner:
 
 
 class GitHubReleaseObserverTests(unittest.TestCase):
-    def observe(self, runner: StaticGhRunner):
-        return observe_github_release(REPOSITORY, identity(), runner=runner)
+    def observe(
+        self,
+        runner: StaticGhRunner,
+        *,
+        environment: dict[str, str] | None = None,
+    ):
+        return observe_github_release(
+            REPOSITORY, identity(), runner=runner, environment=environment
+        )
 
     def test_h01_published_release_metadata_and_digest(self) -> None:
         result = self.observe(StaticGhRunner(pages([release()])))
@@ -464,6 +486,113 @@ class GitHubReleaseObserverTests(unittest.TestCase):
         self.assertEqual(env["LC_ALL"], "C")
         self.assertFalse(kwargs["check"])
         self.assertNotIn("shell", kwargs)
+
+    def test_h27_exact_protected_main_actions_context_accepts_installation_token(
+        self,
+    ) -> None:
+        metadata = json.dumps(
+            {
+                "full_name": REPOSITORY,
+                "permissions": {"pull": True, "push": False, "admin": False},
+            }
+        )
+        runner = StaticGhRunner(pages([]), repository_stdout=metadata)
+
+        result = self.observe(
+            runner,
+            environment=protected_main_environment(),
+        )
+
+        self.assertTrue(result.observations_complete)
+        self.assertFalse(result.viewer_can_push)
+        self.assertFalse(result.github.present)
+        self.assertEqual(len(runner.calls), 2)
+        self.assertTrue(
+            any("installation-token context" in warning for warning in result.warnings)
+        )
+
+    def test_h28_inexact_actions_context_keeps_push_permission_gate(self) -> None:
+        metadata = json.dumps(
+            {
+                "full_name": REPOSITORY,
+                "permissions": {"pull": True, "push": False, "admin": False},
+            }
+        )
+        invalid_values = {
+            "GITHUB_ACTIONS": "false",
+            "GITHUB_EVENT_NAME": "push",
+            "GITHUB_REPOSITORY": "brealorg/another-repository",
+            "GITHUB_REF": "refs/heads/dev",
+            "GITHUB_REF_NAME": "dev",
+            "GITHUB_SHA": "b" * 40,
+            "GITHUB_WORKFLOW_REF": (
+                f"{REPOSITORY}/.github/workflows/release.yml@refs/heads/dev"
+            ),
+        }
+
+        for key, invalid_value in invalid_values.items():
+            with self.subTest(key=key):
+                environment = protected_main_environment()
+                environment[key] = invalid_value
+                runner = StaticGhRunner(pages([]), repository_stdout=metadata)
+
+                result = self.observe(runner, environment=environment)
+
+                self.assertFalse(result.observations_complete)
+                self.assertFalse(result.viewer_can_push)
+                self.assertEqual(len(runner.calls), 1)
+                self.assertTrue(
+                    any(
+                        "draft release visibility" in error
+                        for error in result.errors
+                    )
+                )
+
+    def test_h29_missing_permissions_still_fail_in_exact_actions_context(
+        self,
+    ) -> None:
+        metadata = json.dumps({"full_name": REPOSITORY})
+        runner = StaticGhRunner(pages([]), repository_stdout=metadata)
+
+        result = self.observe(
+            runner,
+            environment=protected_main_environment(),
+        )
+
+        self.assertFalse(result.observations_complete)
+        self.assertIsNone(result.viewer_can_push)
+        self.assertEqual(len(runner.calls), 1)
+        self.assertTrue(
+            any("permissions object" in error for error in result.errors)
+        )
+
+    def test_h30_release_listing_failure_still_fails_in_exact_actions_context(
+        self,
+    ) -> None:
+        metadata = json.dumps(
+            {
+                "full_name": REPOSITORY,
+                "permissions": {"pull": True, "push": False, "admin": False},
+            }
+        )
+        runner = StaticGhRunner(
+            "",
+            listing_returncode=1,
+            listing_stderr="release listing denied",
+            repository_stdout=metadata,
+        )
+
+        result = self.observe(
+            runner,
+            environment=protected_main_environment(),
+        )
+
+        self.assertFalse(result.observations_complete)
+        self.assertFalse(result.viewer_can_push)
+        self.assertEqual(len(runner.calls), 2)
+        self.assertTrue(
+            any("release listing denied" in error for error in result.errors)
+        )
 
 
 if __name__ == "__main__":

--- a/tests/release/test_releasectl_github_release.py
+++ b/tests/release/test_releasectl_github_release.py
@@ -55,6 +55,7 @@ def protected_main_environment() -> dict[str, str]:
         "GITHUB_WORKFLOW_REF": (
             f"{REPOSITORY}/.github/workflows/release.yml@refs/heads/main"
         ),
+        "GITHUB_WORKFLOW_SHA": release_commit,
     }
 
 
@@ -528,6 +529,7 @@ class GitHubReleaseObserverTests(unittest.TestCase):
             "GITHUB_WORKFLOW_REF": (
                 f"{REPOSITORY}/.github/workflows/release.yml@refs/heads/dev"
             ),
+            "GITHUB_WORKFLOW_SHA": "b" * 40,
         }
 
         for key, invalid_value in invalid_values.items():


### PR DESCRIPTION
## Summary

Fix release publication under the protected-main GitHub Actions workflow.

The release observer incorrectly treated the collaborator-oriented `permissions.push` repository field as authoritative for the workflow’s GitHub App installation token, despite the job having explicit `contents: write` permission.

## Scope

- Accept `permissions.push=false` only for the exact protected-main `release.yml` workflow context.
- Bind the exception to repository, workflow_dispatch event, main ref, dispatch SHA and workflow SHA.
- Preserve the existing fail-closed permission gate for all other callers.
- Preserve failures for missing permission metadata and release-listing/API errors.

## Validation

- 30 GitHub release observer tests passed.
- 219 release tests passed.
- All project contracts passed.

## Release impact

This unblocks publication of the already-merged Morphe patch bundle 1.4.97. It does not alter application code or release metadata.