### PR TITLE
chore(release): prepare Morphe patch bundle 1.4.99

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 
 <!-- MORPHE_MANAGER_CHANGELOG_START -->
+## [1.4.99](https://github.com/brealorg/breal-morphe-patches/compare/morphe-patches-98...morphe-patches-99) (2026-07-28)
+
+* **Boost for Reddit:** Bug Fixes Preserve descriptive Imgur comment links when inline previews are rendered. Prevent preview source cleanup from producing empty link destinations.
+
 ## [1.4.98](https://github.com/brealorg/breal-morphe-patches/compare/morphe-patches-97...morphe-patches-98) (2026-07-27)
 
 * **Boost for Reddit:** Bug Fixes Restore Boost's native Subscriptions long-press sort menu.

--- a/README.md
+++ b/README.md
@@ -72,14 +72,14 @@ The repository shorthand shown at the top is the preferred Manager setup. Raw
 
 | Field | Value |
 |---|---|
-| Version | `1.4.98` |
-| Release tag | `morphe-patches-98` |
-| Asset | `patches-1.4.98.mpp` |
-| SHA256 | `2b9a8bddc114f1d30f2122c37b6e01b28307525d9d813f83e6cfdaec33b88106` |
+| Version | `1.4.99` |
+| Release tag | `morphe-patches-99` |
+| Asset | `patches-1.4.99.mpp` |
+| SHA256 | `9a9468026aa4983a56fdf5adef859f9bf4774b657657e0fa48944a61d16c2222` |
 | Manager JSON | `https://raw.githubusercontent.com/brealorg/breal-morphe-patches/main/patches-bundle.json` |
-| Download URL | `https://github.com/brealorg/breal-morphe-patches/releases/download/morphe-patches-98/patches-1.4.98.mpp` |
+| Download URL | `https://github.com/brealorg/breal-morphe-patches/releases/download/morphe-patches-99/patches-1.4.99.mpp` |
 
-SHA256: `2b9a8bddc114f1d30f2122c37b6e01b28307525d9d813f83e6cfdaec33b88106`
+SHA256: `9a9468026aa4983a56fdf5adef859f9bf4774b657657e0fa48944a61d16c2222`
 ## What this bundle does
 
 The current bundle is focused on practical hotfixes for tested app versions, especially Boost for Reddit behavior on newer Android versions.
@@ -126,7 +126,7 @@ Included Imgur patches:
 ### Patches list
 
 <!-- PATCHES_START -->
-> **Patch source version:** `1.4.98` • `main` • 52 unique patches • 104 package entries
+> **Patch source version:** `1.4.99` • `main` • 52 unique patches • 104 package entries
 
 <details>
 <summary><strong>Boost for Reddit</strong> • 43 patches</summary>
@@ -539,16 +539,16 @@ Compatibility with other app versions is not guaranteed.
 
 ## Verification
 
-Release `1.4.98` is prepared and locally verified with:
+Release `1.4.99` is prepared and locally verified with:
 
-- Release tag `morphe-patches-98`.
+- Release tag `morphe-patches-99`.
 - Local built MPP SHA256 matching README.
-`2b9a8bddc114f1d30f2122c37b6e01b28307525d9d813f83e6cfdaec33b88106`
-- `patches-bundle.json` returning version `1.4.98`.
-- `patches-bundle.json` pointing to the `morphe-patches-98` asset.
+`9a9468026aa4983a56fdf5adef859f9bf4774b657657e0fa48944a61d16c2222`
+- `patches-bundle.json` returning version `1.4.99`.
+- `patches-bundle.json` pointing to the `morphe-patches-99` asset.
 - Expected release asset:
-`patches-1.4.98.mpp`
-- `2b9a8bddc114f1d30f2122c37b6e01b28307525d9d813f83e6cfdaec33b88106  patches-1.4.98.mpp`
+`patches-1.4.99.mpp`
+- `9a9468026aa4983a56fdf5adef859f9bf4774b657657e0fa48944a61d16c2222  patches-1.4.99.mpp`
 
 ## Development notes
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,4 +3,4 @@ org.gradle.jvmargs = -Xms512M -Xmx2048M
 org.gradle.parallel = true
 android.useAndroidX = true
 kotlin.code.style = official
-version = 1.4.98
+version = 1.4.99

--- a/patches-bundle.json
+++ b/patches-bundle.json
@@ -1,7 +1,7 @@
 {
-  "created_at": "2026-07-27T00:06:32",
-  "description": "Bug Fixes\nRestore Boost's native Subscriptions long-press sort menu.\n",
-  "download_url": "https://github.com/brealorg/breal-morphe-patches/releases/download/morphe-patches-98/patches-1.4.98.mpp",
-  "signature_download_url": "https://github.com/brealorg/breal-morphe-patches/releases/download/morphe-patches-98/patches-1.4.98.mpp.asc",
-  "version": "1.4.98"
+  "created_at": "2026-07-28T00:47:14",
+  "description": "Bug Fixes\nPreserve descriptive Imgur comment links when inline previews are rendered.\nPrevent preview source cleanup from producing empty link destinations.\n",
+  "download_url": "https://github.com/brealorg/breal-morphe-patches/releases/download/morphe-patches-99/patches-1.4.99.mpp",
+  "signature_download_url": "https://github.com/brealorg/breal-morphe-patches/releases/download/morphe-patches-99/patches-1.4.99.mpp.asc",
+  "version": "1.4.99"
 }

--- a/patches-list.json
+++ b/patches-list.json
@@ -1,6 +1,6 @@
 {
   "NOTE": "Do NOT manually edit this file. This file is automatically updated when semantic release (release.yml) runs. Manually editing this file can break your releases and break third party tools that use this file.",
-  "version": "1.4.98",
+  "version": "1.4.99",
   "patches": [
     {
       "name": "Add Boost Search bottom navigation",


### PR DESCRIPTION
## Summary

Prepare the protected-main metadata for Morphe patch bundle `1.4.99`.

## Release identity

- Version: `1.4.99`
- Tag: `morphe-patches-99`
- Asset: `patches-1.4.99.mpp`
- Candidate MPP SHA256: `9a9468026aa4983a56fdf5adef859f9bf4774b657657e0fa48944a61d16c2222`

## Included user-visible change

- Preserve descriptive Imgur comment links when inline previews are rendered.
- Prevent preview source cleanup from producing empty link destinations.

### User impact

Direct Imgur links in Boost comments open normally again, and long-press no longer reaches the invalid empty-link crash path.

## Validation

- Exact Eclipse Temurin `17.0.19+10`: PASS
- Release metadata preparation: PASS
- Project contracts: PASS
- Android MPP build: PASS
- Full release-feed smoke mode: `FULL_RELEASE`
- README-to-MPP SHA gate: enforced and PASS
- MPP release structure: PASS
- Changed-file scope: exactly five canonical release metadata files

## Publication boundary

This PR does not create `morphe-patches-99`, publish a GitHub Release, update `dev`, dispatch the protected-main release workflow, merge itself, or close Issue #120.

Addresses #120.
