### PR TITLE
fix(release): configure Actions tag identity

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -104,6 +104,18 @@ jobs:
           passphrase: ${{ secrets.GPG_PASSPHRASE }}
           fingerprint: ${{ vars.GPG_FINGERPRINT }}
 
+      - name: Configure release Git identity
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          git config --local user.name "github-actions[bot]"
+          git config --local user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          test "$(git config --local user.name)" = "github-actions[bot]"
+          test "$(git config --local user.email)" = "41898282+github-actions[bot]@users.noreply.github.com"
+          git var GIT_COMMITTER_IDENT
+
       - name: Publish from protected main
         env:
           GPG_FINGERPRINT: ${{ vars.GPG_FINGERPRINT }}

--- a/tools/check-ci-tooling-contract.sh
+++ b/tools/check-ci-tooling-contract.sh
@@ -41,10 +41,32 @@ for raw_path in sys.argv[1:]:
     else:
         consumer_index = text.index("./tools/check-project-contracts.sh")
     assert install_index < consumer_index, f"ripgrep installed too late: {path}"
+
+release_text = Path(sys.argv[2]).read_text(encoding="utf-8")
+identity_required = (
+    "- name: Configure release Git identity",
+    'git config --local user.name "github-actions[bot]"',
+    'git config --local user.email "41898282+github-actions[bot]@users.noreply.github.com"',
+    'test "$(git config --local user.name)" = "github-actions[bot]"',
+    'test "$(git config --local user.email)" = "41898282+github-actions[bot]@users.noreply.github.com"',
+    "git var GIT_COMMITTER_IDENT",
+)
+for marker in identity_required:
+    assert release_text.count(marker) == 1, (
+        f"expected exactly one release Git identity marker {marker!r}"
+    )
+
+import_index = release_text.index("- name: Import GPG key")
+identity_index = release_text.index("- name: Configure release Git identity")
+publish_index = release_text.index("- name: Publish from protected main")
+assert import_index < identity_index < publish_index, (
+    "release Git identity must be configured after GPG import and before publish"
+)
 PY_CHECK
 
 echo 'PROJECT_RUNNER_RIPGREP_PREFLIGHT=PASS'
 echo 'RELEASE_FEED_SMOKE_PROVISIONS_RIPGREP=PASS'
 echo 'RELEASE_FEED_MPP_SHA_GATE=PASS'
 echo 'RELEASE_WORKFLOW_PROVISIONS_RIPGREP=PASS'
+echo 'RELEASE_WORKFLOW_GIT_IDENTITY=PASS'
 echo 'RESULT=MORPHE_CI_TOOLING_CONTRACT_OK'


### PR DESCRIPTION
## Summary

Configure a repository-local Git identity in the protected-main release workflow before it creates the annotated release tag.

## Changes

- Set `user.name` to `github-actions[bot]`.
- Set `user.email` to the GitHub Actions bot noreply address.
- Verify both local Git values and `GIT_COMMITTER_IDENT` before publication.
- Require the identity step and its ordering through the CI tooling contract.

## Validation

- Annotated-tag identity simulation passed.
- CI tooling contract passed.
- All project contracts passed.

## Release impact

This unblocks annotated tag creation for Morphe 1.4.97. It does not change application code, create a release tag, update `dev`, or publish a GitHub Release.