### PR TITLE
fix(boost): preserve Imgur links in inline previews

### DIFF
--- a/extensions/boostforreddit/src/main/java/app/morphe/extension/boostforreddit/giphy/InlineGiphyCommentPreview.java
+++ b/extensions/boostforreddit/src/main/java/app/morphe/extension/boostforreddit/giphy/InlineGiphyCommentPreview.java
@@ -39,6 +39,8 @@ public final class InlineGiphyCommentPreview {
             "MORPHE_BOOST_INLINE_MEDIA_ADAPTIVE_SIZE_ISSUE70_V4";
     private static final String PRERENDER_SOURCE_POLICY_MARKER =
             "morphe_boost_inline_media_prerender_source_policy_v10";
+    private static final String SOURCE_LINK_SAFETY_MARKER =
+            "MORPHE_BOOST_INLINE_MEDIA_SOURCE_LINK_SAFETY_ISSUE120_V3";
     private static final String PREF_INLINE_MEDIA_PREVIEWS_ENABLED =
             "morphe_boost_inline_media_previews_enabled";
     private static final String PREF_INLINE_MEDIA_PREVIEW_SHOW_SOURCE_TEXT =
@@ -500,47 +502,233 @@ public final class InlineGiphyCommentPreview {
     }
 
     private static String removePreviewSourceUrlFromHtml(String html, String sourceUrl) {
-        if (html == null || sourceUrl == null || sourceUrl.length() == 0) return html;
+        if (html == null || sourceUrl == null || sourceUrl.length() == 0) {
+            return html;
+        }
 
         String result = html;
-        String[] variants = sourceUrlVariants(sourceUrl);
 
-        for (String href : variants) {
-            if (href == null || href.length() == 0) continue;
-            for (String label : variants) {
-                if (label == null || label.length() == 0) continue;
-                result = removeExactAnchor(result, href, label);
-            }
-        }
+        String beforeSourceLabelCleanup = result;
+        result = removeSourceLabelAnchors(result, sourceUrl, false);
+        result = removeSourceLabelAnchors(result, sourceUrl, true);
+        boolean sourceLabelAnchorRemoved =
+                !stringEquals(beforeSourceLabelCleanup, result);
+
+        String beforeBareSourceCleanup = result;
+        String[] variants = sourceUrlVariants(sourceUrl);
+        String[] schemeStrippedVariants =
+                sourceUrlVariants(stripHttpScheme(sourceUrl));
 
         for (String candidate : variants) {
             if (candidate == null || candidate.length() == 0) continue;
-            result = result.replace(candidate, "");
+            result = removeTextOutsideHtmlMarkup(result, candidate);
         }
+        for (String candidate : schemeStrippedVariants) {
+            if (candidate == null || candidate.length() == 0) continue;
+            result = removeTextOutsideHtmlMarkup(result, candidate);
+        }
+
+        boolean bareSourceTextRemoved =
+                !stringEquals(beforeBareSourceCleanup, result);
+
+        safeDebugLog(
+                SOURCE_LINK_SAFETY_MARKER
+                        + ": sourceLabelAnchorRemoved="
+                        + sourceLabelAnchorRemoved
+                        + " bareSourceTextRemoved="
+                        + bareSourceTextRemoved
+                        + " descriptiveLinksPreserved=true"
+                        + " source=" + sourceUrl
+        );
 
         result = cleanupHtmlAfterSourceRemoval(result);
         if (isBlankHtml(result)) {
-            // TableTextView.setTextHtml("") returns without clearing old content. Use zero-width space.
             return "&#8203;";
         }
 
         return result;
     }
 
-    private static String removeExactAnchor(String html, String href, String label) {
-        if (html == null || href == null || label == null) return html;
+
+
+
+    private static void safeDebugLog(String message) {
+        try {
+            Log.d(LOG_TAG, message);
+        } catch (Throwable ignored) {
+        }
+    }
+
+
+    private static String removeSourceLabelAnchors(
+            String html,
+            String sourceUrl,
+            boolean encoded
+    ) {
+        if (html == null || sourceUrl == null || sourceUrl.length() == 0) {
+            return html;
+        }
 
         try {
-            String pattern = "(?is)\\s*<a\\b[^>]*href\\s*=\\s*(['\\\"])\\s*"
-                    + Pattern.quote(href)
-                    + "\\s*\\1[^>]*>\\s*"
-                    + Pattern.quote(label)
-                    + "\\s*</a>\\s*";
-            return html.replaceAll(pattern, " ");
+            String patternText = encoded
+                    ? "(?is)&lt;a\\b(?:(?!&gt;).)*?&gt;(.*?)&lt;/a\\s*&gt;"
+                    : "(?is)<a\\b[^>]*>(.*?)</a\\s*>";
+
+            java.util.regex.Matcher matcher =
+                    Pattern.compile(patternText).matcher(html);
+            StringBuffer output = new StringBuffer();
+            boolean changed = false;
+
+            while (matcher.find()) {
+                String inner = matcher.group(1);
+                String replacement;
+                if (isSourceEquivalentLabel(inner, sourceUrl)) {
+                    replacement = " ";
+                    changed = true;
+                } else {
+                    replacement = matcher.group(0);
+                }
+
+                matcher.appendReplacement(
+                        output,
+                        java.util.regex.Matcher.quoteReplacement(replacement)
+                );
+            }
+
+            if (!changed) {
+                return html;
+            }
+
+            matcher.appendTail(output);
+            return output.toString();
         } catch (Throwable ignored) {
             return html;
         }
     }
+
+    private static boolean isSourceEquivalentLabel(
+            String htmlFragment,
+            String sourceUrl
+    ) {
+        String label = normalizeAnchorLabel(htmlFragment);
+        if (label == null || label.length() == 0) {
+            return false;
+        }
+
+        String[] fullVariants = sourceUrlVariants(sourceUrl);
+        for (String candidate : fullVariants) {
+            if (candidate != null && label.equals(candidate)) {
+                return true;
+            }
+        }
+
+        String[] strippedVariants =
+                sourceUrlVariants(stripHttpScheme(sourceUrl));
+        for (String candidate : strippedVariants) {
+            if (candidate != null && label.equals(candidate)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static String normalizeAnchorLabel(String value) {
+        if (value == null) return null;
+
+        return value
+                .replaceAll("(?is)<[^>]+>", "")
+                .replaceAll("(?is)&lt;(?:(?!&gt;).)*?&gt;", "")
+                .replaceAll("(?i)&amp;", "&")
+                .replaceAll("(?i)&quot;", "\"")
+                .replaceAll("(?i)&#34;", "\"")
+                .replaceAll("(?i)&#x22;", "\"")
+                .replaceAll("(?i)&#39;", "'")
+                .replaceAll("(?i)&#x27;", "'")
+                .replaceAll("(?i)&nbsp;", " ")
+                .trim();
+    }
+
+    private static String removeTextOutsideHtmlMarkup(
+            String html,
+            String sourceText
+    ) {
+        if (
+                html == null
+                        || sourceText == null
+                        || sourceText.length() == 0
+        ) {
+            return html;
+        }
+
+        String lowerHtml = html.toLowerCase(java.util.Locale.US);
+        StringBuilder output = new StringBuilder(html.length());
+        int index = 0;
+
+        while (index < html.length()) {
+            int rawTagStart = html.indexOf('<', index);
+            int encodedTagStart = lowerHtml.indexOf("&lt;", index);
+
+            int tagStart;
+            boolean encoded;
+            if (rawTagStart < 0) {
+                tagStart = encodedTagStart;
+                encoded = true;
+            } else if (encodedTagStart < 0) {
+                tagStart = rawTagStart;
+                encoded = false;
+            } else if (rawTagStart <= encodedTagStart) {
+                tagStart = rawTagStart;
+                encoded = false;
+            } else {
+                tagStart = encodedTagStart;
+                encoded = true;
+            }
+
+            if (tagStart < 0) {
+                output.append(
+                        html.substring(index).replace(sourceText, "")
+                );
+                break;
+            }
+
+            if (tagStart > index) {
+                output.append(
+                        html.substring(index, tagStart).replace(sourceText, "")
+                );
+            }
+
+            final int tagEnd;
+            final int tagEndLength;
+            if (encoded) {
+                tagEnd = lowerHtml.indexOf("&gt;", tagStart + 4);
+                tagEndLength = 4;
+            } else {
+                tagEnd = html.indexOf('>', tagStart + 1);
+                tagEndLength = 1;
+            }
+
+            if (tagEnd < 0) {
+                output.append(html.substring(tagStart));
+                break;
+            }
+
+            output.append(
+                    html,
+                    tagStart,
+                    tagEnd + tagEndLength
+            );
+            index = tagEnd + tagEndLength;
+        }
+
+        return output.toString();
+    }
+
+    private static String stripHttpScheme(String value) {
+        if (value == null) return null;
+        return value.replaceFirst("(?i)^https?://", "");
+    }
+
 
     private static String[] sourceUrlVariants(String sourceUrl) {
         String escaped = escapeHtmlUrl(sourceUrl);

--- a/tools/check-boost-inline-preview-link-safety-contract.sh
+++ b/tools/check-boost-inline-preview-link-safety-contract.sh
@@ -1,0 +1,273 @@
+#!/usr/bin/env bash
+
+SOURCE="extensions/boostforreddit/src/main/java/app/morphe/extension/boostforreddit/giphy/InlineGiphyCommentPreview.java"
+FAIL=0
+
+fail() {
+    printf 'FAIL=%s\n' "$*"
+    FAIL=1
+}
+
+printf 'CONTRACT=BOOST_INLINE_PREVIEW_LINK_SAFETY_ISSUE120_V3\n'
+
+if ! command -v javac >/dev/null 2>&1; then
+    fail 'JAVAC_NOT_FOUND'
+fi
+
+ANDROID_JAR="$(
+    find "${ANDROID_HOME:-$HOME/Android/Sdk}/platforms" \
+        -mindepth 2 \
+        -maxdepth 2 \
+        -type f \
+        -name android.jar \
+        -printf '%h %p\n' 2>/dev/null |
+    sort -V |
+    tail -n 1 |
+    awk '{print $2}'
+)"
+
+if [ -z "$ANDROID_JAR" ] || [ ! -f "$ANDROID_JAR" ]; then
+    fail 'ANDROID_JAR_NOT_FOUND'
+fi
+
+if [ ! -f "$SOURCE" ]; then
+    fail 'SOURCE_NOT_FOUND'
+fi
+
+if [ "$FAIL" -eq 0 ]; then
+    grep -Fq \
+        'MORPHE_BOOST_INLINE_MEDIA_SOURCE_LINK_SAFETY_ISSUE120_V3' \
+        "$SOURCE" ||
+        fail 'ISSUE120_V3_MARKER_MISSING'
+
+    grep -Fq 'removeSourceLabelAnchors' "$SOURCE" ||
+        fail 'SOURCE_LABEL_ANCHOR_CLEANUP_MISSING'
+    grep -Fq 'removeTextOutsideHtmlMarkup' "$SOURCE" ||
+        fail 'ENCODED_MARKUP_SAFE_TEXT_REMOVAL_MISSING'
+    grep -Fq 'descriptiveLinksPreserved=true' "$SOURCE" ||
+        fail 'DESCRIPTIVE_LINK_PRESERVATION_MARKER_MISSING'
+
+    if grep -Fq \
+        'MORPHE_BOOST_INLINE_MEDIA_SOURCE_LINK_SHAPE_ISSUE120_V1' \
+        "$SOURCE"; then
+        fail 'SOURCE_SHAPE_DIAGNOSTIC_STILL_PRESENT'
+    fi
+
+    if grep -Fq 'result = result.replace(candidate, "");' "$SOURCE"; then
+        fail 'UNSAFE_BLANKET_REPLACE_PRESENT'
+    fi
+fi
+
+TMP="$(mktemp -d /tmp/morphe-issue120-v3-contract-XXXXXX)"
+trap 'rm -rf "$TMP"' EXIT
+
+HARNESS="$TMP/Issue120LinkSafetyContract.java"
+CLASSES="$TMP/classes"
+mkdir -p "$CLASSES"
+
+cat > "$HARNESS" <<'JAVA'
+package app.morphe.extension.boostforreddit.giphy;
+
+import java.lang.reflect.Method;
+
+public final class Issue120LinkSafetyContract {
+    private static String invoke(String html, String source) throws Exception {
+        Method method = InlineGiphyCommentPreview.class.getDeclaredMethod(
+                "removePreviewSourceUrlFromHtml",
+                String.class,
+                String.class
+        );
+        method.setAccessible(true);
+        return (String) method.invoke(null, html, source);
+    }
+
+    private static void pass(String name) {
+        System.out.println("PASS=" + name);
+    }
+
+    private static void fail(String name, String detail) {
+        throw new AssertionError(name + ": " + detail);
+    }
+
+    private static void assertContains(
+            String name,
+            String expected,
+            String actual
+    ) {
+        if (actual == null || !actual.contains(expected)) {
+            fail(name, "missing=" + expected + " actual=" + actual);
+        }
+        pass(name);
+    }
+
+    private static void assertNotContains(
+            String name,
+            String forbidden,
+            String actual
+    ) {
+        if (actual != null && actual.contains(forbidden)) {
+            fail(name, "forbidden=" + forbidden + " actual=" + actual);
+        }
+        pass(name);
+    }
+
+    private static void assertEquals(
+            String name,
+            String expected,
+            String actual
+    ) {
+        if (expected == null ? actual != null : !expected.equals(actual)) {
+            fail(name, "expected=" + expected + " actual=" + actual);
+        }
+        pass(name);
+    }
+
+    public static void main(String[] args) throws Exception {
+        String source = "https://i.imgur.com/dSsphbN.jpeg";
+        String stripped = "i.imgur.com/dSsphbN.jpeg";
+        String label =
+                "Stuff like this happening every episode is why 100 Kanojo "
+                        + "is banned from r/animenocontext.";
+
+        String encodedIssue =
+                "&lt;div class=\"md\"&gt;&lt;p&gt;"
+                        + "&lt;a href=\"" + source + "\"&gt;"
+                        + label
+                        + "&lt;/a&gt;&lt;/p&gt;\\n&lt;/div&gt;";
+        assertEquals(
+                "ISSUE120_EXACT_ENCODED_DESCRIPTIVE_LINK_PRESERVED",
+                encodedIssue,
+                invoke(encodedIssue, source)
+        );
+
+        String rawDescriptive =
+                "<p><a href=\"" + source + "\">" + label + "</a></p>";
+        assertEquals(
+                "ISSUE120_RAW_DESCRIPTIVE_LINK_PRESERVED",
+                rawDescriptive,
+                invoke(rawDescriptive, source)
+        );
+
+        String rawSourceLabel =
+                "<p><a href=\"" + source + "\">" + stripped + "</a></p>";
+        assertEquals(
+                "ISSUE120_RAW_SOURCE_LABEL_REMOVED",
+                "&#8203;",
+                invoke(rawSourceLabel, source)
+        );
+
+        String emptyHrefSourceLabel =
+                "<p><a href=\"\">" + stripped + "</a></p>";
+        assertEquals(
+                "ISSUE120_EMPTY_HREF_SOURCE_LABEL_REMOVED",
+                "&#8203;",
+                invoke(emptyHrefSourceLabel, source)
+        );
+
+        String missingHrefSourceLabel =
+                "<p><a>" + source + "</a></p>";
+        assertEquals(
+                "ISSUE120_MISSING_HREF_SOURCE_LABEL_REMOVED",
+                "&#8203;",
+                invoke(missingHrefSourceLabel, source)
+        );
+
+        String encodedSourceLabel =
+                "&lt;p&gt;&lt;a href=\"" + source + "\"&gt;"
+                        + stripped
+                        + "&lt;/a&gt;&lt;/p&gt;";
+        String encodedSourceLabelResult = invoke(encodedSourceLabel, source);
+        assertNotContains(
+                "ISSUE120_ENCODED_SOURCE_LABEL_TEXT_REMOVED",
+                stripped,
+                encodedSourceLabelResult
+        );
+        assertNotContains(
+                "ISSUE120_ENCODED_SOURCE_LABEL_ANCHOR_REMOVED",
+                "&lt;a",
+                encodedSourceLabelResult
+        );
+        assertNotContains(
+                "ISSUE120_ENCODED_SOURCE_LABEL_NO_EMPTY_HREF",
+                "href=\"\"",
+                encodedSourceLabelResult
+        );
+
+        String unrelated =
+                "<p><a href=\"https://example.com\">keep</a></p>";
+        assertEquals(
+                "UNRELATED_RAW_LINK_PRESERVED",
+                unrelated,
+                invoke(unrelated, source)
+        );
+
+        String unrelatedEncoded =
+                "&lt;p&gt;&lt;a href=\"https://example.com\"&gt;"
+                        + "keep&lt;/a&gt;&lt;/p&gt;";
+        assertEquals(
+                "UNRELATED_ENCODED_LINK_PRESERVED",
+                unrelatedEncoded,
+                invoke(unrelatedEncoded, source)
+        );
+
+        String bare =
+                "<p>before " + source + " after</p>";
+        String bareResult = invoke(bare, source);
+        assertNotContains(
+                "BARE_SOURCE_TEXT_REMOVED",
+                source,
+                bareResult
+        );
+        assertContains(
+                "BARE_NON_SOURCE_TEXT_PRESERVED",
+                "before",
+                bareResult
+        );
+
+        String rawAttributeOnly =
+                "<span data-source=\"" + source + "\">keep</span>";
+        assertEquals(
+                "RAW_NON_HREF_TAG_ATTRIBUTE_NOT_MUTATED",
+                rawAttributeOnly,
+                invoke(rawAttributeOnly, source)
+        );
+
+        String encodedAttributeOnly =
+                "&lt;span data-source=\"" + source + "\"&gt;"
+                        + "keep&lt;/span&gt;";
+        assertEquals(
+                "ENCODED_NON_HREF_TAG_ATTRIBUTE_NOT_MUTATED",
+                encodedAttributeOnly,
+                invoke(encodedAttributeOnly, source)
+        );
+
+        System.out.println(
+                "RESULT=BOOST_INLINE_PREVIEW_LINK_SAFETY_ISSUE120_V3_PASS"
+        );
+    }
+}
+JAVA
+
+if [ "$FAIL" -eq 0 ]; then
+    javac \
+        -cp "$ANDROID_JAR" \
+        -d "$CLASSES" \
+        "$SOURCE" \
+        "$HARNESS" ||
+        fail 'CONTRACT_COMPILE_FAILED'
+fi
+
+if [ "$FAIL" -eq 0 ]; then
+    java \
+        -cp "$CLASSES:$ANDROID_JAR" \
+        app.morphe.extension.boostforreddit.giphy.Issue120LinkSafetyContract ||
+        fail 'CONTRACT_RUNTIME_FAILED'
+fi
+
+if [ "$FAIL" -eq 0 ]; then
+    printf 'RESULT=BOOST_INLINE_PREVIEW_LINK_SAFETY_ISSUE120_V3_PASS\n'
+else
+    printf 'RESULT=BOOST_INLINE_PREVIEW_LINK_SAFETY_ISSUE120_V3_FAIL\n'
+fi
+
+exit "$FAIL"


### PR DESCRIPTION
## Summary

- preserve descriptive Imgur anchors in raw and entity-escaped comment HTML
- remove only source-equivalent anchors or bare source URL text
- prevent source-text cleanup from producing an empty `href`
- add a host-side regression contract for raw/encoded markup and attribute safety

## Root cause

The inline-preview source cleanup treated entity-escaped markup as ordinary text. For comments shaped like:

```html
&lt;a href="https://i.imgur.com/dSsphbN.jpeg"&gt;descriptive text&lt;/a&gt;
```

it removed the URL from inside the attribute and left `href=""`. Normal tap then produced an empty `ACTION_VIEW`, while long-press could reach Boost's menu adapter with invalid link state.

## Fix

The source policy now distinguishes markup from visible text:

- descriptive anchors are preserved byte-for-byte
- URL-label anchors are removed as complete elements
- bare source URLs are removed only outside raw or entity-escaped tags
- unrelated links and non-`href` attributes are preserved

Inline GIF/Giphy/static-image detection, preview loading, tap-action settings, and image/video routing are unchanged.

## Validation

- semantic blast-radius audit: PASS
- Issue #120 V3 regression contract: PASS
- `git diff --check`: PASS
- final `:patches:buildAndroid`: PASS
- deterministic MPP SHA-256: `776bb8bb9be085bdd804312287292210587d11f8edbaff03c6984d0b426dbcf2`
- saved DEV runtime evidence:
  - descriptive link opens `MediaImageActivity`
  - inline preview opens `MediaImageActivity`
  - empty `ACTION_VIEW`: 0
  - `Error opening link`: 0
  - `String resource ID #0x0`: 0
  - `MenuAdapter` crash: 0
  - fatal exceptions: 0

Fixes #120
