### PR TITLE
chore(release): prepare Morphe patch bundle 1.4.106

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 
 <!-- MORPHE_MANAGER_CHANGELOG_START -->
+## [1.4.106](https://github.com/brealorg/breal-morphe-patches/compare/morphe-patches-105...morphe-patches-106) (2026-08-06)
+
+* **Boost for Reddit:** Keep Reddit native for image posts and galleries; use Imgur by default and ImgBB optionally for comment and text-post images with inline previews.
+
 ## [1.4.105](https://github.com/brealorg/breal-morphe-patches/compare/morphe-patches-104...morphe-patches-105) (2026-08-05)
 
 * **Boost for Reddit:** Use Reddit's native uploader for Boost editor images, single-image posts, and galleries instead of Imgur.

--- a/README.md
+++ b/README.md
@@ -72,14 +72,14 @@ The repository shorthand shown at the top is the preferred Manager setup. Raw
 
 | Field | Value |
 |---|---|
-| Version | `1.4.105` |
-| Release tag | `morphe-patches-105` |
-| Asset | `patches-1.4.105.mpp` |
-| SHA256 | `b61656beb309e0373cd7c8163d2f191f789b2c23c4bcae1c129ae9c0debed41f` |
+| Version | `1.4.106` |
+| Release tag | `morphe-patches-106` |
+| Asset | `patches-1.4.106.mpp` |
+| SHA256 | `74ac18b54429950b30fcc334e0187e5f8e183baf02ed57dcf437bf452f952607` |
 | Manager JSON | `https://raw.githubusercontent.com/brealorg/breal-morphe-patches/main/patches-bundle.json` |
-| Download URL | `https://github.com/brealorg/breal-morphe-patches/releases/download/morphe-patches-105/patches-1.4.105.mpp` |
+| Download URL | `https://github.com/brealorg/breal-morphe-patches/releases/download/morphe-patches-106/patches-1.4.106.mpp` |
 
-SHA256: `b61656beb309e0373cd7c8163d2f191f789b2c23c4bcae1c129ae9c0debed41f`
+SHA256: `74ac18b54429950b30fcc334e0187e5f8e183baf02ed57dcf437bf452f952607`
 ## What this bundle does
 
 The current bundle is focused on practical hotfixes for tested app versions, especially Boost for Reddit behavior on newer Android versions.
@@ -126,7 +126,7 @@ Included Imgur patches:
 ### Patches list
 
 <!-- PATCHES_START -->
-> **Patch source version:** `1.4.105` • `main` • 53 unique patches • 105 package entries
+> **Patch source version:** `1.4.106` • `main` • 53 unique patches • 105 package entries
 
 <details>
 <summary><strong>Boost for Reddit</strong> • 44 patches</summary>
@@ -156,7 +156,7 @@ Included Imgur patches:
 | [Fix Boost comments Lemmy-style toolbar UI](#fix-boost-comments-lemmy-style-toolbar-ui) | Removes the duplicate native comments title by disabling the SlidrTheme window title/actionbar layer while preserving Boost's selected light/dark theme, toolbar title, and dynamic sort subtitle. |  |
 | [Fix Boost FAB nested scroll](#fix-boost-fab-nested-scroll) | Synchronizes Boost FAB hide/show with collapsing-header and nested-scroll motion. |  |
 | [Fix Boost image widget click target](#fix-boost-image-widget-click-target) | Prevents Boost's image widget from opening a stale post by making the CommentsActivity PendingIntent data unique per widget update. |  |
-| [Fix Boost native image upload](#fix-boost-native-image-upload) | Routes Boost editor images, image posts, and galleries through Reddit's bundled native uploader instead of Imgur while retaining the original gallery submission-kind safeguard. GIF and video upload behavior is unchanged. |  |
+| [Fix Boost native image upload](#fix-boost-native-image-upload) | Keeps Boost image posts and galleries on Reddit's native uploader and routes images inserted into comments or text posts through Imgur by default, with ImgBB as a manually selected alternative. GIF and video upload behavior is unchanged. |  |
 | [Fix Boost navigation bar overlap](#fix-boost-navigation-bar-overlap) | Adds runtime system bar inset handling for Boost bottom controls and drawer content on Android 15+ target SDK builds. |  |
 | [Fix Boost target SDK 35 compatibility](#fix-boost-target-sdk-35-compatibility) | Sets Boost for Reddit's target SDK to 35 and fixes BillingClient receiver registration for newer Android versions. |  |
 | [Fix Boost YouTube playback fallback](#fix-boost-youtube-playback-fallback) | Opens the original YouTube link externally when Boost's legacy embedded YouTube player is unavailable. |  |
@@ -540,16 +540,16 @@ Compatibility with other app versions is not guaranteed.
 
 ## Verification
 
-Release `1.4.105` is prepared and locally verified with:
+Release `1.4.106` is prepared and locally verified with:
 
-- Release tag `morphe-patches-105`.
+- Release tag `morphe-patches-106`.
 - Local built MPP SHA256 matching README.
-`b61656beb309e0373cd7c8163d2f191f789b2c23c4bcae1c129ae9c0debed41f`
-- `patches-bundle.json` returning version `1.4.105`.
-- `patches-bundle.json` pointing to the `morphe-patches-105` asset.
+`74ac18b54429950b30fcc334e0187e5f8e183baf02ed57dcf437bf452f952607`
+- `patches-bundle.json` returning version `1.4.106`.
+- `patches-bundle.json` pointing to the `morphe-patches-106` asset.
 - Expected release asset:
-`patches-1.4.105.mpp`
-- `b61656beb309e0373cd7c8163d2f191f789b2c23c4bcae1c129ae9c0debed41f  patches-1.4.105.mpp`
+`patches-1.4.106.mpp`
+- `74ac18b54429950b30fcc334e0187e5f8e183baf02ed57dcf437bf452f952607  patches-1.4.106.mpp`
 
 ## Development notes
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,4 +3,4 @@ org.gradle.jvmargs = -Xms512M -Xmx2048M
 org.gradle.parallel = true
 android.useAndroidX = true
 kotlin.code.style = official
-version = 1.4.105
+version = 1.4.106

--- a/patches-bundle.json
+++ b/patches-bundle.json
@@ -1,7 +1,7 @@
 {
-  "created_at": "2026-08-05T23:50:47",
-  "description": "Use Reddit's native uploader for Boost editor images, single-image posts, and galleries instead of Imgur.\n",
-  "download_url": "https://github.com/brealorg/breal-morphe-patches/releases/download/morphe-patches-105/patches-1.4.105.mpp",
-  "signature_download_url": "https://github.com/brealorg/breal-morphe-patches/releases/download/morphe-patches-105/patches-1.4.105.mpp.asc",
-  "version": "1.4.105"
+  "created_at": "2026-08-06T10:58:37",
+  "description": "Keep Reddit native for image posts and galleries; use Imgur by default and ImgBB optionally for comment and text-post images with inline previews.\n",
+  "download_url": "https://github.com/brealorg/breal-morphe-patches/releases/download/morphe-patches-106/patches-1.4.106.mpp",
+  "signature_download_url": "https://github.com/brealorg/breal-morphe-patches/releases/download/morphe-patches-106/patches-1.4.106.mpp.asc",
+  "version": "1.4.106"
 }

--- a/patches-list.json
+++ b/patches-list.json
@@ -1,6 +1,6 @@
 {
   "NOTE": "Do NOT manually edit this file. This file is automatically updated when semantic release (release.yml) runs. Manually editing this file can break your releases and break third party tools that use this file.",
-  "version": "1.4.105",
+  "version": "1.4.106",
   "patches": [
     {
       "name": "Add Boost Search bottom navigation",
@@ -768,9 +768,12 @@
     },
     {
       "name": "Fix Boost native image upload",
-      "description": "Routes Boost editor images, image posts, and galleries through Reddit's bundled native uploader instead of Imgur while retaining the original gallery submission-kind safeguard. GIF and video upload behavior is unchanged.",
+      "description": "Keeps Boost image posts and galleries on Reddit's native uploader and routes images inserted into comments or text posts through Imgur by default, with ImgBB as a manually selected alternative. GIF and video upload behavior is unchanged.",
       "default": false,
-      "dependencies": [],
+      "dependencies": [
+        "BytecodePatch",
+        "BytecodePatch"
+      ],
       "compatiblePackages": [
         {
           "packageName": "com.rubenmayayo.reddit",


### PR DESCRIPTION
## Summary

Prepare protected-main metadata for Morphe patch bundle `1.4.106`.

## Release identity

- Version: `1.4.106`
- Tag: `morphe-patches-106`
- Asset: `patches-1.4.106.mpp`
- Candidate MPP SHA256: `74ac18b54429950b30fcc334e0187e5f8e183baf02ed57dcf437bf452f952607`

## Included change

- Keep Reddit native for Boost image posts and galleries.
- Use Imgur by default for images in comments and text posts.
- Offer ImgBB as a configurable alternative.
- Show inline previews for both Imgur and ImgBB.

## Validation

- Imgur upload and inline preview: runtime PASS.
- ImgBB upload and inline preview: runtime PASS.
- No automatic provider fallback.
- Normal Boost remained unchanged.

Publication follows through the protected-main release workflow.

Closes #66.