### PR TITLE
chore(release): prepare Morphe patch bundle 1.4.108

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 
 <!-- MORPHE_MANAGER_CHANGELOG_START -->
+## [1.4.108](https://github.com/brealorg/breal-morphe-patches/compare/morphe-patches-107...morphe-patches-108) (2026-08-11)
+
+* **Boost for Reddit:** Harden Boost bottom-navigation semantic state recovery for Search results, reselect routing, Back navigation and cross-activity navigation.
+
 ## [1.4.107](https://github.com/brealorg/breal-morphe-patches/compare/morphe-patches-106...morphe-patches-107) (2026-08-06)
 
 * **Boost for Reddit:** Preserve inline-image row height while Boost recycles comments, preventing image-heavy threads from jumping during upward scrolling.

--- a/README.md
+++ b/README.md
@@ -72,14 +72,14 @@ The repository shorthand shown at the top is the preferred Manager setup. Raw
 
 | Field | Value |
 |---|---|
-| Version | `1.4.107` |
-| Release tag | `morphe-patches-107` |
-| Asset | `patches-1.4.107.mpp` |
-| SHA256 | `a942f3d5277a0e7e1a387f07806b0c303716c05fc108a10f10a73ea968bfea5a` |
+| Version | `1.4.108` |
+| Release tag | `morphe-patches-108` |
+| Asset | `patches-1.4.108.mpp` |
+| SHA256 | `ef7a5f1fb9a217c147ad5f6a40d344dda2e8a7f73b896df078872ca052cf056b` |
 | Manager JSON | `https://raw.githubusercontent.com/brealorg/breal-morphe-patches/main/patches-bundle.json` |
-| Download URL | `https://github.com/brealorg/breal-morphe-patches/releases/download/morphe-patches-107/patches-1.4.107.mpp` |
+| Download URL | `https://github.com/brealorg/breal-morphe-patches/releases/download/morphe-patches-108/patches-1.4.108.mpp` |
 
-SHA256: `a942f3d5277a0e7e1a387f07806b0c303716c05fc108a10f10a73ea968bfea5a`
+SHA256: `ef7a5f1fb9a217c147ad5f6a40d344dda2e8a7f73b896df078872ca052cf056b`
 ## What this bundle does
 
 The current bundle is focused on practical hotfixes for tested app versions, especially Boost for Reddit behavior on newer Android versions.
@@ -126,7 +126,7 @@ Included Imgur patches:
 ### Patches list
 
 <!-- PATCHES_START -->
-> **Patch source version:** `1.4.107` • `main` • 53 unique patches • 105 package entries
+> **Patch source version:** `1.4.108` • `main` • 53 unique patches • 105 package entries
 
 <details>
 <summary><strong>Boost for Reddit</strong> • 44 patches</summary>
@@ -540,16 +540,16 @@ Compatibility with other app versions is not guaranteed.
 
 ## Verification
 
-Release `1.4.107` is prepared and locally verified with:
+Release `1.4.108` is prepared and locally verified with:
 
-- Release tag `morphe-patches-107`.
+- Release tag `morphe-patches-108`.
 - Local built MPP SHA256 matching README.
-`a942f3d5277a0e7e1a387f07806b0c303716c05fc108a10f10a73ea968bfea5a`
-- `patches-bundle.json` returning version `1.4.107`.
-- `patches-bundle.json` pointing to the `morphe-patches-107` asset.
+`ef7a5f1fb9a217c147ad5f6a40d344dda2e8a7f73b896df078872ca052cf056b`
+- `patches-bundle.json` returning version `1.4.108`.
+- `patches-bundle.json` pointing to the `morphe-patches-108` asset.
 - Expected release asset:
-`patches-1.4.107.mpp`
-- `a942f3d5277a0e7e1a387f07806b0c303716c05fc108a10f10a73ea968bfea5a  patches-1.4.107.mpp`
+`patches-1.4.108.mpp`
+- `ef7a5f1fb9a217c147ad5f6a40d344dda2e8a7f73b896df078872ca052cf056b  patches-1.4.108.mpp`
 
 ## Development notes
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,4 +3,4 @@ org.gradle.jvmargs = -Xms512M -Xmx2048M
 org.gradle.parallel = true
 android.useAndroidX = true
 kotlin.code.style = official
-version = 1.4.107
+version = 1.4.108

--- a/patches-bundle.json
+++ b/patches-bundle.json
@@ -1,7 +1,7 @@
 {
-  "created_at": "2026-08-06T12:16:44",
-  "description": "Preserve inline-image row height while Boost recycles comments, preventing image-heavy threads from jumping during upward scrolling.\n",
-  "download_url": "https://github.com/brealorg/breal-morphe-patches/releases/download/morphe-patches-107/patches-1.4.107.mpp",
-  "signature_download_url": "https://github.com/brealorg/breal-morphe-patches/releases/download/morphe-patches-107/patches-1.4.107.mpp.asc",
-  "version": "1.4.107"
+  "created_at": "2026-08-11T00:51:42",
+  "description": "Harden Boost bottom-navigation semantic state recovery for Search results, reselect routing, Back navigation and cross-activity navigation.\n",
+  "download_url": "https://github.com/brealorg/breal-morphe-patches/releases/download/morphe-patches-108/patches-1.4.108.mpp",
+  "signature_download_url": "https://github.com/brealorg/breal-morphe-patches/releases/download/morphe-patches-108/patches-1.4.108.mpp.asc",
+  "version": "1.4.108"
 }

--- a/patches-list.json
+++ b/patches-list.json
@@ -1,6 +1,6 @@
 {
   "NOTE": "Do NOT manually edit this file. This file is automatically updated when semantic release (release.yml) runs. Manually editing this file can break your releases and break third party tools that use this file.",
-  "version": "1.4.107",
+  "version": "1.4.108",
   "patches": [
     {
       "name": "Add Boost Search bottom navigation",

--- a/tools/check-boost-search-route-contract.sh
+++ b/tools/check-boost-search-route-contract.sh
@@ -181,7 +181,7 @@ SELECTION_GUARD_LINE="$(
 SUBREDDIT_SCOPE_LINE="$(
     rg -n -F \
         'attachSubredditSearchScope(' \
-        "$SOURCE" |
+        <<< "$SEARCH_ROUTE_BLOCK" |
         tail -1 |
         cut -d: -f1
 )"
@@ -189,7 +189,7 @@ SUBREDDIT_SCOPE_LINE="$(
 START_ACTIVITY_LINE="$(
     rg -n -m1 -F \
         'activity.startActivity(intent);' \
-        "$SOURCE" |
+        <<< "$SEARCH_ROUTE_BLOCK" |
         cut -d: -f1
 )"
 


### PR DESCRIPTION
Prepare protected-main metadata for Morphe patch bundle 1.4.108.

Included change: Boost bottom-navigation state recovery hardening for #169.

Publication follows through the protected-main release workflow.