### PR TITLE
chore(release): prepare Morphe patch bundle 1.4.107

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 
 <!-- MORPHE_MANAGER_CHANGELOG_START -->
+## [1.4.107](https://github.com/brealorg/breal-morphe-patches/compare/morphe-patches-106...morphe-patches-107) (2026-08-06)
+
+* **Boost for Reddit:** Preserve inline-image row height while Boost recycles comments, preventing image-heavy threads from jumping during upward scrolling.
+
 ## [1.4.106](https://github.com/brealorg/breal-morphe-patches/compare/morphe-patches-105...morphe-patches-106) (2026-08-06)
 
 * **Boost for Reddit:** Keep Reddit native for image posts and galleries; use Imgur by default and ImgBB optionally for comment and text-post images with inline previews.

--- a/README.md
+++ b/README.md
@@ -72,14 +72,14 @@ The repository shorthand shown at the top is the preferred Manager setup. Raw
 
 | Field | Value |
 |---|---|
-| Version | `1.4.106` |
-| Release tag | `morphe-patches-106` |
-| Asset | `patches-1.4.106.mpp` |
-| SHA256 | `74ac18b54429950b30fcc334e0187e5f8e183baf02ed57dcf437bf452f952607` |
+| Version | `1.4.107` |
+| Release tag | `morphe-patches-107` |
+| Asset | `patches-1.4.107.mpp` |
+| SHA256 | `a942f3d5277a0e7e1a387f07806b0c303716c05fc108a10f10a73ea968bfea5a` |
 | Manager JSON | `https://raw.githubusercontent.com/brealorg/breal-morphe-patches/main/patches-bundle.json` |
-| Download URL | `https://github.com/brealorg/breal-morphe-patches/releases/download/morphe-patches-106/patches-1.4.106.mpp` |
+| Download URL | `https://github.com/brealorg/breal-morphe-patches/releases/download/morphe-patches-107/patches-1.4.107.mpp` |
 
-SHA256: `74ac18b54429950b30fcc334e0187e5f8e183baf02ed57dcf437bf452f952607`
+SHA256: `a942f3d5277a0e7e1a387f07806b0c303716c05fc108a10f10a73ea968bfea5a`
 ## What this bundle does
 
 The current bundle is focused on practical hotfixes for tested app versions, especially Boost for Reddit behavior on newer Android versions.
@@ -126,7 +126,7 @@ Included Imgur patches:
 ### Patches list
 
 <!-- PATCHES_START -->
-> **Patch source version:** `1.4.106` • `main` • 53 unique patches • 105 package entries
+> **Patch source version:** `1.4.107` • `main` • 53 unique patches • 105 package entries
 
 <details>
 <summary><strong>Boost for Reddit</strong> • 44 patches</summary>
@@ -540,16 +540,16 @@ Compatibility with other app versions is not guaranteed.
 
 ## Verification
 
-Release `1.4.106` is prepared and locally verified with:
+Release `1.4.107` is prepared and locally verified with:
 
-- Release tag `morphe-patches-106`.
+- Release tag `morphe-patches-107`.
 - Local built MPP SHA256 matching README.
-`74ac18b54429950b30fcc334e0187e5f8e183baf02ed57dcf437bf452f952607`
-- `patches-bundle.json` returning version `1.4.106`.
-- `patches-bundle.json` pointing to the `morphe-patches-106` asset.
+`a942f3d5277a0e7e1a387f07806b0c303716c05fc108a10f10a73ea968bfea5a`
+- `patches-bundle.json` returning version `1.4.107`.
+- `patches-bundle.json` pointing to the `morphe-patches-107` asset.
 - Expected release asset:
-`patches-1.4.106.mpp`
-- `74ac18b54429950b30fcc334e0187e5f8e183baf02ed57dcf437bf452f952607  patches-1.4.106.mpp`
+`patches-1.4.107.mpp`
+- `a942f3d5277a0e7e1a387f07806b0c303716c05fc108a10f10a73ea968bfea5a  patches-1.4.107.mpp`
 
 ## Development notes
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,4 +3,4 @@ org.gradle.jvmargs = -Xms512M -Xmx2048M
 org.gradle.parallel = true
 android.useAndroidX = true
 kotlin.code.style = official
-version = 1.4.106
+version = 1.4.107

--- a/patches-bundle.json
+++ b/patches-bundle.json
@@ -1,7 +1,7 @@
 {
-  "created_at": "2026-08-06T10:58:37",
-  "description": "Keep Reddit native for image posts and galleries; use Imgur by default and ImgBB optionally for comment and text-post images with inline previews.\n",
-  "download_url": "https://github.com/brealorg/breal-morphe-patches/releases/download/morphe-patches-106/patches-1.4.106.mpp",
-  "signature_download_url": "https://github.com/brealorg/breal-morphe-patches/releases/download/morphe-patches-106/patches-1.4.106.mpp.asc",
-  "version": "1.4.106"
+  "created_at": "2026-08-06T12:16:44",
+  "description": "Preserve inline-image row height while Boost recycles comments, preventing image-heavy threads from jumping during upward scrolling.\n",
+  "download_url": "https://github.com/brealorg/breal-morphe-patches/releases/download/morphe-patches-107/patches-1.4.107.mpp",
+  "signature_download_url": "https://github.com/brealorg/breal-morphe-patches/releases/download/morphe-patches-107/patches-1.4.107.mpp.asc",
+  "version": "1.4.107"
 }

--- a/patches-list.json
+++ b/patches-list.json
@@ -1,6 +1,6 @@
 {
   "NOTE": "Do NOT manually edit this file. This file is automatically updated when semantic release (release.yml) runs. Manually editing this file can break your releases and break third party tools that use this file.",
-  "version": "1.4.106",
+  "version": "1.4.107",
   "patches": [
     {
       "name": "Add Boost Search bottom navigation",


### PR DESCRIPTION
## Summary

Prepare protected-main metadata for Morphe patch bundle `1.4.107`.

## Release identity

- Version: `1.4.107`
- Tag: `morphe-patches-107`
- Asset: `patches-1.4.107.mpp`
- Candidate MPP SHA256: `a942f3d5277a0e7e1a387f07806b0c303716c05fc108a10f10a73ea968bfea5a`

## Included change

- Preserve the resolved height of inline comment images while Boost recycles rows.
- Restore cached preview geometry before asynchronous Glide reloads.
- Keep existing Compact, Balanced, and Large adaptive preview sizing.

## Validation

- Issue #164 reproduction flow: visual PASS.
- Cached geometry events: observed.
- Recycled height restorations: observed.
- Stabilization failures: 0.
- Relevant fatal exceptions: 0.
- Normal Boost package remained unchanged.
- Required Issue #164 marker present in the release MPP.

Publication follows through the protected-main release workflow.

Closes #164.
