### PR TITLE
fix(boost): separate bottom navigation reselect handling

### DIFF
--- a/extensions/boostforreddit/src/main/java/app/morphe/extension/boostforreddit/utils/BoostSearchBottomNavigation.java
+++ b/extensions/boostforreddit/src/main/java/app/morphe/extension/boostforreddit/utils/BoostSearchBottomNavigation.java
@@ -4524,11 +4524,7 @@ public final class BoostSearchBottomNavigation {
                                     (MenuItem) args[0];
 
                             boolean handled =
-                                    dispatchHomeGoToTop(
-                                            activity,
-                                            item
-                                    )
-                                    || handleItem(
+                                    handleReselectedItem(
                                             activity,
                                             item
                                     );
@@ -4690,6 +4686,93 @@ public final class BoostSearchBottomNavigation {
         }
 
         return handled;
+    }
+
+    private static boolean handleReselectedItem(
+            Activity activity,
+            MenuItem item
+    ) {
+        if (activity == null || item == null) {
+            return false;
+        }
+
+        int selectedId = item.getItemId();
+
+        int homeId = resourceId(activity, "item_home", "id");
+        int searchId = resourceId(activity, "item_search", "id");
+        int subscriptionsId = resourceId(
+                activity,
+                "item_subs",
+                "id"
+        );
+        int inboxId = resourceId(activity, "item_inbox", "id");
+        int profileId = resourceId(
+                activity,
+                "item_profile",
+                "id"
+        );
+
+        int currentItemId =
+                selectedItemIdForActivity(activity, -1);
+        String activityName = activity.getClass().getName();
+        final String stateMachineMarker =
+                "MORPHE_BOOST_BOTTOM_NAV_STATE_MACHINE_ISSUE163_V1";
+
+        if (
+                currentItemId == 0
+                        || selectedId != currentItemId
+        ) {
+            Log.w(
+                    TAG,
+                    "Bottom navigation invalid reselect ignored marker="
+                            + stateMachineMarker
+                            + " activity="
+                            + activityName
+                            + " currentItemId="
+                            + currentItemId
+                            + " selectedId="
+                            + selectedId
+            );
+            return false;
+        }
+
+        Log.i(
+                TAG,
+                "Bottom navigation reselect transition marker="
+                        + stateMachineMarker
+                        + " activity="
+                        + activityName
+                        + " selectedId="
+                        + selectedId
+        );
+
+        if (selectedId == homeId) {
+            return dispatchHomeGoToTop(activity, item);
+        }
+
+        if (selectedId == searchId) {
+            return focusSearchInput(activity);
+        }
+
+        if (selectedId == subscriptionsId) {
+            if (SUBREDDIT_ACTIVITY.equals(activityName)) {
+                return completeStaticTabTransition(
+                        activity,
+                        openSubscriptions(activity)
+                );
+            }
+
+            return true;
+        }
+
+        if (
+                selectedId == inboxId
+                        || selectedId == profileId
+        ) {
+            return true;
+        }
+
+        return false;
     }
 
     private static boolean handleItem(

--- a/tools/check-boost-bottom-navigation-state-machine-contract.sh
+++ b/tools/check-boost-bottom-navigation-state-machine-contract.sh
@@ -1,0 +1,135 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SOURCE="$ROOT/extensions/boostforreddit/src/main/java/app/morphe/extension/boostforreddit/utils/BoostSearchBottomNavigation.java"
+
+python3 - "$SOURCE" <<'PY'
+from pathlib import Path
+import re
+import sys
+
+source_path = Path(sys.argv[1])
+if not source_path.is_file():
+    raise SystemExit(f"FAIL=SOURCE_MISSING path={source_path}")
+
+source = source_path.read_text(encoding="utf-8")
+
+
+def method_body(name: str) -> str:
+    signature = re.search(
+        rf"(?m)^[ \t]*private[ \t]+static[ \t]+"
+        rf"[^\s(]+[ \t]+{re.escape(name)}[ \t]*\(",
+        source,
+    )
+    if signature is None:
+        raise SystemExit(f"FAIL=METHOD_NOT_FOUND method={name}")
+
+    opening = source.find("{", signature.end())
+    if opening < 0 or ";" in source[signature.end() : opening]:
+        raise SystemExit(f"FAIL=METHOD_BODY_NOT_FOUND method={name}")
+
+    depth = 0
+    for offset in range(opening, len(source)):
+        character = source[offset]
+        if character == "{":
+            depth += 1
+        elif character == "}":
+            depth -= 1
+            if depth == 0:
+                return source[signature.start() : offset + 1]
+
+    raise SystemExit(f"FAIL=METHOD_NOT_CLOSED method={name}")
+
+
+selected_listener = method_body("attachSelectedListener")
+reselected_listener = method_body("attachReselectedListener")
+selected_handler = method_body("handleItem")
+
+if "handleItem(" not in selected_listener:
+    raise SystemExit("FAIL=SELECT_LISTENER_LOST_SELECTION_HANDLER")
+
+if (
+    "dispatchHomeGoToTop(" not in reselected_listener
+    and "handleReselectedItem(" not in reselected_listener
+):
+    raise SystemExit("FAIL=HOME_RESELECT_ROUTE_MISSING")
+
+current_guard = "selectedId == currentItemId"
+subscriptions_route = "if (selectedId == subscriptionsId)"
+
+guard_offset = selected_handler.find(current_guard)
+subscriptions_offset = selected_handler.find(subscriptions_route)
+
+broken_issue163_path = (
+    "handleItem(" in reselected_listener
+    and guard_offset >= 0
+    and subscriptions_offset >= 0
+    and guard_offset < subscriptions_offset
+)
+
+if broken_issue163_path:
+    print("BROKEN_RESELECT_CALLS_SELECTION_HANDLER=YES")
+    print("BROKEN_CURRENT_ITEM_GUARD_PRECEDES_SUBSCRIPTIONS_ROUTE=YES")
+    raise SystemExit(
+        "FAIL=ISSUE163_RESELECT_SWALLOWED_BY_CURRENT_ITEM_GUARD"
+    )
+
+if "handleItem(" in reselected_listener:
+    raise SystemExit(
+        "FAIL=RESELECT_DISPATCH_NOT_SEPARATED shared_handler=handleItem"
+    )
+
+if "dispatchHomeGoToTop(" in reselected_listener:
+    raise SystemExit(
+        "FAIL=RESELECT_POLICY_SPLIT home_route=listener"
+    )
+
+dedicated_call = "handleReselectedItem("
+if dedicated_call not in reselected_listener:
+    raise SystemExit(
+        "FAIL=DEDICATED_RESELECT_HANDLER_NOT_WIRED "
+        "expected=handleReselectedItem"
+    )
+
+reselected_handler = method_body("handleReselectedItem")
+
+required_policy_tokens = (
+    "MORPHE_BOOST_BOTTOM_NAV_STATE_MACHINE_ISSUE163_V1",
+    "homeId",
+    "searchId",
+    "subscriptionsId",
+    "inboxId",
+    "profileId",
+    "dispatchHomeGoToTop(",
+    "focusSearchInput(",
+    "openSubscriptions(",
+)
+
+for token in required_policy_tokens:
+    if token not in reselected_handler:
+        raise SystemExit(
+            f"FAIL=RESELECT_POLICY_TOKEN_MISSING token={token}"
+        )
+
+reselect_guard_offset = reselected_handler.find(current_guard)
+reselect_subscriptions_offset = reselected_handler.find(subscriptions_route)
+
+if reselect_subscriptions_offset < 0:
+    raise SystemExit("FAIL=RESELECT_SUBSCRIPTIONS_ROUTE_MISSING")
+
+if (
+    reselect_guard_offset >= 0
+    and reselect_guard_offset < reselect_subscriptions_offset
+):
+    raise SystemExit(
+        "FAIL=RESELECT_CURRENT_ITEM_GUARD_SWALLOWS_SUBSCRIPTIONS"
+    )
+
+print("PASS=SELECT_AND_RESELECT_DISPATCH_SEPARATED")
+print("PASS=RESELECT_POLICY_COVERS_FIVE_DESTINATIONS")
+print("PASS=SUBSCRIPTIONS_RESELECT_ROUTE_REACHABLE")
+print("MARKER=MORPHE_BOOST_BOTTOM_NAV_STATE_MACHINE_ISSUE163_V1")
+PY
+
+echo "RESULT=MORPHE_ISSUE163_STATE_MACHINE_CONTRACT_PASS"


### PR DESCRIPTION
## Summary

- separate bottom-navigation selection and reselection handling
- restore the Subscriptions reselect route after opening a subreddit
- preserve Home go-to-top, Search focus, and stable no-op behavior where appropriate
- add a contract test covering all five reselect destinations

## Root cause

Selection and reselection shared the normal selection handler. Because Subscriptions was already selected while viewing a subreddit, the current-item guard returned before the Subscriptions route could run.

The dedicated reselect policy now allows Boost's native current-subreddit Subscriptions route to remain reachable without changing ordinary selection behavior.

## Validation

- full `:patches:buildAndroid` build passed
- all three bottom-navigation contracts passed
- DEV package: `com.rubenmayayo.reddit.dev`
- DEV APK SHA-256: `431cf93ea66cbbeee3898a9216d1a92f857332e2c2e0e02bcc9c43df7e74d1dd`
- Pixel 6, Android 17, three-button navigation:
  - Subscriptions reselect from a subreddit opened the expected list
  - reselect while the list was displayed remained stable
  - Home reselect still returned the feed to the top
- three expected state-machine runtime markers
- zero relevant fatal errors
- Normal Boost remained unchanged

The reporter's Moto G Play on Android 14 has not been directly tested.

Addresses #163.