### PR TITLE
chore(release): prepare Morphe patch bundle 1.4.109

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 
 <!-- MORPHE_MANAGER_CHANGELOG_START -->
+## [1.4.109](https://github.com/brealorg/breal-morphe-patches/compare/morphe-patches-108...morphe-patches-109) (2026-08-17)
+
+* **Boost for Reddit:** Fix Boost image viewer loading progress overlapping Android's 3-button navigation bar.
+
 ## [1.4.108](https://github.com/brealorg/breal-morphe-patches/compare/morphe-patches-107...morphe-patches-108) (2026-08-11)
 
 * **Boost for Reddit:** Harden Boost bottom-navigation semantic state recovery for Search results, reselect routing, Back navigation and cross-activity navigation.

--- a/README.md
+++ b/README.md
@@ -72,14 +72,14 @@ The repository shorthand shown at the top is the preferred Manager setup. Raw
 
 | Field | Value |
 |---|---|
-| Version | `1.4.108` |
-| Release tag | `morphe-patches-108` |
-| Asset | `patches-1.4.108.mpp` |
-| SHA256 | `ef7a5f1fb9a217c147ad5f6a40d344dda2e8a7f73b896df078872ca052cf056b` |
+| Version | `1.4.109` |
+| Release tag | `morphe-patches-109` |
+| Asset | `patches-1.4.109.mpp` |
+| SHA256 | `0258f080b835826a0f51030d672dee25700d596af6a5953af5ffcf8401ce4949` |
 | Manager JSON | `https://raw.githubusercontent.com/brealorg/breal-morphe-patches/main/patches-bundle.json` |
-| Download URL | `https://github.com/brealorg/breal-morphe-patches/releases/download/morphe-patches-108/patches-1.4.108.mpp` |
+| Download URL | `https://github.com/brealorg/breal-morphe-patches/releases/download/morphe-patches-109/patches-1.4.109.mpp` |
 
-SHA256: `ef7a5f1fb9a217c147ad5f6a40d344dda2e8a7f73b896df078872ca052cf056b`
+SHA256: `0258f080b835826a0f51030d672dee25700d596af6a5953af5ffcf8401ce4949`
 ## What this bundle does
 
 The current bundle is focused on practical hotfixes for tested app versions, especially Boost for Reddit behavior on newer Android versions.
@@ -126,7 +126,7 @@ Included Imgur patches:
 ### Patches list
 
 <!-- PATCHES_START -->
-> **Patch source version:** `1.4.108` • `main` • 53 unique patches • 105 package entries
+> **Patch source version:** `1.4.109` • `main` • 53 unique patches • 105 package entries
 
 <details>
 <summary><strong>Boost for Reddit</strong> • 44 patches</summary>
@@ -540,16 +540,16 @@ Compatibility with other app versions is not guaranteed.
 
 ## Verification
 
-Release `1.4.108` is prepared and locally verified with:
+Release `1.4.109` is prepared and locally verified with:
 
-- Release tag `morphe-patches-108`.
+- Release tag `morphe-patches-109`.
 - Local built MPP SHA256 matching README.
-`ef7a5f1fb9a217c147ad5f6a40d344dda2e8a7f73b896df078872ca052cf056b`
-- `patches-bundle.json` returning version `1.4.108`.
-- `patches-bundle.json` pointing to the `morphe-patches-108` asset.
+`0258f080b835826a0f51030d672dee25700d596af6a5953af5ffcf8401ce4949`
+- `patches-bundle.json` returning version `1.4.109`.
+- `patches-bundle.json` pointing to the `morphe-patches-109` asset.
 - Expected release asset:
-`patches-1.4.108.mpp`
-- `ef7a5f1fb9a217c147ad5f6a40d344dda2e8a7f73b896df078872ca052cf056b  patches-1.4.108.mpp`
+`patches-1.4.109.mpp`
+- `0258f080b835826a0f51030d672dee25700d596af6a5953af5ffcf8401ce4949  patches-1.4.109.mpp`
 
 ## Development notes
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,4 +3,4 @@ org.gradle.jvmargs = -Xms512M -Xmx2048M
 org.gradle.parallel = true
 android.useAndroidX = true
 kotlin.code.style = official
-version = 1.4.108
+version = 1.4.109

--- a/patches-bundle.json
+++ b/patches-bundle.json
@@ -1,7 +1,7 @@
 {
-  "created_at": "2026-08-11T00:51:42",
-  "description": "Harden Boost bottom-navigation semantic state recovery for Search results, reselect routing, Back navigation and cross-activity navigation.\n",
-  "download_url": "https://github.com/brealorg/breal-morphe-patches/releases/download/morphe-patches-108/patches-1.4.108.mpp",
-  "signature_download_url": "https://github.com/brealorg/breal-morphe-patches/releases/download/morphe-patches-108/patches-1.4.108.mpp.asc",
-  "version": "1.4.108"
+  "created_at": "2026-08-17T13:23:36",
+  "description": "Fix Boost image viewer loading progress overlapping Android's 3-button navigation bar.\n",
+  "download_url": "https://github.com/brealorg/breal-morphe-patches/releases/download/morphe-patches-109/patches-1.4.109.mpp",
+  "signature_download_url": "https://github.com/brealorg/breal-morphe-patches/releases/download/morphe-patches-109/patches-1.4.109.mpp.asc",
+  "version": "1.4.109"
 }

--- a/patches-list.json
+++ b/patches-list.json
@@ -1,6 +1,6 @@
 {
   "NOTE": "Do NOT manually edit this file. This file is automatically updated when semantic release (release.yml) runs. Manually editing this file can break your releases and break third party tools that use this file.",
-  "version": "1.4.108",
+  "version": "1.4.109",
   "patches": [
     {
       "name": "Add Boost Search bottom navigation",


### PR DESCRIPTION
Prepare protected-main metadata for Morphe patch bundle 1.4.109.

Included change: Fix Boost image viewer loading progress overlapping Android's 3-button navigation bar (#170).

Release identity:
- Version: `1.4.109`
- Tag: `morphe-patches-109`
- Asset: `patches-1.4.109.mpp`
- Candidate MPP SHA256: `0258f080b835826a0f51030d672dee25700d596af6a5953af5ffcf8401ce4949`

Validation:
- Issue #170 runtime validation: PASS
- canonical MPP build: PASS
- release gate: PASS
- required `classes.dex`: present
- required `extensions/boostforreddit.mpe`: present
- Issue #170 release marker: present
- README SHA256 matches candidate MPP

Publication follows through the protected-main release workflow.
