### PR TITLE
fix(release): harden notes, Java and diagnostics

### DIFF
--- a/.github/workflows/release-feed-smoke.yml
+++ b/.github/workflows/release-feed-smoke.yml
@@ -31,7 +31,7 @@ jobs:
         uses: actions/setup-java@03ad4de0992f5dab5e18fcb136590ce7c4a0ac95 # v5
         with:
           distribution: temurin
-          java-version: '17'
+          java-version: '17.0.19+10'
 
       - name: Set up Gradle
         uses: gradle/actions/setup-gradle@3f131e8634966bd73d06cc69884922b02e6faf92 # v6

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,12 +4,25 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: 'Release version already committed through a pull request, for example 1.4.95'
+        description: 'Release version already committed through a pull request, for example 1.4.99'
         required: true
         type: string
-      release_notes:
-        description: 'Human-readable GitHub Release notes: title, app/area, Changes, User impact'
+      app_area:
+        description: 'Affected app or area, for example Boost for Reddit. The heading is generated automatically.'
         required: true
+        type: string
+      changes:
+        description: 'Concrete changes, one item per line. Bullets and headings are generated automatically.'
+        required: true
+        type: string
+      user_impact:
+        description: 'User-visible impact in plain text. The heading is generated automatically.'
+        required: true
+        type: string
+      issue_number:
+        description: 'Optional GitHub issue number without #'
+        required: false
+        default: ''
         type: string
       confirm:
         description: 'Type MORPHE_RELEASE_FROM_PROTECTED_MAIN'
@@ -29,7 +42,10 @@ jobs:
       packages: read
     env:
       VERSION: ${{ inputs.version }}
-      RELEASE_NOTES: ${{ inputs.release_notes }}
+      APP_AREA: ${{ inputs.app_area }}
+      CHANGES: ${{ inputs.changes }}
+      USER_IMPACT: ${{ inputs.user_impact }}
+      ISSUE_NUMBER: ${{ inputs.issue_number }}
       CONFIRM: ${{ inputs.confirm }}
       RELEASE_COMMIT: ${{ github.sha }}
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -44,14 +60,14 @@ jobs:
           test "$GITHUB_REF_NAME" = "main"
           test "$CONFIRM" = "MORPHE_RELEASE_FROM_PROTECTED_MAIN"
           [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]
-          test -n "$RELEASE_NOTES"
+          test -n "$APP_AREA"
+          test -n "$CHANGES"
+          test -n "$USER_IMPACT"
+          test -z "$ISSUE_NUMBER" || [[ "$ISSUE_NUMBER" =~ ^[0-9]+$ ]]
 
           TAG="morphe-patches-${VERSION##*.}"
-          NOTES_FILE="$RUNNER_TEMP/release-notes-$VERSION.md"
-          printf '%s\n' "$RELEASE_NOTES" > "$NOTES_FILE"
 
           echo "TAG=$TAG" >> "$GITHUB_ENV"
-          echo "NOTES_FILE=$NOTES_FILE" >> "$GITHUB_ENV"
           echo "VERSION=$VERSION"
           echo "TAG=$TAG"
           echo "RELEASE_COMMIT=$RELEASE_COMMIT"
@@ -62,11 +78,41 @@ jobs:
           ref: main
           fetch-depth: 0
 
+      - name: Compose and validate release notes
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          NOTES_FILE="$RUNNER_TEMP/release-notes-$VERSION.md"
+
+          ARGS=(
+            python3 scripts/compose-release-notes.py
+            --version "$VERSION"
+            --app-area "$APP_AREA"
+            --changes "$CHANGES"
+            --user-impact "$USER_IMPACT"
+            --output "$NOTES_FILE"
+          )
+
+          if test -n "$ISSUE_NUMBER"; then
+            ARGS+=(--issue-number "$ISSUE_NUMBER")
+          fi
+
+          "${ARGS[@]}"
+
+          python3 scripts/validate-release-notes.py \
+            --notes-file "$NOTES_FILE" \
+            --version "$VERSION" \
+            --human-input-only
+
+          echo "NOTES_FILE=$NOTES_FILE" >> "$GITHUB_ENV"
+          echo "RELEASE_NOTES_INPUT_VALIDATION=PASS"
+
       - name: Setup Java
         uses: actions/setup-java@03ad4de0992f5dab5e18fcb136590ce7c4a0ac95 # v5
         with:
           distribution: 'temurin'
-          java-version: '17'
+          java-version: '17.0.19+10'
 
       - name: Install ripgrep
         shell: bash

--- a/scripts/compose-release-notes.py
+++ b/scripts/compose-release-notes.py
@@ -1,0 +1,121 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import re
+from pathlib import Path
+
+VERSION_RE = re.compile(r"^[0-9]+\.[0-9]+\.[0-9]+$")
+ISSUE_RE = re.compile(r"^[0-9]+$")
+
+
+def fail(message: str) -> None:
+    raise SystemExit(f"FAIL: {message}")
+
+
+def require_nonempty(value: str, label: str) -> str:
+    normalized = value.strip()
+    if not normalized:
+        fail(f"{label} must not be empty")
+    if "\x00" in normalized:
+        fail(f"{label} must not contain NUL")
+    return normalized
+
+
+def normalize_app_area(value: str) -> str:
+    normalized = require_nonempty(value, "app area")
+    if "\n" in normalized or "\r" in normalized:
+        fail("app area must be a single line")
+    if normalized.startswith("#"):
+        fail("app area must not include a Markdown heading prefix")
+    return normalized
+
+
+def normalize_changes(value: str) -> list[str]:
+    normalized = require_nonempty(value, "changes")
+    items: list[str] = []
+    for raw_line in normalized.splitlines():
+        line = raw_line.strip()
+        if not line:
+            continue
+        if line.startswith(("-", "*", "•")):
+            line = line.lstrip("-*•").strip()
+        if line:
+            items.append(f"- {line}")
+    if not items:
+        fail("changes must contain at least one concrete item")
+    return items
+
+
+def compose_release_notes(
+    *,
+    version: str,
+    app_area: str,
+    changes: str,
+    user_impact: str,
+    issue_number: str = "",
+) -> str:
+    if not VERSION_RE.fullmatch(version):
+        fail(f"invalid semantic version: {version!r}")
+
+    app_heading = normalize_app_area(app_area)
+    change_lines = normalize_changes(changes)
+    impact = require_nonempty(user_impact, "user impact")
+
+    issue = issue_number.strip()
+    if issue and not ISSUE_RE.fullmatch(issue):
+        fail("issue number must contain digits only")
+
+    lines = [
+        f"# Morphe patch bundle {version}",
+        "",
+        f"### {app_heading}",
+        "",
+        "### Changes",
+        "",
+        *change_lines,
+        "",
+        "### User impact",
+        "",
+        impact,
+    ]
+    if issue:
+        lines.extend(("", f"Issue: #{issue}."))
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Compose canonical human-readable Morphe release notes without "
+            "requiring callers to provide Markdown headings."
+        )
+    )
+    parser.add_argument("--version", required=True)
+    parser.add_argument("--app-area", required=True)
+    parser.add_argument("--changes", required=True)
+    parser.add_argument("--user-impact", required=True)
+    parser.add_argument("--issue-number", default="")
+    parser.add_argument("--output", required=True)
+    args = parser.parse_args()
+
+    body = compose_release_notes(
+        version=args.version,
+        app_area=args.app_area,
+        changes=args.changes,
+        user_impact=args.user_impact,
+        issue_number=args.issue_number,
+    )
+
+    output = Path(args.output)
+    output.parent.mkdir(parents=True, exist_ok=True)
+    output.write_text(body, encoding="utf-8")
+
+    print("RELEASE_NOTES_COMPOSED=PASS")
+    print(f"RELEASE_NOTES_FILE={output}")
+    print(f"RELEASE_NOTES_VERSION={args.version}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/prepare-release.py
+++ b/scripts/prepare-release.py
@@ -31,6 +31,50 @@ def run(cmd: list[str]) -> None:
     subprocess.run(cmd, check=True)
 
 
+# MORPHE_RELEASE_JAVA17_PREFLIGHT_V1
+RELEASE_JAVA_SPECIFICATION_VERSION = "17"
+
+
+def detect_java_specification_version() -> str:
+    try:
+        completed = subprocess.run(
+            ["java", "-XshowSettings:properties", "-version"],
+            check=False,
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+        )
+    except FileNotFoundError as exc:
+        raise SystemExit(
+            "Release preparation requires Java 17, but java was not found. "
+            "No files changed."
+        ) from exc
+
+    output = completed.stdout + "\n" + completed.stderr
+    match = re.search(
+        r"(?m)^\s*java\.specification\.version\s*=\s*([^\s]+)\s*$",
+        output,
+    )
+    if completed.returncode != 0 or not match:
+        raise SystemExit(
+            "Release preparation could not determine the active Java "
+            "specification version. No files changed."
+        )
+    return match.group(1)
+
+
+def require_release_java_17() -> None:
+    detected = detect_java_specification_version()
+    if detected != RELEASE_JAVA_SPECIFICATION_VERSION:
+        raise SystemExit(
+            "Release preparation requires Java 17 because the MPP digest is "
+            f"JDK-sensitive; detected Java {detected}. No files changed."
+        )
+    print("RELEASE_JAVA_SPECIFICATION_VERSION=17")
+    print("RELEASE_JAVA_PREFLIGHT=PASS")
+
+
 def parse_gradle_version(path: Path) -> str:
     text = read(path)
     match = re.search(r"(?m)^\s*version\s*=\s*([^\s#]+)\s*$", text)
@@ -302,6 +346,8 @@ def main() -> int:
     parser.add_argument("--skip-gate", action="store_true", help="Do not run scripts/release-gate.py after preparing.")
     parser.add_argument("--dry-run", action="store_true", help="Print intended values without changing files or building.")
     args = parser.parse_args()
+
+    require_release_java_17()
 
     gradle_path = ROOT / "gradle.properties"
     bundle_path = ROOT / "patches-bundle.json"

--- a/scripts/releasectl.py
+++ b/scripts/releasectl.py
@@ -29,6 +29,23 @@ _SHA1_RE = re.compile(r"^[0-9a-f]{40}$")
 _SHA256_RE = re.compile(r"^[0-9a-f]{64}$")
 
 
+class ReleaseInputValidationError(RuntimeError):
+    # Caller-supplied release input is invalid before release mutation.
+    pass
+
+
+class ArtifactDigestMismatch(RuntimeError):
+    # A protected-main rebuild differs from the committed release digest.
+
+    def __init__(self, expected: str, actual: str) -> None:
+        self.expected = expected
+        self.actual = actual
+        super().__init__(
+            "built MPP digest mismatch: "
+            f"expected={expected}, actual={actual}"
+        )
+
+
 class ReleaseState(str, Enum):
     NOT_FINALIZED = "NOT_FINALIZED"
     LOCAL_FINALIZED = "LOCAL_FINALIZED"
@@ -3547,6 +3564,8 @@ class WorkflowExecutionResult:
     already_satisfied: bool = False
     error: str | None = None
     next_command: str | None = None
+    actual_mpp_sha256: str | None = None
+    failure_category: str | None = None
 
     def as_dict(self) -> dict[str, Any]:
         return _jsonable(self)
@@ -3851,12 +3870,16 @@ def _render_workflow_text(result: WorkflowExecutionResult) -> str:
         f"NEXT_ACTION={result.next_action.value}",
         f"RELEASE_COMMIT={result.release_commit or 'UNKNOWN'}",
         f"MPP_SHA256={result.mpp_sha256 or 'UNKNOWN'}",
+        f"EXPECTED_MPP_SHA256={result.mpp_sha256 or 'UNKNOWN'}",
+        f"ACTUAL_MPP_SHA256={result.actual_mpp_sha256 or 'UNKNOWN'}",
         f"TRANSACTION_LOG={result.transaction_log}",
         f"INNER_RESULT={result.result}",
         f"POSTCHECK_RESULT={result.postcheck_result}",
         f"FINAL_STATE={result.state.value}",
         f"ALREADY_SATISFIED={_yes_no(result.already_satisfied)}",
     ]
+    if result.failure_category:
+        lines.append(f"FAILURE_CATEGORY={result.failure_category}")
     if result.next_command:
         lines.append(f"NEXT_COMMAND={result.next_command}")
     if result.error:
@@ -3872,19 +3895,24 @@ def _workflow_failure(
     transaction_log: Path,
     error: str,
     state: ReleaseState = ReleaseState.INCONSISTENT_ABORT,
+    next_action: NextAction = NextAction.MANUAL_DIAGNOSIS,
     release_commit: str | None = None,
     mpp_sha256: str | None = None,
+    actual_mpp_sha256: str | None = None,
+    failure_category: str = "RELEASE_WORKFLOW_FAILED",
 ) -> WorkflowExecutionResult:
     return WorkflowExecutionResult(
         command=command,
         result=result_token,
         state=state,
-        next_action=NextAction.MANUAL_DIAGNOSIS,
+        next_action=next_action,
         release_commit=release_commit,
         mpp_sha256=mpp_sha256,
         transaction_log=str(transaction_log),
         postcheck_result="FAIL",
         error=error,
+        actual_mpp_sha256=actual_mpp_sha256,
+        failure_category=failure_category,
     )
 
 
@@ -4050,9 +4078,7 @@ def _prepare_protected_main_local_release(
         raise RuntimeError(f"canonical MPP is unavailable: {mpp_path}")
     actual_sha = _sha256_file(mpp_path)
     if actual_sha != identity.mpp_sha256:
-        raise RuntimeError(
-            "built MPP digest does not match the SHA committed through the release pull request"
-        )
+        raise ArtifactDigestMismatch(identity.mpp_sha256, actual_sha)
     _run_mutation(
         runner,
         repo_root,
@@ -4267,6 +4293,41 @@ def _publish_draft_release(
     )
 
 
+def _release_notes_validation_failure(
+    label: str,
+    result: MutationCommandResult,
+) -> ReleaseInputValidationError:
+    detail = result.stderr.strip() or result.stdout.strip() or "no diagnostic output"
+    return ReleaseInputValidationError(
+        f"{label} failed with exit {result.returncode}: {detail}"
+    )
+
+
+def _validate_human_release_notes(
+    repo_root: Path,
+    version: str,
+    release_notes_file: Path,
+    runner: MutationRunner,
+) -> None:
+    result = runner.run(
+        repo_root,
+        (
+            "python3",
+            "scripts/validate-release-notes.py",
+            "--notes-file",
+            str(release_notes_file),
+            "--version",
+            version,
+            "--human-input-only",
+        ),
+    )
+    if result.returncode != 0:
+        raise _release_notes_validation_failure(
+            "human release notes validation",
+            result,
+        )
+
+
 def _compose_and_validate_release_notes(
     repo_root: Path,
     identity: ReleaseIdentity,
@@ -4290,8 +4351,7 @@ def _compose_and_validate_release_notes(
         + f"- MPP SHA256: `{identity.mpp_sha256}`.\n",
         encoding="utf-8",
     )
-    _run_mutation(
-        runner,
+    result = runner.run(
         repo_root,
         (
             "python3", "scripts/validate-release-notes.py",
@@ -4302,8 +4362,12 @@ def _compose_and_validate_release_notes(
             "--sha256", identity.mpp_sha256,
             "--require-sha",
         ),
-        label="release notes validation",
     )
+    if result.returncode != 0:
+        raise _release_notes_validation_failure(
+            "release notes validation",
+            result,
+        )
     return notes_path
 
 
@@ -5117,10 +5181,19 @@ def publish_release_workflow(
     active_runner = runner or SubprocessMutationRunner()
     repo_root = _resolve_mutation_repo_root(repo_path, active_runner)
     log_path = transaction_log_path(repo_root, tag)
+    identity: ReleaseIdentity | None = None
     try:
         notes_source = Path(release_notes_file).expanduser().resolve()
         if not notes_source.is_file() or notes_source.is_symlink():
-            raise RuntimeError(f"release notes file is unavailable: {notes_source}")
+            raise ReleaseInputValidationError(
+                f"release notes file is unavailable: {notes_source}"
+            )
+        _validate_human_release_notes(
+            repo_root,
+            version,
+            notes_source,
+            active_runner,
+        )
         if protected_main_commit is not None:
             if mpp_sha256 is not None:
                 raise RuntimeError(
@@ -5308,15 +5381,57 @@ def publish_release_workflow(
             )
         raise RuntimeError("release workflow exceeded the maximum resume iteration count")
     except (OSError, RuntimeError, ValueError) as exc:
+        release_commit = (
+            identity.release_commit
+            if identity is not None
+            else protected_main_commit
+        )
+        expected_sha = (
+            identity.mpp_sha256
+            if identity is not None
+            else (mpp_sha256.strip().lower() if mpp_sha256 else None)
+        )
+        actual_sha: str | None = None
+        failure_category = "RELEASE_WORKFLOW_FAILED"
+        failure_state = ReleaseState.INCONSISTENT_ABORT
+        failure_next_action = NextAction.MANUAL_DIAGNOSIS
+
+        if isinstance(exc, ReleaseInputValidationError):
+            failure_category = "INPUT_VALIDATION_FAILED"
+            failure_state = ReleaseState.NOT_FINALIZED
+            failure_next_action = NextAction.PUBLISH
+        elif isinstance(exc, ArtifactDigestMismatch):
+            failure_category = "ARTIFACT_MISMATCH"
+            failure_state = ReleaseState.NOT_FINALIZED
+            actual_sha = exc.actual
+
         append_transaction_entry(
-            log_path, command=command_name, phase="ABORT", status="FAILED",
-            version=version, tag=tag, details={"error": str(exc)},
+            log_path,
+            command=command_name,
+            phase="ABORT",
+            status="FAILED",
+            version=version,
+            tag=tag,
+            release_commit=release_commit,
+            mpp_sha256=expected_sha,
+            details={
+                "error": str(exc),
+                "failure_category": failure_category,
+                "expected_mpp_sha256": expected_sha,
+                "actual_mpp_sha256": actual_sha,
+            },
         )
         return _workflow_failure(
             command=command_name,
             result_token="MORPHE_RELEASE_PUBLISH_EXISTING_FAIL",
             transaction_log=log_path,
             error=str(exc),
+            state=failure_state,
+            next_action=failure_next_action,
+            release_commit=release_commit,
+            mpp_sha256=expected_sha,
+            actual_mpp_sha256=actual_sha,
+            failure_category=failure_category,
         )
 
 def _identity_from_args(args: argparse.Namespace) -> ReleaseIdentity:

--- a/scripts/validate-release-notes.py
+++ b/scripts/validate-release-notes.py
@@ -6,25 +6,23 @@ import re
 import sys
 from pathlib import Path
 
-REQUIRED_SECTIONS = (
-    "### Changes",
-    "### User impact",
-    "### Validation",
-)
-
+STANDARD_HEADINGS = {
+    "changes",
+    "user impact",
+    "validation",
+}
 GENERIC_ONLY_FRAGMENTS = (
     "Final local release gate passed before publish.",
     "README SHA is aligned to the published MPP.",
     "Assets:",
     "Validation:",
 )
-
 FORBIDDEN_GENERIC_TITLES = {
     "morphe-patches",
     "release notes",
 }
-
-MIN_LENGTH = 450
+MIN_FULL_LENGTH = 450
+MIN_HUMAN_LENGTH = 80
 
 
 def fail(message: str) -> None:
@@ -56,16 +54,31 @@ def concrete_bullets(body: str) -> list[str]:
     return bullets
 
 
-def has_app_heading(body: str) -> bool:
-    headings = re.findall(r"(?m)^###\s+(.+?)\s*$", body)
-    for heading in headings:
-        normalized = heading.strip().lower()
-        if normalized in {"changes", "user impact", "validation"}:
+def exact_heading_positions(body: str, heading: str) -> list[int]:
+    pattern = re.compile(rf"(?m)^{re.escape(heading)}\s*$")
+    return [match.start() for match in pattern.finditer(body)]
+
+
+def app_heading_positions(body: str) -> list[int]:
+    positions: list[int] = []
+    for match in re.finditer(r"(?m)^###\s+(.+?)\s*$", body):
+        normalized = match.group(1).strip().lower()
+        if normalized in STANDARD_HEADINGS:
             continue
         if normalized in FORBIDDEN_GENERIC_TITLES:
             continue
-        return True
-    return False
+        positions.append(match.start())
+    return positions
+
+
+def section_body(body: str, heading: str) -> str:
+    positions = exact_heading_positions(body, heading)
+    if len(positions) != 1:
+        return ""
+    start = positions[0] + len(heading)
+    following = re.search(r"(?m)^###\s+", body[start:])
+    end = start + following.start() if following else len(body)
+    return body[start:end].strip()
 
 
 def validate(
@@ -76,59 +89,106 @@ def validate(
     asset: str,
     sha256: str,
     require_sha: bool,
+    human_input_only: bool = False,
 ) -> list[str]:
     errors: list[str] = []
+    minimum = MIN_HUMAN_LENGTH if human_input_only else MIN_FULL_LENGTH
 
-    if len(body) < MIN_LENGTH:
-        errors.append(f"release notes are too short: {len(body)} chars, expected at least {MIN_LENGTH}")
+    if len(body) < minimum:
+        errors.append(
+            f"release notes are too short: {len(body)} chars, "
+            f"expected at least {minimum}"
+        )
 
-    title = f"Morphe patch bundle {version}"
-    if title not in body:
-        errors.append(f"release notes missing title text: {title!r}")
+    expected_title = f"# Morphe patch bundle {version}"
+    if len(exact_heading_positions(body, expected_title)) != 1:
+        errors.append(f"release notes missing exact title heading: {expected_title!r}")
 
-    if not has_app_heading(body):
-        errors.append("release notes missing app/area heading, for example '### Boost for Reddit'")
+    apps = app_heading_positions(body)
+    if not apps:
+        errors.append(
+            "release notes missing app/area heading, "
+            "for example '### Boost for Reddit'"
+        )
 
-    for section in REQUIRED_SECTIONS:
-        if section not in body:
-            errors.append(f"release notes missing required section: {section}")
+    required = ["### Changes", "### User impact"]
+    if not human_input_only:
+        required.append("### Validation")
 
-    bullets = concrete_bullets(body)
-    if not bullets:
-        errors.append("release notes missing at least one concrete non-validation change bullet")
+    for heading in required:
+        positions = exact_heading_positions(body, heading)
+        if len(positions) != 1:
+            errors.append(
+                f"release notes require exactly one exact section heading: {heading}"
+            )
 
-    if tag not in body:
-        errors.append(f"release notes missing release tag: {tag}")
+    for wrong in ("## Changes", "## User impact", "## Validation"):
+        if exact_heading_positions(body, wrong):
+            errors.append(
+                f"release notes must use a level-three heading instead of {wrong!r}"
+            )
 
-    if asset not in body:
-        errors.append(f"release notes missing asset name: {asset}")
+    changes_positions = exact_heading_positions(body, "### Changes")
+    impact_positions = exact_heading_positions(body, "### User impact")
+    validation_positions = exact_heading_positions(body, "### Validation")
 
-    if require_sha:
-        if not re.fullmatch(r"[0-9a-f]{64}", sha256):
-            errors.append(f"invalid expected sha256 argument: {sha256!r}")
-        elif sha256 not in body:
-            errors.append("release notes missing expected MPP SHA256")
+    if apps and changes_positions and apps[0] > changes_positions[0]:
+        errors.append("app/area heading must appear before Changes")
+    if changes_positions and impact_positions:
+        if changes_positions[0] > impact_positions[0]:
+            errors.append("Changes must appear before User impact")
+    if not human_input_only and impact_positions and validation_positions:
+        if impact_positions[0] > validation_positions[0]:
+            errors.append("User impact must appear before Validation")
 
-    validation_pos = body.find("### Validation")
-    changes_pos = body.find("### Changes")
-    if validation_pos != -1 and changes_pos != -1 and validation_pos < changes_pos:
-        errors.append("Validation section appears before Changes; release notes look validation-first/generic")
+    changes_body = section_body(body, "### Changes")
+    if changes_positions and not concrete_bullets(changes_body):
+        errors.append(
+            "Changes section must contain at least one concrete change bullet"
+        )
 
-    lowered = body.lower()
-    if "assets:" in lowered and "### changes" not in lowered:
-        errors.append("release notes look assets-only and lack Changes section")
+    impact_body = section_body(body, "### User impact")
+    if impact_positions and not impact_body:
+        errors.append("User impact section must not be empty")
+
+    if not human_input_only:
+        if not tag:
+            errors.append("expected release tag argument is empty")
+        elif tag not in body:
+            errors.append(f"release notes missing release tag: {tag}")
+
+        if not asset:
+            errors.append("expected release asset argument is empty")
+        elif asset not in body:
+            errors.append(f"release notes missing asset name: {asset}")
+
+        if require_sha:
+            if not re.fullmatch(r"[0-9a-f]{64}", sha256):
+                errors.append(f"invalid expected sha256 argument: {sha256!r}")
+            elif sha256 not in body:
+                errors.append("release notes missing expected MPP SHA256")
 
     return errors
 
 
 def main() -> int:
-    parser = argparse.ArgumentParser(description="Validate human-readable GitHub release notes for Morphe releases.")
+    parser = argparse.ArgumentParser(
+        description="Validate human-readable GitHub release notes for Morphe releases."
+    )
     parser.add_argument("--notes-file", required=True)
     parser.add_argument("--version", required=True)
-    parser.add_argument("--tag", required=True)
-    parser.add_argument("--asset", required=True)
+    parser.add_argument("--tag", default="")
+    parser.add_argument("--asset", default="")
     parser.add_argument("--sha256", default="")
     parser.add_argument("--require-sha", action="store_true")
+    parser.add_argument(
+        "--human-input-only",
+        action="store_true",
+        help=(
+            "Validate the human-authored title/app/Changes/User impact portion "
+            "before build, signing, and final Validation metadata are added."
+        ),
+    )
     args = parser.parse_args()
 
     body = read_body(Path(args.notes_file))
@@ -139,6 +199,7 @@ def main() -> int:
         asset=args.asset,
         sha256=args.sha256,
         require_sha=args.require_sha,
+        human_input_only=args.human_input_only,
     )
 
     if errors:
@@ -147,10 +208,13 @@ def main() -> int:
         return 1
 
     print("RELEASE_NOTES_OK")
+    print(f"mode={'human' if args.human_input_only else 'full'}")
     print(f"chars={len(body)}")
     print(f"version={args.version}")
-    print(f"tag={args.tag}")
-    print(f"asset={args.asset}")
+    if args.tag:
+        print(f"tag={args.tag}")
+    if args.asset:
+        print(f"asset={args.asset}")
     if args.sha256:
         print(f"sha256={args.sha256}")
     return 0

--- a/tests/tools/test_release_pipeline_hardening_source_contract.py
+++ b/tests/tools/test_release_pipeline_hardening_source_contract.py
@@ -1,0 +1,187 @@
+from __future__ import annotations
+
+import importlib.util
+import subprocess
+import sys
+import unittest
+from pathlib import Path
+from unittest import mock
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def load_script(name: str, relative_path: str):
+    path = ROOT / relative_path
+    spec = importlib.util.spec_from_file_location(name, path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"could not load {path}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+class ReleasePipelineHardeningSourceContract(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.compose = load_script(
+            "morphe_compose_release_notes",
+            "scripts/compose-release-notes.py",
+        )
+        cls.validator = load_script(
+            "morphe_validate_release_notes",
+            "scripts/validate-release-notes.py",
+        )
+        cls.prepare = load_script(
+            "morphe_prepare_release",
+            "scripts/prepare-release.py",
+        )
+        cls.releasectl = load_script(
+            "morphe_releasectl",
+            "scripts/releasectl.py",
+        )
+
+    def test_structured_composer_generates_exact_headings(self) -> None:
+        body = self.compose.compose_release_notes(
+            version="1.4.99",
+            app_area="Boost for Reddit",
+            changes="Restore native action\nAdd regression coverage",
+            user_impact="Long-press works again.",
+            issue_number="135",
+        )
+        self.assertIn("\n### Boost for Reddit\n", body)
+        self.assertIn("\n### Changes\n", body)
+        self.assertIn("\n### User impact\n", body)
+        self.assertNotIn("\n## Changes\n", body)
+        self.assertEqual(
+            self.validator.validate(
+                body,
+                version="1.4.99",
+                tag="",
+                asset="",
+                sha256="",
+                require_sha=False,
+                human_input_only=True,
+            ),
+            [],
+        )
+
+    def test_level_two_changes_heading_is_rejected(self) -> None:
+        body = self.compose.compose_release_notes(
+            version="1.4.99",
+            app_area="Boost for Reddit",
+            changes="Restore native action",
+            user_impact="Long-press works again.",
+        ).replace("### Changes", "## Changes")
+        errors = self.validator.validate(
+            body,
+            version="1.4.99",
+            tag="",
+            asset="",
+            sha256="",
+            require_sha=False,
+            human_input_only=True,
+        )
+        self.assertTrue(
+            any("level-three heading" in error for error in errors),
+            errors,
+        )
+
+    def test_java_21_is_rejected_before_release_preparation(self) -> None:
+        output = "    java.specification.version = 21\n"
+        completed = subprocess.CompletedProcess(
+            args=["java"],
+            returncode=0,
+            stdout="",
+            stderr=output,
+        )
+        with mock.patch.object(
+            self.prepare.subprocess,
+            "run",
+            return_value=completed,
+        ):
+            with self.assertRaises(SystemExit) as raised:
+                self.prepare.require_release_java_17()
+        self.assertIn("requires Java 17", str(raised.exception))
+        self.assertIn("No files changed", str(raised.exception))
+
+    def test_java_17_is_accepted(self) -> None:
+        output = "    java.specification.version = 17\n"
+        completed = subprocess.CompletedProcess(
+            args=["java"],
+            returncode=0,
+            stdout="",
+            stderr=output,
+        )
+        with mock.patch.object(
+            self.prepare.subprocess,
+            "run",
+            return_value=completed,
+        ):
+            self.prepare.require_release_java_17()
+
+    def test_release_failure_preserves_known_identity_and_digest(self) -> None:
+        mismatch = self.releasectl.ArtifactDigestMismatch(
+            "a" * 64,
+            "b" * 64,
+        )
+        result = self.releasectl._workflow_failure(
+            command="publish",
+            result_token="FAIL",
+            transaction_log=Path("/tmp/release.jsonl"),
+            error=str(mismatch),
+            state=self.releasectl.ReleaseState.NOT_FINALIZED,
+            next_action=self.releasectl.NextAction.MANUAL_DIAGNOSIS,
+            release_commit="c" * 40,
+            mpp_sha256=mismatch.expected,
+            actual_mpp_sha256=mismatch.actual,
+            failure_category="ARTIFACT_MISMATCH",
+        )
+        rendered = self.releasectl._render_workflow_text(result)
+        self.assertIn(f"RELEASE_COMMIT={'c' * 40}", rendered)
+        self.assertIn(f"EXPECTED_MPP_SHA256={'a' * 64}", rendered)
+        self.assertIn(f"ACTUAL_MPP_SHA256={'b' * 64}", rendered)
+        self.assertIn("FAILURE_CATEGORY=ARTIFACT_MISMATCH", rendered)
+        self.assertNotIn("STATE=INCONSISTENT_ABORT", rendered)
+
+    def test_source_ordering_and_exact_runtime_contract(self) -> None:
+        workflow = (ROOT / ".github/workflows/release.yml").read_text(
+            encoding="utf-8"
+        )
+        smoke = (
+            ROOT / ".github/workflows/release-feed-smoke.yml"
+        ).read_text(encoding="utf-8")
+        prepare = (ROOT / "scripts/prepare-release.py").read_text(
+            encoding="utf-8"
+        )
+        ctl = (ROOT / "scripts/releasectl.py").read_text(encoding="utf-8")
+
+        self.assertNotIn("      release_notes:", workflow)
+        self.assertIn("java-version: '17.0.19+10'", workflow)
+        self.assertIn("java-version: '17.0.19+10'", smoke)
+
+        checkout = workflow.index("- name: Checkout exact main")
+        notes = workflow.index("- name: Compose and validate release notes")
+        java = workflow.index("- name: Setup Java")
+        gpg = workflow.index("- name: Import GPG key")
+        self.assertLess(checkout, notes)
+        self.assertLess(notes, java)
+        self.assertLess(java, gpg)
+
+        preflight = prepare.index("require_release_java_17()")
+        first_mutation = prepare.index("write(gradle_path, gradle_text)")
+        self.assertLess(preflight, first_mutation)
+
+        for marker in (
+            "INPUT_VALIDATION_FAILED",
+            "ARTIFACT_MISMATCH",
+            "EXPECTED_MPP_SHA256",
+            "ACTUAL_MPP_SHA256",
+            "ReleaseInputValidationError",
+            "ArtifactDigestMismatch",
+        ):
+            self.assertIn(marker, ctl)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/check-ci-tooling-contract.sh
+++ b/tools/check-ci-tooling-contract.sh
@@ -6,11 +6,19 @@ SMOKE_WORKFLOW="$ROOT/.github/workflows/release-feed-smoke.yml"
 RELEASE_WORKFLOW="$ROOT/.github/workflows/release.yml"
 PROJECT_RUNNER="$ROOT/tools/check-project-contracts.sh"
 FEED_RUNNER="$ROOT/tools/release-feed-smoke.sh"
+COMPOSER="$ROOT/scripts/compose-release-notes.py"
+VALIDATOR="$ROOT/scripts/validate-release-notes.py"
 
-test -f "$SMOKE_WORKFLOW"
-test -f "$RELEASE_WORKFLOW"
-test -f "$PROJECT_RUNNER"
-test -f "$FEED_RUNNER"
+for path in \
+  "$SMOKE_WORKFLOW" \
+  "$RELEASE_WORKFLOW" \
+  "$PROJECT_RUNNER" \
+  "$FEED_RUNNER" \
+  "$COMPOSER" \
+  "$VALIDATOR"
+do
+  test -f "$path"
+done
 
 rg -q -F "command -v rg" "$PROJECT_RUNNER"
 rg -q -F "./tools/check-project-contracts.sh" "$FEED_RUNNER"
@@ -23,14 +31,18 @@ python3 - "$SMOKE_WORKFLOW" "$RELEASE_WORKFLOW" <<'PY_CHECK'
 import sys
 from pathlib import Path
 
-for raw_path in sys.argv[1:]:
-    path = Path(raw_path)
-    text = path.read_text(encoding="utf-8")
+smoke_path = Path(sys.argv[1])
+release_path = Path(sys.argv[2])
+smoke_text = smoke_path.read_text(encoding="utf-8")
+release_text = release_path.read_text(encoding="utf-8")
+
+for path, text in ((smoke_path, smoke_text), (release_path, release_text)):
     required = (
         "- name: Install ripgrep",
         "if ! command -v rg >/dev/null 2>&1; then",
         "sudo apt-get install --yes ripgrep",
         "rg --version",
+        "java-version: '17.0.19+10'",
     )
     for marker in required:
         assert marker in text, f"missing {marker!r}: {path}"
@@ -42,7 +54,33 @@ for raw_path in sys.argv[1:]:
         consumer_index = text.index("./tools/check-project-contracts.sh")
     assert install_index < consumer_index, f"ripgrep installed too late: {path}"
 
-release_text = Path(sys.argv[2]).read_text(encoding="utf-8")
+for input_name in ("app_area", "changes", "user_impact", "issue_number"):
+    assert f"      {input_name}:" in release_text, (
+        f"missing structured release input {input_name!r}"
+    )
+
+assert "      release_notes:" not in release_text
+assert "RELEASE_NOTES: ${{ inputs.release_notes }}" not in release_text
+
+notes_required = (
+    "- name: Compose and validate release notes",
+    "python3 scripts/compose-release-notes.py",
+    "python3 scripts/validate-release-notes.py",
+    "--human-input-only",
+    "RELEASE_NOTES_INPUT_VALIDATION=PASS",
+)
+for marker in notes_required:
+    assert release_text.count(marker) == 1, (
+        f"expected exactly one release-notes marker {marker!r}"
+    )
+
+checkout_index = release_text.index("- name: Checkout exact main")
+notes_index = release_text.index("- name: Compose and validate release notes")
+java_index = release_text.index("- name: Setup Java")
+gpg_index = release_text.index("- name: Import GPG key")
+publish_index = release_text.index("- name: Publish from protected main")
+assert checkout_index < notes_index < java_index < gpg_index < publish_index
+
 identity_required = (
     "- name: Configure release Git identity",
     'git config --local user.name "github-actions[bot]"',
@@ -56,17 +94,15 @@ for marker in identity_required:
         f"expected exactly one release Git identity marker {marker!r}"
     )
 
-import_index = release_text.index("- name: Import GPG key")
 identity_index = release_text.index("- name: Configure release Git identity")
-publish_index = release_text.index("- name: Publish from protected main")
-assert import_index < identity_index < publish_index, (
-    "release Git identity must be configured after GPG import and before publish"
-)
+assert gpg_index < identity_index < publish_index
 PY_CHECK
 
 echo 'PROJECT_RUNNER_RIPGREP_PREFLIGHT=PASS'
 echo 'RELEASE_FEED_SMOKE_PROVISIONS_RIPGREP=PASS'
 echo 'RELEASE_FEED_MPP_SHA_GATE=PASS'
 echo 'RELEASE_WORKFLOW_PROVISIONS_RIPGREP=PASS'
+echo 'RELEASE_WORKFLOW_STRUCTURED_NOTES=PASS'
+echo 'RELEASE_WORKFLOW_EXACT_TEMURIN17=PASS'
 echo 'RELEASE_WORKFLOW_GIT_IDENTITY=PASS'
 echo 'RESULT=MORPHE_CI_TOOLING_CONTRACT_OK'


### PR DESCRIPTION
## Summary

- replace free-form Markdown release notes with structured app, changes, user-impact, and issue inputs
- generate canonical `###` headings automatically and validate human input before Java, Gradle, or GPG work
- pin release and release-smoke workflows to exact Temurin `17.0.19+10`
- reject local release preparation under non-Java-17 runtimes before metadata mutation
- preserve known release commit and expected/actual MPP digests in `releasectl.py` failures
- classify release input errors as `INPUT_VALIDATION_FAILED` and digest differences as `ARTIFACT_MISMATCH`

## Regression coverage

- canonical composer generates exact `### Changes` and `### User impact`
- `## Changes` is rejected
- Java 21 release preparation is rejected before mutation
- Java 17 release preparation is accepted
- artifact mismatch output retains release commit, expected SHA, actual SHA, and failure category
- workflow ordering requires notes validation before Java and GPG

## Mutation boundary

This PR does not bump a release version, change patch behavior, create or move tags, publish a release, update `dev`, close issues, or merge itself.