### PR TITLE
chore(release): prepare Morphe patch bundle 1.4.112

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 
 <!-- MORPHE_MANAGER_CHANGELOG_START -->
+## [1.4.112](https://github.com/brealorg/breal-morphe-patches/compare/morphe-patches-111...morphe-patches-112) (2026-09-08)
+
+* **Boost for Reddit:** Fix Boost bottom navigation Activity retention discovered while investigating progressive memory growth and OutOfMemoryError crashes.
+
 ## [1.4.111](https://github.com/brealorg/breal-morphe-patches/compare/morphe-patches-110...morphe-patches-111) (2026-08-20)
 
 * **Boost for Reddit:** Fix Redgifs URL cache corruption that caused HTTP 403 responses and repeated playback stalls.

--- a/README.md
+++ b/README.md
@@ -72,14 +72,14 @@ The repository shorthand shown at the top is the preferred Manager setup. Raw
 
 | Field | Value |
 |---|---|
-| Version | `1.4.111` |
-| Release tag | `morphe-patches-111` |
-| Asset | `patches-1.4.111.mpp` |
-| SHA256 | `86c1f10f85281a8af4426042a67fb2111327543f16401ba7f1bb58903e7f5a74` |
+| Version | `1.4.112` |
+| Release tag | `morphe-patches-112` |
+| Asset | `patches-1.4.112.mpp` |
+| SHA256 | `f3ba094e0481069eacb816a31983ef27fec8dcff44b433ae88ced852e9285ed1` |
 | Manager JSON | `https://raw.githubusercontent.com/brealorg/breal-morphe-patches/main/patches-bundle.json` |
-| Download URL | `https://github.com/brealorg/breal-morphe-patches/releases/download/morphe-patches-111/patches-1.4.111.mpp` |
+| Download URL | `https://github.com/brealorg/breal-morphe-patches/releases/download/morphe-patches-112/patches-1.4.112.mpp` |
 
-SHA256: `86c1f10f85281a8af4426042a67fb2111327543f16401ba7f1bb58903e7f5a74`
+SHA256: `f3ba094e0481069eacb816a31983ef27fec8dcff44b433ae88ced852e9285ed1`
 ## What this bundle does
 
 The current bundle is focused on practical hotfixes for tested app versions, especially Boost for Reddit behavior on newer Android versions.
@@ -126,7 +126,7 @@ Included Imgur patches:
 ### Patches list
 
 <!-- PATCHES_START -->
-> **Patch source version:** `1.4.111` • `main` • 53 unique patches • 105 package entries
+> **Patch source version:** `1.4.112` • `main` • 53 unique patches • 105 package entries
 
 <details>
 <summary><strong>Boost for Reddit</strong> • 44 patches</summary>
@@ -540,16 +540,16 @@ Compatibility with other app versions is not guaranteed.
 
 ## Verification
 
-Release `1.4.111` is prepared and locally verified with:
+Release `1.4.112` is prepared and locally verified with:
 
-- Release tag `morphe-patches-111`.
+- Release tag `morphe-patches-112`.
 - Local built MPP SHA256 matching README.
-`86c1f10f85281a8af4426042a67fb2111327543f16401ba7f1bb58903e7f5a74`
-- `patches-bundle.json` returning version `1.4.111`.
-- `patches-bundle.json` pointing to the `morphe-patches-111` asset.
+`f3ba094e0481069eacb816a31983ef27fec8dcff44b433ae88ced852e9285ed1`
+- `patches-bundle.json` returning version `1.4.112`.
+- `patches-bundle.json` pointing to the `morphe-patches-112` asset.
 - Expected release asset:
-`patches-1.4.111.mpp`
-- `86c1f10f85281a8af4426042a67fb2111327543f16401ba7f1bb58903e7f5a74  patches-1.4.111.mpp`
+`patches-1.4.112.mpp`
+- `f3ba094e0481069eacb816a31983ef27fec8dcff44b433ae88ced852e9285ed1  patches-1.4.112.mpp`
 
 ## Development notes
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,4 +3,4 @@ org.gradle.jvmargs = -Xms512M -Xmx2048M
 org.gradle.parallel = true
 android.useAndroidX = true
 kotlin.code.style = official
-version = 1.4.111
+version = 1.4.112

--- a/patches-bundle.json
+++ b/patches-bundle.json
@@ -1,7 +1,7 @@
 {
-  "created_at": "2026-08-20T22:55:54",
-  "description": "Fix Redgifs URL cache corruption that caused HTTP 403 responses and repeated playback stalls.\n",
-  "download_url": "https://github.com/brealorg/breal-morphe-patches/releases/download/morphe-patches-111/patches-1.4.111.mpp",
-  "signature_download_url": "https://github.com/brealorg/breal-morphe-patches/releases/download/morphe-patches-111/patches-1.4.111.mpp.asc",
-  "version": "1.4.111"
+  "created_at": "2026-09-08T22:25:53",
+  "description": "Fix Boost bottom navigation Activity retention discovered while investigating progressive memory growth and OutOfMemoryError crashes.\n",
+  "download_url": "https://github.com/brealorg/breal-morphe-patches/releases/download/morphe-patches-112/patches-1.4.112.mpp",
+  "signature_download_url": "https://github.com/brealorg/breal-morphe-patches/releases/download/morphe-patches-112/patches-1.4.112.mpp.asc",
+  "version": "1.4.112"
 }

--- a/patches-list.json
+++ b/patches-list.json
@@ -1,6 +1,6 @@
 {
   "NOTE": "Do NOT manually edit this file. This file is automatically updated when semantic release (release.yml) runs. Manually editing this file can break your releases and break third party tools that use this file.",
-  "version": "1.4.111",
+  "version": "1.4.112",
   "patches": [
     {
       "name": "Add Boost Search bottom navigation",


### PR DESCRIPTION
## Summary

- prepare Morphe patch bundle 1.4.112
- publish the merged #191 Activity-retention fix from #192
- update Manager/release metadata and reproducible MPP SHA

## Validation

- #191 focused weak-value registry regression: PASS
- Boost DEV build/install: PASS
- extended 15-minute browsing/runtime memory qualification: PASS
- PR #192 CI: PASS
- release metadata build/gate: PASS

The code tree being released is the already qualified #191/#192 tree; this release PR changes only release metadata generated by the repository release tooling.

Related to #191 and #192.
