### PR TITLE
fix(boost): select Subscriptions for subreddit screens

### DIFF
--- a/extensions/boostforreddit/src/main/java/app/morphe/extension/boostforreddit/utils/BoostSearchBottomNavigation.java
+++ b/extensions/boostforreddit/src/main/java/app/morphe/extension/boostforreddit/utils/BoostSearchBottomNavigation.java
@@ -96,6 +96,8 @@ public final class BoostSearchBottomNavigation {
             "MORPHE_BOOST_NATIVE_PROFILE_LONGPRESS_ISSUE97_V2";
     private static final String NATIVE_SUBSCRIPTIONS_LONG_PRESS_MARKER =
             "MORPHE_BOOST_NATIVE_SUBSCRIPTIONS_LONGPRESS_ISSUE135_V1";
+    private static final String SUBREDDIT_SELECTION_MARKER =
+            "MORPHE_BOOST_SUBREDDIT_BOTTOM_NAV_SELECTION_ISSUE134_V1";
     private static final String CURRENT_SUBREDDIT_SUBSCRIPTIONS_MARKER =
             "MORPHE_BOOST_SUBSCRIPTIONS_CURRENT_SUBREDDIT_ISSUE141_V2_NATIVE_J6";
     private static final String NAVIGATION_VISIBILITY_STATE_MARKER =
@@ -3072,6 +3074,22 @@ public final class BoostSearchBottomNavigation {
             return resourceId(
                     activity,
                     "item_search",
+                    "id"
+            );
+        }
+
+        if (SUBREDDIT_ACTIVITY.equals(activityName)) {
+            Log.i(
+                    TAG,
+                    "Subreddit selects Subscriptions marker="
+                            + SUBREDDIT_SELECTION_MARKER
+                            + " activity="
+                            + activityName
+            );
+
+            return resourceId(
+                    activity,
+                    "item_subs",
                     "id"
             );
         }

--- a/tools/check-boost-subreddit-bottom-nav-selection-contract.sh
+++ b/tools/check-boost-subreddit-bottom-nav-selection-contract.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SOURCE="$ROOT/extensions/boostforreddit/src/main/java/app/morphe/extension/boostforreddit/utils/BoostSearchBottomNavigation.java"
+
+python3 - "$SOURCE" <<'PY'
+from pathlib import Path
+import re
+import sys
+
+source_path = Path(sys.argv[1])
+source = source_path.read_text(encoding="utf-8")
+
+marker = "MORPHE_BOOST_SUBREDDIT_BOTTOM_NAV_SELECTION_ISSUE134_V1"
+if marker not in source:
+    raise SystemExit(f"FAIL=ISSUE134_MARKER_MISSING marker={marker}")
+
+match = re.search(
+    r"private static int selectedItemIdForActivity\(.*?\n    }\n\n    private static void setCheckedItem",
+    source,
+    flags=re.S,
+)
+if match is None:
+    raise SystemExit("FAIL=SELECTED_ITEM_RESOLVER_NOT_FOUND")
+
+resolver = match.group(0)
+required = (
+    "SUBREDDIT_ACTIVITY.equals(activityName)",
+    '"item_subs"',
+    "SUBREDDIT_SELECTION_MARKER",
+)
+for token in required:
+    if token not in resolver:
+        raise SystemExit(f"FAIL=ISSUE134_RESOLVER_TOKEN_MISSING token={token}")
+
+subreddit_block = re.search(
+    r"if \(SUBREDDIT_ACTIVITY\.equals\(activityName\)\) \{.*?return resourceId\(.*?\"item_subs\".*?\);.*?\n        }",
+    resolver,
+    flags=re.S,
+)
+if subreddit_block is None:
+    raise SystemExit("FAIL=SUBREDDIT_NOT_MAPPED_DIRECTLY_TO_SUBSCRIPTIONS")
+
+issue117 = re.search(
+    r"private static boolean preserveSourceSelectionAfterRoute\(.*?\n    }\n\n    private static String attachSubredditNavigationListeners",
+    source,
+    flags=re.S,
+)
+if issue117 is None:
+    raise SystemExit("FAIL=ISSUE117_SOURCE_SELECTION_GUARD_NOT_FOUND")
+
+issue117_body = issue117.group(0)
+for token in (
+    "SOURCE_SELECTION_RETAINED_MARKER",
+    "selectedItemIdForActivity",
+    "return false;",
+):
+    if token not in issue117_body:
+        raise SystemExit(f"FAIL=ISSUE117_GUARD_REGRESSED token={token}")
+
+print("PASS=ISSUE134_SUBREDDIT_ACTIVITY_MAPS_TO_SUBSCRIPTIONS")
+print("PASS=ISSUE117_SOURCE_SELECTION_GUARD_RETAINED")
+print(f"MARKER={marker}")
+PY
+
+echo "RESULT=MORPHE_ISSUE134_SOURCE_CONTRACT_PASS"


### PR DESCRIPTION
## Summary

- map Boost's `SubredditActivity` to the **Subscriptions** bottom-navigation destination
- preserve the Issue #117 source-selection behavior for Android Back
- add a focused source contract for Issue #134

## Root cause

`SubredditActivity` was defined but omitted from the Activity-to-destination resolver. The fallback selection was therefore applied and continuously enforced by the navigation stability guard.

## Validation

- focused Issue #134 source contract: PASS
- Issue #117 source-selection guard retained: PASS
- Android MPP build and required-entry gate: PASS
- normal candidate static and bytecode safety gates: PASS
- Boost DEV on Pixel 6 / Android 17:
  - sidebar → subreddit → Subscriptions selected: PASS
  - subreddit title → subreddit → Subscriptions selected: PASS
  - in-app `r/...` link → subreddit → Subscriptions selected: PASS
- runtime marker count: 4
- fatal runtime signals: 0
- normal Boost package unchanged

Addresses #134.
