### PR TITLE
Fix Boost Image Viewer safe-area layout and prepare 1.4.110

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 
 <!-- MORPHE_MANAGER_CHANGELOG_START -->
+## [1.4.110](https://github.com/brealorg/breal-morphe-patches/compare/morphe-patches-109...morphe-patches-110) (2026-08-17)
+
+* **Boost for Reddit:** Fix Boost Image Viewer safe-area layout so images stay clear of system bars and display cutouts.
+
 ## [1.4.109](https://github.com/brealorg/breal-morphe-patches/compare/morphe-patches-108...morphe-patches-109) (2026-08-17)
 
 * **Boost for Reddit:** Fix Boost image viewer loading progress overlapping Android's 3-button navigation bar.

--- a/README.md
+++ b/README.md
@@ -72,14 +72,14 @@ The repository shorthand shown at the top is the preferred Manager setup. Raw
 
 | Field | Value |
 |---|---|
-| Version | `1.4.109` |
-| Release tag | `morphe-patches-109` |
-| Asset | `patches-1.4.109.mpp` |
-| SHA256 | `0258f080b835826a0f51030d672dee25700d596af6a5953af5ffcf8401ce4949` |
+| Version | `1.4.110` |
+| Release tag | `morphe-patches-110` |
+| Asset | `patches-1.4.110.mpp` |
+| SHA256 | `5a3cce778d1e15574ef8ff493a095eed62f847ac37e1269238284ed9080afba8` |
 | Manager JSON | `https://raw.githubusercontent.com/brealorg/breal-morphe-patches/main/patches-bundle.json` |
-| Download URL | `https://github.com/brealorg/breal-morphe-patches/releases/download/morphe-patches-109/patches-1.4.109.mpp` |
+| Download URL | `https://github.com/brealorg/breal-morphe-patches/releases/download/morphe-patches-110/patches-1.4.110.mpp` |
 
-SHA256: `0258f080b835826a0f51030d672dee25700d596af6a5953af5ffcf8401ce4949`
+SHA256: `5a3cce778d1e15574ef8ff493a095eed62f847ac37e1269238284ed9080afba8`
 ## What this bundle does
 
 The current bundle is focused on practical hotfixes for tested app versions, especially Boost for Reddit behavior on newer Android versions.
@@ -126,7 +126,7 @@ Included Imgur patches:
 ### Patches list
 
 <!-- PATCHES_START -->
-> **Patch source version:** `1.4.109` • `main` • 53 unique patches • 105 package entries
+> **Patch source version:** `1.4.110` • `main` • 53 unique patches • 105 package entries
 
 <details>
 <summary><strong>Boost for Reddit</strong> • 44 patches</summary>
@@ -540,16 +540,16 @@ Compatibility with other app versions is not guaranteed.
 
 ## Verification
 
-Release `1.4.109` is prepared and locally verified with:
+Release `1.4.110` is prepared and locally verified with:
 
-- Release tag `morphe-patches-109`.
+- Release tag `morphe-patches-110`.
 - Local built MPP SHA256 matching README.
-`0258f080b835826a0f51030d672dee25700d596af6a5953af5ffcf8401ce4949`
-- `patches-bundle.json` returning version `1.4.109`.
-- `patches-bundle.json` pointing to the `morphe-patches-109` asset.
+`5a3cce778d1e15574ef8ff493a095eed62f847ac37e1269238284ed9080afba8`
+- `patches-bundle.json` returning version `1.4.110`.
+- `patches-bundle.json` pointing to the `morphe-patches-110` asset.
 - Expected release asset:
-`patches-1.4.109.mpp`
-- `0258f080b835826a0f51030d672dee25700d596af6a5953af5ffcf8401ce4949  patches-1.4.109.mpp`
+`patches-1.4.110.mpp`
+- `5a3cce778d1e15574ef8ff493a095eed62f847ac37e1269238284ed9080afba8  patches-1.4.110.mpp`
 
 ## Development notes
 

--- a/extensions/boostforreddit/src/main/java/app/morphe/extension/boostforreddit/utils/BoostSystemBarInsetsFix.java
+++ b/extensions/boostforreddit/src/main/java/app/morphe/extension/boostforreddit/utils/BoostSystemBarInsetsFix.java
@@ -52,6 +52,8 @@ public final class BoostSystemBarInsetsFix {
     private static final String COMMENTS_ACTIVITY_NAME = "com.rubenmayayo.reddit.ui.comments.CommentsActivity";
     private static final String IMAGE_VIEWER_LOADING_INSET_MARKER =
             "MORPHE_BOOST_IMAGE_VIEWER_LOADING_INSET_ISSUE170_V1";
+    private static final String IMAGE_VIEWER_SAFE_AREA_MARKER =
+            "MORPHE_BOOST_IMAGE_VIEWER_SAFE_AREA_ISSUE171_V1";
     private static final String TAG = "MorpheInsetsFix";
 
     private static final WeakHashMap<Application, Boolean> INSTALLED = new WeakHashMap<>();
@@ -99,24 +101,25 @@ public final class BoostSystemBarInsetsFix {
         try {
             if (!shouldApply(activity)) return;
 
-            View bottomBar = findViewByName(activity, "bottom_bar");
-            if (bottomBar != null) {
-                applyBottomInsetPadding(bottomBar, false);
-            }
-
             String className = activity.getClass().getName();
             if (className.endsWith(".ui.activities.MediaImageActivity")) {
-                View loadingProgress = findViewByName(activity, "loading_shit");
-                if (loadingProgress != null) {
-                    applyBottomInsetPadding(loadingProgress, false);
+                View content = activity.findViewById(android.R.id.content);
+                if (content != null) {
+                    applySafeAreaPadding(content);
                     Log.i(
                             TAG,
-                            "image viewer loading inset marker="
-                                    + IMAGE_VIEWER_LOADING_INSET_MARKER
+                            "image viewer safe area marker="
+                                    + IMAGE_VIEWER_SAFE_AREA_MARKER
                                     + " activity="
                                     + className
                     );
                 }
+                return;
+            }
+
+            View bottomBar = findViewByName(activity, "bottom_bar");
+            if (bottomBar != null) {
+                applyBottomInsetPadding(bottomBar, false);
             }
         } catch (Throwable ignored) {
         }
@@ -395,6 +398,117 @@ public final class BoostSystemBarInsetsFix {
                 }
             }
         });
+    }
+
+    private static void applySafeAreaPadding(final View view) {
+        if (view == null) return;
+
+        saveOriginalPadding(view);
+
+        view.setOnApplyWindowInsetsListener(new View.OnApplyWindowInsetsListener() {
+            @Override
+            public WindowInsets onApplyWindowInsets(View v, WindowInsets insets) {
+                try {
+                    applySafeAreaPaddingNow(v, insets);
+                } catch (Throwable ignored) {
+                }
+                return insets;
+            }
+        });
+
+        view.post(new Runnable() {
+            @Override
+            public void run() {
+                try {
+                    applySafeAreaPaddingNow(view, getBestCurrentInsets(view));
+                    view.requestApplyInsets();
+                } catch (Throwable ignored) {
+                }
+            }
+        });
+    }
+
+    private static void applySafeAreaPaddingNow(View view, WindowInsets insets) {
+        if (view == null) return;
+
+        saveOriginalPadding(view);
+
+        Padding original = ORIGINAL_PADDING.get(view);
+        if (original == null) return;
+
+        WindowInsets effectiveInsets =
+                insets != null ? insets : getBestCurrentInsets(view);
+
+        int leftInset = 0;
+        int topInset = 0;
+        int rightInset = 0;
+        int bottomInset = 0;
+
+        if (effectiveInsets != null) {
+            if (Build.VERSION.SDK_INT >= 30) {
+                Insets safeInsets = effectiveInsets.getInsets(
+                        WindowInsets.Type.systemBars()
+                                | WindowInsets.Type.displayCutout()
+                );
+                if (safeInsets != null) {
+                    leftInset = safeInsets.left;
+                    topInset = safeInsets.top;
+                    rightInset = safeInsets.right;
+                    bottomInset = safeInsets.bottom;
+                }
+            } else {
+                leftInset = effectiveInsets.getSystemWindowInsetLeft();
+                topInset = effectiveInsets.getSystemWindowInsetTop();
+                rightInset = effectiveInsets.getSystemWindowInsetRight();
+                bottomInset = effectiveInsets.getSystemWindowInsetBottom();
+
+                if (Build.VERSION.SDK_INT >= 28) {
+                    android.view.DisplayCutout cutout =
+                            effectiveInsets.getDisplayCutout();
+                    if (cutout != null) {
+                        leftInset = Math.max(
+                                leftInset,
+                                cutout.getSafeInsetLeft()
+                        );
+                        topInset = Math.max(
+                                topInset,
+                                cutout.getSafeInsetTop()
+                        );
+                        rightInset = Math.max(
+                                rightInset,
+                                cutout.getSafeInsetRight()
+                        );
+                        bottomInset = Math.max(
+                                bottomInset,
+                                cutout.getSafeInsetBottom()
+                        );
+                    }
+                }
+            }
+        }
+
+        int targetLeft = original.left + Math.max(0, leftInset);
+        int targetTop = original.top + Math.max(0, topInset);
+        int targetRight = original.right + Math.max(0, rightInset);
+        int targetBottom = original.bottom + Math.max(0, bottomInset);
+
+        if (
+                view.getPaddingLeft() == targetLeft
+                        && view.getPaddingTop() == targetTop
+                        && view.getPaddingRight() == targetRight
+                        && view.getPaddingBottom() == targetBottom
+        ) {
+            return;
+        }
+
+        view.setPadding(
+                targetLeft,
+                targetTop,
+                targetRight,
+                targetBottom
+        );
+        view.requestLayout();
+        view.invalidate();
     }
 
     private static void saveOriginalPadding(View view) {

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,4 +3,4 @@ org.gradle.jvmargs = -Xms512M -Xmx2048M
 org.gradle.parallel = true
 android.useAndroidX = true
 kotlin.code.style = official
-version = 1.4.109
+version = 1.4.110

--- a/patches-bundle.json
+++ b/patches-bundle.json
@@ -1,7 +1,7 @@
 {
-  "created_at": "2026-08-17T13:23:36",
-  "description": "Fix Boost image viewer loading progress overlapping Android's 3-button navigation bar.\n",
-  "download_url": "https://github.com/brealorg/breal-morphe-patches/releases/download/morphe-patches-109/patches-1.4.109.mpp",
-  "signature_download_url": "https://github.com/brealorg/breal-morphe-patches/releases/download/morphe-patches-109/patches-1.4.109.mpp.asc",
-  "version": "1.4.109"
+  "created_at": "2026-08-17T17:02:08",
+  "description": "Fix Boost Image Viewer safe-area layout so images stay clear of system bars and display cutouts.\n",
+  "download_url": "https://github.com/brealorg/breal-morphe-patches/releases/download/morphe-patches-110/patches-1.4.110.mpp",
+  "signature_download_url": "https://github.com/brealorg/breal-morphe-patches/releases/download/morphe-patches-110/patches-1.4.110.mpp.asc",
+  "version": "1.4.110"
 }

--- a/patches-list.json
+++ b/patches-list.json
@@ -1,6 +1,6 @@
 {
   "NOTE": "Do NOT manually edit this file. This file is automatically updated when semantic release (release.yml) runs. Manually editing this file can break your releases and break third party tools that use this file.",
-  "version": "1.4.109",
+  "version": "1.4.110",
   "patches": [
     {
       "name": "Add Boost Search bottom navigation",


### PR DESCRIPTION
Refs #171

- Keep Boost Image Viewer content inside Android system-bar and display-cutout safe areas.
- Preserve Image Viewer zoom and swipe-dismiss behavior.
- Prepare Morphe patch bundle 1.4.110 in the same protected-main PR.

Validation:
- :patches:buildAndroid PASS
- MPP structure PASS
- bytecode safety gate PASS with 0 findings
- Boost DEV build/install PASS
- MORPHE_BOOST_IMAGE_VIEWER_SAFE_AREA_ISSUE171_V1 observed in MediaImageActivity
- manual Image Viewer safe-area, zoom and swipe-dismiss validation PASS