### PR TITLE
feat(boost): add configurable editor image hosts

### DIFF
--- a/extensions/boostforreddit/src/main/java/app/morphe/extension/boostforreddit/giphy/InlineGiphyCommentPreview.java
+++ b/extensions/boostforreddit/src/main/java/app/morphe/extension/boostforreddit/giphy/InlineGiphyCommentPreview.java
@@ -82,7 +82,8 @@ public final class InlineGiphyCommentPreview {
             Pattern.compile("https?://(?:external-preview|preview)\\.redd\\.it/[^\\s\"'<>]+", Pattern.CASE_INSENSITIVE);
 
     private static final Pattern DIRECT_STATIC_IMAGE_URL_PATTERN =
-            Pattern.compile("https?://(?:i\\.imgur\\.com|i\\.redd\\.it)/[^\\s\"'<>]+?\\.(?:png|jpe?g|webp)(?:\\?[^\\s\"'<>)]*)?", Pattern.CASE_INSENSITIVE);
+            Pattern.compile("https?://(?:i\\.imgur\\.com|i\\.ibb\\.co|image\\.ibb\\.co|i\\.redd\\.it)/[^\\s\"'<>]+?\\.(?:png|jpe?g|webp)(?:\\?[^\\s\"'<>)]*)?", Pattern.CASE_INSENSITIVE);
+
 
     private static final Pattern DIRECT_GIF_URL_PATTERN =
             Pattern.compile("https?://[^\\s\"'<>]+?\\.gif(?:\\?[^\\s\"'<>)]*)?", Pattern.CASE_INSENSITIVE);
@@ -2151,6 +2152,7 @@ public final class InlineGiphyCommentPreview {
             }
             return new PreviewSource(url, url);
         }
+
 
         Matcher staticImage = DIRECT_STATIC_IMAGE_URL_PATTERN.matcher(normalized);
         while (staticImage.find()) {

--- a/extensions/boostforreddit/src/main/java/app/morphe/extension/boostforreddit/settings/MorpheSettingsV5ImageHostingFragment.java
+++ b/extensions/boostforreddit/src/main/java/app/morphe/extension/boostforreddit/settings/MorpheSettingsV5ImageHostingFragment.java
@@ -1,0 +1,429 @@
+/*
+ * Modifications Copyright 2026 brealorg.
+ *
+ * See the included NOTICE file for GPLv3 §7(b) and §7(c) terms that apply to this code.
+ */
+package app.morphe.extension.boostforreddit.settings;
+
+import android.app.Activity;
+import android.content.Context;
+import android.text.InputType;
+import android.text.TextUtils;
+import android.view.LayoutInflater;
+import android.view.Menu;
+import android.view.MenuItem;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.LinearLayout;
+import android.widget.ScrollView;
+import android.widget.TextView;
+import android.widget.Toast;
+
+import androidx.fragment.app.Fragment;
+
+import app.morphe.extension.boostforreddit.upload.ExternalImageUploadSettings;
+import app.morphe.extension.boostforreddit.utils.BoostSystemBarInsetsFix;
+
+/** Morphe-owned Material settings page for image-upload routing. */
+public final class MorpheSettingsV5ImageHostingFragment extends Fragment {
+    public static final String CONTRACT_MARKER =
+            "MORPHE_BOOST_IMAGE_HOSTING_MATERIAL_SETTINGS_ISSUE66_V2";
+
+    private MorpheSettingsV4Theme.Tokens tokens;
+    private LinearLayout providerGroup;
+    private LinearLayout imgBbSection;
+
+    @Override
+    public View onCreateView(
+            LayoutInflater inflater,
+            ViewGroup container,
+            android.os.Bundle savedInstanceState
+    ) {
+        Context context = inflater.getContext();
+        tokens = MorpheSettingsV4Theme.resolve(context);
+        setHasOptionsMenu(true);
+
+        ScrollView scrollView = new ScrollView(context);
+        scrollView.setFillViewport(true);
+        scrollView.setClipToPadding(false);
+        scrollView.setBackgroundColor(tokens.background);
+
+        LinearLayout content = new LinearLayout(context);
+        content.setOrientation(LinearLayout.VERTICAL);
+        content.setPadding(dp(16), dp(8), dp(16), dp(32));
+        scrollView.addView(
+                content,
+                new ScrollView.LayoutParams(
+                        ViewGroup.LayoutParams.MATCH_PARENT,
+                        ViewGroup.LayoutParams.WRAP_CONTENT
+                )
+        );
+
+        content.addView(MorpheSettingsV14Ui.pageIntro(
+                context,
+                tokens,
+                "Image posts and galleries use Reddit's native uploader. "
+                        + "Images inserted into comments or text posts use "
+                        + "Imgur by default, with ImgBB as an alternative."
+        ));
+
+        addSpace(content, 22);
+        addSectionLabel(content, "Post media");
+        addSpace(content, 7);
+
+        LinearLayout postGroup = addGroup(content);
+        addStaticRow(
+                postGroup,
+                "Image posts and galleries",
+                "Reddit native"
+        );
+
+        addSpace(content, 22);
+        addSectionLabel(content, "Comments and text posts");
+        addSpace(content, 7);
+
+        providerGroup = addGroup(content);
+        rebuildProviderRows();
+
+        imgBbSection = new LinearLayout(context);
+        imgBbSection.setOrientation(LinearLayout.VERTICAL);
+        content.addView(
+                imgBbSection,
+                new LinearLayout.LayoutParams(
+                        ViewGroup.LayoutParams.MATCH_PARENT,
+                        ViewGroup.LayoutParams.WRAP_CONTENT
+                )
+        );
+        rebuildImgBbSection();
+
+        addSpace(content, 22);
+        addSectionLabel(content, "Failure handling");
+        addSpace(content, 7);
+
+        LinearLayout behaviorGroup = addGroup(content);
+        addStaticRow(
+                behaviorGroup,
+                "Automatic fallback",
+                "Off — a failed upload stays with the selected provider"
+        );
+
+        TextView note = MorpheSettingsV14Ui.supportingText(
+                context,
+                tokens,
+                "Provider changes apply to new comment and text-post uploads. "
+                        + "GIF and video upload behavior is unchanged."
+        );
+        LinearLayout.LayoutParams noteParams =
+                new LinearLayout.LayoutParams(
+                        ViewGroup.LayoutParams.MATCH_PARENT,
+                        ViewGroup.LayoutParams.WRAP_CONTENT
+                );
+        noteParams.topMargin = dp(10);
+        content.addView(note, noteParams);
+
+        return scrollView;
+    }
+
+    @Override
+    public void onResume() {
+        super.onResume();
+        styleHost();
+        if (providerGroup != null) {
+            rebuildProviderRows();
+        }
+        if (imgBbSection != null) {
+            rebuildImgBbSection();
+        }
+    }
+
+    @Override
+    public void onPause() {
+        Activity activity = hostActivity();
+        if (activity != null) {
+            BoostSystemBarInsetsFix.clearMorpheSettingsV4SystemBars(activity);
+        }
+        super.onPause();
+    }
+
+    @Override
+    public void onPrepareOptionsMenu(Menu menu) {
+        super.onPrepareOptionsMenu(menu);
+        MorpheSettingsV5Search.prepareMenu(this, menu);
+    }
+
+    @Override
+    public boolean onOptionsItemSelected(MenuItem item) {
+        if (MorpheSettingsV5Search.handleMenuItem(this, item)) {
+            return true;
+        }
+        return super.onOptionsItemSelected(item);
+    }
+
+    private void rebuildProviderRows() {
+        providerGroup.removeAllViews();
+        String selected = ExternalImageUploadSettings.getEditorProvider();
+
+        addProviderRow(
+                "Imgur",
+                "Default for comments and text posts.",
+                ExternalImageUploadSettings.PROVIDER_IMGUR,
+                selected
+        );
+        addProviderRow(
+                "ImgBB",
+                "Alternative external host. Requires your personal API key.",
+                ExternalImageUploadSettings.PROVIDER_IMGBB,
+                selected
+        );
+    }
+
+    private void addProviderRow(
+            String title,
+            String summary,
+            String provider,
+            String selected
+    ) {
+        MorpheSettingsV14Ui.ChoiceRow row =
+                MorpheSettingsV14Ui.choiceRow(
+                        requireContext(),
+                        tokens,
+                        title,
+                        summary,
+                        TextUtils.equals(provider, selected)
+                );
+
+        row.setOnClickListener(view -> {
+            ExternalImageUploadSettings.save(provider, null);
+            rebuildProviderRows();
+            rebuildImgBbSection();
+        });
+
+        MorpheSettingsV14Ui.addSegmentedRow(
+                providerGroup,
+                row,
+                tokens
+        );
+    }
+
+    private void rebuildImgBbSection() {
+        imgBbSection.removeAllViews();
+
+        boolean selected = ExternalImageUploadSettings.PROVIDER_IMGBB.equals(
+                ExternalImageUploadSettings.getEditorProvider()
+        );
+        imgBbSection.setVisibility(selected ? View.VISIBLE : View.GONE);
+
+        if (!selected) {
+            return;
+        }
+
+        addSpace(imgBbSection, 22);
+        addSectionLabel(imgBbSection, "ImgBB API key");
+        addSpace(imgBbSection, 7);
+
+        String currentKey = ExternalImageUploadSettings.getImgBbApiKey();
+        MorpheSettingsV14Ui.Field field =
+                MorpheSettingsV14Ui.outlinedField(
+                        requireContext(),
+                        tokens,
+                        "Personal API key",
+                        currentKey
+                );
+        field.input.setInputType(
+                InputType.TYPE_CLASS_TEXT
+                        | InputType.TYPE_TEXT_VARIATION_PASSWORD
+        );
+        field.input.setHint("Required for ImgBB uploads");
+        imgBbSection.addView(
+                field.root,
+                new LinearLayout.LayoutParams(
+                        ViewGroup.LayoutParams.MATCH_PARENT,
+                        ViewGroup.LayoutParams.WRAP_CONTENT
+                )
+        );
+
+        LinearLayout actions = new LinearLayout(requireContext());
+        actions.setOrientation(LinearLayout.HORIZONTAL);
+
+        TextView save = MorpheSettingsV14Ui.action(
+                requireContext(),
+                tokens,
+                "Save API key",
+                true
+        );
+        save.setOnClickListener(view -> {
+            String value = field.input.getText().toString().trim();
+            if (TextUtils.isEmpty(value)) {
+                field.input.setError("An ImgBB API key is required");
+                field.input.requestFocus();
+                return;
+            }
+
+            ExternalImageUploadSettings.save(
+                    ExternalImageUploadSettings.PROVIDER_IMGBB,
+                    value
+            );
+            Toast.makeText(
+                    requireContext(),
+                    "ImgBB API key saved",
+                    Toast.LENGTH_SHORT
+            ).show();
+            rebuildImgBbSection();
+        });
+
+        LinearLayout.LayoutParams saveParams =
+                new LinearLayout.LayoutParams(
+                        0,
+                        ViewGroup.LayoutParams.WRAP_CONTENT,
+                        1.0f
+                );
+        actions.addView(save, saveParams);
+
+        if (!TextUtils.isEmpty(currentKey)) {
+            TextView remove = MorpheSettingsV14Ui.action(
+                    requireContext(),
+                    tokens,
+                    "Remove key",
+                    false
+            );
+            remove.setOnClickListener(view -> {
+                ExternalImageUploadSettings.save(
+                        ExternalImageUploadSettings.PROVIDER_IMGBB,
+                        ""
+                );
+                Toast.makeText(
+                        requireContext(),
+                        "ImgBB API key removed",
+                        Toast.LENGTH_SHORT
+                ).show();
+                rebuildImgBbSection();
+            });
+
+            LinearLayout.LayoutParams removeParams =
+                    new LinearLayout.LayoutParams(
+                            0,
+                            ViewGroup.LayoutParams.WRAP_CONTENT,
+                            1.0f
+                    );
+            removeParams.setMarginStart(dp(10));
+            actions.addView(remove, removeParams);
+        }
+
+        LinearLayout.LayoutParams actionsParams =
+                new LinearLayout.LayoutParams(
+                        ViewGroup.LayoutParams.MATCH_PARENT,
+                        ViewGroup.LayoutParams.WRAP_CONTENT
+                );
+        actionsParams.topMargin = dp(12);
+        imgBbSection.addView(actions, actionsParams);
+
+        TextView note = MorpheSettingsV14Ui.supportingText(
+                requireContext(),
+                tokens,
+                "Use a personal key from api.imgbb.com. The key is stored "
+                        + "in Boost's local preferences and is used only for "
+                        + "ImgBB uploads."
+        );
+        LinearLayout.LayoutParams noteParams =
+                new LinearLayout.LayoutParams(
+                        ViewGroup.LayoutParams.MATCH_PARENT,
+                        ViewGroup.LayoutParams.WRAP_CONTENT
+                );
+        noteParams.topMargin = dp(6);
+        imgBbSection.addView(note, noteParams);
+    }
+
+    private void addStaticRow(
+            LinearLayout group,
+            String title,
+            String summary
+    ) {
+        LinearLayout row = MorpheSettingsV14Ui.baseRow(
+                requireContext(),
+                tokens
+        );
+        row.setClickable(false);
+        row.setFocusable(false);
+
+        LinearLayout labels = MorpheSettingsV14Ui.labels(
+                requireContext(),
+                tokens,
+                title,
+                summary
+        );
+        row.addView(
+                labels,
+                new LinearLayout.LayoutParams(
+                        0,
+                        ViewGroup.LayoutParams.WRAP_CONTENT,
+                        1.0f
+                )
+        );
+
+        MorpheSettingsV14Ui.addSegmentedRow(group, row, tokens);
+    }
+
+    private LinearLayout addGroup(LinearLayout parent) {
+        LinearLayout group = MorpheSettingsV14Ui.group(requireContext());
+        parent.addView(
+                group,
+                new LinearLayout.LayoutParams(
+                        ViewGroup.LayoutParams.MATCH_PARENT,
+                        ViewGroup.LayoutParams.WRAP_CONTENT
+                )
+        );
+        return group;
+    }
+
+    private void addSectionLabel(LinearLayout parent, String value) {
+        parent.addView(MorpheSettingsV14Ui.sectionLabel(
+                requireContext(),
+                tokens,
+                value
+        ));
+    }
+
+    private void addSpace(LinearLayout parent, int heightDp) {
+        View space = new View(requireContext());
+        parent.addView(
+                space,
+                new LinearLayout.LayoutParams(1, dp(heightDp))
+        );
+    }
+
+    private void styleHost() {
+        Activity activity = hostActivity();
+        if (activity == null || tokens == null) {
+            return;
+        }
+
+        activity.setTitle("Image hosting");
+        BoostSystemBarInsetsFix.applyMorpheSettingsV4SystemBars(
+                activity,
+                tokens.background,
+                tokens.dark
+        );
+
+        int toolbarId = MorpheSettingsV4Catalog.resourceId(
+                activity,
+                "id",
+                "toolbar"
+        );
+        View toolbar = toolbarId == 0
+                ? null
+                : activity.findViewById(toolbarId);
+        if (toolbar != null) {
+            toolbar.setBackgroundColor(tokens.background);
+            toolbar.setElevation(0);
+        }
+    }
+
+    private Activity hostActivity() {
+        Context context = getContext();
+        return context instanceof Activity ? (Activity) context : null;
+    }
+
+    private int dp(float value) {
+        return MorpheSettingsV4Theme.dp(requireContext(), value);
+    }
+}

--- a/extensions/boostforreddit/src/main/java/app/morphe/extension/boostforreddit/settings/MorpheSettingsV5MorpheFragment.java
+++ b/extensions/boostforreddit/src/main/java/app/morphe/extension/boostforreddit/settings/MorpheSettingsV5MorpheFragment.java
@@ -8,7 +8,10 @@ import android.view.Menu;
 import android.view.MenuItem;
 import android.view.View;
 
+import androidx.preference.Preference;
 import androidx.preference.PreferenceFragmentCompat;
+
+import app.morphe.extension.boostforreddit.upload.ExternalImageUploadSettings;
 
 import app.morphe.extension.boostforreddit.utils.BoostSystemBarInsetsFix;
 
@@ -25,6 +28,8 @@ public final class MorpheSettingsV5MorpheFragment
     private static final String RESOURCE_NAME =
             "morphe_boost_settings_skeleton";
     private static final String BOOST_PACKAGE = "com.rubenmayayo.reddit";
+    private static final String IMAGE_HOSTING_KEY =
+            "morphe_boost_image_hosting_settings";
 
     private MorpheSettingsV4Theme.Tokens tokens;
 
@@ -61,7 +66,15 @@ public final class MorpheSettingsV5MorpheFragment
     @Override
     public void onResume() {
         super.onResume();
+        refreshImageHostingSummary();
         styleHost();
+    }
+
+    private void refreshImageHostingSummary() {
+        Preference preference = findPreference(IMAGE_HOSTING_KEY);
+        if (preference != null) {
+            preference.setSummary(ExternalImageUploadSettings.summary());
+        }
     }
 
     @Override

--- a/extensions/boostforreddit/src/main/java/app/morphe/extension/boostforreddit/upload/EditorImagePreview.java
+++ b/extensions/boostforreddit/src/main/java/app/morphe/extension/boostforreddit/upload/EditorImagePreview.java
@@ -1,0 +1,632 @@
+/*
+ * Modifications Copyright 2026 brealorg.
+ *
+ * See the included NOTICE file for GPLv3 §7(b) and §7(c) terms that apply to this code.
+ */
+package app.morphe.extension.boostforreddit.upload;
+
+import android.content.Context;
+import android.graphics.drawable.GradientDrawable;
+import android.net.Uri;
+import android.text.Editable;
+import android.text.TextUtils;
+import android.text.TextWatcher;
+import android.util.Log;
+import android.util.TypedValue;
+import android.view.View;
+import android.view.ViewGroup;
+import android.view.ViewParent;
+import android.widget.EditText;
+import android.widget.FrameLayout;
+import android.widget.ImageView;
+import android.widget.LinearLayout;
+
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.WeakHashMap;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Live image preview for Boost editors using FormattingBar.setEditText.
+ *
+ * The source URL remains in the EditText because Reddit comments and self
+ * posts require it in submitted Markdown. This class only adds a visual
+ * preview directly above the active editor.
+ */
+public final class EditorImagePreview {
+    public static final String CONTRACT_MARKER =
+            "MORPHE_BOOST_EDITOR_IMAGE_PREVIEW_ISSUE66_V1";
+
+    private static final String TAG = "MorpheEditorPreview";
+    private static final String PREVIEW_TAG =
+            "morphe_boost_editor_image_preview_issue66_v1";
+
+    private static final int MAX_PREVIEWS = 4;
+    private static final long UPDATE_DELAY_MS = 120L;
+
+    private static final Pattern IMAGE_URL_PATTERN = Pattern.compile(
+            "https?://(?:"
+                    + "(?:i\\.redd\\.it|preview\\.redd\\.it|"
+                    + "external-preview\\.redd\\.it)/[^\\s\\\"'<>]+"
+                    + "|(?:i\\.ibb\\.co|image\\.ibb\\.co)/[^\\s\\\"'<>]+"
+                    + "|i\\.imgur\\.com/[^\\s\\\"'<>]+"
+                    + ")",
+            Pattern.CASE_INSENSITIVE
+    );
+
+    private static final WeakHashMap<EditText, Session> SESSIONS =
+            new WeakHashMap<>();
+
+    private EditorImagePreview() {
+    }
+
+    public static void bind(final EditText editText) {
+        if (editText == null) {
+            return;
+        }
+
+        editText.post(new Runnable() {
+            @Override
+            public void run() {
+                bindOnMain(editText);
+            }
+        });
+    }
+
+    private static void bindOnMain(EditText editText) {
+        synchronized (SESSIONS) {
+            if (SESSIONS.containsKey(editText)) {
+                return;
+            }
+
+            Session session = new Session(editText);
+            SESSIONS.put(editText, session);
+            session.attach(0);
+        }
+    }
+
+    private static final class Session implements TextWatcher {
+        private final EditText editText;
+        private final Runnable renderRunnable;
+
+        private LinearLayout previewContainer;
+        private List<String> renderedUrls = new ArrayList<>();
+        private boolean attached;
+
+        Session(EditText editText) {
+            this.editText = editText;
+            this.renderRunnable = new Runnable() {
+                @Override
+                public void run() {
+                    render();
+                }
+            };
+        }
+
+        void attach(final int attempt) {
+            if (attached) {
+                return;
+            }
+
+            Placement placement = findPlacement(editText);
+
+            if (placement == null) {
+                if (attempt < 5) {
+                    editText.postDelayed(new Runnable() {
+                        @Override
+                        public void run() {
+                            attach(attempt + 1);
+                        }
+                    }, 50L);
+                } else {
+                    Log.w(
+                            TAG,
+                            CONTRACT_MARKER
+                                    + ": no safe vertical editor host for "
+                                    + editText.getClass().getName()
+                    );
+                }
+                return;
+            }
+
+            previewContainer = new LinearLayout(editText.getContext());
+            previewContainer.setTag(PREVIEW_TAG);
+            previewContainer.setOrientation(LinearLayout.VERTICAL);
+            previewContainer.setVisibility(View.GONE);
+            previewContainer.setImportantForAccessibility(
+                    View.IMPORTANT_FOR_ACCESSIBILITY_NO
+            );
+
+            LinearLayout.LayoutParams containerParams =
+                    new LinearLayout.LayoutParams(
+                            ViewGroup.LayoutParams.MATCH_PARENT,
+                            ViewGroup.LayoutParams.WRAP_CONTENT
+                    );
+
+            int insertionIndex = Math.max(
+                    0,
+                    Math.min(
+                            placement.index,
+                            placement.parent.getChildCount()
+                    )
+            );
+
+            placement.parent.addView(
+                    previewContainer,
+                    insertionIndex,
+                    containerParams
+            );
+
+            editText.addTextChangedListener(this);
+            attached = true;
+            scheduleRender();
+
+            Log.d(
+                    TAG,
+                    CONTRACT_MARKER
+                            + ": bound editor="
+                            + editText.getClass().getName()
+                            + " host="
+                            + placement.parent.getClass().getName()
+                            + " index="
+                            + insertionIndex
+            );
+        }
+
+        @Override
+        public void beforeTextChanged(
+                CharSequence value,
+                int start,
+                int count,
+                int after
+        ) {
+        }
+
+        @Override
+        public void onTextChanged(
+                CharSequence value,
+                int start,
+                int before,
+                int count
+        ) {
+            scheduleRender();
+        }
+
+        @Override
+        public void afterTextChanged(Editable value) {
+        }
+
+        private void scheduleRender() {
+            editText.removeCallbacks(renderRunnable);
+            editText.postDelayed(renderRunnable, UPDATE_DELAY_MS);
+        }
+
+        private void render() {
+            if (!attached || previewContainer == null) {
+                return;
+            }
+
+            CharSequence value = editText.getText();
+            List<String> urls = extractImageUrls(
+                    value == null ? "" : value.toString()
+            );
+
+            if (urls.equals(renderedUrls)) {
+                return;
+            }
+
+            renderedUrls = urls;
+            previewContainer.removeAllViews();
+
+            if (urls.isEmpty()) {
+                previewContainer.setVisibility(View.GONE);
+                Log.d(TAG, CONTRACT_MARKER + ": hidden; no image URL");
+                return;
+            }
+
+            Context context = editText.getContext();
+            int maxHeightPx = resolveMaxPreviewHeightPx(context);
+
+            for (String url : urls) {
+                previewContainer.addView(
+                        createPreviewCard(context, url, maxHeightPx)
+                );
+            }
+
+            previewContainer.setVisibility(View.VISIBLE);
+            previewContainer.requestLayout();
+
+            Log.d(
+                    TAG,
+                    CONTRACT_MARKER
+                            + ": rendered count="
+                            + urls.size()
+                            + " urls="
+                            + urls
+            );
+        }
+    }
+
+    private static final class Placement {
+        final LinearLayout parent;
+        final int index;
+
+        Placement(LinearLayout parent, int index) {
+            this.parent = parent;
+            this.index = index;
+        }
+    }
+
+    private static Placement findPlacement(EditText editText) {
+        View current = editText;
+        ViewParent parent = current.getParent();
+
+        while (parent instanceof ViewGroup) {
+            ViewGroup group = (ViewGroup) parent;
+
+            if (group instanceof LinearLayout) {
+                LinearLayout linearLayout = (LinearLayout) group;
+
+                if (
+                        linearLayout.getOrientation() == LinearLayout.VERTICAL
+                                && !isTextInputLayout(linearLayout)
+                ) {
+                    int index = linearLayout.indexOfChild(current);
+                    if (index >= 0) {
+                        return new Placement(linearLayout, index);
+                    }
+                }
+            }
+
+            if (!(group instanceof View)) {
+                break;
+            }
+
+            current = (View) group;
+            parent = current.getParent();
+        }
+
+        return null;
+    }
+
+    private static boolean isTextInputLayout(View view) {
+        return view != null
+                && "com.google.android.material.textfield.TextInputLayout"
+                .equals(view.getClass().getName());
+    }
+
+    private static View createPreviewCard(
+            Context context,
+            String url,
+            int maxHeightPx
+    ) {
+        FrameLayout card = new FrameLayout(context);
+
+        LinearLayout.LayoutParams cardParams =
+                new LinearLayout.LayoutParams(
+                        ViewGroup.LayoutParams.MATCH_PARENT,
+                        ViewGroup.LayoutParams.WRAP_CONTENT
+                );
+
+        int horizontalMargin = dp(context, 16);
+        int verticalMargin = dp(context, 8);
+
+        cardParams.setMargins(
+                horizontalMargin,
+                verticalMargin,
+                horizontalMargin,
+                verticalMargin
+        );
+        card.setLayoutParams(cardParams);
+
+        GradientDrawable background = new GradientDrawable();
+        background.setColor(
+                resolveThemeColor(
+                        context,
+                        android.R.attr.colorControlHighlight,
+                        0x22808080
+                )
+        );
+        background.setCornerRadius(dp(context, 12));
+        card.setBackground(background);
+        card.setClipToOutline(true);
+
+        ImageView imageView = new ImageView(context);
+        imageView.setAdjustViewBounds(true);
+        imageView.setScaleType(ImageView.ScaleType.FIT_CENTER);
+        imageView.setMinimumHeight(dp(context, 96));
+        imageView.setMaxHeight(maxHeightPx);
+        imageView.setContentDescription("Editor image preview");
+
+        FrameLayout.LayoutParams imageParams =
+                new FrameLayout.LayoutParams(
+                        ViewGroup.LayoutParams.MATCH_PARENT,
+                        ViewGroup.LayoutParams.WRAP_CONTENT
+                );
+
+        card.addView(imageView, imageParams);
+        loadWithGlide(context, url, imageView);
+
+        return card;
+    }
+
+    private static List<String> extractImageUrls(String value) {
+        Set<String> unique = new LinkedHashSet<>();
+
+        if (TextUtils.isEmpty(value)) {
+            return new ArrayList<>();
+        }
+
+        String normalized = value.replace("&amp;", "&");
+        Matcher matcher = IMAGE_URL_PATTERN.matcher(normalized);
+
+        while (matcher.find() && unique.size() < MAX_PREVIEWS) {
+            String url = cleanUrlTail(matcher.group());
+            if (isSupportedImageUrl(url)) {
+                unique.add(url);
+            }
+        }
+
+        return new ArrayList<>(unique);
+    }
+
+    private static String cleanUrlTail(String value) {
+        if (value == null) {
+            return "";
+        }
+
+        String result = value;
+
+        while (!result.isEmpty()) {
+            char last = result.charAt(result.length() - 1);
+            if (
+                    last == ')'
+                            || last == ']'
+                            || last == '}'
+                            || last == ','
+                            || last == ';'
+            ) {
+                result = result.substring(0, result.length() - 1);
+                continue;
+            }
+            break;
+        }
+
+        return result;
+    }
+
+    private static boolean isSupportedImageUrl(String url) {
+        if (TextUtils.isEmpty(url)) {
+            return false;
+        }
+
+        try {
+            Uri uri = Uri.parse(url);
+            String scheme = uri.getScheme();
+            String host = uri.getHost();
+
+            if (
+                    !("http".equalsIgnoreCase(scheme)
+                            || "https".equalsIgnoreCase(scheme))
+                            || TextUtils.isEmpty(host)
+            ) {
+                return false;
+            }
+
+            String normalizedHost =
+                    host.toLowerCase(java.util.Locale.US);
+
+                    return "i.redd.it".equals(normalizedHost)
+                    || "preview.redd.it".equals(normalizedHost)
+                    || "external-preview.redd.it".equals(normalizedHost)
+                    || "i.ibb.co".equals(normalizedHost)
+                    || "image.ibb.co".equals(normalizedHost)
+                    || "i.imgur.com".equals(normalizedHost);
+        } catch (Throwable ignored) {
+            return false;
+        }
+    }
+
+    private static int resolveMaxPreviewHeightPx(Context context) {
+        int screenHeightDp = 800;
+
+        try {
+            int configured =
+                    context.getResources()
+                            .getConfiguration()
+                            .screenHeightDp;
+            if (configured > 0) {
+                screenHeightDp = configured;
+            }
+        } catch (Throwable ignored) {
+        }
+
+        int targetDp = Math.round(screenHeightDp * 0.36f);
+        targetDp = Math.max(180, Math.min(320, targetDp));
+        return dp(context, targetDp);
+    }
+
+    private static int resolveThemeColor(
+            Context context,
+            int attribute,
+            int fallback
+    ) {
+        try {
+            TypedValue value = new TypedValue();
+
+            if (!context.getTheme().resolveAttribute(
+                    attribute,
+                    value,
+                    true
+            )) {
+                return fallback;
+            }
+
+            if (
+                    value.type >= TypedValue.TYPE_FIRST_COLOR_INT
+                            && value.type <= TypedValue.TYPE_LAST_COLOR_INT
+            ) {
+                return value.data;
+            }
+
+            if (value.resourceId != 0) {
+                return context.getResources().getColor(value.resourceId);
+            }
+        } catch (Throwable ignored) {
+        }
+
+        return fallback;
+    }
+
+    private static int dp(Context context, int value) {
+        return Math.round(
+                value
+                        * context.getResources()
+                        .getDisplayMetrics()
+                        .density
+        );
+    }
+
+    private static void loadWithGlide(
+            Context context,
+            String url,
+            ImageView imageView
+    ) {
+        try {
+            Class<?> glideClass =
+                    Class.forName("com.bumptech.glide.Glide");
+            Method with = glideClass.getMethod(
+                    "with",
+                    Context.class
+            );
+            Object requestManager =
+                    with.invoke(null, context);
+
+            Object requestBuilder =
+                    invokeLoad(requestManager, url);
+
+            if (requestBuilder == null) {
+                Log.w(
+                        TAG,
+                        CONTRACT_MARKER
+                                + ": Glide load method unavailable"
+                );
+                return;
+            }
+
+            invokeInto(requestBuilder, imageView);
+        } catch (Throwable throwable) {
+            Log.w(
+                    TAG,
+                    CONTRACT_MARKER
+                            + ": Glide preview load failed url="
+                            + url,
+                    throwable
+            );
+        }
+    }
+
+    private static Object invokeLoad(
+            Object requestManager,
+            String url
+    ) {
+        try {
+            try {
+                Method method = requestManager
+                        .getClass()
+                        .getMethod("t", String.class);
+                method.setAccessible(true);
+                return method.invoke(requestManager, url);
+            } catch (Throwable ignored) {
+            }
+
+            Method[] methods =
+                    requestManager.getClass().getMethods();
+
+            for (Method method : methods) {
+                if (!"load".equals(method.getName())) {
+                    continue;
+                }
+
+                Class<?>[] parameters =
+                        method.getParameterTypes();
+
+                if (parameters.length != 1) {
+                    continue;
+                }
+
+                Class<?> parameter = parameters[0];
+
+                if (
+                        parameter == String.class
+                                || parameter == Object.class
+                                || CharSequence.class
+                                .isAssignableFrom(parameter)
+                ) {
+                    method.setAccessible(true);
+                    return method.invoke(requestManager, url);
+                }
+            }
+        } catch (Throwable ignored) {
+        }
+
+        return null;
+    }
+
+    private static void invokeInto(
+            Object requestBuilder,
+            ImageView imageView
+    ) {
+        try {
+            try {
+                Method method = requestBuilder
+                        .getClass()
+                        .getMethod("C0", ImageView.class);
+                method.setAccessible(true);
+                method.invoke(requestBuilder, imageView);
+                return;
+            } catch (Throwable ignored) {
+            }
+
+            Method[] methods =
+                    requestBuilder.getClass().getMethods();
+
+            for (Method method : methods) {
+                if (!"into".equals(method.getName())) {
+                    continue;
+                }
+
+                Class<?>[] parameters =
+                        method.getParameterTypes();
+
+                if (parameters.length != 1) {
+                    continue;
+                }
+
+                Class<?> parameter = parameters[0];
+
+                if (
+                        parameter == ImageView.class
+                                || parameter.isAssignableFrom(
+                                ImageView.class
+                        )
+                ) {
+                    method.setAccessible(true);
+                    method.invoke(requestBuilder, imageView);
+                    return;
+                }
+            }
+        } catch (Throwable throwable) {
+            Log.w(
+                    TAG,
+                    CONTRACT_MARKER
+                            + ": Glide into failed",
+                    throwable
+            );
+        }
+    }
+}

--- a/extensions/boostforreddit/src/main/java/app/morphe/extension/boostforreddit/upload/ExternalImageUploadFactory.java
+++ b/extensions/boostforreddit/src/main/java/app/morphe/extension/boostforreddit/upload/ExternalImageUploadFactory.java
@@ -1,0 +1,104 @@
+/*
+ * Modifications Copyright 2026 brealorg.
+ *
+ * See the included NOTICE file for GPLv3 §7(b) and §7(c) terms that apply to this code.
+ */
+package app.morphe.extension.boostforreddit.upload;
+
+import com.rubenmayayo.reddit.models.imgur.Upload;
+
+import java.util.List;
+import java.util.Locale;
+
+import de.e;
+import de.f;
+
+/** Creates the configured Boost media uploader without changing post/gallery routing. */
+public final class ExternalImageUploadFactory {
+    public static final String CONTRACT_MARKER =
+            "MORPHE_BOOST_EXTERNAL_IMAGE_HOST_FACTORY_ISSUE66_V1";
+
+    private ExternalImageUploadFactory() {
+    }
+
+    public static de.b create(String provider) {
+        String normalized = provider == null
+                ? "reddit"
+                : provider.trim().toLowerCase(Locale.US);
+
+        if ("imgbb".equals(normalized)) {
+            return new ImgBbUploader();
+        }
+        if ("imgur_free".equals(normalized)) {
+            return instantiate(
+                    "ee.a",
+                    "Boost's legacy Imgur uploader is unavailable."
+            );
+        }
+        if ("imgur_paid".equals(normalized)) {
+            return instantiate(
+                    "ee.b",
+                    "Boost's paid Imgur uploader is unavailable."
+            );
+        }
+        if ("vgy".equals(normalized)) {
+            return instantiate(
+                    "ge.b",
+                    "Boost's legacy vgy uploader is unavailable."
+            );
+        }
+
+        return instantiate(
+                "fe.b",
+                "Boost's native Reddit uploader is unavailable."
+        );
+    }
+
+    private static de.b instantiate(String className, String failureMessage) {
+        try {
+            Object value = Class.forName(className)
+                    .getDeclaredConstructor()
+                    .newInstance();
+            if (value instanceof de.b) {
+                return (de.b) value;
+            }
+        } catch (Throwable ignored) {
+        }
+
+        return new UnavailableUploader(failureMessage);
+    }
+
+    private static final class UnavailableUploader implements de.b {
+        private final String message;
+
+        private UnavailableUploader(String message) {
+            this.message = message;
+        }
+
+        @Override
+        public void a(
+                String title,
+                List<Upload> uploads,
+                f.b progress,
+                e listener
+        ) {
+            fail(listener);
+        }
+
+        @Override
+        public void b(Upload upload, f.b progress, e listener) {
+            fail(listener);
+        }
+
+        @Override
+        public void c(Upload upload, f.b progress, e listener) {
+            fail(listener);
+        }
+
+        private void fail(e listener) {
+            if (listener != null) {
+                listener.c(null, message);
+            }
+        }
+    }
+}

--- a/extensions/boostforreddit/src/main/java/app/morphe/extension/boostforreddit/upload/ExternalImageUploadSettings.java
+++ b/extensions/boostforreddit/src/main/java/app/morphe/extension/boostforreddit/upload/ExternalImageUploadSettings.java
@@ -1,0 +1,122 @@
+/*
+ * Modifications Copyright 2026 brealorg.
+ *
+ * See the included NOTICE file for GPLv3 §7(b) and §7(c) terms that apply to this code.
+ */
+package app.morphe.extension.boostforreddit.upload;
+
+import android.content.Context;
+import android.content.SharedPreferences;
+import android.text.TextUtils;
+
+import java.util.Locale;
+
+import app.morphe.extension.shared.Utils;
+
+/** Local settings for Boost editor image hosting. */
+public final class ExternalImageUploadSettings {
+    public static final String CONTRACT_MARKER =
+            "MORPHE_BOOST_EXTERNAL_IMAGE_HOST_SETTINGS_ISSUE66_V1";
+
+    public static final String PREF_EXTERNAL_IMAGE_HOST =
+            "morphe_boost_external_image_host";
+    public static final String PREF_IMGBB_API_KEY =
+            "morphe_boost_imgbb_api_key";
+
+    public static final String PROVIDER_REDDIT = "reddit";
+    public static final String PROVIDER_IMGBB = "imgbb";
+    public static final String PROVIDER_IMGUR = "imgur_free";
+
+    private ExternalImageUploadSettings() {
+    }
+
+    public static String getEditorProvider() {
+        SharedPreferences preferences = preferences();
+        if (preferences == null) {
+            return PROVIDER_IMGUR;
+        }
+
+        String stored = preferences.getString(
+                PREF_EXTERNAL_IMAGE_HOST,
+                PROVIDER_IMGUR
+        );
+        String normalized = normalizeProvider(stored);
+
+        // Migrate the temporary Reddit-for-editor policy to final Imgur default.
+        if (!TextUtils.equals(stored, normalized)) {
+            preferences.edit()
+                    .putString(PREF_EXTERNAL_IMAGE_HOST, normalized)
+                    .apply();
+        }
+
+        return normalized;
+    }
+
+    public static String getImgBbApiKey() {
+        SharedPreferences preferences = preferences();
+        if (preferences == null) {
+            return "";
+        }
+        String value = preferences.getString(PREF_IMGBB_API_KEY, "");
+        return value == null ? "" : value.trim();
+    }
+
+    public static void save(String provider, String imgBbApiKey) {
+        SharedPreferences preferences = preferences();
+        if (preferences == null) {
+            return;
+        }
+
+        SharedPreferences.Editor editor = preferences.edit()
+                .putString(
+                        PREF_EXTERNAL_IMAGE_HOST,
+                        normalizeProvider(provider)
+                );
+
+        if (imgBbApiKey != null) {
+            editor.putString(PREF_IMGBB_API_KEY, imgBbApiKey.trim());
+        }
+
+        editor.apply();
+    }
+
+    public static String summary() {
+        String provider = getEditorProvider();
+        if (PROVIDER_IMGBB.equals(provider)) {
+            return TextUtils.isEmpty(getImgBbApiKey())
+                    ? "Comments and text posts: ImgBB — API key required"
+                    : "Comments and text posts: ImgBB — configured";
+        }
+        return "Comments and text posts: Imgur — default";
+    }
+
+    public static String normalizeProvider(String value) {
+        if (value == null) {
+            return PROVIDER_IMGUR;
+        }
+
+        String normalized = value.trim().toLowerCase(Locale.US);
+        if (PROVIDER_IMGBB.equals(normalized)
+                || PROVIDER_IMGUR.equals(normalized)) {
+            return normalized;
+        }
+
+        // Reddit is valid for image posts/galleries, not editor attachments.
+        return PROVIDER_IMGUR;
+    }
+
+    private static SharedPreferences preferences() {
+        try {
+            Context context = Utils.getContext();
+            if (context == null) {
+                return null;
+            }
+            return context.getSharedPreferences(
+                    context.getPackageName() + "_preferences",
+                    Context.MODE_PRIVATE
+            );
+        } catch (Throwable ignored) {
+            return null;
+        }
+    }
+}

--- a/extensions/boostforreddit/src/main/java/app/morphe/extension/boostforreddit/upload/ImgBbUploader.java
+++ b/extensions/boostforreddit/src/main/java/app/morphe/extension/boostforreddit/upload/ImgBbUploader.java
@@ -1,0 +1,197 @@
+/*
+ * Modifications Copyright 2026 brealorg.
+ *
+ * See the included NOTICE file for GPLv3 §7(b) and §7(c) terms that apply to this code.
+ */
+package app.morphe.extension.boostforreddit.upload;
+
+import android.net.Uri;
+import android.os.Handler;
+import android.os.Looper;
+import android.text.TextUtils;
+
+import com.rubenmayayo.reddit.models.imgur.Upload;
+
+import org.json.JSONObject;
+
+import java.io.BufferedInputStream;
+import java.io.BufferedOutputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.net.URLConnection;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+
+import de.e;
+import de.f;
+
+/** ImgBB editor uploader using only Android/JDK network ABI. */
+public final class ImgBbUploader implements de.b {
+    public static final String CONTRACT_MARKER =
+            "MORPHE_BOOST_IMGBB_EDITOR_UPLOAD_ISSUE66_V1";
+    public static final String FRAMEWORK_MULTIPART_MARKER =
+            "MORPHE_BOOST_IMGBB_FRAMEWORK_MULTIPART_ISSUE66_V2";
+
+    private static final String API_URL = "https://api.imgbb.com/1/upload";
+    private static final long MAX_IMAGE_BYTES = 32L * 1024L * 1024L;
+    private static final int BUFFER_SIZE = 16 * 1024;
+    private static final Handler MAIN = new Handler(Looper.getMainLooper());
+
+    @Override
+    public void a(String title, List<Upload> uploads, f.b progress, e listener) {
+        if (uploads == null || uploads.isEmpty()) {
+            failure(listener, new IOException("No image selected"), "No image selected.");
+            return;
+        }
+        c(uploads.get(0), progress, listener);
+    }
+
+    @Override
+    public void b(Upload upload, f.b progress, e listener) {
+        c(upload, progress, listener);
+    }
+
+    @Override
+    public void c(Upload upload, f.b progress, e listener) {
+        File image = upload == null ? null : upload.image;
+        if (image == null || !image.isFile()) {
+            failure(listener, new IOException("Selected image is unavailable"), "The selected image is unavailable.");
+            return;
+        }
+        if (image.length() > MAX_IMAGE_BYTES) {
+            failure(listener, new IOException("Image exceeds ImgBB limit"), "ImgBB supports images up to 32 MB.");
+            return;
+        }
+        String apiKey = ExternalImageUploadSettings.getImgBbApiKey();
+        if (TextUtils.isEmpty(apiKey)) {
+            failure(listener, new IOException("ImgBB API key is missing"), "Add an ImgBB API key in Morphe settings.");
+            return;
+        }
+        String mimeType = URLConnection.guessContentTypeFromName(image.getName());
+        if (TextUtils.isEmpty(mimeType)) mimeType = "application/octet-stream";
+        final String selectedMimeType = mimeType;
+        new Thread(
+                () -> upload(image, selectedMimeType, apiKey, progress, listener),
+                "Morphe-ImgBB-upload"
+        ).start();
+    }
+
+    private static void upload(File image, String mimeType, String apiKey, f.b progress, e listener) {
+        HttpURLConnection connection = null;
+        try {
+            String endpoint = Uri.parse(API_URL).buildUpon()
+                    .appendQueryParameter("key", apiKey).build().toString();
+            String boundary = "----MorpheImgBB" + Long.toHexString(System.nanoTime());
+            byte[] prefix = multipartPrefix(boundary, safeFilename(image.getName()), mimeType);
+            byte[] suffix = ("\r\n--" + boundary + "--\r\n").getBytes(StandardCharsets.UTF_8);
+            long contentLength = prefix.length + image.length() + suffix.length;
+
+            connection = (HttpURLConnection) new URL(endpoint).openConnection();
+            connection.setRequestMethod("POST");
+            connection.setConnectTimeout(30_000);
+            connection.setReadTimeout(60_000);
+            connection.setDoInput(true);
+            connection.setDoOutput(true);
+            connection.setUseCaches(false);
+            connection.setInstanceFollowRedirects(true);
+            connection.setFixedLengthStreamingMode(contentLength);
+            connection.setRequestProperty("Accept", "application/json");
+            connection.setRequestProperty("Content-Type", "multipart/form-data; boundary=" + boundary);
+
+            reportProgress(progress, 0);
+            try (BufferedOutputStream output = new BufferedOutputStream(connection.getOutputStream());
+                 FileInputStream input = new FileInputStream(image)) {
+                output.write(prefix);
+                byte[] buffer = new byte[BUFFER_SIZE];
+                long written = 0L;
+                int lastPercent = -1;
+                int read;
+                while ((read = input.read(buffer)) != -1) {
+                    output.write(buffer, 0, read);
+                    written += read;
+                    int percent = image.length() <= 0L ? 99 : (int) Math.min(99L, (written * 100L) / image.length());
+                    if (percent != lastPercent) {
+                        lastPercent = percent;
+                        reportProgress(progress, percent);
+                    }
+                }
+                output.write(suffix);
+                output.flush();
+            }
+
+            int statusCode = connection.getResponseCode();
+            String json = readUtf8(statusCode >= 200 && statusCode < 400
+                    ? connection.getInputStream() : connection.getErrorStream());
+            JSONObject root = TextUtils.isEmpty(json) ? new JSONObject() : new JSONObject(json);
+            JSONObject data = root.optJSONObject("data");
+            String imageUrl = data == null ? "" : data.optString("url", "");
+            boolean successful = statusCode >= 200 && statusCode < 300
+                    && root.optBoolean("success", false) && imageUrl.startsWith("https://");
+            if (!successful) {
+                String message = errorMessage(root, statusCode);
+                failure(listener, new IOException(message), message);
+                return;
+            }
+            reportProgress(progress, 100);
+            success(listener, imageUrl);
+        } catch (Exception exception) {
+            failure(listener, exception, networkErrorMessage(exception));
+        } finally {
+            if (connection != null) connection.disconnect();
+        }
+    }
+
+    private static byte[] multipartPrefix(String boundary, String filename, String mimeType) {
+        String value = "--" + boundary + "\r\n"
+                + "Content-Disposition: form-data; name=\"image\"; filename=\"" + filename + "\"\r\n"
+                + "Content-Type: " + mimeType + "\r\n\r\n";
+        return value.getBytes(StandardCharsets.UTF_8);
+    }
+
+    private static String safeFilename(String value) {
+        if (TextUtils.isEmpty(value)) return "image";
+        return value.replace("\\", "_").replace("\"", "'").replace("\r", "_").replace("\n", "_");
+    }
+
+    private static String readUtf8(InputStream stream) throws IOException {
+        if (stream == null) return "";
+        try (BufferedInputStream input = new BufferedInputStream(stream);
+             ByteArrayOutputStream output = new ByteArrayOutputStream()) {
+            byte[] buffer = new byte[BUFFER_SIZE];
+            int read;
+            while ((read = input.read(buffer)) != -1) output.write(buffer, 0, read);
+            return output.toString(StandardCharsets.UTF_8.name());
+        }
+    }
+
+    private static String errorMessage(JSONObject root, int statusCode) {
+        JSONObject error = root.optJSONObject("error");
+        String message = error == null ? "" : error.optString("message", "");
+        if (TextUtils.isEmpty(message)) message = root.optString("status_txt", "");
+        if (TextUtils.isEmpty(message)) message = "ImgBB rejected the upload (HTTP " + statusCode + ").";
+        return message;
+    }
+
+    private static String networkErrorMessage(Exception exception) {
+        String detail = exception.getMessage();
+        if (TextUtils.isEmpty(detail)) detail = exception.getClass().getSimpleName();
+        return "ImgBB upload failed: " + detail;
+    }
+
+    private static void reportProgress(f.b progress, int percent) {
+        if (progress != null) MAIN.post(() -> progress.a(percent));
+    }
+
+    private static void success(e listener, String imageUrl) {
+        if (listener != null) MAIN.post(() -> listener.onSuccess(imageUrl));
+    }
+
+    private static void failure(e listener, Exception exception, String message) {
+        if (listener != null) MAIN.post(() -> listener.c(exception, message));
+    }
+}

--- a/extensions/boostforreddit/stub/src/main/java/com/rubenmayayo/reddit/models/imgur/ImageResponse.java
+++ b/extensions/boostforreddit/stub/src/main/java/com/rubenmayayo/reddit/models/imgur/ImageResponse.java
@@ -1,0 +1,6 @@
+package com.rubenmayayo.reddit.models.imgur;
+
+public class ImageResponse {
+    public static class UploadedImage {
+    }
+}

--- a/extensions/boostforreddit/stub/src/main/java/com/rubenmayayo/reddit/models/imgur/Upload.java
+++ b/extensions/boostforreddit/stub/src/main/java/com/rubenmayayo/reddit/models/imgur/Upload.java
@@ -1,0 +1,10 @@
+package com.rubenmayayo.reddit.models.imgur;
+
+import java.io.File;
+
+public class Upload {
+    public boolean disableAudio;
+    public File image;
+    public String title;
+    public String url;
+}

--- a/extensions/boostforreddit/stub/src/main/java/de/b.java
+++ b/extensions/boostforreddit/stub/src/main/java/de/b.java
@@ -1,0 +1,13 @@
+package de;
+
+import com.rubenmayayo.reddit.models.imgur.Upload;
+
+import java.util.List;
+
+public interface b {
+    void a(String title, List<Upload> uploads, f.b progress, e listener);
+
+    void b(Upload upload, f.b progress, e listener);
+
+    void c(Upload upload, f.b progress, e listener);
+}

--- a/extensions/boostforreddit/stub/src/main/java/de/e.java
+++ b/extensions/boostforreddit/stub/src/main/java/de/e.java
@@ -1,0 +1,15 @@
+package de;
+
+import com.rubenmayayo.reddit.models.imgur.ImageResponse;
+
+import java.util.List;
+
+public interface e {
+    void a(List<?> items);
+
+    void b(ImageResponse.UploadedImage uploadedImage);
+
+    void c(Exception exception, String message);
+
+    void onSuccess(String url);
+}

--- a/extensions/boostforreddit/stub/src/main/java/de/f.java
+++ b/extensions/boostforreddit/stub/src/main/java/de/f.java
@@ -1,0 +1,7 @@
+package de;
+
+public class f {
+    public interface b {
+        void a(int percent);
+    }
+}

--- a/patches/src/main/kotlin/app/morphe/patches/reddit/customclients/boostforreddit/fix/upload/Fingerprints.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/reddit/customclients/boostforreddit/fix/upload/Fingerprints.kt
@@ -10,9 +10,17 @@ import app.morphe.patcher.Fingerprint
 
 private const val BOOST_REMOTE_CONFIG_CLASS = "Lsb/a;"
 
+internal val editorImagePreviewFormattingBarSetEditTextFingerprint = Fingerprint(
+    definingClass = "Lcom/rubenmayayo/reddit/ui/customviews/FormattingBar;",
+    name = "setEditText",
+    returnType = "V",
+    parameters = listOf("Landroid/widget/EditText;"),
+)
+
 internal val submitGallerySubmissionKindFingerprint = Fingerprint(
     custom = { method, classDef ->
-        classDef.type == "Lcom/rubenmayayo/reddit/ui/submit/v2/SubmitGalleryFragment;" &&
+        classDef.type ==
+            "Lcom/rubenmayayo/reddit/ui/submit/v2/SubmitGalleryFragment;" &&
             method.name == "R1"
     }
 )
@@ -47,4 +55,17 @@ internal val nativeRedditSubmitAsImageKindFingerprint = Fingerprint(
     returnType = "Z",
     parameters = emptyList(),
     strings = listOf("submit_reddit_as_image_kind"),
+)
+
+internal val mediaUploaderFactoryFingerprint = Fingerprint(
+    definingClass = "Lde/c;",
+    name = "d",
+    returnType = "Lde/b;",
+    parameters = listOf("Ljava/lang/String;"),
+    strings = listOf(
+        "imgur_free",
+        "imgur_paid",
+        "vgy",
+        "reddit",
+    ),
 )

--- a/patches/src/main/kotlin/app/morphe/patches/reddit/customclients/boostforreddit/fix/upload/FixNativeImageUploadPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/reddit/customclients/boostforreddit/fix/upload/FixNativeImageUploadPatch.kt
@@ -10,6 +10,8 @@ import app.morphe.patcher.extensions.InstructionExtensions.addInstructions
 import app.morphe.patcher.extensions.InstructionExtensions.replaceInstruction
 import app.morphe.patcher.patch.bytecodePatch
 import app.morphe.patches.reddit.customclients.boostforreddit.BoostCompatible
+import app.morphe.patches.reddit.customclients.boostforreddit.misc.extension.sharedExtensionPatch
+import app.morphe.patches.reddit.customclients.boostforreddit.misc.settings.boostMorpheSettingsSkeletonPatch
 import app.morphe.util.getReference
 import app.morphe.util.indexOfFirstInstructionOrThrow
 import com.android.tools.smali.dexlib2.Opcode
@@ -18,26 +20,49 @@ import com.android.tools.smali.dexlib2.iface.reference.MethodReference
 
 private const val REDDIT_UPLOAD_PROVIDER = "reddit"
 
+private const val UPLOAD_SETTINGS_DESCRIPTOR =
+    "Lapp/morphe/extension/boostforreddit/upload/ExternalImageUploadSettings;"
+
+private const val UPLOAD_FACTORY_DESCRIPTOR =
+    "Lapp/morphe/extension/boostforreddit/upload/ExternalImageUploadFactory;"
+
 private const val NATIVE_REDDIT_UPLOAD_MARKER =
     "MORPHE_BOOST_NATIVE_REDDIT_IMAGE_UPLOAD_ISSUE66_V2"
+
+private const val EXTERNAL_IMAGE_HOST_MARKER =
+    "MORPHE_BOOST_EXTERNAL_IMAGE_HOST_ISSUE66_V1"
+
+private const val IMAGE_HOST_POLICY_MARKER =
+    "MORPHE_BOOST_IMAGE_HOST_POLICY_ISSUE66_V3"
 
 @Suppress("unused")
 val fixNativeImageUploadPatch = bytecodePatch(
     name = "Fix Boost native image upload",
     description =
-        "Routes Boost editor images, image posts, and galleries through " +
-            "Reddit's bundled native uploader instead of Imgur while " +
-            "retaining the original gallery submission-kind safeguard. " +
+        "Keeps Boost image posts and galleries on Reddit's native uploader " +
+            "and routes images inserted into comments or text posts through " +
+            "Imgur by default, with ImgBB as a manually selected alternative. " +
             "GIF and video upload behavior is unchanged.",
     default = false
 ) {
+    dependsOn(sharedExtensionPatch, boostMorpheSettingsSkeletonPatch)
     compatibleWith(*BoostCompatible)
 
     execute {
         check(NATIVE_REDDIT_UPLOAD_MARKER.endsWith("ISSUE66_V2"))
+        check(EXTERNAL_IMAGE_HOST_MARKER.endsWith("ISSUE66_V1"))
+        check(IMAGE_HOST_POLICY_MARKER.endsWith("ISSUE66_V3"))
+
+        nativeRedditUploaderFormatFingerprint.method.addInstructions(
+            0,
+            """
+                invoke-static {}, $UPLOAD_SETTINGS_DESCRIPTOR->getEditorProvider()Ljava/lang/String;
+                move-result-object v0
+                return-object v0
+            """.trimIndent(),
+        )
 
         arrayOf(
-            nativeRedditUploaderFormatFingerprint,
             nativeRedditUploaderSubmitFingerprint,
             nativeRedditUploaderSubmitMultipleFingerprint,
         ).forEach { fingerprint ->
@@ -46,27 +71,46 @@ val fixNativeImageUploadPatch = bytecodePatch(
                 """
                     const-string v0, "$REDDIT_UPLOAD_PROVIDER"
                     return-object v0
-                """,
+                """.trimIndent(),
             )
         }
+
+        mediaUploaderFactoryFingerprint.method.addInstructions(
+            0,
+            """
+                invoke-static {p0}, $UPLOAD_FACTORY_DESCRIPTOR->create(Ljava/lang/String;)Lde/b;
+                move-result-object v0
+                return-object v0
+            """.trimIndent(),
+        )
 
         nativeRedditSubmitAsImageKindFingerprint.method.addInstructions(
             0,
             """
                 const/4 v0, 0x1
                 return v0
-            """,
+            """.trimIndent(),
+        )
+
+        editorImagePreviewFormattingBarSetEditTextFingerprint.method.addInstructions(
+            0,
+            """
+                invoke-static {p1}, Lapp/morphe/extension/boostforreddit/upload/EditorImagePreview;->bind(Landroid/widget/EditText;)V
+            """.trimIndent(),
         )
 
         submitGallerySubmissionKindFingerprint.method.apply {
-            val submitAsImageRemoteConfigCallIndex = indexOfFirstInstructionOrThrow {
-                opcode == Opcode.INVOKE_STATIC &&
-                    getReference<MethodReference>()?.toString() == "Lsb/a;->f0()Z"
-            }
+            val submitAsImageRemoteConfigCallIndex =
+                indexOfFirstInstructionOrThrow {
+                    opcode == Opcode.INVOKE_STATIC &&
+                        getReference<MethodReference>()?.toString() ==
+                        "Lsb/a;->f0()Z"
+                }
 
             val moveResultIndex = submitAsImageRemoteConfigCallIndex + 1
             val moveResultInstruction =
-                implementation!!.instructions[moveResultIndex] as OneRegisterInstruction
+                implementation!!.instructions[moveResultIndex] as
+                    OneRegisterInstruction
             val moveResultRegister = moveResultInstruction.registerA
 
             replaceInstruction(
@@ -79,7 +123,9 @@ val fixNativeImageUploadPatch = bytecodePatch(
                 """
                     const-string v0, "MORPHE_ISSUE17_NATIVE_IMAGE_UPLOAD_V1"
                     const-string v0, "$NATIVE_REDDIT_UPLOAD_MARKER"
-                """,
+                    const-string v0, "$EXTERNAL_IMAGE_HOST_MARKER"
+                    const-string v0, "$IMAGE_HOST_POLICY_MARKER"
+                """.trimIndent(),
             )
         }
     }

--- a/patches/src/main/kotlin/app/morphe/patches/reddit/customclients/boostforreddit/misc/settings/BoostMorpheSettingsSkeletonPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/reddit/customclients/boostforreddit/misc/settings/BoostMorpheSettingsSkeletonPatch.kt
@@ -127,6 +127,15 @@ private val boostMorpheSettingsResourcesPatch = resourcePatch(
                             android:defaultValue="image_viewer" />
                     </PreferenceCategory>
 
+                    <PreferenceCategory android:title="Media uploads">
+                        <Preference
+                            android:icon="@drawable/ic_photo_outline_24dp"
+                            android:key="morphe_boost_image_hosting_settings"
+                            android:title="Image hosting"
+                            android:summary="Images added to text: Imgur — default"
+                            android:fragment="app.morphe.extension.boostforreddit.settings.MorpheSettingsV5ImageHostingFragment" />
+                    </PreferenceCategory>
+
                     <PreferenceCategory android:title="Search">
                         <CheckBoxPreference
                             android:key="morphe_boost_search_open_keyboard_on_entry"

--- a/tools/check-boost-editor-image-preview-contract.sh
+++ b/tools/check-boost-editor-image-preview-contract.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+PREVIEW="$ROOT/extensions/boostforreddit/src/main/java/app/morphe/extension/boostforreddit/upload/EditorImagePreview.java"
+FINGERPRINTS="$ROOT/patches/src/main/kotlin/app/morphe/patches/reddit/customclients/boostforreddit/fix/upload/Fingerprints.kt"
+PATCH="$ROOT/patches/src/main/kotlin/app/morphe/patches/reddit/customclients/boostforreddit/fix/upload/FixNativeImageUploadPatch.kt"
+
+python3 - "$PREVIEW" "$FINGERPRINTS" "$PATCH" <<'PY'
+from pathlib import Path
+import sys
+
+preview = Path(sys.argv[1]).read_text(encoding='utf-8')
+fingerprints = Path(sys.argv[2]).read_text(encoding='utf-8')
+patch = Path(sys.argv[3]).read_text(encoding='utf-8')
+
+for token in (
+    'MORPHE_BOOST_EDITOR_IMAGE_PREVIEW_ISSUE66_V1',
+    'implements TextWatcher',
+    'MAX_PREVIEWS = 4',
+    r'i\\.ibb\\.co',
+    r'i\\.imgur\\.com',
+    r'i\\.redd\\.it',
+    r'preview\\.redd\\.it',
+    'findPlacement(EditText editText)',
+    'LinearLayout.VERTICAL',
+    'TextInputLayout',
+    'editText.addTextChangedListener',
+    'previewContainer.setVisibility(View.GONE)',
+    'previewContainer.setVisibility(View.VISIBLE)',
+    'loadWithGlide',
+):
+    assert token in preview, token
+
+assert 'reddit-uploaded-media.s3-accelerate.amazonaws.com' not in preview
+assert 'editable.delete(' not in preview
+assert 'editable.replace(' not in preview
+
+for token in (
+    'editorImagePreviewFormattingBarSetEditTextFingerprint',
+    'definingClass = "Lcom/rubenmayayo/reddit/ui/customviews/FormattingBar;"',
+    'name = "setEditText"',
+    'parameters = listOf("Landroid/widget/EditText;")',
+):
+    assert token in fingerprints, token
+
+for token in (
+    'editorImagePreviewFormattingBarSetEditTextFingerprint.method.addInstructions',
+    'EditorImagePreview;->bind(Landroid/widget/EditText;)V',
+):
+    assert token in patch, token
+
+print('PASS=FORMATTING_BAR_SHARED_EDITOR_HOOK_PRESENT')
+print('PASS=PUBLIC_IMGUR_AND_IMGBB_EDITOR_PREVIEWS_SUPPORTED')
+print('PASS=RAW_REDDIT_S3_EDITOR_PREVIEW_REJECTED')
+print('PASS=SOURCE_URL_REMAINS_IN_EDITOR')
+print('PASS=PREVIEW_REMOVES_WHEN_URL_REMOVED')
+print('RESULT=MORPHE_ISSUE66_EDITOR_IMAGE_PREVIEW_FINAL_POLICY_PASS')
+PY

--- a/tools/check-boost-morphe-settings-contract.sh
+++ b/tools/check-boost-morphe-settings-contract.sh
@@ -106,6 +106,7 @@ preference_keys = [
     "morphe_boost_direct_reddit_gif_tap_action",
     "morphe_boost_giphy_preview_tap_action",
     "morphe_boost_static_preview_tap_action",
+    "morphe_boost_image_hosting_settings",
     "morphe_boost_search_open_keyboard_on_entry",
     "morphe_boost_prefer_high_refresh_rate",
     "morphe_boost_reddit_undelete_enabled",
@@ -156,11 +157,31 @@ assert categories == [
     "Media previews",
     "Image viewer",
     "Open behavior",
+    "Media uploads",
     "Search",
     "Display &amp; performance",
     "Recovery &amp; archives",
     "Settings",
 ]
+
+image_hosting = re.search(
+    r'<Preference\s+'
+    r'[^>]*android:key="morphe_boost_image_hosting_settings"[^>]*/>',
+    settings,
+    re.S,
+)
+assert image_hosting is not None
+image_hosting_xml = image_hosting.group(0)
+assert 'android:title="Image hosting"' in image_hosting_xml
+assert (
+    'android:summary="Images added to text: Imgur — default"'
+    in image_hosting_xml
+)
+assert (
+    'android:fragment="app.morphe.extension.boostforreddit.settings.'
+    'MorpheSettingsV5ImageHostingFragment"'
+    in image_hosting_xml
+)
 
 legacy_start = settings.index('get("res/xml/pref_headers_v2.xml")')
 v2_start = settings.index('"morphe_boost_settings_layout_v2" to')

--- a/tools/check-boost-native-reddit-image-upload-contract.sh
+++ b/tools/check-boost-native-reddit-image-upload-contract.sh
@@ -2,156 +2,131 @@
 set -euo pipefail
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-DIR="$ROOT/patches/src/main/kotlin/app/morphe/patches/reddit/customclients/boostforreddit/fix/upload"
-FINGERPRINTS="$DIR/Fingerprints.kt"
-PATCH="$DIR/FixNativeImageUploadPatch.kt"
-DUPLICATE_PATCH="$DIR/UseNativeRedditImageUploadsPatch.kt"
-BUILDER="$ROOT/tools/build-boost-candidate.sh"
 
-test -f "$FINGERPRINTS"
-test -f "$PATCH"
-test ! -e "$DUPLICATE_PATCH"
-
-python3 - "$FINGERPRINTS" "$PATCH" "$BUILDER" <<'PY'
+python3 - "$ROOT" <<'PY'
 from pathlib import Path
 import re
 import sys
 
-fingerprints_path = Path(sys.argv[1])
-patch_path = Path(sys.argv[2])
-builder_path = Path(sys.argv[3])
+root = Path(sys.argv[1])
+upload = root / 'extensions/boostforreddit/src/main/java/app/morphe/extension/boostforreddit/upload'
+settings_dir = root / 'extensions/boostforreddit/src/main/java/app/morphe/extension/boostforreddit/settings'
+patch_dir = root / 'patches/src/main/kotlin/app/morphe/patches/reddit/customclients/boostforreddit/fix/upload'
 
-fingerprints = fingerprints_path.read_text(encoding="utf-8")
-patch = patch_path.read_text(encoding="utf-8")
-builder = (
-    builder_path.read_text(encoding="utf-8")
-    if builder_path.is_file()
-    else ""
+settings = (upload / 'ExternalImageUploadSettings.java').read_text(encoding='utf-8')
+factory = (upload / 'ExternalImageUploadFactory.java').read_text(encoding='utf-8')
+imgbb = (upload / 'ImgBbUploader.java').read_text(encoding='utf-8')
+material = (settings_dir / 'MorpheSettingsV5ImageHostingFragment.java').read_text(encoding='utf-8')
+comment = (root / 'extensions/boostforreddit/src/main/java/app/morphe/extension/boostforreddit/giphy/InlineGiphyCommentPreview.java').read_text(encoding='utf-8')
+editor = (upload / 'EditorImagePreview.java').read_text(encoding='utf-8')
+fingerprints = (patch_dir / 'Fingerprints.kt').read_text(encoding='utf-8')
+patch = (patch_dir / 'FixNativeImageUploadPatch.kt').read_text(encoding='utf-8')
+
+assert not (upload / 'ProgressRequestBody.java').exists()
+
+for token in (
+    'PROVIDER_REDDIT = "reddit"',
+    'PROVIDER_IMGBB = "imgbb"',
+    'PROVIDER_IMGUR = "imgur_free"',
+    'return PROVIDER_IMGUR;',
+    'PREF_EXTERNAL_IMAGE_HOST,\n                PROVIDER_IMGUR',
+    'TextUtils.equals(stored, normalized)',
+    'Comments and text posts: Imgur — default',
+    'Comments and text posts: ImgBB — configured',
+):
+    assert token in settings, token
+
+normalize = re.search(
+    r'public static String normalizeProvider\(String value\) \{(.*?)\n    \}',
+    settings,
+    re.S,
 )
+assert normalize
+assert 'PROVIDER_IMGBB.equals(normalized)' in normalize.group(1)
+assert 'PROVIDER_IMGUR.equals(normalized)' in normalize.group(1)
+assert 'PROVIDER_REDDIT.equals(normalized)' not in normalize.group(1)
 
-assert fingerprints.count(
-    "internal val submitGallerySubmissionKindFingerprint"
-) == 1
-assert (
-    'classDef.type == '
-    '"Lcom/rubenmayayo/reddit/ui/submit/v2/SubmitGalleryFragment;"'
-    in fingerprints
-)
-assert 'method.name == "R1"' in fingerprints
+for token in (
+    '"Imgur"',
+    '"Default for comments and text posts."',
+    'ExternalImageUploadSettings.PROVIDER_IMGUR',
+    '"ImgBB"',
+    'ExternalImageUploadSettings.PROVIDER_IMGBB',
+    '"Comments and text posts"',
+    '"Image posts and galleries"',
+    '"Reddit native"',
+    '"Automatic fallback"',
+):
+    assert token in material, token
+assert 'ExternalImageUploadSettings.PROVIDER_REDDIT' not in material
+assert material.index('ExternalImageUploadSettings.PROVIDER_IMGUR') < material.index('ExternalImageUploadSettings.PROVIDER_IMGBB')
 
-expected_remote_config = (
-    (
-        "nativeRedditUploaderFormatFingerprint",
-        "w",
-        "Ljava/lang/String;",
-        "uploader_format",
-    ),
-    (
-        "nativeRedditUploaderSubmitFingerprint",
-        "S",
-        "Ljava/lang/String;",
-        "uploader_submit",
-    ),
-    (
-        "nativeRedditUploaderSubmitMultipleFingerprint",
-        "T",
-        "Ljava/lang/String;",
-        "uploader_submit_multiple",
-    ),
-    (
-        "nativeRedditSubmitAsImageKindFingerprint",
-        "f0",
-        "Z",
-        "submit_reddit_as_image_kind",
-    ),
-)
+for token in ('"imgbb"', '"ee.a"', '"fe.b"', 'new ImgBbUploader()'):
+    assert token in factory, token
 
-assert fingerprints.count(
-    'private const val BOOST_REMOTE_CONFIG_CLASS = "Lsb/a;"'
-) == 1
+for token in (
+    'MORPHE_BOOST_IMGBB_FRAMEWORK_MULTIPART_ISSUE66_V2',
+    'HttpURLConnection',
+    'setRequestMethod("POST")',
+    'multipart/form-data; boundary=',
+    'appendQueryParameter("key", apiKey)',
+    'data.optString("url", "")',
+    'listener.c(exception, message)',
+):
+    assert token in imgbb, token
+for forbidden in ('okhttp3.', 'okio.', 'ProgressRequestBody', 'BufferedSink'):
+    assert forbidden not in imgbb, forbidden
 
-for variable, method, return_type, key in expected_remote_config:
-    pattern = re.compile(
-        rf"internal val {re.escape(variable)} = Fingerprint\(\s*"
-        rf"definingClass = BOOST_REMOTE_CONFIG_CLASS,\s*"
-        rf'name = "{re.escape(method)}",\s*'
-        rf'returnType = "{re.escape(return_type)}",\s*'
-        rf"parameters = emptyList\(\),\s*"
-        rf'strings = listOf\("{re.escape(key)}"\),\s*'
-        rf"\)",
-        re.S,
-    )
-    assert pattern.search(fingerprints), variable
-    assert fingerprints.count(f'"{key}"') == 1, key
+for token in (
+    r'i\\.imgur\\.com',
+    r'i\\.ibb\\.co',
+    r'image\\.ibb\\.co',
+    r'i\\.redd\\.it',
+):
+    assert token in comment, token
+assert 'reddit-uploaded-media' not in comment
+assert 'MORPHE_BOOST_REDDIT_UPLOADED_MEDIA_INLINE_PREVIEW_ISSUE66_V1' not in comment
 
-required_patch_tokens = (
-    'name = "Fix Boost native image upload"',
-    'private const val REDDIT_UPLOAD_PROVIDER = "reddit"',
-    "MORPHE_BOOST_NATIVE_REDDIT_IMAGE_UPLOAD_ISSUE66_V2",
-    "MORPHE_ISSUE17_NATIVE_IMAGE_UPLOAD_V1",
-    "compatibleWith(*BoostCompatible)",
-    "nativeRedditUploaderFormatFingerprint",
-    "nativeRedditUploaderSubmitFingerprint",
-    "nativeRedditUploaderSubmitMultipleFingerprint",
-    "nativeRedditSubmitAsImageKindFingerprint",
-    "submitGallerySubmissionKindFingerprint",
+for token in (r'i\\.ibb\\.co', r'i\\.imgur\\.com', r'i\\.redd\\.it'):
+    assert token in editor, token
+assert 'reddit-uploaded-media' not in editor
+
+for token in (
+    'name = "w"',
+    'name = "S"',
+    'name = "T"',
+    'name = "f0"',
+    'editorImagePreviewFormattingBarSetEditTextFingerprint',
+    'mediaUploaderFactoryFingerprint',
+):
+    assert token in fingerprints, token
+
+for token in (
+    'getEditorProvider()Ljava/lang/String;',
+    'nativeRedditUploaderSubmitFingerprint',
+    'nativeRedditUploaderSubmitMultipleFingerprint',
     'const-string v0, "$REDDIT_UPLOAD_PROVIDER"',
-    "const/4 v0, 0x1",
-    "return-object v0",
-    "return v0",
-    'getReference<MethodReference>()?.toString() == "Lsb/a;->f0()Z"',
-    "replaceInstruction(",
-    "default = false",
-)
-
-for token in required_patch_tokens:
+    '$UPLOAD_FACTORY_DESCRIPTOR->create',
+    'MORPHE_BOOST_IMAGE_HOST_POLICY_ISSUE66_V3',
+    'EditorImagePreview;->bind(Landroid/widget/EditText;)V',
+):
     assert token in patch, token
 
 assert re.search(
-    r"arrayOf\(\s*"
-    r"nativeRedditUploaderFormatFingerprint,\s*"
-    r"nativeRedditUploaderSubmitFingerprint,\s*"
-    r"nativeRedditUploaderSubmitMultipleFingerprint,\s*"
-    r"\)\.forEach",
+    r'arrayOf\(\s*nativeRedditUploaderSubmitFingerprint,\s*'
+    r'nativeRedditUploaderSubmitMultipleFingerprint,\s*\)\.forEach',
     patch,
     re.S,
 )
 
-assert patch.count("val fixNativeImageUploadPatch = bytecodePatch(") == 1
-assert "val useNativeRedditImageUploadsPatch" not in patch
-assert patch.count('const-string v0, "$REDDIT_UPLOAD_PROVIDER"') == 1
-assert patch.count("const/4 v0, 0x1") >= 1
-
-assert '"Reddit\'s bundled native uploader instead of Imgur while " +' in patch
-assert '"GIF and video upload behavior is unchanged."' in patch
-
-for forbidden in (
-    "gifv_uploader_submit",
-    "ImgurFreeUploader",
-    "ImgurPaidUploader",
-    "VgyImageUploader",
-    "api.imgur.com",
-    "imgbb",
-    "imagechest",
-    "postimages",
-    "catbox",
-    "OkHttpClient",
-    "Retrofit",
-):
-    assert forbidden not in patch, forbidden
-
-if builder:
-    assert builder.count('"Fix Boost native image upload"') >= 1
-
-print("PASS=ORIGINAL_ISSUE17_GALLERY_SAFEGUARD_RETAINED")
-print("PASS=EDITOR_SINGLE_AND_GALLERY_PROVIDERS_FORCE_REDDIT")
-print("PASS=NATIVE_IMAGE_SUBMISSION_KIND_ENABLED_GLOBALLY")
-print("PASS=DUPLICATE_PATCH_REMOVED")
-print("PASS=GIF_VIDEO_PROVIDER_UNCHANGED")
-print("PASS=NO_EXTERNAL_UPLOAD_IMPLEMENTATION_ADDED")
-print(
-    "MARKER=MORPHE_BOOST_NATIVE_REDDIT_IMAGE_UPLOAD_ISSUE66_V2"
-)
+print('PASS=IMAGE_POSTS_AND_GALLERIES_FORCE_REDDIT_NATIVE')
+print('PASS=COMMENT_AND_TEXT_IMAGES_DEFAULT_TO_IMGUR')
+print('PASS=TEMPORARY_REDDIT_EDITOR_SELECTION_MIGRATES_TO_IMGUR')
+print('PASS=IMGBB_REMAINS_MANUAL_ALTERNATIVE')
+print('PASS=NO_AUTOMATIC_PROVIDER_FALLBACK')
+print('PASS=RAW_REDDIT_S3_PREVIEW_REMOVED')
+print('PASS=IMGBB_PUBLISHED_COMMENT_PREVIEW_SUPPORTED')
+print('PASS=IMGBB_HTTPURLCONNECTION_TRANSPORT_RETAINED')
+print('MARKER=MORPHE_BOOST_IMAGE_HOST_POLICY_ISSUE66_V3')
+print('RESULT=MORPHE_ISSUE66_FINAL_PROVIDER_POLICY_CONTRACT_PASS')
 PY
-
-echo "RESULT=MORPHE_ISSUE66_NATIVE_REDDIT_IMAGE_UPLOAD_V2_CONTRACT_PASS"


### PR DESCRIPTION
## Summary

Add the final Boost media-hosting policy:

- Reddit native for image posts and galleries.
- Imgur as the default for images in comments and text posts.
- ImgBB as a configurable manual alternative.
- Inline editor and published-comment previews for Imgur and ImgBB.
- No automatic provider fallback.

## Validation

- Imgur upload and inline preview: runtime PASS.
- ImgBB upload and inline preview: runtime PASS.
- ImgBB uses HttpURLConnection; the incompatible custom OkHttp/Okio request body is removed.
- Relevant fatal exceptions and ANRs: 0.
- Normal Boost remained unchanged.

Closes #66.