### PR TITLE
Fix Redgifs URL cache corruption in Boost causing 403 + ~6s stall on every video open

### DIFF
--- a/extensions/boostforreddit/src/main/java/app/morphe/extension/boostforreddit/http/OkHttpRequestHook.java
+++ b/extensions/boostforreddit/src/main/java/app/morphe/extension/boostforreddit/http/OkHttpRequestHook.java
@@ -15,6 +15,7 @@ import app.morphe.extension.boostforreddit.http.reddit.RedditFixAudioInDownloads
 import app.morphe.extension.boostforreddit.http.reddit.RedditMediaUndeleteInterceptor;
 import app.morphe.extension.boostforreddit.http.reddit.RedditSubmissionUndeleteInterceptor;
 import app.morphe.extension.boostforreddit.http.reddit.RedditSubredditUndeleteInterceptor;
+import app.morphe.extension.boostforreddit.http.redgifs.RedgifsUrlSanitizerInterceptor;
 import app.morphe.extension.boostforreddit.http.wayback.WaybackThrottlingInterceptor;
 import app.morphe.extension.shared.fixes.feed.RAllPatch;
 import app.morphe.extension.shared.requests.BaseOkHttpRequestHook;
@@ -37,6 +38,7 @@ public class OkHttpRequestHook extends BaseOkHttpRequestHook {
     @Override
     protected List<Interceptor> getInterceptors() {
         return List.of(
+                new RedgifsUrlSanitizerInterceptor(),
                 new RedditMediaUndeleteInterceptor(),
                 new RedditSubmissionUndeleteInterceptor(),
                 new RedditSubredditUndeleteInterceptor(),

--- a/extensions/boostforreddit/src/main/java/app/morphe/extension/boostforreddit/http/redgifs/RedgifsUrlSanitizerInterceptor.java
+++ b/extensions/boostforreddit/src/main/java/app/morphe/extension/boostforreddit/http/redgifs/RedgifsUrlSanitizerInterceptor.java
@@ -1,0 +1,75 @@
+package app.morphe.extension.boostforreddit.http.redgifs;
+
+import androidx.annotation.NonNull;
+
+import java.io.IOException;
+
+import app.morphe.extension.shared.Logger;
+import okhttp3.HttpUrl;
+import okhttp3.Interceptor;
+import okhttp3.Request;
+import okhttp3.Response;
+
+/**
+ * Boost's Redgifs URL cache (Firebase remote config flag {@code rg_api_save}) appends a
+ * {@code &boost_expires=<epoch millis>} marker to every URL it stores, but the reader
+ * ({@code h0.g0}) never strips it before handing the URL to the video player. When the
+ * resolved URL has no query string the marker is glued onto the path itself
+ * ({@code ....mp4&boost_expires=123}), so the expiry check cannot even see it. Either way
+ * the CDN rejects the request with a 403, the player burns ~6 seconds in its retry ladder,
+ * and only then does Boost's own 403 recovery ({@code rg_api_retry}) re-resolve and play.
+ * Every tap on a Redgifs post pays that penalty again because the fresh URL is re-cached
+ * with the same marker.
+ *
+ * <p>Stripping the marker here, just before the request leaves the app, keeps the cache
+ * usable: the stored URL is valid once the marker is removed, so cached opens play
+ * immediately instead of 403-ing into the recovery path.
+ */
+public class RedgifsUrlSanitizerInterceptor implements Interceptor {
+    private static final String MARKER = "boost_expires";
+
+    @NonNull
+    @Override
+    public Response intercept(@NonNull Chain chain) throws IOException {
+        Request request = chain.request();
+        HttpUrl url = request.url();
+
+        String host = url.host();
+        if (!host.equals("redgifs.com") && !host.endsWith(".redgifs.com")) {
+            return chain.proceed(request);
+        }
+
+        HttpUrl cleaned = removeMarker(url);
+        if (cleaned == null || cleaned.equals(url)) {
+            return chain.proceed(request);
+        }
+
+        Logger.printDebug(() -> "Removed " + MARKER + " marker from " + host + " request");
+        return chain.proceed(request.newBuilder().url(cleaned).build());
+    }
+
+    /**
+     * Removes the marker whether it was parsed as a real query parameter
+     * ({@code ?expires=...&boost_expires=123}) or ended up inside the path because the
+     * original URL had no query string ({@code /Name.mp4&boost_expires=123}).
+     * Returns null when the URL carries no marker.
+     */
+    static HttpUrl removeMarker(HttpUrl url) {
+        boolean changed = false;
+        HttpUrl.Builder builder = url.newBuilder();
+
+        if (url.queryParameter(MARKER) != null) {
+            builder.removeAllQueryParameters(MARKER);
+            changed = true;
+        }
+
+        String path = url.encodedPath();
+        int glued = path.indexOf("&" + MARKER + "=");
+        if (glued >= 0) {
+            builder.encodedPath(path.substring(0, glued));
+            changed = true;
+        }
+
+        return changed ? builder.build() : null;
+    }
+}


### PR DESCRIPTION
## Summary

Boost has a built-in resolved-URL cache for Redgifs media (Firebase remote config flags `rg_api_save` / `rg_api_expire_minutes` / `rg_api_retry` in its `RemoteConfigHelper`). When it stores a URL it appends `&boost_expires=<epoch millis>` to the string, but the reader never strips the marker before handing the URL to ExoPlayer:

- If the resolved URL has a query string, the extra parameter invalidates the CDN check → 403.
- Modern Redgifs URLs have **no** query string, so the marker is glued onto the filename itself (`....mp4&boost_expires=123...`). The expiry check reads it via `Uri.getQueryParameter`, which can't see it in that form, so the corrupted entry is also never expired.

Result on every tap of a video post: the player fetches the corrupted URL, gets 403, burns ~6 seconds in ExoPlayer's default retry ladder (0+1+2+3s), and only then does Boost's own `rg_api_retry` recovery re-resolve and play. The fresh URL is immediately re-cached **with the marker again**, so the next open pays the full penalty too. This is a stock Boost defect in the generic media path, reproducible with SFW content.

## Evidence

- Same signed URL, `curl -r 0-0`: clean → **206**; with `&boost_expires=123` appended → **403**.
- Logcat across three consecutive opens: `MediaVideoActivity` displayed → `ExoPlaybackException / InvalidResponseCodeException: 403` at +6.2s, +5.9s, +6.3s, each followed by the cache-clear recovery in the player error handler.
- Decompiled call chain: cache write appends the marker (`GifUrlExtractorCancelable` and `RedGifsWorker`), cache read validates but never strips it before returning the URL to the player.

## Fix

`RedgifsUrlSanitizerInterceptor`, registered first in `OkHttpRequestHook`: for `*.redgifs.com` requests, strip the marker whether it arrived as a real query parameter or glued into the path. Requests without the marker pass through untouched (no URL rebuild). The stored URLs are perfectly valid once the marker is stripped, so this also makes the cache useful again: opening a video that's already in the cache now starts playback immediately.

No fingerprints or patch logic change; one new extension file plus its registration.

## Testing

- URL surgery unit-tested against real OkHttp (path-glued form, query form, lone parameter, clean URLs untouched).
- On device (Boost 1.12.12, bundle built from this branch): the tap-to-play stall is gone, and reopening the same video starts instantly.
