### PR TITLE
fix(boost): preserve descriptive Imgur comment links

### DIFF
--- a/extensions/boostforreddit/src/main/java/app/morphe/extension/boostforreddit/giphy/InlineGiphyCommentPreview.java
+++ b/extensions/boostforreddit/src/main/java/app/morphe/extension/boostforreddit/giphy/InlineGiphyCommentPreview.java
@@ -499,32 +499,233 @@ public final class InlineGiphyCommentPreview {
         }
     }
 
-    private static String removePreviewSourceUrlFromHtml(String html, String sourceUrl) {
-        if (html == null || sourceUrl == null || sourceUrl.length() == 0) return html;
+    private static final String ISSUE120_LINK_SAFETY_MARKER =
+            "MORPHE_BOOST_ISSUE120_LINK_SAFETY_V1";
+
+    private static String removePreviewSourceUrlFromHtml(
+            String html,
+            String sourceUrl
+    ) {
+        if (html == null || sourceUrl == null || sourceUrl.length() == 0) {
+            return html;
+        }
 
         String result = html;
-        String[] variants = sourceUrlVariants(sourceUrl);
 
-        for (String href : variants) {
-            if (href == null || href.length() == 0) continue;
-            for (String label : variants) {
-                if (label == null || label.length() == 0) continue;
-                result = removeExactAnchor(result, href, label);
-            }
-        }
+        String beforeAnchorCleanup = result;
+        result = removeSourceEquivalentAnchors(result, sourceUrl, false);
+        result = removeSourceEquivalentAnchors(result, sourceUrl, true);
+        boolean sourceEquivalentAnchorRemoved =
+                !stringEquals(beforeAnchorCleanup, result);
 
-        for (String candidate : variants) {
+        String beforeBareTextCleanup = result;
+        String[] fullVariants = sourceUrlVariants(sourceUrl);
+        String[] strippedVariants = sourceUrlVariants(
+                stripHttpSchemeForIssue120(sourceUrl)
+        );
+
+        for (String candidate : fullVariants) {
             if (candidate == null || candidate.length() == 0) continue;
-            result = result.replace(candidate, "");
+            result = removeTextOutsideHtmlMarkup(result, candidate);
         }
+
+        for (String candidate : strippedVariants) {
+            if (candidate == null || candidate.length() == 0) continue;
+            result = removeTextOutsideHtmlMarkup(result, candidate);
+        }
+
+        boolean bareSourceTextRemoved =
+                !stringEquals(beforeBareTextCleanup, result);
+
+        Log.d(
+                LOG_TAG,
+                ISSUE120_LINK_SAFETY_MARKER
+                        + ": sourceEquivalentAnchorRemoved="
+                        + sourceEquivalentAnchorRemoved
+                        + " bareSourceTextRemoved="
+                        + bareSourceTextRemoved
+        );
 
         result = cleanupHtmlAfterSourceRemoval(result);
         if (isBlankHtml(result)) {
-            // TableTextView.setTextHtml("") returns without clearing old content. Use zero-width space.
             return "&#8203;";
         }
 
         return result;
+    }
+
+
+    private static String removeSourceEquivalentAnchors(
+            String html,
+            String sourceUrl,
+            boolean encoded
+    ) {
+        if (html == null || sourceUrl == null || sourceUrl.length() == 0) {
+            return html;
+        }
+
+        try {
+            String patternText = encoded
+                    ? "(?is)&lt;a\\b(?:(?!&gt;).)*?&gt;(.*?)&lt;/a\\s*&gt;"
+                    : "(?is)<a\\b[^>]*>(.*?)</a\\s*>";
+
+            Matcher matcher = Pattern.compile(patternText).matcher(html);
+            StringBuffer output = new StringBuffer();
+            boolean changed = false;
+
+            while (matcher.find()) {
+                String replacement;
+                if (isSourceEquivalentLabel(matcher.group(1), sourceUrl)) {
+                    replacement = " ";
+                    changed = true;
+                } else {
+                    replacement = matcher.group(0);
+                }
+
+                matcher.appendReplacement(
+                        output,
+                        Matcher.quoteReplacement(replacement)
+                );
+            }
+
+            if (!changed) {
+                return html;
+            }
+
+            matcher.appendTail(output);
+            return output.toString();
+        } catch (Throwable ignored) {
+            return html;
+        }
+    }
+
+    private static boolean isSourceEquivalentLabel(
+            String htmlFragment,
+            String sourceUrl
+    ) {
+        String normalizedLabel = normalizeIssue120AnchorLabel(htmlFragment);
+        if (normalizedLabel == null || normalizedLabel.length() == 0) {
+            return false;
+        }
+
+        String[] fullVariants = sourceUrlVariants(sourceUrl);
+        for (String candidate : fullVariants) {
+            if (candidate != null && normalizedLabel.equals(candidate)) {
+                return true;
+            }
+        }
+
+        String[] strippedVariants = sourceUrlVariants(
+                stripHttpSchemeForIssue120(sourceUrl)
+        );
+        for (String candidate : strippedVariants) {
+            if (candidate != null && normalizedLabel.equals(candidate)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static String normalizeIssue120AnchorLabel(String value) {
+        if (value == null) return null;
+
+        return value
+                .replaceAll("(?is)<[^>]+>", "")
+                .replaceAll("(?is)&lt;(?:(?!&gt;).)*?&gt;", "")
+                .replaceAll("(?i)&amp;", "&")
+                .replaceAll("(?i)&quot;", "\"")
+                .replaceAll("(?i)&#34;", "\"")
+                .replaceAll("(?i)&#x22;", "\"")
+                .replaceAll("(?i)&#39;", "'")
+                .replaceAll("(?i)&#x27;", "'")
+                .replaceAll("(?i)&nbsp;", " ")
+                .trim();
+    }
+
+    private static String stripHttpSchemeForIssue120(String value) {
+        if (value == null) return null;
+
+        if (value.regionMatches(true, 0, "https://", 0, 8)) {
+            return value.substring(8);
+        }
+
+        if (value.regionMatches(true, 0, "http://", 0, 7)) {
+            return value.substring(7);
+        }
+
+        return value;
+    }
+
+    private static String removeTextOutsideHtmlMarkup(
+            String html,
+            String sourceText
+    ) {
+        if (
+                html == null
+                        || sourceText == null
+                        || sourceText.length() == 0
+        ) {
+            return html;
+        }
+
+        String lowerHtml = html.toLowerCase(java.util.Locale.US);
+        StringBuilder output = new StringBuilder(html.length());
+        int index = 0;
+
+        while (index < html.length()) {
+            int rawTagStart = html.indexOf('<', index);
+            int encodedTagStart = lowerHtml.indexOf("&lt;", index);
+
+            int tagStart;
+            boolean encoded;
+            if (rawTagStart < 0) {
+                tagStart = encodedTagStart;
+                encoded = true;
+            } else if (encodedTagStart < 0) {
+                tagStart = rawTagStart;
+                encoded = false;
+            } else if (rawTagStart <= encodedTagStart) {
+                tagStart = rawTagStart;
+                encoded = false;
+            } else {
+                tagStart = encodedTagStart;
+                encoded = true;
+            }
+
+            if (tagStart < 0) {
+                output.append(
+                        html.substring(index).replace(sourceText, "")
+                );
+                break;
+            }
+
+            if (tagStart > index) {
+                output.append(
+                        html.substring(index, tagStart).replace(sourceText, "")
+                );
+            }
+
+            final int tagEnd;
+            final int tagEndLength;
+            if (encoded) {
+                tagEnd = lowerHtml.indexOf("&gt;", tagStart + 4);
+                tagEndLength = 4;
+            } else {
+                tagEnd = html.indexOf('>', tagStart + 1);
+                tagEndLength = 1;
+            }
+
+            if (tagEnd < 0) {
+                output.append(html.substring(tagStart));
+                break;
+            }
+
+            output.append(html, tagStart, tagEnd + tagEndLength);
+            index = tagEnd + tagEndLength;
+        }
+
+        return output.toString();
     }
 
     private static String removeExactAnchor(String html, String href, String label) {

--- a/tools/check-boost-issue120-link-safety.sh
+++ b/tools/check-boost-issue120-link-safety.sh
@@ -1,0 +1,256 @@
+#!/usr/bin/env bash
+
+SOURCE="extensions/boostforreddit/src/main/java/app/morphe/extension/boostforreddit/giphy/InlineGiphyCommentPreview.java"
+MARKER="MORPHE_BOOST_ISSUE120_LINK_SAFETY_V1"
+FAIL=0
+
+fail() {
+    printf 'FAIL=%s\n' "$1"
+    FAIL=1
+}
+
+printf 'CONTRACT=BOOST_ISSUE120_LINK_SAFETY_V1\n'
+
+ANDROID_JAR="$(
+    find "${ANDROID_HOME:-$HOME/Android/Sdk}/platforms" \
+        -mindepth 2 \
+        -maxdepth 2 \
+        -type f \
+        -name android.jar \
+        -printf '%h %p\n' 2>/dev/null |
+    sort -V |
+    tail -n 1 |
+    awk '{print $2}'
+)"
+
+test -f "$ANDROID_JAR" ||
+    fail 'ANDROID_JAR_NOT_FOUND'
+
+test -f "$SOURCE" ||
+    fail 'SOURCE_NOT_FOUND'
+
+grep -Fq "$MARKER" "$SOURCE" ||
+    fail 'CLEAN_FIX_MARKER_MISSING'
+
+if grep -Fq 'result = result.replace(candidate, "");' "$SOURCE"; then
+    fail 'UNSAFE_BLANKET_REPLACE_PRESENT'
+fi
+
+for forbidden in \
+    MORPHE_BOOST_ISSUE120_URLSPAN_DIAG_V1 \
+    Issue120DiagnosticUrlSpan \
+    URLSPAN_SNAPSHOT \
+    COMMENT_LINK_CLICK \
+    PREVIEW_CLICK
+do
+    if grep -Fq "$forbidden" "$SOURCE"; then
+        fail "DIAGNOSTIC_TOKEN_PRESENT_${forbidden}"
+    fi
+done
+
+TMP="$(mktemp -d /tmp/morphe-issue120-clean-contract-XXXXXX)"
+trap 'rm -rf "$TMP"' EXIT
+
+HARNESS="$TMP/Issue120LinkSafetyContract.java"
+LOG_STUB="$TMP/android/util/Log.java"
+CLASSES="$TMP/classes"
+mkdir -p "$CLASSES" "$(dirname "$LOG_STUB")"
+
+cat > "$LOG_STUB" <<'JAVA'
+package android.util;
+
+public final class Log {
+    private Log() {
+    }
+
+    public static int d(String tag, String message) {
+        return 0;
+    }
+
+    public static int d(String tag, String message, Throwable throwable) {
+        return 0;
+    }
+
+    public static int i(String tag, String message) {
+        return 0;
+    }
+
+    public static int i(String tag, String message, Throwable throwable) {
+        return 0;
+    }
+
+    public static int w(String tag, String message) {
+        return 0;
+    }
+
+    public static int w(String tag, String message, Throwable throwable) {
+        return 0;
+    }
+
+    public static int e(String tag, String message) {
+        return 0;
+    }
+
+    public static int e(String tag, String message, Throwable throwable) {
+        return 0;
+    }
+}
+JAVA
+
+cat > "$HARNESS" <<'JAVA'
+package app.morphe.extension.boostforreddit.giphy;
+
+import java.lang.reflect.Method;
+
+public final class Issue120LinkSafetyContract {
+    private static String invoke(String html, String source) throws Exception {
+        Method method = InlineGiphyCommentPreview.class.getDeclaredMethod(
+                "removePreviewSourceUrlFromHtml",
+                String.class,
+                String.class
+        );
+        method.setAccessible(true);
+        return (String) method.invoke(null, html, source);
+    }
+
+    private static void assertEquals(
+            String name,
+            String expected,
+            String actual
+    ) {
+        if (expected == null ? actual != null : !expected.equals(actual)) {
+            throw new AssertionError(
+                    name + " expected=" + expected + " actual=" + actual
+            );
+        }
+        System.out.println("PASS=" + name);
+    }
+
+    private static void assertNotContains(
+            String name,
+            String forbidden,
+            String actual
+    ) {
+        if (actual != null && actual.contains(forbidden)) {
+            throw new AssertionError(
+                    name + " forbidden=" + forbidden + " actual=" + actual
+            );
+        }
+        System.out.println("PASS=" + name);
+    }
+
+    public static void main(String[] args) throws Exception {
+        String source = "https://i.imgur.com/dSsphbN.jpeg";
+        String stripped = "i.imgur.com/dSsphbN.jpeg";
+        String label =
+                "Stuff like this happening every episode is why 100 Kanojo "
+                        + "is banned from r/animenocontext.";
+
+        String exactIssue =
+                "&lt;div class=\"md\"&gt;&lt;p&gt;"
+                        + "&lt;a href=\"" + source + "\"&gt;"
+                        + label
+                        + "&lt;/a&gt;&lt;/p&gt;\\n&lt;/div&gt;";
+
+        assertEquals(
+                "EXACT_ISSUE120_DESCRIPTIVE_ANCHOR_PRESERVED",
+                exactIssue,
+                invoke(exactIssue, source)
+        );
+
+        String rawDescriptive =
+                "<p><a href=\"" + source + "\">" + label + "</a></p>";
+        assertEquals(
+                "RAW_DESCRIPTIVE_ANCHOR_PRESERVED",
+                rawDescriptive,
+                invoke(rawDescriptive, source)
+        );
+
+        String encodedSourceLabel =
+                "&lt;p&gt;&lt;a href=\"" + source + "\"&gt;"
+                        + stripped
+                        + "&lt;/a&gt;&lt;/p&gt;";
+        String encodedSourceLabelResult =
+                invoke(encodedSourceLabel, source);
+        assertNotContains(
+                "ENCODED_SOURCE_LABEL_REMOVED",
+                stripped,
+                encodedSourceLabelResult
+        );
+        assertNotContains(
+                "ENCODED_SOURCE_LABEL_NO_EMPTY_HREF",
+                "href=\"\"",
+                encodedSourceLabelResult
+        );
+
+        String rawSourceLabel =
+                "<p><a href=\"" + source + "\">" + source + "</a></p>";
+        assertEquals(
+                "RAW_SOURCE_LABEL_REMOVED",
+                "&#8203;",
+                invoke(rawSourceLabel, source)
+        );
+
+        String bareSource =
+                "<p>before " + source + " after</p>";
+        assertNotContains(
+                "BARE_SOURCE_TEXT_REMOVED",
+                source,
+                invoke(bareSource, source)
+        );
+
+        String encodedAttribute =
+                "&lt;span data-source=\"" + source + "\"&gt;"
+                        + "keep&lt;/span&gt;";
+        assertEquals(
+                "ENCODED_NON_HREF_ATTRIBUTE_PRESERVED",
+                encodedAttribute,
+                invoke(encodedAttribute, source)
+        );
+
+        String unrelated =
+                "&lt;p&gt;&lt;a href=\"https://example.com\"&gt;"
+                        + "keep&lt;/a&gt;&lt;/p&gt;";
+        assertEquals(
+                "UNRELATED_ENCODED_LINK_PRESERVED",
+                unrelated,
+                invoke(unrelated, source)
+        );
+
+        System.out.println(
+                "RESULT=BOOST_ISSUE120_LINK_SAFETY_V1_PASS"
+        );
+    }
+}
+JAVA
+
+if [ "$FAIL" -eq 0 ]; then
+    javac \
+        -cp "$ANDROID_JAR" \
+        -d "$CLASSES" \
+        "$SOURCE" \
+        "$HARNESS" ||
+        fail 'CONTRACT_COMPILE_FAILED'
+fi
+
+if [ "$FAIL" -eq 0 ]; then
+    javac \
+        -d "$CLASSES" \
+        "$LOG_STUB" ||
+        fail 'HOST_ANDROID_LOG_STUB_COMPILE_FAILED'
+fi
+
+if [ "$FAIL" -eq 0 ]; then
+    java \
+        -cp "$CLASSES:$ANDROID_JAR" \
+        app.morphe.extension.boostforreddit.giphy.Issue120LinkSafetyContract ||
+        fail 'CONTRACT_RUNTIME_FAILED'
+fi
+
+if [ "$FAIL" -eq 0 ]; then
+    printf 'RESULT=BOOST_ISSUE120_LINK_SAFETY_V1_PASS\n'
+else
+    printf 'RESULT=BOOST_ISSUE120_LINK_SAFETY_V1_FAIL\n'
+fi
+
+exit "$FAIL"


### PR DESCRIPTION
## Summary

Fixes Boost comment links that remained visibly clickable but failed with an empty destination when an inline Imgur preview was also rendered.

## Root cause

The inline-preview source cleanup removed the preview URL globally from the comment HTML. For entity-escaped descriptive anchors such as:

```html
&lt;a href="https://i.imgur.com/dSsphbN.jpeg"&gt;descriptive text&lt;/a&gt;
```

that produced `href=""`. Normal taps then attempted to open an empty URL, and the same invalid link state could affect long-press handling.

## Change

- Preserve raw and entity-escaped descriptive anchors and their attributes.
- Remove an anchor only when its visible label is equivalent to the preview source URL.
- Remove bare visible source URLs only outside HTML markup.
- Preserve unrelated links and non-`href` attributes.
- Add a host-side regression contract covering the reported markup and adjacent cases.

## Validation

- Host regression contract: PASS
- `./gradlew :patches:buildAndroid --no-daemon`: PASS
- Candidate static gate: PASS
- Bytecode safety gate: PASS
- Clean DEV APK built from Boost 1.12.12 and installed over USB: PASS
- Normal tap on the descriptive text opened `MediaImageActivity`: PASS
- First and second long-press retained the same process and comment activity: PASS
- No empty `ACTION_VIEW`, `Error opening link`, `Resources$NotFoundException`, `MenuView$MenuAdapter`, fatal exception, crash, or ANR evidence
- Diagnostic-only URLSpan instrumentation is absent from the submitted candidate

Addresses #120
