### PR TITLE
chore(release): prepare Morphe patch bundle 1.4.102

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 
 <!-- MORPHE_MANAGER_CHANGELOG_START -->
+## [1.4.102](https://github.com/brealorg/breal-morphe-patches/compare/morphe-patches-101...morphe-patches-102) (2026-07-29)
+
+* **Boost for Reddit:** Keep Boost's sticky Settings footer visible above system navigation.
+
 ## [1.4.101](https://github.com/brealorg/breal-morphe-patches/compare/morphe-patches-100...morphe-patches-101) (2026-07-29)
 
 * **Boost for Reddit:** Fix a crash when opening Add account in Boost for Reddit. Package the runtime extension required by the Spoof client URL hook.

--- a/README.md
+++ b/README.md
@@ -72,14 +72,14 @@ The repository shorthand shown at the top is the preferred Manager setup. Raw
 
 | Field | Value |
 |---|---|
-| Version | `1.4.101` |
-| Release tag | `morphe-patches-101` |
-| Asset | `patches-1.4.101.mpp` |
-| SHA256 | `9a50d3dbce38962489beeb678bbc8ede2a2df5ae3bf0b772186af2af8bc089ff` |
+| Version | `1.4.102` |
+| Release tag | `morphe-patches-102` |
+| Asset | `patches-1.4.102.mpp` |
+| SHA256 | `3dc66ca15849716d59c406764af64156b0ea51be6ebb49c73d73db4a3152045a` |
 | Manager JSON | `https://raw.githubusercontent.com/brealorg/breal-morphe-patches/main/patches-bundle.json` |
-| Download URL | `https://github.com/brealorg/breal-morphe-patches/releases/download/morphe-patches-101/patches-1.4.101.mpp` |
+| Download URL | `https://github.com/brealorg/breal-morphe-patches/releases/download/morphe-patches-102/patches-1.4.102.mpp` |
 
-SHA256: `9a50d3dbce38962489beeb678bbc8ede2a2df5ae3bf0b772186af2af8bc089ff`
+SHA256: `3dc66ca15849716d59c406764af64156b0ea51be6ebb49c73d73db4a3152045a`
 ## What this bundle does
 
 The current bundle is focused on practical hotfixes for tested app versions, especially Boost for Reddit behavior on newer Android versions.
@@ -126,7 +126,7 @@ Included Imgur patches:
 ### Patches list
 
 <!-- PATCHES_START -->
-> **Patch source version:** `1.4.101` • `main` • 52 unique patches • 104 package entries
+> **Patch source version:** `1.4.102` • `main` • 52 unique patches • 104 package entries
 
 <details>
 <summary><strong>Boost for Reddit</strong> • 43 patches</summary>
@@ -539,16 +539,16 @@ Compatibility with other app versions is not guaranteed.
 
 ## Verification
 
-Release `1.4.101` is prepared and locally verified with:
+Release `1.4.102` is prepared and locally verified with:
 
-- Release tag `morphe-patches-101`.
+- Release tag `morphe-patches-102`.
 - Local built MPP SHA256 matching README.
-`9a50d3dbce38962489beeb678bbc8ede2a2df5ae3bf0b772186af2af8bc089ff`
-- `patches-bundle.json` returning version `1.4.101`.
-- `patches-bundle.json` pointing to the `morphe-patches-101` asset.
+`3dc66ca15849716d59c406764af64156b0ea51be6ebb49c73d73db4a3152045a`
+- `patches-bundle.json` returning version `1.4.102`.
+- `patches-bundle.json` pointing to the `morphe-patches-102` asset.
 - Expected release asset:
-`patches-1.4.101.mpp`
-- `9a50d3dbce38962489beeb678bbc8ede2a2df5ae3bf0b772186af2af8bc089ff  patches-1.4.101.mpp`
+`patches-1.4.102.mpp`
+- `3dc66ca15849716d59c406764af64156b0ea51be6ebb49c73d73db4a3152045a  patches-1.4.102.mpp`
 
 ## Development notes
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,4 +3,4 @@ org.gradle.jvmargs = -Xms512M -Xmx2048M
 org.gradle.parallel = true
 android.useAndroidX = true
 kotlin.code.style = official
-version = 1.4.101
+version = 1.4.102

--- a/patches-bundle.json
+++ b/patches-bundle.json
@@ -1,7 +1,7 @@
 {
-  "created_at": "2026-07-29T00:00:27",
-  "description": "Fix a crash when opening Add account in Boost for Reddit.\nPackage the runtime extension required by the Spoof client URL hook.\n",
-  "download_url": "https://github.com/brealorg/breal-morphe-patches/releases/download/morphe-patches-101/patches-1.4.101.mpp",
-  "signature_download_url": "https://github.com/brealorg/breal-morphe-patches/releases/download/morphe-patches-101/patches-1.4.101.mpp.asc",
-  "version": "1.4.101"
+  "created_at": "2026-07-29T11:51:52",
+  "description": "Keep Boost's sticky Settings footer visible above system navigation.\n",
+  "download_url": "https://github.com/brealorg/breal-morphe-patches/releases/download/morphe-patches-102/patches-1.4.102.mpp",
+  "signature_download_url": "https://github.com/brealorg/breal-morphe-patches/releases/download/morphe-patches-102/patches-1.4.102.mpp.asc",
+  "version": "1.4.102"
 }

--- a/patches-list.json
+++ b/patches-list.json
@@ -1,6 +1,6 @@
 {
   "NOTE": "Do NOT manually edit this file. This file is automatically updated when semantic release (release.yml) runs. Manually editing this file can break your releases and break third party tools that use this file.",
-  "version": "1.4.101",
+  "version": "1.4.102",
   "patches": [
     {
       "name": "Add Boost Search bottom navigation",


### PR DESCRIPTION
## Summary

Prepare the protected-main metadata for Morphe patch bundle `1.4.102`.

## Release identity

- Version: `1.4.102`
- Tag: `morphe-patches-102`
- Asset: `patches-1.4.102.mpp`
- Candidate MPP SHA256: `3dc66ca15849716d59c406764af64156b0ea51be6ebb49c73d73db4a3152045a`

## Included user-visible change

- Keep Boost's sticky Settings footer visible above system navigation.

### User impact

On gesture-navigation devices, enabling **Sticky Settings** no longer leaves the Settings row clipped beneath the system navigation area. The footer remains usable, the final subscription remains reachable, and disabling Sticky Settings restores the non-sticky layout without a phantom gap.

## Validation

- Exact Eclipse Temurin `17.0.19+10`: PASS
- Issue #150 feature runtime validation on Pixel 6 / Android 17 / gesture navigation: PASS
- Release metadata preparation: PASS
- Project contracts: PASS
- Three independent Android MPP builds produced the same SHA256: PASS
- Full committed-state release-feed smoke mode: `FULL_RELEASE`
- README-to-MPP SHA gate: enforced and PASS
- MPP release structure: PASS
- Changed-file scope: exactly five canonical release metadata files
- Runtime marker: `MORPHE_BOOST_DRAWER_STICKY_FOOTER_CLEARANCE_ISSUE150_V5_SYSTEM_INSET`
- Candidate MPP SHA256: `3dc66ca15849716d59c406764af64156b0ea51be6ebb49c73d73db4a3152045a`

## Publication boundary

This PR does not create `morphe-patches-102`, publish a GitHub Release, update `dev`, dispatch the protected-main release workflow, merge itself, enable auto-merge, delete branches, or close Issue #150.

Addresses #150.
