### PR TITLE
Fix bottom navigation activity retention

### DIFF
--- a/extensions/boostforreddit/src/main/java/app/morphe/extension/boostforreddit/utils/BoostSearchBottomNavigation.java
+++ b/extensions/boostforreddit/src/main/java/app/morphe/extension/boostforreddit/utils/BoostSearchBottomNavigation.java
@@ -122,12 +122,12 @@ public final class BoostSearchBottomNavigation {
     private static final java.util.WeakHashMap<View, Boolean>
             OWNED_MENU_INSTALLED =
                     new java.util.WeakHashMap<>();
-    private static final java.util.WeakHashMap<Activity, FrameLayout>
+    private static final WeakValueRegistry<Activity, FrameLayout>
             DECOR_NAVIGATION_CONTAINERS =
-                    new java.util.WeakHashMap<>();
-    private static final java.util.WeakHashMap<Activity, View>
+                    new WeakValueRegistry<>();
+    private static final WeakValueRegistry<Activity, View>
             DECOR_NAVIGATION_VIEWS =
-                    new java.util.WeakHashMap<>();
+                    new WeakValueRegistry<>();
     private static final java.util.WeakHashMap<Activity, Integer>
             INBOX_BADGE_COUNTS =
                     new java.util.WeakHashMap<>();

--- a/extensions/boostforreddit/src/main/java/app/morphe/extension/boostforreddit/utils/WeakValueRegistry.java
+++ b/extensions/boostforreddit/src/main/java/app/morphe/extension/boostforreddit/utils/WeakValueRegistry.java
@@ -1,0 +1,36 @@
+package app.morphe.extension.boostforreddit.utils;
+
+import java.lang.ref.WeakReference;
+import java.util.WeakHashMap;
+
+/**
+ * A non-owning lookup for objects owned elsewhere, such as attached Views.
+ * Both keys and values are weak: a value may point back to its key through
+ * a Context without making the registry an Activity retention root.
+ * Do not use this for state whose only owner would be the registry.
+ */
+final class WeakValueRegistry<K, V> {
+    private final WeakHashMap<K, WeakReference<V>> entries = new WeakHashMap<>();
+
+    synchronized V get(K key) {
+        WeakReference<V> reference = entries.get(key);
+        V value = reference == null ? null : reference.get();
+        if (reference != null && value == null) {
+            entries.remove(key);
+        }
+        return value;
+    }
+
+    synchronized void put(K key, V value) {
+        if (value == null) {
+            entries.remove(key);
+        } else {
+            entries.put(key, new WeakReference<>(value));
+        }
+    }
+
+    synchronized V remove(K key) {
+        WeakReference<V> reference = entries.remove(key);
+        return reference == null ? null : reference.get();
+    }
+}

--- a/tools/check-boost-memory-retention-issue191.sh
+++ b/tools/check-boost-memory-retention-issue191.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+set -u
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)" || exit 1
+python3 - "$ROOT" <<'PY'
+import pathlib
+import re
+import subprocess
+import sys
+import tempfile
+
+root = pathlib.Path(sys.argv[1])
+base = root / 'extensions/boostforreddit/src/main/java/app/morphe/extension/boostforreddit/utils'
+source = (base / 'BoostSearchBottomNavigation.java').read_text()
+for name, value in [('DECOR_NAVIGATION_CONTAINERS', 'FrameLayout'), ('DECOR_NAVIGATION_VIEWS', 'View')]:
+    pattern = rf'private\s+static\s+final\s+WeakValueRegistry<Activity,\s*{value}>\s+{name}\s*=\s*new\s+WeakValueRegistry<>\(\);'
+    if len(re.findall(pattern, source)) != 1:
+        raise SystemExit(f'FAIL: {name} is not wired to the non-owning registry')
+print('NAVIGATION_REGISTRY_WIRING=PASS', flush=True)
+with tempfile.TemporaryDirectory(prefix='boost-issue191-jvm-') as output:
+    subprocess.run(['javac', '-encoding', 'UTF-8', '-d', output,
+                    str(base / 'WeakValueRegistry.java'),
+                    str(root / 'tools/tests/BoostWeakValueRegistryTest.java')], check=True)
+    subprocess.run(['java', '-Xmx64m', '-XX:+UseSerialGC', '-cp', output,
+                    'app.morphe.extension.boostforreddit.utils.BoostWeakValueRegistryTest'],
+                   check=True, timeout=25)
+PY

--- a/tools/tests/BoostWeakValueRegistryTest.java
+++ b/tools/tests/BoostWeakValueRegistryTest.java
@@ -1,0 +1,123 @@
+package app.morphe.extension.boostforreddit.utils;
+
+import java.lang.ref.Reference;
+import java.lang.ref.WeakReference;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.WeakHashMap;
+
+public final class BoostWeakValueRegistryTest {
+    private static final class Owner {
+        Node attached;
+        final byte[] retainedScreen = new byte[64 * 1024];
+    }
+
+    private static final class Node {
+        final Owner context;
+        Node(Owner context) { this.context = context; }
+    }
+
+    private static void require(boolean condition, String message) {
+        if (!condition) throw new AssertionError(message);
+    }
+
+    private static void collect() throws InterruptedException {
+        System.gc();
+        Thread.sleep(20L);
+    }
+
+    private static void awaitCleared(List<? extends WeakReference<?>> references)
+            throws InterruptedException {
+        for (int attempt = 0; attempt < 150; attempt++) {
+            collect();
+            boolean allCleared = true;
+            for (WeakReference<?> reference : references) {
+                if (reference.get() != null) allCleared = false;
+            }
+            if (allCleared) return;
+        }
+        throw new AssertionError("objects remained strongly reachable after repeated GC");
+    }
+
+    private static WeakReference<Owner> legacyCycle(WeakHashMap<Owner, Node> registry) {
+        Owner owner = new Owner();
+        Node node = new Node(owner);
+        owner.attached = node;
+        registry.put(owner, node);
+        return new WeakReference<>(owner);
+    }
+
+    private static List<WeakReference<?>> closedScreens(
+            WeakValueRegistry<Owner, Node> containers,
+            WeakValueRegistry<Owner, Node> navigation) {
+        List<WeakReference<?>> references = new ArrayList<>();
+        for (int i = 0; i < 128; i++) {
+            Owner owner = new Owner();
+            Node container = new Node(owner);
+            Node view = new Node(owner);
+            owner.attached = container;
+            containers.put(owner, container);
+            navigation.put(owner, view);
+            require(containers.get(owner) == container, "live container lookup");
+            require(navigation.get(owner) == view, "live navigation lookup");
+            references.add(new WeakReference<>(owner));
+            references.add(new WeakReference<>(container));
+            references.add(new WeakReference<>(view));
+        }
+        return references;
+    }
+
+    private static WeakReference<Node> detachedValue(
+            WeakValueRegistry<Owner, Node> registry, Owner liveOwner) {
+        Node node = new Node(liveOwner);
+        registry.put(liveOwner, node);
+        return new WeakReference<>(node);
+    }
+
+    public static void main(String[] args) throws Exception {
+        WeakHashMap<Owner, Node> legacy = new WeakHashMap<>();
+        WeakReference<Owner> legacyOwner = legacyCycle(legacy);
+        for (int i = 0; i < 5; i++) collect();
+        require(legacyOwner.get() != null, "negative control must reproduce retention");
+        require(legacy.size() == 1, "legacy map must still own its value");
+        System.out.println("LEGACY_STRONG_VALUE_CYCLE=REPRODUCED");
+        legacy.clear();
+        awaitCleared(List.of(legacyOwner));
+
+        WeakValueRegistry<Owner, Node> containers = new WeakValueRegistry<>();
+        WeakValueRegistry<Owner, Node> navigation = new WeakValueRegistry<>();
+        List<WeakReference<?>> closed = closedScreens(containers, navigation);
+        awaitCleared(closed);
+        System.out.println("CLOSED_SCREEN_CYCLES_COLLECTED=128");
+        Reference.reachabilityFence(containers);
+        Reference.reachabilityFence(navigation);
+
+        Owner active = new Owner();
+        active.attached = new Node(active);
+        navigation.put(active, active.attached);
+        for (int i = 0; i < 5; i++) collect();
+        require(navigation.get(active) == active.attached, "attached view must remain available");
+        System.out.println("LIVE_TREE_OWNERSHIP_AND_LOOKUP=PASS");
+
+        Node replacement = new Node(active);
+        navigation.put(active, replacement);
+        require(navigation.get(active) == replacement, "replacement lookup");
+        require(navigation.remove(active) == replacement, "remove returns former value");
+        require(navigation.get(active) == null, "removed entry lookup");
+        require(navigation.remove(active) == null, "missing entry removal");
+        navigation.put(active, replacement);
+        navigation.put(active, null);
+        require(navigation.get(active) == null, "null value removes entry");
+        Reference.reachabilityFence(replacement);
+        System.out.println("REPLACE_REMOVE_AND_MISSING_LOOKUP=PASS");
+
+        WeakReference<Node> detached = detachedValue(navigation, active);
+        awaitCleared(List.of(detached));
+        require(navigation.get(active) == null, "collected value must behave as cache miss");
+        require(active.attached != null, "owner is deliberately still alive");
+        Reference.reachabilityFence(active);
+        Reference.reachabilityFence(navigation);
+        System.out.println("DETACHED_VALUE_WITH_LIVE_OWNER=PASS");
+        System.out.println("RESULT=BOOST_ISSUE191_WEAK_VALUE_REGISTRY_JVM_PASS");
+    }
+}


### PR DESCRIPTION
## Summary

- replace the static bottom-navigation `WeakHashMap<Activity, View>` / `WeakHashMap<Activity, FrameLayout>` registries with weak-value storage so registered views cannot retain their owning Activity through `View.getContext()`
- preserve existing navigation lookup/replacement/removal behavior
- add a focused JVM regression guard that reproduces the legacy strong-value retention cycle and verifies collection of abandoned screen cycles

## Validation

- focused registry regression: PASS
  - legacy strong-value cycle reproduced
  - 128 abandoned screen cycles collected with the candidate
  - live lookup, replacement/removal, and detached-value behavior pass
- Android MPP build: PASS
- verified Boost DEV APK install: PASS
- extended DEV runtime: PASS
  - 15 minutes of feed scrolling and repeated comment opening
  - Search, subreddit, and Home navigation exercised
  - no OOM, fatal exception, ANR, or observed browsing degradation
  - Java heap reached a recoverable plateau and fell again after peaks
- manual runtime assessment: normal

This fixes a concrete Breal Activity/View retention path found while investigating #191. It does not claim that every possible cause of the reporter's Galaxy S24 OOM has been independently reproduced or excluded.

Related to #191.
