### PR TITLE
fix(boost): preserve inline preview height on recycle

### DIFF
--- a/extensions/boostforreddit/src/main/java/app/morphe/extension/boostforreddit/giphy/StableInlinePreviewHeight.java
+++ b/extensions/boostforreddit/src/main/java/app/morphe/extension/boostforreddit/giphy/StableInlinePreviewHeight.java
@@ -1,0 +1,336 @@
+package app.morphe.extension.boostforreddit.giphy;
+
+import android.util.Log;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.ImageView;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.util.Map;
+import java.util.WeakHashMap;
+
+/**
+ * Preserves the resolved inline-preview slot while Boost recycles comment rows.
+ *
+ * <p>The existing preview implementation intentionally uses {@code WRAP_CONTENT}
+ * so Glide can resolve the media aspect ratio. A recycled holder creates a fresh
+ * ImageView, however, and temporarily collapses that slot until Glide resolves
+ * the drawable again. Cache the resolved geometry against the active comment
+ * model and restore it synchronously on the next bind.</p>
+ */
+public final class StableInlinePreviewHeight {
+    private static final String LOG_TAG = "InlineGiphy";
+    private static final String PREVIEW_TAG =
+            "morphe_boost_inline_giphy_preview";
+    private static final String PREVIEW_CONTENT_DESCRIPTION =
+            "Inline media preview";
+    private static final String CONTRACT_MARKER =
+            "MORPHE_BOOST_INLINE_MEDIA_STABLE_RECYCLED_HEIGHT_ISSUE164_V1";
+
+    private static final Map<Object, PreviewGeometry> CACHED_GEOMETRIES =
+            new WeakHashMap<>();
+
+    private StableInlinePreviewHeight() {
+    }
+
+    private static final class PreviewGeometry {
+        final int contentSignature;
+        final int widthPx;
+        final int heightPx;
+
+        PreviewGeometry(int contentSignature, int widthPx, int heightPx) {
+            this.contentSignature = contentSignature;
+            this.widthPx = widthPx;
+            this.heightPx = heightPx;
+        }
+    }
+
+    public static void bind(
+            Object holder,
+            Object commentModel,
+            Object glideRequestManager
+    ) {
+        InlineGiphyCommentPreview.bind(
+                holder,
+                commentModel,
+                glideRequestManager
+        );
+
+        try {
+            stabilize(holder, commentModel);
+        } catch (Throwable throwable) {
+            Log.w(
+                    LOG_TAG,
+                    CONTRACT_MARKER + ": stabilization failed",
+                    throwable
+            );
+        }
+    }
+
+    private static void stabilize(Object holder, final Object commentModel) {
+        if (holder == null || commentModel == null) return;
+
+        View itemView = getItemView(holder);
+        if (!(itemView instanceof ViewGroup)) return;
+
+        View preview = findTaggedPreview((ViewGroup) itemView);
+        if (!(preview instanceof ViewGroup)) return;
+
+        final ImageView imageView =
+                findPreviewImage((ViewGroup) preview);
+        if (imageView == null) return;
+
+        final int contentSignature =
+                resolveContentSignature(commentModel);
+        restoreCachedGeometry(
+                commentModel,
+                contentSignature,
+                imageView
+        );
+
+        imageView.addOnLayoutChangeListener(
+                new View.OnLayoutChangeListener() {
+                    @Override
+                    public void onLayoutChange(
+                            View view,
+                            int left,
+                            int top,
+                            int right,
+                            int bottom,
+                            int oldLeft,
+                            int oldTop,
+                            int oldRight,
+                            int oldBottom
+                    ) {
+                        cacheResolvedGeometryIfReady(
+                                commentModel,
+                                contentSignature,
+                                imageView
+                        );
+                    }
+                }
+        );
+
+        // Glide may satisfy a memory-cache request synchronously.
+        cacheResolvedGeometryIfReady(
+                commentModel,
+                contentSignature,
+                imageView
+        );
+    }
+
+    private static void restoreCachedGeometry(
+            Object commentModel,
+            int contentSignature,
+            ImageView imageView
+    ) {
+        PreviewGeometry geometry;
+        synchronized (CACHED_GEOMETRIES) {
+            geometry = CACHED_GEOMETRIES.get(commentModel);
+        }
+
+        if (
+                geometry == null
+                        || geometry.contentSignature != contentSignature
+                        || geometry.widthPx <= 0
+                        || geometry.heightPx <= 0
+        ) {
+            return;
+        }
+
+        ViewGroup.LayoutParams params = imageView.getLayoutParams();
+        if (params == null) return;
+
+        int targetWidthPx = resolveTargetWidthPx(imageView, params);
+        if (targetWidthPx <= 0) return;
+
+        int restoredHeightPx = Math.round(
+                geometry.heightPx
+                        * (targetWidthPx / (float) geometry.widthPx)
+        );
+        restoredHeightPx = clampToImageMaximum(
+                imageView,
+                restoredHeightPx
+        );
+        if (restoredHeightPx <= 0) return;
+
+        params.height = restoredHeightPx;
+        imageView.setLayoutParams(params);
+
+        Log.d(
+                LOG_TAG,
+                CONTRACT_MARKER
+                        + ": restored widthPx=" + targetWidthPx
+                        + " heightPx=" + restoredHeightPx
+        );
+    }
+
+    private static void cacheResolvedGeometryIfReady(
+            Object commentModel,
+            int contentSignature,
+            ImageView imageView
+    ) {
+        if (
+                commentModel == null
+                        || imageView == null
+                        || imageView.getDrawable() == null
+        ) {
+            return;
+        }
+
+        int widthPx = imageView.getWidth();
+        int heightPx = imageView.getHeight();
+        if (widthPx <= 0 || heightPx <= 0) return;
+
+        heightPx = clampToImageMaximum(imageView, heightPx);
+        if (heightPx <= 0) return;
+
+        PreviewGeometry previous;
+        PreviewGeometry resolved = new PreviewGeometry(
+                contentSignature,
+                widthPx,
+                heightPx
+        );
+
+        synchronized (CACHED_GEOMETRIES) {
+            previous = CACHED_GEOMETRIES.put(
+                    commentModel,
+                    resolved
+            );
+        }
+
+        if (
+                previous == null
+                        || previous.contentSignature != contentSignature
+                        || previous.widthPx != widthPx
+                        || previous.heightPx != heightPx
+        ) {
+            Log.d(
+                    LOG_TAG,
+                    CONTRACT_MARKER
+                            + ": cached widthPx=" + widthPx
+                            + " heightPx=" + heightPx
+            );
+        }
+    }
+
+    private static int resolveTargetWidthPx(
+            ImageView imageView,
+            ViewGroup.LayoutParams params
+    ) {
+        if (params.width > 0) return params.width;
+        if (imageView.getWidth() > 0) return imageView.getWidth();
+
+        int maxWidthPx = imageView.getMaxWidth();
+        return maxWidthPx > 0 ? maxWidthPx : 0;
+    }
+
+    private static int clampToImageMaximum(
+            ImageView imageView,
+            int heightPx
+    ) {
+        if (heightPx <= 0) return 0;
+
+        int maximumHeightPx = imageView.getMaxHeight();
+        if (
+                maximumHeightPx > 0
+                        && maximumHeightPx < Integer.MAX_VALUE
+        ) {
+            return Math.min(heightPx, maximumHeightPx);
+        }
+
+        return heightPx;
+    }
+
+    private static int resolveContentSignature(Object commentModel) {
+        String source = callStringMethod(commentModel, "S0");
+        if (source == null) {
+            source = callStringMethod(commentModel, "T0");
+        }
+
+        return source == null ? 0 : source.hashCode();
+    }
+
+    private static String callStringMethod(
+            Object target,
+            String methodName
+    ) {
+        if (target == null || methodName == null) return null;
+
+        try {
+            Method method = target.getClass().getMethod(methodName);
+            method.setAccessible(true);
+            Object value = method.invoke(target);
+            return value instanceof String ? (String) value : null;
+        } catch (Throwable ignored) {
+            return null;
+        }
+    }
+
+    private static View getItemView(Object holder) {
+        if (holder == null) return null;
+
+        Class<?> cursor = holder.getClass();
+        while (cursor != null) {
+            try {
+                Field field = cursor.getDeclaredField("itemView");
+                field.setAccessible(true);
+                Object value = field.get(holder);
+                return value instanceof View ? (View) value : null;
+            } catch (NoSuchFieldException ignored) {
+                cursor = cursor.getSuperclass();
+            } catch (Throwable ignored) {
+                return null;
+            }
+        }
+
+        return null;
+    }
+
+    private static View findTaggedPreview(ViewGroup root) {
+        if (root == null) return null;
+        if (PREVIEW_TAG.equals(root.getTag())) return root;
+
+        for (int index = 0; index < root.getChildCount(); index++) {
+            View child = root.getChildAt(index);
+            if (child == null) continue;
+            if (PREVIEW_TAG.equals(child.getTag())) return child;
+
+            if (child instanceof ViewGroup) {
+                View nested = findTaggedPreview((ViewGroup) child);
+                if (nested != null) return nested;
+            }
+        }
+
+        return null;
+    }
+
+    private static ImageView findPreviewImage(ViewGroup root) {
+        for (int index = 0; index < root.getChildCount(); index++) {
+            View child = root.getChildAt(index);
+            if (child == null) continue;
+
+            if (child instanceof ImageView) {
+                CharSequence description =
+                        child.getContentDescription();
+                if (
+                        description != null
+                                && PREVIEW_CONTENT_DESCRIPTION.contentEquals(
+                                description
+                        )
+                ) {
+                    return (ImageView) child;
+                }
+            }
+
+            if (child instanceof ViewGroup) {
+                ImageView nested =
+                        findPreviewImage((ViewGroup) child);
+                if (nested != null) return nested;
+            }
+        }
+
+        return null;
+    }
+}

--- a/patches/src/main/kotlin/app/morphe/patches/reddit/customclients/boostforreddit/fix/giphy/InlineGiphyCommentPreviewPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/reddit/customclients/boostforreddit/fix/giphy/InlineGiphyCommentPreviewPatch.kt
@@ -22,6 +22,9 @@ private const val COMMENT_VIEW_HOLDER_DESCRIPTOR =
 private const val INLINE_GIPHY_EXTENSION_DESCRIPTOR =
     "Lapp/morphe/extension/boostforreddit/giphy/InlineGiphyCommentPreview;"
 
+private const val STABLE_INLINE_PREVIEW_HEIGHT_DESCRIPTOR =
+    "Lapp/morphe/extension/boostforreddit/giphy/StableInlinePreviewHeight;"
+
 private const val TABLE_TEXT_VIEW_DESCRIPTOR =
     "Lcom/rubenmayayo/reddit/ui/customviews/TableTextView;"
 
@@ -40,7 +43,7 @@ val inlineGiphyCommentPreviewPatch = bytecodePatch(
                 0,
                 """
                     invoke-static {p0, p1}, $INLINE_GIPHY_EXTENSION_DESCRIPTOR->cleanCommentHtml(Ljava/lang/Object;Ljava/lang/Object;)V
-                    invoke-static {p0, p1, p5}, $INLINE_GIPHY_EXTENSION_DESCRIPTOR->bind(Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;)V
+                    invoke-static {p0, p1, p5}, $STABLE_INLINE_PREVIEW_HEIGHT_DESCRIPTOR->bind(Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;)V
                     """
             )
 

--- a/scripts/verify-boost-inline-preview-height-contract.py
+++ b/scripts/verify-boost-inline-preview-height-contract.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python3
+# Static contract for Boost issue #164 inline-preview height stability.
+
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+HELPER = ROOT / (
+    "extensions/boostforreddit/src/main/java/app/morphe/extension/"
+    "boostforreddit/giphy/StableInlinePreviewHeight.java"
+)
+PATCH = ROOT / (
+    "patches/src/main/kotlin/app/morphe/patches/reddit/customclients/"
+    "boostforreddit/fix/giphy/InlineGiphyCommentPreviewPatch.kt"
+)
+
+helper = HELPER.read_text(encoding="utf-8")
+patch = PATCH.read_text(encoding="utf-8")
+
+required_helper_contracts = {
+    "issue marker":
+        "MORPHE_BOOST_INLINE_MEDIA_STABLE_RECYCLED_HEIGHT_ISSUE164_V1",
+    "weak comment cache":
+        "new WeakHashMap<>()",
+    "existing preview bind delegation":
+        "InlineGiphyCommentPreview.bind(",
+    "synchronous cached-height restore":
+        "restoreCachedGeometry(",
+    "resolved drawable guard":
+        "imageView.getDrawable() == null",
+    "layout measurement listener":
+        "addOnLayoutChangeListener(",
+    "width-aware height scaling":
+        "targetWidthPx / (float) geometry.widthPx",
+    "adaptive maximum-height clamp":
+        "imageView.getMaxHeight()",
+    "comment-content invalidation":
+        "geometry.contentSignature != contentSignature",
+}
+
+required_patch_contracts = {
+    "stable helper descriptor":
+        "StableInlinePreviewHeight;",
+    "stable bind dispatch":
+        "$STABLE_INLINE_PREVIEW_HEIGHT_DESCRIPTOR->bind",
+    "original source cleanup":
+        "$INLINE_GIPHY_EXTENSION_DESCRIPTOR->cleanCommentHtml",
+    "original post-bind source policy":
+        "$INLINE_GIPHY_EXTENSION_DESCRIPTOR->applySourceTextPolicyAfterBind",
+    "original collapse synchronization":
+        "$INLINE_GIPHY_EXTENSION_DESCRIPTOR->syncWithCommentState",
+}
+
+failures: list[str] = []
+
+for name, marker in required_helper_contracts.items():
+    if marker not in helper:
+        failures.append(f"helper missing {name}: {marker}")
+
+for name, marker in required_patch_contracts.items():
+    if marker not in patch:
+        failures.append(f"patch missing {name}: {marker}")
+
+direct_old_bind = (
+    "$INLINE_GIPHY_EXTENSION_DESCRIPTOR->bind"
+    "(Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;)V"
+)
+if direct_old_bind in patch:
+    failures.append("patch still dispatches directly to the unstable bind path")
+
+if failures:
+    for failure in failures:
+        print(f"FAIL={failure}")
+    raise SystemExit(1)
+
+print("ISSUE=164")
+print("SOURCE_CONTRACT=PASS")
+print("CACHE_SCOPE=WEAK_COMMENT_MODEL")
+print("HEIGHT_RESTORE=BEFORE_ASYNC_GLIDE_LAYOUT")
+print("ADAPTIVE_SIZE_BEHAVIOR=PRESERVED")
+print("RESULT=ISSUE164_INLINE_PREVIEW_HEIGHT_CONTRACT_PASS")


### PR DESCRIPTION
## Summary

- preserve the last resolved inline-image height while Boost recycles comment rows
- restore the slot synchronously before the asynchronous Glide reload
- retain Compact, Balanced, and Large adaptive sizing
- invalidate cached geometry if the comment content changes

## Root cause

The adaptive preview-size change replaced the old fixed-height image slot with `WRAP_CONTENT`. Every recycled comment bind creates a new `ImageView`, so its row temporarily collapses and expands again when Glide resolves the drawable.

## Verification

- [x] static source contract
- [x] `git diff --check`
- [x] `./gradlew :patches:buildAndroid`
- [x] MPP contains `classes.dex`
- [x] MPP contains `extensions/boostforreddit.mpe`
- [x] DEV candidate built from the original Boost 1.12.12 APK
- [x] reproduction thread scrolled down and back up repeatedly
- [x] cached geometry observed
- [x] recycled height restoration observed
- [x] visual result PASS
- [x] relevant fatal exceptions: 0
- [x] stabilization failures: 0
- [x] normal Boost package unchanged

Fixes #164
