### PR TITLE
fix(boost): keep image viewer loading bar above navigation

### DIFF
--- a/extensions/boostforreddit/src/main/java/app/morphe/extension/boostforreddit/utils/BoostSystemBarInsetsFix.java
+++ b/extensions/boostforreddit/src/main/java/app/morphe/extension/boostforreddit/utils/BoostSystemBarInsetsFix.java
@@ -50,6 +50,8 @@ public final class BoostSystemBarInsetsFix {
     private static final String DECOR_NAVIGATION_CONTAINER_TAG =
             "morphe_boost_decor_owned_navigation_container";
     private static final String COMMENTS_ACTIVITY_NAME = "com.rubenmayayo.reddit.ui.comments.CommentsActivity";
+    private static final String IMAGE_VIEWER_LOADING_INSET_MARKER =
+            "MORPHE_BOOST_IMAGE_VIEWER_LOADING_INSET_ISSUE170_V1";
     private static final String TAG = "MorpheInsetsFix";
 
     private static final WeakHashMap<Application, Boolean> INSTALLED = new WeakHashMap<>();
@@ -100,6 +102,21 @@ public final class BoostSystemBarInsetsFix {
             View bottomBar = findViewByName(activity, "bottom_bar");
             if (bottomBar != null) {
                 applyBottomInsetPadding(bottomBar, false);
+            }
+
+            String className = activity.getClass().getName();
+            if (className.endsWith(".ui.activities.MediaImageActivity")) {
+                View loadingProgress = findViewByName(activity, "loading_shit");
+                if (loadingProgress != null) {
+                    applyBottomInsetPadding(loadingProgress, false);
+                    Log.i(
+                            TAG,
+                            "image viewer loading inset marker="
+                                    + IMAGE_VIEWER_LOADING_INSET_MARKER
+                                    + " activity="
+                                    + className
+                    );
+                }
             }
         } catch (Throwable ignored) {
         }


### PR DESCRIPTION
Fixes #170.

Boost's image viewer anchors both `bottom_bar` and `loading_shit` independently to the bottom of the edge-to-edge layout. The existing navigation inset fix adjusted only `bottom_bar`, leaving the image loading progress beneath the system navigation bar when using 3-button navigation.

Apply the existing bottom navigation inset handling to `loading_shit` specifically in `MediaImageActivity`. `MediaVideoActivity` is left unchanged because its loading progress is already positioned above `bottom_bar`.

Validated on Android with 3-button navigation:
- canonical MPP build PASS
- static candidate gate PASS
- bytecode safety gate PASS
- DEV runtime marker PASS
- image loading bar visually clears the system navigation bar
- no fatal/ANR observed
