### PR TITLE
chore(release): prepare Morphe patch bundle 1.4.103

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Changelog
 
 <!-- MORPHE_MANAGER_CHANGELOG_START -->
+## [1.4.103](https://github.com/brealorg/breal-morphe-patches/compare/morphe-patches-102...morphe-patches-103) (2026-07-29)
+
+* **Boost for Reddit:** Bug Fixes
+
+• Opening a subreddit now activates the Subscriptions tab in Boost's bottom navigation.
+
 ## [1.4.102](https://github.com/brealorg/breal-morphe-patches/compare/morphe-patches-101...morphe-patches-102) (2026-07-29)
 
 * **Boost for Reddit:** Keep Boost's sticky Settings footer visible above system navigation.

--- a/README.md
+++ b/README.md
@@ -72,14 +72,14 @@ The repository shorthand shown at the top is the preferred Manager setup. Raw
 
 | Field | Value |
 |---|---|
-| Version | `1.4.102` |
-| Release tag | `morphe-patches-102` |
-| Asset | `patches-1.4.102.mpp` |
-| SHA256 | `3dc66ca15849716d59c406764af64156b0ea51be6ebb49c73d73db4a3152045a` |
+| Version | `1.4.103` |
+| Release tag | `morphe-patches-103` |
+| Asset | `patches-1.4.103.mpp` |
+| SHA256 | `9764c0bcf4984bdbdd49b61762a74c14639c575f33179772e931632d7561b908` |
 | Manager JSON | `https://raw.githubusercontent.com/brealorg/breal-morphe-patches/main/patches-bundle.json` |
-| Download URL | `https://github.com/brealorg/breal-morphe-patches/releases/download/morphe-patches-102/patches-1.4.102.mpp` |
+| Download URL | `https://github.com/brealorg/breal-morphe-patches/releases/download/morphe-patches-103/patches-1.4.103.mpp` |
 
-SHA256: `3dc66ca15849716d59c406764af64156b0ea51be6ebb49c73d73db4a3152045a`
+SHA256: `9764c0bcf4984bdbdd49b61762a74c14639c575f33179772e931632d7561b908`
 ## What this bundle does
 
 The current bundle is focused on practical hotfixes for tested app versions, especially Boost for Reddit behavior on newer Android versions.
@@ -126,7 +126,7 @@ Included Imgur patches:
 ### Patches list
 
 <!-- PATCHES_START -->
-> **Patch source version:** `1.4.102` • `main` • 52 unique patches • 104 package entries
+> **Patch source version:** `1.4.103` • `main` • 52 unique patches • 104 package entries
 
 <details>
 <summary><strong>Boost for Reddit</strong> • 43 patches</summary>
@@ -539,16 +539,16 @@ Compatibility with other app versions is not guaranteed.
 
 ## Verification
 
-Release `1.4.102` is prepared and locally verified with:
+Release `1.4.103` is prepared and locally verified with:
 
-- Release tag `morphe-patches-102`.
+- Release tag `morphe-patches-103`.
 - Local built MPP SHA256 matching README.
-`3dc66ca15849716d59c406764af64156b0ea51be6ebb49c73d73db4a3152045a`
-- `patches-bundle.json` returning version `1.4.102`.
-- `patches-bundle.json` pointing to the `morphe-patches-102` asset.
+`9764c0bcf4984bdbdd49b61762a74c14639c575f33179772e931632d7561b908`
+- `patches-bundle.json` returning version `1.4.103`.
+- `patches-bundle.json` pointing to the `morphe-patches-103` asset.
 - Expected release asset:
-`patches-1.4.102.mpp`
-- `3dc66ca15849716d59c406764af64156b0ea51be6ebb49c73d73db4a3152045a  patches-1.4.102.mpp`
+`patches-1.4.103.mpp`
+- `9764c0bcf4984bdbdd49b61762a74c14639c575f33179772e931632d7561b908  patches-1.4.103.mpp`
 
 ## Development notes
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,4 +3,4 @@ org.gradle.jvmargs = -Xms512M -Xmx2048M
 org.gradle.parallel = true
 android.useAndroidX = true
 kotlin.code.style = official
-version = 1.4.102
+version = 1.4.103

--- a/patches-bundle.json
+++ b/patches-bundle.json
@@ -1,7 +1,7 @@
 {
-  "created_at": "2026-07-29T11:51:52",
-  "description": "Keep Boost's sticky Settings footer visible above system navigation.\n",
-  "download_url": "https://github.com/brealorg/breal-morphe-patches/releases/download/morphe-patches-102/patches-1.4.102.mpp",
-  "signature_download_url": "https://github.com/brealorg/breal-morphe-patches/releases/download/morphe-patches-102/patches-1.4.102.mpp.asc",
-  "version": "1.4.102"
+  "created_at": "2026-07-29T22:36:00",
+  "description": "Bug Fixes\n\n• Opening a subreddit now activates the Subscriptions tab in Boost's bottom navigation.\n",
+  "download_url": "https://github.com/brealorg/breal-morphe-patches/releases/download/morphe-patches-103/patches-1.4.103.mpp",
+  "signature_download_url": "https://github.com/brealorg/breal-morphe-patches/releases/download/morphe-patches-103/patches-1.4.103.mpp.asc",
+  "version": "1.4.103"
 }

--- a/patches-list.json
+++ b/patches-list.json
@@ -1,6 +1,6 @@
 {
   "NOTE": "Do NOT manually edit this file. This file is automatically updated when semantic release (release.yml) runs. Manually editing this file can break your releases and break third party tools that use this file.",
-  "version": "1.4.102",
+  "version": "1.4.103",
   "patches": [
     {
       "name": "Add Boost Search bottom navigation",


### PR DESCRIPTION
## Summary

Prepare the protected-main metadata for Morphe patch bundle `1.4.103`.

## Release identity

- Version: `1.4.103`
- Tag: `morphe-patches-103`
- Asset: `patches-1.4.103.mpp`
- Candidate MPP SHA256: `9764c0bcf4984bdbdd49b61762a74c14639c575f33179772e931632d7561b908`

## Included user-visible change

- Opening any subreddit now activates the **Subscriptions** destination in Boost's bottom navigation.

### User impact

The bottom bar now reflects subreddit context consistently when a subreddit is opened from the navigation drawer, a subreddit title, or an in-app `r/...` link. The previously released Android Back source-selection behavior remains intact.

## Validation

- exact Java runtime `17.0.19+10`: PASS
- Issue #134 DEV runtime on Pixel 6 / Android 17: PASS
- sidebar, subreddit-title and in-app link routes: PASS
- runtime marker count: 4
- fatal runtime signals: 0
- focused source contract: PASS
- release metadata preparation and release gate: PASS
- MPP release structure and Issue #134 marker: PASS
- candidate MPP SHA256: `9764c0bcf4984bdbdd49b61762a74c14639c575f33179772e931632d7561b908`

## Publication boundary

This PR only prepares protected-main release metadata. Publication is performed afterward by the repository's protected-main release workflow.

Addresses #134.
