### PR TITLE
chore(release): prepare Morphe patch bundle 1.4.104

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 
 <!-- MORPHE_MANAGER_CHANGELOG_START -->
+## [1.4.104](https://github.com/brealorg/breal-morphe-patches/compare/morphe-patches-103...morphe-patches-104) (2026-08-02)
+
+* **Boost for Reddit:** Fix Boost bottom navigation reselect handling.
+
 ## [1.4.103](https://github.com/brealorg/breal-morphe-patches/compare/morphe-patches-102...morphe-patches-103) (2026-07-29)
 
 * **Boost for Reddit:** Bug Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 <!-- MORPHE_MANAGER_CHANGELOG_START -->
 ## [1.4.104](https://github.com/brealorg/breal-morphe-patches/compare/morphe-patches-103...morphe-patches-104) (2026-08-02)
 
-* **Boost for Reddit:** Fix Boost bottom navigation reselect handling.
+* **Boost for Reddit:** Enable configurable quick-flick dismissal in Boost image viewers. Fix Boost bottom navigation reselect handling.
 
 ## [1.4.103](https://github.com/brealorg/breal-morphe-patches/compare/morphe-patches-102...morphe-patches-103) (2026-07-29)
 

--- a/README.md
+++ b/README.md
@@ -72,14 +72,14 @@ The repository shorthand shown at the top is the preferred Manager setup. Raw
 
 | Field | Value |
 |---|---|
-| Version | `1.4.103` |
-| Release tag | `morphe-patches-103` |
-| Asset | `patches-1.4.103.mpp` |
-| SHA256 | `9764c0bcf4984bdbdd49b61762a74c14639c575f33179772e931632d7561b908` |
+| Version | `1.4.104` |
+| Release tag | `morphe-patches-104` |
+| Asset | `patches-1.4.104.mpp` |
+| SHA256 | `c54f224e5bfd6cd2acc78d55a805cc60305c0f0b08634fffe4b9cdd1b12af4cf` |
 | Manager JSON | `https://raw.githubusercontent.com/brealorg/breal-morphe-patches/main/patches-bundle.json` |
-| Download URL | `https://github.com/brealorg/breal-morphe-patches/releases/download/morphe-patches-103/patches-1.4.103.mpp` |
+| Download URL | `https://github.com/brealorg/breal-morphe-patches/releases/download/morphe-patches-104/patches-1.4.104.mpp` |
 
-SHA256: `9764c0bcf4984bdbdd49b61762a74c14639c575f33179772e931632d7561b908`
+SHA256: `c54f224e5bfd6cd2acc78d55a805cc60305c0f0b08634fffe4b9cdd1b12af4cf`
 ## What this bundle does
 
 The current bundle is focused on practical hotfixes for tested app versions, especially Boost for Reddit behavior on newer Android versions.
@@ -126,10 +126,10 @@ Included Imgur patches:
 ### Patches list
 
 <!-- PATCHES_START -->
-> **Patch source version:** `1.4.103` • `main` • 52 unique patches • 104 package entries
+> **Patch source version:** `1.4.104` • `main` • 53 unique patches • 105 package entries
 
 <details>
-<summary><strong>Boost for Reddit</strong> • 43 patches</summary>
+<summary><strong>Boost for Reddit</strong> • 44 patches</summary>
 
 
 
@@ -183,6 +183,7 @@ Included Imgur patches:
 | [Standardize Boost Inbox and Profile bottom navigation](#standardize-boost-inbox-and-profile-bottom-navigation) | Applies the canonical five-destination Material bottom-navigation contract after Inbox and Profile complete lifecycle setup. |  |
 | [Support keyboard GIF insertion](#support-keyboard-gif-insertion) | Enables keyboard GIF/image rich content insertion through Android receive-content when a public URL is available. |  |
 | [Theme Boost settings icons](#theme-boost-settings-icons) | Uses the active theme primary text color for Boost preference icons. |  |
+| [Tune Boost image dismissal](#tune-boost-image-dismissal) | Adds image-viewer-only quick-flick dismissal with a moderate distance option without changing GIF, video, or general navigation gestures. |  |
 
 </details>
 
@@ -539,16 +540,16 @@ Compatibility with other app versions is not guaranteed.
 
 ## Verification
 
-Release `1.4.103` is prepared and locally verified with:
+Release `1.4.104` is prepared and locally verified with:
 
-- Release tag `morphe-patches-103`.
+- Release tag `morphe-patches-104`.
 - Local built MPP SHA256 matching README.
-`9764c0bcf4984bdbdd49b61762a74c14639c575f33179772e931632d7561b908`
-- `patches-bundle.json` returning version `1.4.103`.
-- `patches-bundle.json` pointing to the `morphe-patches-103` asset.
+`c54f224e5bfd6cd2acc78d55a805cc60305c0f0b08634fffe4b9cdd1b12af4cf`
+- `patches-bundle.json` returning version `1.4.104`.
+- `patches-bundle.json` pointing to the `morphe-patches-104` asset.
 - Expected release asset:
-`patches-1.4.103.mpp`
-- `9764c0bcf4984bdbdd49b61762a74c14639c575f33179772e931632d7561b908  patches-1.4.103.mpp`
+`patches-1.4.104.mpp`
+- `c54f224e5bfd6cd2acc78d55a805cc60305c0f0b08634fffe4b9cdd1b12af4cf  patches-1.4.104.mpp`
 
 ## Development notes
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,4 +3,4 @@ org.gradle.jvmargs = -Xms512M -Xmx2048M
 org.gradle.parallel = true
 android.useAndroidX = true
 kotlin.code.style = official
-version = 1.4.103
+version = 1.4.104

--- a/patches-bundle.json
+++ b/patches-bundle.json
@@ -1,7 +1,7 @@
 {
-  "created_at": "2026-07-29T22:36:00",
-  "description": "Bug Fixes\n\n• Opening a subreddit now activates the Subscriptions tab in Boost's bottom navigation.\n",
-  "download_url": "https://github.com/brealorg/breal-morphe-patches/releases/download/morphe-patches-103/patches-1.4.103.mpp",
-  "signature_download_url": "https://github.com/brealorg/breal-morphe-patches/releases/download/morphe-patches-103/patches-1.4.103.mpp.asc",
-  "version": "1.4.103"
+  "created_at": "2026-08-02T21:29:00",
+  "description": "Fix Boost bottom navigation reselect handling.\n",
+  "download_url": "https://github.com/brealorg/breal-morphe-patches/releases/download/morphe-patches-104/patches-1.4.104.mpp",
+  "signature_download_url": "https://github.com/brealorg/breal-morphe-patches/releases/download/morphe-patches-104/patches-1.4.104.mpp.asc",
+  "version": "1.4.104"
 }

--- a/patches-bundle.json
+++ b/patches-bundle.json
@@ -1,6 +1,6 @@
 {
-  "created_at": "2026-08-02T21:29:00",
-  "description": "Fix Boost bottom navigation reselect handling.\n",
+  "created_at": "2026-08-02T21:53:46",
+  "description": "Enable configurable quick-flick dismissal in Boost image viewers.\nFix Boost bottom navigation reselect handling.\n",
   "download_url": "https://github.com/brealorg/breal-morphe-patches/releases/download/morphe-patches-104/patches-1.4.104.mpp",
   "signature_download_url": "https://github.com/brealorg/breal-morphe-patches/releases/download/morphe-patches-104/patches-1.4.104.mpp.asc",
   "version": "1.4.104"

--- a/patches-list.json
+++ b/patches-list.json
@@ -1,6 +1,6 @@
 {
   "NOTE": "Do NOT manually edit this file. This file is automatically updated when semantic release (release.yml) runs. Manually editing this file can break your releases and break third party tools that use this file.",
-  "version": "1.4.103",
+  "version": "1.4.104",
   "patches": [
     {
       "name": "Add Boost Search bottom navigation",
@@ -2671,6 +2671,34 @@
       "description": "Uses the active theme primary text color for Boost preference icons.",
       "default": true,
       "dependencies": [],
+      "compatiblePackages": [
+        {
+          "packageName": "com.rubenmayayo.reddit",
+          "name": "Boost for Reddit",
+          "description": null,
+          "apkFileType": "APK_REQUIRED",
+          "appIconColor": "#FF4500",
+          "signatures": null,
+          "targets": [
+            {
+              "version": "1.12.12",
+              "versionCodes": null,
+              "isExperimental": false,
+              "minSdk": 21,
+              "description": null
+            }
+          ]
+        }
+      ],
+      "options": []
+    },
+    {
+      "name": "Tune Boost image dismissal",
+      "description": "Adds image-viewer-only quick-flick dismissal with a moderate distance option without changing GIF, video, or general navigation gestures.",
+      "default": true,
+      "dependencies": [
+        "BytecodePatch"
+      ],
       "compatiblePackages": [
         {
           "packageName": "com.rubenmayayo.reddit",


### PR DESCRIPTION
## Summary

Prepare the protected-main metadata for Morphe patch bundle `1.4.104`.

## Release identity

- Version: `1.4.104`
- Tag: `morphe-patches-104`
- Asset: `patches-1.4.104.mpp`
- Candidate MPP SHA256: `c54f224e5bfd6cd2acc78d55a805cc60305c0f0b08634fffe4b9cdd1b12af4cf`

## Included user-visible changes

- Enable configurable quick-flick dismissal in Boost image viewers.
- Re-selecting Subscriptions while viewing a subreddit now opens the expected Subscriptions list.

### User impact

Boost image viewers now use velocity-aware quick-flick dismissal with a moderate 10% default drag threshold. Slider value 12 restores original Boost behavior; GIF, video, and general navigation gestures remain outside this patch's scope.

Boost can now leave the current-subreddit context through the already-selected Subscriptions destination. Home go-to-top and the remaining bottom-navigation reselect behavior remain intact.

## Validation

- exact Java runtime `17.0.19+10`: PASS
- Issue #96 DEV runtime on Pixel 6 / Android 17: PASS
- image-dismiss runtime marker: `MORPHE_BOOST_IMAGE_DISMISS_TUNING_ISSUE96_V4_1`
- default runtime values: `flingBack=true backFactor=0.1 dismissDistancePercent=10`
- zoom and pan regression: PASS
- GIF and video regression: PASS
- force-stop and relaunch: PASS
- Issue #163 DEV runtime on Pixel 6 / Android 17 / three-button navigation: PASS
- Subscriptions reselect and stable-list behavior: PASS
- Home reselect regression path: PASS
- all three bottom-navigation contracts: PASS
- expected bottom-navigation runtime markers: 3
- relevant fatal runtime signals: 0
- release metadata preparation and release gate: PASS
- MPP release structure and both Issue #96 / Issue #163 markers: PASS
- candidate MPP SHA256: `c54f224e5bfd6cd2acc78d55a805cc60305c0f0b08634fffe4b9cdd1b12af4cf`
- Normal Boost remained unchanged

The reporter's Moto G Play on Android 14 has not been directly tested.

## Publication boundary

This PR only prepares protected-main release metadata. Publication is performed afterward by the repository's protected-main release workflow.

Addresses #96 and #163.