### PR TITLE
fix(ci): separate code-only MPP smoke from release SHA gate

### DIFF
--- a/.github/workflows/release-feed-smoke.yml
+++ b/.github/workflows/release-feed-smoke.yml
@@ -26,6 +26,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          fetch-depth: 0
 
       - name: Set up Java
         uses: actions/setup-java@03ad4de0992f5dab5e18fcb136590ce7c4a0ac95 # v5
@@ -48,4 +50,6 @@ jobs:
           rg --version
 
       - name: Run smoke
+        env:
+          RELEASE_FEED_BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.before }}
         run: ./tools/release-feed-smoke.sh

--- a/scripts/classify-release-feed-change.py
+++ b/scripts/classify-release-feed-change.py
@@ -1,0 +1,144 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import subprocess
+from pathlib import Path
+from typing import Iterable
+
+MODE_CODE_ONLY = "CODE_ONLY"
+MODE_FULL_RELEASE = "FULL_RELEASE"
+
+RELEASE_METADATA_PATHS = (
+    "CHANGELOG.md",
+    "README.md",
+    "gradle.properties",
+    "patches-bundle.json",
+    "patches-list.json",
+)
+_RELEASE_METADATA_SET = frozenset(RELEASE_METADATA_PATHS)
+
+
+def normalize_changed_paths(paths: Iterable[str]) -> tuple[str, ...]:
+    return tuple(
+        sorted(
+            {
+                path.strip()
+                for path in paths
+                if path is not None and path.strip()
+            }
+        )
+    )
+
+
+def classify_changed_paths(
+    paths: Iterable[str],
+) -> tuple[str, tuple[str, ...], tuple[str, ...]]:
+    changed = normalize_changed_paths(paths)
+    metadata = tuple(
+        path for path in changed if path in _RELEASE_METADATA_SET
+    )
+    mode = MODE_FULL_RELEASE if metadata else MODE_CODE_ONLY
+    return mode, changed, metadata
+
+
+def require_commit(repo: Path, revision: str) -> str:
+    result = subprocess.run(
+        [
+            "git",
+            "-C",
+            str(repo),
+            "rev-parse",
+            "--verify",
+            f"{revision}^{{commit}}",
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+    )
+    if result.returncode != 0:
+        detail = result.stderr.strip() or result.stdout.strip()
+        raise RuntimeError(
+            f"could not resolve commit {revision!r}: {detail}"
+        )
+    return result.stdout.strip()
+
+
+def git_changed_paths(
+    repo: Path,
+    base: str,
+    head: str = "HEAD",
+) -> tuple[str, ...]:
+    require_commit(repo, base)
+    require_commit(repo, head)
+
+    result = subprocess.run(
+        [
+            "git",
+            "-C",
+            str(repo),
+            "diff",
+            "--name-only",
+            "--no-renames",
+            "--diff-filter=ACDMRTUXB",
+            base,
+            head,
+            "--",
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+    )
+    if result.returncode != 0:
+        detail = result.stderr.strip() or result.stdout.strip()
+        raise RuntimeError(
+            f"git diff failed for {base!r}..{head!r}: {detail}"
+        )
+    return normalize_changed_paths(result.stdout.splitlines())
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Classify whether release-feed CI must enforce the committed "
+            "release MPP SHA or may use the code-only SHA exception."
+        )
+    )
+    parser.add_argument("--base", required=True)
+    parser.add_argument("--head", default="HEAD")
+    parser.add_argument("--repo", default=".")
+    args = parser.parse_args()
+
+    repo = Path(args.repo).resolve()
+    changed = git_changed_paths(repo, args.base, args.head)
+    mode, changed, metadata = classify_changed_paths(changed)
+
+    print(f"RELEASE_FEED_BASE_SHA={require_commit(repo, args.base)}")
+    print(f"RELEASE_FEED_HEAD_SHA={require_commit(repo, args.head)}")
+    print(f"CHANGED_FILE_COUNT={len(changed)}")
+    print(
+        "CHANGED_FILES="
+        + (",".join(changed) if changed else "NONE")
+    )
+    print(
+        "RELEASE_METADATA_FILES="
+        + (",".join(metadata) if metadata else "NONE")
+    )
+    print(
+        "RELEASE_METADATA_CHANGED="
+        + ("YES" if metadata else "NO")
+    )
+    print(f"RELEASE_FEED_GATE_MODE={mode}")
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except RuntimeError as error:
+        print(f"FAIL={error}")
+        raise SystemExit(1)

--- a/scripts/release-gate.py
+++ b/scripts/release-gate.py
@@ -108,6 +108,14 @@ def main() -> int:
     parser.add_argument("--marker", action="append", default=[], help="Binary/text marker that must exist anywhere in the releasable MPP.")
     parser.add_argument("--stale", action="append", default=[], help="Old value that must not exist in release metadata files.")
     parser.add_argument("--skip-staged-check", action="store_true", help="Do not check for staged build artifacts.")
+    parser.add_argument(
+        "--skip-readme-sha",
+        action="store_true",
+        help=(
+            "Skip only the README-to-built-MPP SHA equality check. "
+            "This is reserved for code-only release-feed CI changes."
+        ),
+    )
     args = parser.parse_args()
 
     root = Path.cwd()
@@ -187,7 +195,14 @@ def main() -> int:
         actual_sha = sha256_file(mpp_path)
         readme_sha = read_readme_sha(readme)
 
-        req(readme_sha == actual_sha, f"README SHA does not match built MPP. README={readme_sha}, actual={actual_sha}")
+        if args.skip_readme_sha:
+            print("README_SHA_GATE=SKIPPED_CODE_ONLY_CHANGE")
+        else:
+            req(
+                readme_sha == actual_sha,
+                "README SHA does not match built MPP. "
+                f"README={readme_sha}, actual={actual_sha}",
+            )
 
         try:
             with zipfile.ZipFile(mpp_path) as z:

--- a/tests/tools/test_release_feed_change_classifier_source_contract.py
+++ b/tests/tools/test_release_feed_change_classifier_source_contract.py
@@ -1,0 +1,193 @@
+from __future__ import annotations
+
+import importlib.util
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def load_classifier():
+    path = ROOT / "scripts/classify-release-feed-change.py"
+    spec = importlib.util.spec_from_file_location(
+        "morphe_release_feed_change_classifier",
+        path,
+    )
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"could not load {path}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def run_git(repo: Path, *args: str) -> str:
+    result = subprocess.run(
+        ["git", "-C", str(repo), *args],
+        check=True,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+    )
+    return result.stdout.strip()
+
+
+class ReleaseFeedChangeClassifierSourceContract(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.classifier = load_classifier()
+
+    def test_canonical_release_metadata_scope_is_exact(self) -> None:
+        self.assertEqual(
+            self.classifier.RELEASE_METADATA_PATHS,
+            (
+                "CHANGELOG.md",
+                "README.md",
+                "gradle.properties",
+                "patches-bundle.json",
+                "patches-list.json",
+            ),
+        )
+
+    def test_code_only_paths_use_code_only_mode(self) -> None:
+        mode, changed, metadata = (
+            self.classifier.classify_changed_paths(
+                [
+                    "extensions/boostforreddit/src/main/java/Fix.java",
+                    "tools/check-example-contract.sh",
+                ]
+            )
+        )
+        self.assertEqual(mode, self.classifier.MODE_CODE_ONLY)
+        self.assertEqual(
+            changed,
+            (
+                "extensions/boostforreddit/src/main/java/Fix.java",
+                "tools/check-example-contract.sh",
+            ),
+        )
+        self.assertEqual(metadata, ())
+
+    def test_every_release_metadata_path_requires_full_gate(self) -> None:
+        for path in self.classifier.RELEASE_METADATA_PATHS:
+            with self.subTest(path=path):
+                mode, _changed, metadata = (
+                    self.classifier.classify_changed_paths([path])
+                )
+                self.assertEqual(
+                    mode,
+                    self.classifier.MODE_FULL_RELEASE,
+                )
+                self.assertEqual(metadata, (path,))
+
+    def test_adjacent_docs_do_not_trigger_release_sha_gate(self) -> None:
+        mode, _changed, metadata = (
+            self.classifier.classify_changed_paths(
+                ["docs/release-validation-policy.md"]
+            )
+        )
+        self.assertEqual(mode, self.classifier.MODE_CODE_ONLY)
+        self.assertEqual(metadata, ())
+
+    def test_real_git_diff_classifies_code_then_metadata(self) -> None:
+        with tempfile.TemporaryDirectory(
+            prefix="morphe-release-feed-classifier-"
+        ) as tmp:
+            repo = Path(tmp)
+            run_git(repo, "init")
+            run_git(repo, "config", "user.name", "Contract")
+            run_git(repo, "config", "user.email", "contract@example.invalid")
+
+            for path in self.classifier.RELEASE_METADATA_PATHS:
+                target = repo / path
+                target.parent.mkdir(parents=True, exist_ok=True)
+                target.write_text(f"{path}\n", encoding="utf-8")
+
+            code = repo / "src/Fix.java"
+            code.parent.mkdir(parents=True, exist_ok=True)
+            code.write_text("class Fix {}\n", encoding="utf-8")
+
+            run_git(repo, "add", ".")
+            run_git(repo, "commit", "-m", "base")
+            base = run_git(repo, "rev-parse", "HEAD")
+
+            code.write_text("class Fix { int value; }\n", encoding="utf-8")
+            run_git(repo, "add", "src/Fix.java")
+            run_git(repo, "commit", "-m", "code")
+
+            code_changed = self.classifier.git_changed_paths(
+                repo,
+                base,
+                "HEAD",
+            )
+            code_mode, _changed, metadata = (
+                self.classifier.classify_changed_paths(code_changed)
+            )
+            self.assertEqual(
+                code_mode,
+                self.classifier.MODE_CODE_ONLY,
+            )
+            self.assertEqual(metadata, ())
+
+            readme = repo / "README.md"
+            readme.write_text("new release sha\n", encoding="utf-8")
+            run_git(repo, "add", "README.md")
+            run_git(repo, "commit", "-m", "metadata")
+
+            metadata_changed = self.classifier.git_changed_paths(
+                repo,
+                base,
+                "HEAD",
+            )
+            metadata_mode, _changed, metadata = (
+                self.classifier.classify_changed_paths(metadata_changed)
+            )
+            self.assertEqual(
+                metadata_mode,
+                self.classifier.MODE_FULL_RELEASE,
+            )
+            self.assertEqual(metadata, ("README.md",))
+
+    def test_ci_and_release_gate_source_contract(self) -> None:
+        workflow = (
+            ROOT / ".github/workflows/release-feed-smoke.yml"
+        ).read_text(encoding="utf-8")
+        feed = (ROOT / "tools/release-feed-smoke.sh").read_text(
+            encoding="utf-8"
+        )
+        gate = (ROOT / "scripts/release-gate.py").read_text(
+            encoding="utf-8"
+        )
+        release_workflow = (
+            ROOT / ".github/workflows/release.yml"
+        ).read_text(encoding="utf-8")
+
+        self.assertEqual(workflow.count("fetch-depth: 0"), 1)
+        self.assertEqual(
+            workflow.count(
+                "RELEASE_FEED_BASE_SHA: "
+                "${{ github.event.pull_request.base.sha || github.event.before }}"
+            ),
+            1,
+        )
+        self.assertIn(
+            "scripts/classify-release-feed-change.py",
+            feed,
+        )
+        self.assertIn(
+            "RELEASE_GATE_ARGS+=(--skip-readme-sha)",
+            feed,
+        )
+        self.assertIn('"--skip-readme-sha"', gate)
+        self.assertIn(
+            "README_SHA_GATE=SKIPPED_CODE_ONLY_CHANGE",
+            gate,
+        )
+        self.assertNotIn("--skip-readme-sha", release_workflow)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/check-ci-tooling-contract.sh
+++ b/tools/check-ci-tooling-contract.sh
@@ -6,6 +6,8 @@ SMOKE_WORKFLOW="$ROOT/.github/workflows/release-feed-smoke.yml"
 RELEASE_WORKFLOW="$ROOT/.github/workflows/release.yml"
 PROJECT_RUNNER="$ROOT/tools/check-project-contracts.sh"
 FEED_RUNNER="$ROOT/tools/release-feed-smoke.sh"
+RELEASE_GATE="$ROOT/scripts/release-gate.py"
+CLASSIFIER="$ROOT/scripts/classify-release-feed-change.py"
 COMPOSER="$ROOT/scripts/compose-release-notes.py"
 VALIDATOR="$ROOT/scripts/validate-release-notes.py"
 
@@ -14,6 +16,8 @@ for path in \
   "$RELEASE_WORKFLOW" \
   "$PROJECT_RUNNER" \
   "$FEED_RUNNER" \
+  "$RELEASE_GATE" \
+  "$CLASSIFIER" \
   "$COMPOSER" \
   "$VALIDATOR"
 do
@@ -22,19 +26,35 @@ done
 
 rg -q -F "command -v rg" "$PROJECT_RUNNER"
 rg -q -F "./tools/check-project-contracts.sh" "$FEED_RUNNER"
-rg -q -F "python3 scripts/release-gate.py" "$FEED_RUNNER"
+rg -q -F "python3 scripts/classify-release-feed-change.py" "$FEED_RUNNER"
+rg -q -F "python3" "$FEED_RUNNER"
+rg -q -F "scripts/release-gate.py" "$FEED_RUNNER"
 rg -q -F -- '--version "$VERSION"' "$FEED_RUNNER"
 rg -q -F -- '--tag "$TAG"' "$FEED_RUNNER"
 rg -q -F -- '--mpp "$MPP"' "$FEED_RUNNER"
+rg -q -F -- '--skip-readme-sha' "$FEED_RUNNER"
+rg -q -F 'README_SHA_GATE=SKIPPED_CODE_ONLY_CHANGE' "$RELEASE_GATE"
 
-python3 - "$SMOKE_WORKFLOW" "$RELEASE_WORKFLOW" <<'PY_CHECK'
+python3 - \
+  "$SMOKE_WORKFLOW" \
+  "$RELEASE_WORKFLOW" \
+  "$FEED_RUNNER" \
+  "$RELEASE_GATE" \
+  "$CLASSIFIER" <<'PY_CHECK'
 import sys
 from pathlib import Path
 
 smoke_path = Path(sys.argv[1])
 release_path = Path(sys.argv[2])
+feed_path = Path(sys.argv[3])
+gate_path = Path(sys.argv[4])
+classifier_path = Path(sys.argv[5])
+
 smoke_text = smoke_path.read_text(encoding="utf-8")
 release_text = release_path.read_text(encoding="utf-8")
+feed_text = feed_path.read_text(encoding="utf-8")
+gate_text = gate_path.read_text(encoding="utf-8")
+classifier_text = classifier_path.read_text(encoding="utf-8")
 
 for path, text in ((smoke_path, smoke_text), (release_path, release_text)):
     required = (
@@ -53,6 +73,38 @@ for path, text in ((smoke_path, smoke_text), (release_path, release_text)):
     else:
         consumer_index = text.index("./tools/check-project-contracts.sh")
     assert install_index < consumer_index, f"ripgrep installed too late: {path}"
+
+assert smoke_text.count("fetch-depth: 0") == 1
+assert smoke_text.count(
+    "RELEASE_FEED_BASE_SHA: "
+    "${{ github.event.pull_request.base.sha || github.event.before }}"
+) == 1
+
+feed_required = (
+    "scripts/classify-release-feed-change.py",
+    'BASE_SHA="${RELEASE_FEED_BASE_SHA:-}"',
+    'RELEASE_FEED_GATE_MODE=$GATE_MODE',
+    'RELEASE_GATE_ARGS+=(--skip-readme-sha)',
+)
+for marker in feed_required:
+    assert feed_text.count(marker) == 1, marker
+
+assert gate_text.count('"--skip-readme-sha"') == 1
+assert gate_text.count(
+    "README_SHA_GATE=SKIPPED_CODE_ONLY_CHANGE"
+) == 1
+assert "if args.skip_readme_sha:" in gate_text
+
+for marker in (
+    "CHANGELOG.md",
+    "README.md",
+    "gradle.properties",
+    "patches-bundle.json",
+    "patches-list.json",
+):
+    assert classifier_text.count(f'"{marker}"') == 1, marker
+
+assert "--skip-readme-sha" not in release_text
 
 for input_name in ("app_area", "changes", "user_impact", "issue_number"):
     assert f"      {input_name}:" in release_text, (
@@ -101,6 +153,9 @@ PY_CHECK
 echo 'PROJECT_RUNNER_RIPGREP_PREFLIGHT=PASS'
 echo 'RELEASE_FEED_SMOKE_PROVISIONS_RIPGREP=PASS'
 echo 'RELEASE_FEED_MPP_SHA_GATE=PASS'
+echo 'RELEASE_FEED_CODE_ONLY_SHA_EXCEPTION=PASS'
+echo 'RELEASE_FEED_RELEASE_METADATA_FULL_GATE=PASS'
+echo 'RELEASE_FEED_BASE_COMPARISON=PASS'
 echo 'RELEASE_WORKFLOW_PROVISIONS_RIPGREP=PASS'
 echo 'RELEASE_WORKFLOW_STRUCTURED_NOTES=PASS'
 echo 'RELEASE_WORKFLOW_EXACT_TEMURIN17=PASS'

--- a/tools/release-feed-smoke.sh
+++ b/tools/release-feed-smoke.sh
@@ -26,9 +26,46 @@ test -f "$MPP"
 TAG="morphe-patches-${VERSION##*.}"
 echo "TAG=$TAG"
 
-python3 scripts/release-gate.py \
-  --version "$VERSION" \
-  --tag "$TAG" \
+GATE_MODE="FULL_RELEASE"
+GATE_REASON="BASE_SHA_UNAVAILABLE_FAIL_CLOSED"
+BASE_SHA="${RELEASE_FEED_BASE_SHA:-}"
+
+if test -n "$BASE_SHA"; then
+  if [[ "$BASE_SHA" =~ ^0+$ ]]; then
+    GATE_REASON="ZERO_BASE_SHA_FAIL_CLOSED"
+  else
+    [[ "$BASE_SHA" =~ ^[0-9a-f]{40}$ ]]
+
+    CLASSIFICATION="$(
+      python3 scripts/classify-release-feed-change.py \
+        --base "$BASE_SHA" \
+        --head HEAD
+    )"
+    printf '%s\n' "$CLASSIFICATION"
+
+    GATE_MODE="$(
+      printf '%s\n' "$CLASSIFICATION" |
+        awk -F= '$1 == "RELEASE_FEED_GATE_MODE" { print $2 }'
+    )"
+    test "$GATE_MODE" = "CODE_ONLY" || test "$GATE_MODE" = "FULL_RELEASE"
+    GATE_REASON="CLASSIFIED_FROM_BASE_SHA"
+  fi
+fi
+
+echo "RELEASE_FEED_GATE_MODE=$GATE_MODE"
+echo "RELEASE_FEED_GATE_REASON=$GATE_REASON"
+
+RELEASE_GATE_ARGS=(
+  scripts/release-gate.py
+  --version "$VERSION"
+  --tag "$TAG"
   --mpp "$MPP"
+)
+
+if test "$GATE_MODE" = "CODE_ONLY"; then
+  RELEASE_GATE_ARGS+=(--skip-readme-sha)
+fi
+
+python3 "${RELEASE_GATE_ARGS[@]}"
 
 tools/check-mpp-release-asset.sh "$MPP"


### PR DESCRIPTION
## Summary

Make the release-feed smoke workflow distinguish ordinary code/tooling pull requests from release-metadata preparation.

Code-only changes still run project contracts, feed generation, the full MPP build, release metadata validation, and MPP structure checks. They skip only the README-to-built-MPP SHA equality check, because changing patch or tooling code necessarily changes the candidate MPP bytes while README still describes the currently published release.

## Root cause

`tools/release-feed-smoke.sh` ran `scripts/release-gate.py` unconditionally with the full published-release SHA requirement. Any code-only pull request that changed MPP output therefore failed against the SHA committed for the existing release, even when the build and all other gates passed.

## Change

- Classify the exact base-to-head diff as `CODE_ONLY` or `FULL_RELEASE`.
- Treat changes to `CHANGELOG.md`, `README.md`, `gradle.properties`, `patches-bundle.json`, or `patches-list.json` as release metadata requiring the full SHA gate.
- Add a narrowly scoped `--skip-readme-sha` option used only by code-only release-feed CI.
- Fetch enough Git history for exact base comparison.
- Fail closed to the full release gate when the base SHA is absent or invalid.
- Add source contracts covering all five release metadata paths and a real Git-diff classification flow.

## Validation

- Exact six-file committed candidate classification: `CODE_ONLY`
- Release metadata changed: `NO`
- Classifier source contract: PASS
- CI tooling contract: PASS
- Full `tools/release-feed-smoke.sh` against the committed candidate: PASS
- `:patches:buildAndroid`: PASS
- `RELEASE GATE OK`: PASS
- `MPP_RELEASE_ASSET_STRUCTURE_OK`: PASS
- Complete six-file patch apply-check against exact base: PASS
- Validated Git tree: `3ee6fffe685790844fdcd133ad126923cb9537b5`

## Scope and mutation boundary

This is CI/tooling-only. It does not change release metadata, publish a release, alter Issue #120, modify PR #147, rerun CI, or merge either pull request.

Unblocks the valid code-only release-feed check path required before PR #147 can proceed.
