### PR TITLE
fix(release): gate prepared MPP SHA in CI

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,11 +75,11 @@ The repository shorthand shown at the top is the preferred Manager setup. Raw
 | Version | `1.4.97` |
 | Release tag | `morphe-patches-97` |
 | Asset | `patches-1.4.97.mpp` |
-| SHA256 | `20dd7acebf91fe248c4c80d5a2389af6eef73c4fae057618800f1cddbd1495b8` |
+| SHA256 | `4722ebd94d7d926f39949ebb1ec08d92564d5565134554be662a2819e607c415` |
 | Manager JSON | `https://raw.githubusercontent.com/brealorg/breal-morphe-patches/main/patches-bundle.json` |
 | Download URL | `https://github.com/brealorg/breal-morphe-patches/releases/download/morphe-patches-97/patches-1.4.97.mpp` |
 
-SHA256: `20dd7acebf91fe248c4c80d5a2389af6eef73c4fae057618800f1cddbd1495b8`
+SHA256: `4722ebd94d7d926f39949ebb1ec08d92564d5565134554be662a2819e607c415`
 ## What this bundle does
 
 The current bundle is focused on practical hotfixes for tested app versions, especially Boost for Reddit behavior on newer Android versions.
@@ -539,16 +539,16 @@ Compatibility with other app versions is not guaranteed.
 
 ## Verification
 
-Release `1.4.97` is prepared and locally verified with:
+Release `1.4.97` is prepared and GitHub Actions verified with:
 
 - Release tag `morphe-patches-97`.
-- Local built MPP SHA256 matching README.
-`20dd7acebf91fe248c4c80d5a2389af6eef73c4fae057618800f1cddbd1495b8`
+- GitHub Actions MPP SHA256 matching README.
+`4722ebd94d7d926f39949ebb1ec08d92564d5565134554be662a2819e607c415`
 - `patches-bundle.json` returning version `1.4.97`.
 - `patches-bundle.json` pointing to the `morphe-patches-97` asset.
 - Expected release asset:
 `patches-1.4.97.mpp`
-- `20dd7acebf91fe248c4c80d5a2389af6eef73c4fae057618800f1cddbd1495b8  patches-1.4.97.mpp`
+- `4722ebd94d7d926f39949ebb1ec08d92564d5565134554be662a2819e607c415  patches-1.4.97.mpp`
 
 ## Development notes
 

--- a/tools/check-ci-tooling-contract.sh
+++ b/tools/check-ci-tooling-contract.sh
@@ -14,6 +14,10 @@ test -f "$FEED_RUNNER"
 
 rg -q -F "command -v rg" "$PROJECT_RUNNER"
 rg -q -F "./tools/check-project-contracts.sh" "$FEED_RUNNER"
+rg -q -F "python3 scripts/release-gate.py" "$FEED_RUNNER"
+rg -q -F -- '--version "$VERSION"' "$FEED_RUNNER"
+rg -q -F -- '--tag "$TAG"' "$FEED_RUNNER"
+rg -q -F -- '--mpp "$MPP"' "$FEED_RUNNER"
 
 python3 - "$SMOKE_WORKFLOW" "$RELEASE_WORKFLOW" <<'PY_CHECK'
 import sys
@@ -41,5 +45,6 @@ PY_CHECK
 
 echo 'PROJECT_RUNNER_RIPGREP_PREFLIGHT=PASS'
 echo 'RELEASE_FEED_SMOKE_PROVISIONS_RIPGREP=PASS'
+echo 'RELEASE_FEED_MPP_SHA_GATE=PASS'
 echo 'RELEASE_WORKFLOW_PROVISIONS_RIPGREP=PASS'
 echo 'RESULT=MORPHE_CI_TOOLING_CONTRACT_OK'

--- a/tools/release-feed-smoke.sh
+++ b/tools/release-feed-smoke.sh
@@ -23,4 +23,12 @@ echo "MPP=$MPP"
 test -n "$MPP"
 test -f "$MPP"
 
+TAG="morphe-patches-${VERSION##*.}"
+echo "TAG=$TAG"
+
+python3 scripts/release-gate.py \
+  --version "$VERSION" \
+  --tag "$TAG" \
+  --mpp "$MPP"
+
 tools/check-mpp-release-asset.sh "$MPP"


### PR DESCRIPTION
## Summary

Correct the prepared Morphe 1.4.97 MPP SHA to the byte-identical artifact produced by two independent GitHub Actions builds, and prevent future release PRs from passing with a mismatching committed SHA.

## Changes

- Update the 1.4.97 README SHA to `4722ebd94d7d926f39949ebb1ec08d92564d5565134554be662a2819e607c415`.
- Run the existing `scripts/release-gate.py` after the MPP build in release-feed smoke.
- Require the SHA gate through the CI tooling contract.

## Evidence

- PR #136 GitHub Actions MPP SHA: `4722ebd94d7d926f39949ebb1ec08d92564d5565134554be662a2819e607c415`.
- PR #137 independently produced the same MPP bytes and SHA.
- The corrected metadata passed `release-gate.py` against the retained PR #136 artifact.
- All project contracts passed.

## Release impact

This corrects the already-prepared 1.4.97 metadata. It does not change application code, create a tag, update `dev`, or publish a release.