### PR TITLE
chore(release): prepare Morphe patch bundle 1.4.101

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 
 <!-- MORPHE_MANAGER_CHANGELOG_START -->
+## [1.4.101](https://github.com/brealorg/breal-morphe-patches/compare/morphe-patches-100...morphe-patches-101) (2026-07-29)
+
+* **Boost for Reddit:** Fix a crash when opening Add account in Boost for Reddit. Package the runtime extension required by the Spoof client URL hook.
+
 ## [1.4.100](https://github.com/brealorg/breal-morphe-patches/compare/morphe-patches-99...morphe-patches-100) (2026-07-28)
 
 * **Boost for Reddit:** Preserve the current subreddit when opening Subscriptions from a subreddit. Honor Boost's Scroll to current subreddit preference through the native route.

--- a/README.md
+++ b/README.md
@@ -72,14 +72,14 @@ The repository shorthand shown at the top is the preferred Manager setup. Raw
 
 | Field | Value |
 |---|---|
-| Version | `1.4.100` |
-| Release tag | `morphe-patches-100` |
-| Asset | `patches-1.4.100.mpp` |
-| SHA256 | `3726d773ad5e1ac9c7783b3775f54e45b19556c6d1527248fda5dd5f0b4d07bf` |
+| Version | `1.4.101` |
+| Release tag | `morphe-patches-101` |
+| Asset | `patches-1.4.101.mpp` |
+| SHA256 | `9a50d3dbce38962489beeb678bbc8ede2a2df5ae3bf0b772186af2af8bc089ff` |
 | Manager JSON | `https://raw.githubusercontent.com/brealorg/breal-morphe-patches/main/patches-bundle.json` |
-| Download URL | `https://github.com/brealorg/breal-morphe-patches/releases/download/morphe-patches-100/patches-1.4.100.mpp` |
+| Download URL | `https://github.com/brealorg/breal-morphe-patches/releases/download/morphe-patches-101/patches-1.4.101.mpp` |
 
-SHA256: `3726d773ad5e1ac9c7783b3775f54e45b19556c6d1527248fda5dd5f0b4d07bf`
+SHA256: `9a50d3dbce38962489beeb678bbc8ede2a2df5ae3bf0b772186af2af8bc089ff`
 ## What this bundle does
 
 The current bundle is focused on practical hotfixes for tested app versions, especially Boost for Reddit behavior on newer Android versions.
@@ -126,7 +126,7 @@ Included Imgur patches:
 ### Patches list
 
 <!-- PATCHES_START -->
-> **Patch source version:** `1.4.100` • `main` • 52 unique patches • 104 package entries
+> **Patch source version:** `1.4.101` • `main` • 52 unique patches • 104 package entries
 
 <details>
 <summary><strong>Boost for Reddit</strong> • 43 patches</summary>
@@ -539,16 +539,16 @@ Compatibility with other app versions is not guaranteed.
 
 ## Verification
 
-Release `1.4.100` is prepared and locally verified with:
+Release `1.4.101` is prepared and locally verified with:
 
-- Release tag `morphe-patches-100`.
+- Release tag `morphe-patches-101`.
 - Local built MPP SHA256 matching README.
-`3726d773ad5e1ac9c7783b3775f54e45b19556c6d1527248fda5dd5f0b4d07bf`
-- `patches-bundle.json` returning version `1.4.100`.
-- `patches-bundle.json` pointing to the `morphe-patches-100` asset.
+`9a50d3dbce38962489beeb678bbc8ede2a2df5ae3bf0b772186af2af8bc089ff`
+- `patches-bundle.json` returning version `1.4.101`.
+- `patches-bundle.json` pointing to the `morphe-patches-101` asset.
 - Expected release asset:
-`patches-1.4.100.mpp`
-- `3726d773ad5e1ac9c7783b3775f54e45b19556c6d1527248fda5dd5f0b4d07bf  patches-1.4.100.mpp`
+`patches-1.4.101.mpp`
+- `9a50d3dbce38962489beeb678bbc8ede2a2df5ae3bf0b772186af2af8bc089ff  patches-1.4.101.mpp`
 
 ## Development notes
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,4 +3,4 @@ org.gradle.jvmargs = -Xms512M -Xmx2048M
 org.gradle.parallel = true
 android.useAndroidX = true
 kotlin.code.style = official
-version = 1.4.100
+version = 1.4.101

--- a/patches-bundle.json
+++ b/patches-bundle.json
@@ -1,7 +1,7 @@
 {
-  "created_at": "2026-07-28T17:45:17",
-  "description": "Preserve the current subreddit when opening Subscriptions from a subreddit.\nHonor Boost's Scroll to current subreddit preference through the native route.\n",
-  "download_url": "https://github.com/brealorg/breal-morphe-patches/releases/download/morphe-patches-100/patches-1.4.100.mpp",
-  "signature_download_url": "https://github.com/brealorg/breal-morphe-patches/releases/download/morphe-patches-100/patches-1.4.100.mpp.asc",
-  "version": "1.4.100"
+  "created_at": "2026-07-29T00:00:27",
+  "description": "Fix a crash when opening Add account in Boost for Reddit.\nPackage the runtime extension required by the Spoof client URL hook.\n",
+  "download_url": "https://github.com/brealorg/breal-morphe-patches/releases/download/morphe-patches-101/patches-1.4.101.mpp",
+  "signature_download_url": "https://github.com/brealorg/breal-morphe-patches/releases/download/morphe-patches-101/patches-1.4.101.mpp.asc",
+  "version": "1.4.101"
 }

--- a/patches-list.json
+++ b/patches-list.json
@@ -1,6 +1,6 @@
 {
   "NOTE": "Do NOT manually edit this file. This file is automatically updated when semantic release (release.yml) runs. Manually editing this file can break your releases and break third party tools that use this file.",
-  "version": "1.4.100",
+  "version": "1.4.101",
   "patches": [
     {
       "name": "Add Boost Search bottom navigation",
@@ -1939,7 +1939,9 @@
       "name": "Spoof client",
       "description": "Restores functionality of the app by using custom client ID.",
       "default": true,
-      "dependencies": [],
+      "dependencies": [
+        "BytecodePatch"
+      ],
       "compatiblePackages": [
         {
           "packageName": "com.rubenmayayo.reddit",


### PR DESCRIPTION
Prepare protected-main release metadata for Issue #152. Exact Java 17 runtime and deterministic MPP validation passed. Addresses #152.