### PR TITLE
chore(release): prepare Morphe patch bundle 1.4.111

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 
 <!-- MORPHE_MANAGER_CHANGELOG_START -->
+## [1.4.111](https://github.com/brealorg/breal-morphe-patches/compare/morphe-patches-110...morphe-patches-111) (2026-08-20)
+
+* **Boost for Reddit:** Fix Redgifs URL cache corruption that caused HTTP 403 responses and repeated playback stalls.
+
 ## [1.4.110](https://github.com/brealorg/breal-morphe-patches/compare/morphe-patches-109...morphe-patches-110) (2026-08-17)
 
 * **Boost for Reddit:** Fix Boost Image Viewer safe-area layout so images stay clear of system bars and display cutouts.

--- a/README.md
+++ b/README.md
@@ -72,14 +72,14 @@ The repository shorthand shown at the top is the preferred Manager setup. Raw
 
 | Field | Value |
 |---|---|
-| Version | `1.4.110` |
-| Release tag | `morphe-patches-110` |
-| Asset | `patches-1.4.110.mpp` |
-| SHA256 | `5a3cce778d1e15574ef8ff493a095eed62f847ac37e1269238284ed9080afba8` |
+| Version | `1.4.111` |
+| Release tag | `morphe-patches-111` |
+| Asset | `patches-1.4.111.mpp` |
+| SHA256 | `86c1f10f85281a8af4426042a67fb2111327543f16401ba7f1bb58903e7f5a74` |
 | Manager JSON | `https://raw.githubusercontent.com/brealorg/breal-morphe-patches/main/patches-bundle.json` |
-| Download URL | `https://github.com/brealorg/breal-morphe-patches/releases/download/morphe-patches-110/patches-1.4.110.mpp` |
+| Download URL | `https://github.com/brealorg/breal-morphe-patches/releases/download/morphe-patches-111/patches-1.4.111.mpp` |
 
-SHA256: `5a3cce778d1e15574ef8ff493a095eed62f847ac37e1269238284ed9080afba8`
+SHA256: `86c1f10f85281a8af4426042a67fb2111327543f16401ba7f1bb58903e7f5a74`
 ## What this bundle does
 
 The current bundle is focused on practical hotfixes for tested app versions, especially Boost for Reddit behavior on newer Android versions.
@@ -126,7 +126,7 @@ Included Imgur patches:
 ### Patches list
 
 <!-- PATCHES_START -->
-> **Patch source version:** `1.4.110` • `main` • 53 unique patches • 105 package entries
+> **Patch source version:** `1.4.111` • `main` • 53 unique patches • 105 package entries
 
 <details>
 <summary><strong>Boost for Reddit</strong> • 44 patches</summary>
@@ -540,16 +540,16 @@ Compatibility with other app versions is not guaranteed.
 
 ## Verification
 
-Release `1.4.110` is prepared and locally verified with:
+Release `1.4.111` is prepared and locally verified with:
 
-- Release tag `morphe-patches-110`.
+- Release tag `morphe-patches-111`.
 - Local built MPP SHA256 matching README.
-`5a3cce778d1e15574ef8ff493a095eed62f847ac37e1269238284ed9080afba8`
-- `patches-bundle.json` returning version `1.4.110`.
-- `patches-bundle.json` pointing to the `morphe-patches-110` asset.
+`86c1f10f85281a8af4426042a67fb2111327543f16401ba7f1bb58903e7f5a74`
+- `patches-bundle.json` returning version `1.4.111`.
+- `patches-bundle.json` pointing to the `morphe-patches-111` asset.
 - Expected release asset:
-`patches-1.4.110.mpp`
-- `5a3cce778d1e15574ef8ff493a095eed62f847ac37e1269238284ed9080afba8  patches-1.4.110.mpp`
+`patches-1.4.111.mpp`
+- `86c1f10f85281a8af4426042a67fb2111327543f16401ba7f1bb58903e7f5a74  patches-1.4.111.mpp`
 
 ## Development notes
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,4 +3,4 @@ org.gradle.jvmargs = -Xms512M -Xmx2048M
 org.gradle.parallel = true
 android.useAndroidX = true
 kotlin.code.style = official
-version = 1.4.110
+version = 1.4.111

--- a/patches-bundle.json
+++ b/patches-bundle.json
@@ -1,7 +1,7 @@
 {
-  "created_at": "2026-08-17T17:02:08",
-  "description": "Fix Boost Image Viewer safe-area layout so images stay clear of system bars and display cutouts.\n",
-  "download_url": "https://github.com/brealorg/breal-morphe-patches/releases/download/morphe-patches-110/patches-1.4.110.mpp",
-  "signature_download_url": "https://github.com/brealorg/breal-morphe-patches/releases/download/morphe-patches-110/patches-1.4.110.mpp.asc",
-  "version": "1.4.110"
+  "created_at": "2026-08-20T22:55:54",
+  "description": "Fix Redgifs URL cache corruption that caused HTTP 403 responses and repeated playback stalls.\n",
+  "download_url": "https://github.com/brealorg/breal-morphe-patches/releases/download/morphe-patches-111/patches-1.4.111.mpp",
+  "signature_download_url": "https://github.com/brealorg/breal-morphe-patches/releases/download/morphe-patches-111/patches-1.4.111.mpp.asc",
+  "version": "1.4.111"
 }

--- a/patches-list.json
+++ b/patches-list.json
@@ -1,6 +1,6 @@
 {
   "NOTE": "Do NOT manually edit this file. This file is automatically updated when semantic release (release.yml) runs. Manually editing this file can break your releases and break third party tools that use this file.",
-  "version": "1.4.110",
+  "version": "1.4.111",
   "patches": [
     {
       "name": "Add Boost Search bottom navigation",


### PR DESCRIPTION
Prepare protected-main release metadata and deterministic MPP digest for the Redgifs cache-corruption fix merged in #186.