### PR TITLE
fix(boost): include spoof client extension

### DIFF
--- a/patches/src/main/kotlin/app/morphe/patches/reddit/customclients/boostforreddit/api/SpoofClientPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/reddit/customclients/boostforreddit/api/SpoofClientPatch.kt
@@ -12,6 +12,7 @@ import app.morphe.patcher.extensions.InstructionExtensions.addInstructions
 import app.morphe.patcher.extensions.InstructionExtensions.getInstruction
 import app.morphe.patcher.extensions.InstructionExtensions.replaceInstruction
 import app.morphe.patches.reddit.customclients.boostforreddit.BoostCompatible
+import app.morphe.patches.reddit.customclients.boostforreddit.misc.extension.sharedExtensionPatch
 import app.morphe.patches.reddit.customclients.spoofClientPatch
 import app.morphe.util.getReference
 import app.morphe.util.indexOfFirstInstructionOrThrow
@@ -23,6 +24,7 @@ import com.android.tools.smali.dexlib2.iface.reference.TypeReference
 const val JRAW_NEW_URL_EXTENSION_CLASS_DESCRIPTOR = "Lapp/morphe/extension/boostforreddit/http/HttpUtils;"
 
 val spoofClientPatch = spoofClientPatch { clientIdOption, redirectUriOption, userAgentOption ->
+    dependsOn(sharedExtensionPatch)
     compatibleWith(*BoostCompatible)
 
     val clientId by clientIdOption

--- a/tests/tools/test_release_feed_change_classifier_source_contract.py
+++ b/tests/tools/test_release_feed_change_classifier_source_contract.py
@@ -181,6 +181,26 @@ class ReleaseFeedChangeClassifierSourceContract(unittest.TestCase):
             "RELEASE_GATE_ARGS+=(--skip-readme-sha)",
             feed,
         )
+        self.assertLess(
+            feed.index("scripts/classify-release-feed-change.py"),
+            feed.index("./tools/check-patches-list-feed.sh --write"),
+        )
+        self.assertIn(
+            'if test "$GATE_MODE" = "CODE_ONLY"; then',
+            feed,
+        )
+        self.assertIn(
+            "PATCHES_LIST_DRIFT=EXPECTED_CODE_ONLY_CHANGE",
+            feed,
+        )
+        self.assertIn(
+            'git diff --exit-code -- patches-list.json',
+            feed,
+        )
+        self.assertIn(
+            "PATCHES_LIST_DRIFT=NONE_FULL_RELEASE",
+            feed,
+        )
         self.assertIn('"--skip-readme-sha"', gate)
         self.assertIn(
             "README_SHA_GATE=SKIPPED_CODE_ONLY_CHANGE",

--- a/tools/check-boost-spoof-client-extension-contract.sh
+++ b/tools/check-boost-spoof-client-extension-contract.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT"
+
+PATCH='patches/src/main/kotlin/app/morphe/patches/reddit/customclients/boostforreddit/api/SpoofClientPatch.kt'
+SHARED='patches/src/main/kotlin/app/morphe/patches/reddit/customclients/boostforreddit/misc/extension/SharedExtensionPatch.kt'
+HTTP='extensions/boostforreddit/src/main/java/app/morphe/extension/boostforreddit/http/HttpUtils.java'
+
+test -f "$PATCH"
+test -f "$SHARED"
+test -f "$HTTP"
+
+test "$(rg -c -F \
+    'import app.morphe.patches.reddit.customclients.boostforreddit.misc.extension.sharedExtensionPatch' \
+    "$PATCH")" -eq 1
+
+test "$(rg -c -F \
+    'dependsOn(sharedExtensionPatch)' \
+    "$PATCH")" -eq 1
+
+test "$(rg -c -F \
+    'const val JRAW_NEW_URL_EXTENSION_CLASS_DESCRIPTOR = "Lapp/morphe/extension/boostforreddit/http/HttpUtils;"' \
+    "$PATCH")" -eq 1
+
+test "$(rg -c -F \
+    'invoke-static       { p0 }, $JRAW_NEW_URL_EXTENSION_CLASS_DESCRIPTOR->createUrl(Ljava/lang/String;)Ljava/net/URL;' \
+    "$PATCH")" -eq 1
+
+test "$(rg -c -F \
+    'val sharedExtensionPatch = sharedExtensionPatch("boostforreddit", initHook)' \
+    "$SHARED")" -eq 1
+
+test "$(rg -c -F \
+    'package app.morphe.extension.boostforreddit.http;' \
+    "$HTTP")" -eq 1
+
+test "$(rg -c -F \
+    'public class HttpUtils {' \
+    "$HTTP")" -eq 1
+
+test "$(rg -c -F \
+    'public static URL createUrl(String href) {' \
+    "$HTTP")" -eq 1
+
+PATCH_FILE="$PATCH" python3 <<'PY'
+from pathlib import Path
+import os
+
+text = Path(os.environ["PATCH_FILE"]).read_text(encoding="utf-8")
+
+dependency = text.index("    dependsOn(sharedExtensionPatch)\n")
+compatibility = text.index("    compatibleWith(*BoostCompatible)\n")
+execute = text.index("    execute {\n")
+descriptor = text.index(
+    'const val JRAW_NEW_URL_EXTENSION_CLASS_DESCRIPTOR = '
+    '"Lapp/morphe/extension/boostforreddit/http/HttpUtils;"'
+)
+call = text.index(
+    "invoke-static       { p0 }, "
+    "$JRAW_NEW_URL_EXTENSION_CLASS_DESCRIPTOR"
+    "->createUrl(Ljava/lang/String;)Ljava/net/URL;"
+)
+
+assert dependency < compatibility < execute
+assert descriptor < execute < call
+
+print("DEPENDENCY_PRECEDES_PATCH_EXECUTION=PASS")
+print("HTTPUTILS_DESCRIPTOR_AND_CALL_MATCH=PASS")
+PY
+
+echo 'BOOST_SPOOF_CLIENT_SHARED_EXTENSION_IMPORT=PASS'
+echo 'BOOST_SPOOF_CLIENT_SHARED_EXTENSION_DEPENDENCY=PASS'
+echo 'BOOST_HTTPUTILS_CREATEURL_SOURCE_CONTRACT=PASS'
+echo 'RESULT=MORPHE_BOOST_SPOOF_CLIENT_EXTENSION_CONTRACT_OK'

--- a/tools/release-feed-smoke.sh
+++ b/tools/release-feed-smoke.sh
@@ -10,22 +10,6 @@ PY
 
 echo "VERSION=$VERSION"
 
-./tools/check-project-contracts.sh
-
-./tools/check-patches-list-feed.sh --write "$VERSION"
-git diff --exit-code -- patches-list.json
-
-./gradlew :patches:buildAndroid --no-daemon
-
-MPP="$(tools/boost-resolve-mpp.sh --version "$VERSION")"
-echo "MPP=$MPP"
-
-test -n "$MPP"
-test -f "$MPP"
-
-TAG="morphe-patches-${VERSION##*.}"
-echo "TAG=$TAG"
-
 GATE_MODE="FULL_RELEASE"
 GATE_REASON="BASE_SHA_UNAVAILABLE_FAIL_CLOSED"
 BASE_SHA="${RELEASE_FEED_BASE_SHA:-}"
@@ -54,6 +38,33 @@ fi
 
 echo "RELEASE_FEED_GATE_MODE=$GATE_MODE"
 echo "RELEASE_FEED_GATE_REASON=$GATE_REASON"
+
+./tools/check-project-contracts.sh
+
+./tools/check-patches-list-feed.sh --write "$VERSION"
+
+if test "$GATE_MODE" = "CODE_ONLY"; then
+  if git diff --quiet -- patches-list.json; then
+    echo "PATCHES_LIST_DRIFT=NONE_CODE_ONLY_CHANGE"
+  else
+    echo "PATCHES_LIST_DRIFT=EXPECTED_CODE_ONLY_CHANGE"
+    git --no-pager diff -- patches-list.json
+  fi
+else
+  git diff --exit-code -- patches-list.json
+  echo "PATCHES_LIST_DRIFT=NONE_FULL_RELEASE"
+fi
+
+./gradlew :patches:buildAndroid --no-daemon
+
+MPP="$(tools/boost-resolve-mpp.sh --version "$VERSION")"
+echo "MPP=$MPP"
+
+test -n "$MPP"
+test -f "$MPP"
+
+TAG="morphe-patches-${VERSION##*.}"
+echo "TAG=$TAG"
 
 RELEASE_GATE_ARGS=(
   scripts/release-gate.py


### PR DESCRIPTION
## Summary

- Make Boost's **Spoof client** patch depend on the shared Boost runtime extension.
- Ensure the existing `JrawUtils.newUrl()` hook can resolve `HttpUtils.createUrl()`.
- Add an auto-discovered regression contract that locks the dependency, descriptor and extension method together.
- Allow code-only release-feed CI to observe generated `patches-list.json` drift without treating the uncommitted release catalog as a prepared release.

## Root cause

The Boost Spoof client bytecode patch inserted a call to:

```text
app.morphe.extension.boostforreddit.http.HttpUtils.createUrl()
```

but did not declare `dependsOn(sharedExtensionPatch)`. A minimal installation containing Spoof client therefore patched `JrawUtils` while omitting the class it invoked.

Android consequently raised `ClassNotFoundException` and `NoClassDefFoundError` from `LoginActivity.onCreate()` when **Add account** was selected.

The dependency change also exposed a CI boundary defect: code-only changes were allowed to produce a new MPP SHA, but generated patch-catalog drift was rejected before the subsequent release PR could commit all five canonical release metadata files.

## Changes

- Add the missing shared-extension dependency before Boost compatibility and patch execution.
- Classify the release-feed change before regenerating the patch catalog.
- For `CODE_ONLY`, print and accept generated catalog drift while retaining the README SHA exception.
- For `FULL_RELEASE`, continue requiring an exact clean `patches-list.json`.

## Validation

- Complete reporter logcat inspected: exactly one fatal Boost crash, caused by missing `HttpUtils`
- Minimal patch selection: Spoof client, Modify login WebView and target SDK compatibility
- Normal and final signed DEV APK extension/class/call-site proof: PASS
- Bytecode safety gate: PASS
- Exact Java 17 MPP runtime tested: `7fcc2ec093a66ea63f768b05bd54bc2a929eef566eebc37b69cf024bbe943dae`
- Add account launched DEV `LoginActivity`: PASS
- `NoClassDefFoundError` / `ClassNotFoundException` for `HttpUtils`: absent
- DEV fatal exception: absent
- Full project contracts: PASS
- Local code-only release-feed smoke with expected generated catalog drift: PASS
- Full-release catalog cleanliness remains fail-closed

## Publication boundary

This PR does not bump the patch-bundle version, commit release metadata, create or move a tag, publish a GitHub Release, update `dev`, bypass protected main, or close Issue #152.

Addresses #152.
