### PR TITLE
chore(release): prepare Morphe patch bundle 1.4.100

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 
 <!-- MORPHE_MANAGER_CHANGELOG_START -->
+## [1.4.100](https://github.com/brealorg/breal-morphe-patches/compare/morphe-patches-99...morphe-patches-100) (2026-07-28)
+
+* **Boost for Reddit:** Preserve the current subreddit when opening Subscriptions from a subreddit. Honor Boost's Scroll to current subreddit preference through the native route.
+
 ## [1.4.99](https://github.com/brealorg/breal-morphe-patches/compare/morphe-patches-98...morphe-patches-99) (2026-07-28)
 
 * **Boost for Reddit:** Bug Fixes Preserve descriptive Imgur comment links when inline previews are rendered. Prevent preview source cleanup from producing empty link destinations.

--- a/README.md
+++ b/README.md
@@ -72,14 +72,14 @@ The repository shorthand shown at the top is the preferred Manager setup. Raw
 
 | Field | Value |
 |---|---|
-| Version | `1.4.99` |
-| Release tag | `morphe-patches-99` |
-| Asset | `patches-1.4.99.mpp` |
-| SHA256 | `9a9468026aa4983a56fdf5adef859f9bf4774b657657e0fa48944a61d16c2222` |
+| Version | `1.4.100` |
+| Release tag | `morphe-patches-100` |
+| Asset | `patches-1.4.100.mpp` |
+| SHA256 | `3726d773ad5e1ac9c7783b3775f54e45b19556c6d1527248fda5dd5f0b4d07bf` |
 | Manager JSON | `https://raw.githubusercontent.com/brealorg/breal-morphe-patches/main/patches-bundle.json` |
-| Download URL | `https://github.com/brealorg/breal-morphe-patches/releases/download/morphe-patches-99/patches-1.4.99.mpp` |
+| Download URL | `https://github.com/brealorg/breal-morphe-patches/releases/download/morphe-patches-100/patches-1.4.100.mpp` |
 
-SHA256: `9a9468026aa4983a56fdf5adef859f9bf4774b657657e0fa48944a61d16c2222`
+SHA256: `3726d773ad5e1ac9c7783b3775f54e45b19556c6d1527248fda5dd5f0b4d07bf`
 ## What this bundle does
 
 The current bundle is focused on practical hotfixes for tested app versions, especially Boost for Reddit behavior on newer Android versions.
@@ -126,7 +126,7 @@ Included Imgur patches:
 ### Patches list
 
 <!-- PATCHES_START -->
-> **Patch source version:** `1.4.99` • `main` • 52 unique patches • 104 package entries
+> **Patch source version:** `1.4.100` • `main` • 52 unique patches • 104 package entries
 
 <details>
 <summary><strong>Boost for Reddit</strong> • 43 patches</summary>
@@ -539,16 +539,16 @@ Compatibility with other app versions is not guaranteed.
 
 ## Verification
 
-Release `1.4.99` is prepared and locally verified with:
+Release `1.4.100` is prepared and locally verified with:
 
-- Release tag `morphe-patches-99`.
+- Release tag `morphe-patches-100`.
 - Local built MPP SHA256 matching README.
-`9a9468026aa4983a56fdf5adef859f9bf4774b657657e0fa48944a61d16c2222`
-- `patches-bundle.json` returning version `1.4.99`.
-- `patches-bundle.json` pointing to the `morphe-patches-99` asset.
+`3726d773ad5e1ac9c7783b3775f54e45b19556c6d1527248fda5dd5f0b4d07bf`
+- `patches-bundle.json` returning version `1.4.100`.
+- `patches-bundle.json` pointing to the `morphe-patches-100` asset.
 - Expected release asset:
-`patches-1.4.99.mpp`
-- `9a9468026aa4983a56fdf5adef859f9bf4774b657657e0fa48944a61d16c2222  patches-1.4.99.mpp`
+`patches-1.4.100.mpp`
+- `3726d773ad5e1ac9c7783b3775f54e45b19556c6d1527248fda5dd5f0b4d07bf  patches-1.4.100.mpp`
 
 ## Development notes
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,4 +3,4 @@ org.gradle.jvmargs = -Xms512M -Xmx2048M
 org.gradle.parallel = true
 android.useAndroidX = true
 kotlin.code.style = official
-version = 1.4.99
+version = 1.4.100

--- a/patches-bundle.json
+++ b/patches-bundle.json
@@ -1,7 +1,7 @@
 {
-  "created_at": "2026-07-28T00:47:14",
-  "description": "Bug Fixes\nPreserve descriptive Imgur comment links when inline previews are rendered.\nPrevent preview source cleanup from producing empty link destinations.\n",
-  "download_url": "https://github.com/brealorg/breal-morphe-patches/releases/download/morphe-patches-99/patches-1.4.99.mpp",
-  "signature_download_url": "https://github.com/brealorg/breal-morphe-patches/releases/download/morphe-patches-99/patches-1.4.99.mpp.asc",
-  "version": "1.4.99"
+  "created_at": "2026-07-28T17:45:17",
+  "description": "Preserve the current subreddit when opening Subscriptions from a subreddit.\nHonor Boost's Scroll to current subreddit preference through the native route.\n",
+  "download_url": "https://github.com/brealorg/breal-morphe-patches/releases/download/morphe-patches-100/patches-1.4.100.mpp",
+  "signature_download_url": "https://github.com/brealorg/breal-morphe-patches/releases/download/morphe-patches-100/patches-1.4.100.mpp.asc",
+  "version": "1.4.100"
 }

--- a/patches-list.json
+++ b/patches-list.json
@@ -1,6 +1,6 @@
 {
   "NOTE": "Do NOT manually edit this file. This file is automatically updated when semantic release (release.yml) runs. Manually editing this file can break your releases and break third party tools that use this file.",
-  "version": "1.4.99",
+  "version": "1.4.100",
   "patches": [
     {
       "name": "Add Boost Search bottom navigation",


### PR DESCRIPTION
## Summary

Prepare the protected-main metadata for Morphe patch bundle `1.4.100`.

## Release identity

- Version: `1.4.100`
- Tag: `morphe-patches-100`
- Asset: `patches-1.4.100.mpp`
- Candidate MPP SHA256: `3726d773ad5e1ac9c7783b3775f54e45b19556c6d1527248fda5dd5f0b4d07bf`

## Included user-visible change

- Preserve the current subreddit when opening Subscriptions from a subreddit.
- Honor Boost's **Scroll to current subreddit** preference through the native context-aware route.

### User impact

Opening Subscriptions from a subreddit now targets the active subreddit instead of starting at the top of the list, while Boost remains responsible for applying its own preference and scrolling policy.

## Validation

- Exact Eclipse Temurin `17.0.19+10`: PASS
- Release metadata preparation: PASS
- Project contracts: PASS
- Three independent Android MPP builds produced the same SHA256: PASS
- Full synthetic committed-state release-feed smoke mode: `FULL_RELEASE`
- README-to-MPP SHA gate: enforced and PASS
- MPP release structure: PASS
- Changed-file scope: exactly five canonical release metadata files
- Candidate MPP SHA256: `3726d773ad5e1ac9c7783b3775f54e45b19556c6d1527248fda5dd5f0b4d07bf`

## Publication boundary

This PR does not create `morphe-patches-100`, publish a GitHub Release, update `dev`, dispatch the protected-main release workflow, merge itself, enable auto-merge, or close Issue #141.

Addresses #141.
