### PR TITLE
chore(release): prepare patch bundle 1.4.98

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 
 <!-- MORPHE_MANAGER_CHANGELOG_START -->
+## [1.4.98](https://github.com/brealorg/breal-morphe-patches/compare/morphe-patches-97...morphe-patches-98) (2026-07-27)
+
+* **Boost for Reddit:** Bug Fixes Restore Boost's native Subscriptions long-press sort menu.
+
 ## [1.4.97](https://github.com/brealorg/breal-morphe-patches/compare/morphe-patches-96...morphe-patches-97) (2026-07-26)
 
 * **Boost for Reddit:** Bug Fixes Repair malformed parenthesized Reddit links in Boost.

--- a/README.md
+++ b/README.md
@@ -72,14 +72,14 @@ The repository shorthand shown at the top is the preferred Manager setup. Raw
 
 | Field | Value |
 |---|---|
-| Version | `1.4.97` |
-| Release tag | `morphe-patches-97` |
-| Asset | `patches-1.4.97.mpp` |
-| SHA256 | `4722ebd94d7d926f39949ebb1ec08d92564d5565134554be662a2819e607c415` |
+| Version | `1.4.98` |
+| Release tag | `morphe-patches-98` |
+| Asset | `patches-1.4.98.mpp` |
+| SHA256 | `af53ce35c7bd7177505c016b9c513e5fca495d5cca471299892006ca0b65765a` |
 | Manager JSON | `https://raw.githubusercontent.com/brealorg/breal-morphe-patches/main/patches-bundle.json` |
-| Download URL | `https://github.com/brealorg/breal-morphe-patches/releases/download/morphe-patches-97/patches-1.4.97.mpp` |
+| Download URL | `https://github.com/brealorg/breal-morphe-patches/releases/download/morphe-patches-98/patches-1.4.98.mpp` |
 
-SHA256: `4722ebd94d7d926f39949ebb1ec08d92564d5565134554be662a2819e607c415`
+SHA256: `af53ce35c7bd7177505c016b9c513e5fca495d5cca471299892006ca0b65765a`
 ## What this bundle does
 
 The current bundle is focused on practical hotfixes for tested app versions, especially Boost for Reddit behavior on newer Android versions.
@@ -126,7 +126,7 @@ Included Imgur patches:
 ### Patches list
 
 <!-- PATCHES_START -->
-> **Patch source version:** `1.4.97` • `main` • 52 unique patches • 104 package entries
+> **Patch source version:** `1.4.98` • `main` • 52 unique patches • 104 package entries
 
 <details>
 <summary><strong>Boost for Reddit</strong> • 43 patches</summary>
@@ -539,16 +539,16 @@ Compatibility with other app versions is not guaranteed.
 
 ## Verification
 
-Release `1.4.97` is prepared and GitHub Actions verified with:
+Release `1.4.98` is prepared and locally verified with:
 
-- Release tag `morphe-patches-97`.
-- GitHub Actions MPP SHA256 matching README.
-`4722ebd94d7d926f39949ebb1ec08d92564d5565134554be662a2819e607c415`
-- `patches-bundle.json` returning version `1.4.97`.
-- `patches-bundle.json` pointing to the `morphe-patches-97` asset.
+- Release tag `morphe-patches-98`.
+- Local built MPP SHA256 matching README.
+`af53ce35c7bd7177505c016b9c513e5fca495d5cca471299892006ca0b65765a`
+- `patches-bundle.json` returning version `1.4.98`.
+- `patches-bundle.json` pointing to the `morphe-patches-98` asset.
 - Expected release asset:
-`patches-1.4.97.mpp`
-- `4722ebd94d7d926f39949ebb1ec08d92564d5565134554be662a2819e607c415  patches-1.4.97.mpp`
+`patches-1.4.98.mpp`
+- `af53ce35c7bd7177505c016b9c513e5fca495d5cca471299892006ca0b65765a  patches-1.4.98.mpp`
 
 ## Development notes
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,4 +3,4 @@ org.gradle.jvmargs = -Xms512M -Xmx2048M
 org.gradle.parallel = true
 android.useAndroidX = true
 kotlin.code.style = official
-version = 1.4.97
+version = 1.4.98

--- a/patches-bundle.json
+++ b/patches-bundle.json
@@ -1,7 +1,7 @@
 {
-  "created_at": "2026-07-26T14:17:22",
-  "description": "Bug Fixes\nRepair malformed parenthesized Reddit links in Boost.\n",
-  "download_url": "https://github.com/brealorg/breal-morphe-patches/releases/download/morphe-patches-97/patches-1.4.97.mpp",
-  "signature_download_url": "https://github.com/brealorg/breal-morphe-patches/releases/download/morphe-patches-97/patches-1.4.97.mpp.asc",
-  "version": "1.4.97"
+  "created_at": "2026-07-27T00:06:32",
+  "description": "Bug Fixes\nRestore Boost's native Subscriptions long-press sort menu.\n",
+  "download_url": "https://github.com/brealorg/breal-morphe-patches/releases/download/morphe-patches-98/patches-1.4.98.mpp",
+  "signature_download_url": "https://github.com/brealorg/breal-morphe-patches/releases/download/morphe-patches-98/patches-1.4.98.mpp.asc",
+  "version": "1.4.98"
 }

--- a/patches-list.json
+++ b/patches-list.json
@@ -1,6 +1,6 @@
 {
   "NOTE": "Do NOT manually edit this file. This file is automatically updated when semantic release (release.yml) runs. Manually editing this file can break your releases and break third party tools that use this file.",
-  "version": "1.4.97",
+  "version": "1.4.98",
   "patches": [
     {
       "name": "Add Boost Search bottom navigation",


### PR DESCRIPTION
## Summary

- prepare Morphe patch bundle 1.4.98
- publish the Boost Subscriptions long-press fix from PR #140
- update Manager feed, README verification data and changelog
- bind publication to the deterministic prepared MPP

## Release identity

- Version: `1.4.98`
- Tag: `morphe-patches-98`
- Asset: `patches-1.4.98.mpp`
- MPP SHA256: `af53ce35c7bd7177505c016b9c513e5fca495d5cca471299892006ca0b65765a`

## Validation

- release gate: PASS
- Manager changelog gate: PASS
- deterministic MPP build: PASS
- Issue #135 marker present: PASS
- canonical five-file metadata scope: PASS

This PR prepares protected `main` only. It does not publish the release.

Refs #135