### PR TITLE
fix(boost): retain bounded video back buffer on rewind

### DIFF
--- a/patches/src/main/kotlin/app/morphe/patches/reddit/customclients/boostforreddit/fix/media/VideoBackBufferRewindPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/reddit/customclients/boostforreddit/fix/media/VideoBackBufferRewindPatch.kt
@@ -15,19 +15,12 @@ import com.android.tools.smali.dexlib2.Opcode
 import com.android.tools.smali.dexlib2.iface.instruction.OneRegisterInstruction
 
 private const val CONTRACT_MARKER =
-    "MORPHE_BOOST_VIDEO_REWIND_BACKBUFFER_ISSUE188_V1"
+    "MORPHE_BOOST_VIDEO_REWIND_BACKBUFFER_ISSUE188_V2"
 
-// Boost 1.12.12 preserves the ExoPlayer source identity DefaultLoadControl.java
-// at Ls3/c;. Static discovery and the issue contract prove that:
-//   b()Z returns retainBackBufferFromKeyframe
-//   c()J returns backBufferDurationUs
-private val retainBackBufferFromKeyframeFingerprint = Fingerprint(
-    definingClass = "Ls3/c;",
-    name = "b",
-    returnType = "Z",
-    parameters = emptyList(),
-)
-
+// Boost 1.12.12 preserves ExoPlayer DefaultLoadControl.java at Ls3/c;.
+// c()J is getBackBufferDurationUs(). We intentionally leave b()Z
+// (retainBackBufferFromKeyframe) untouched so ExoPlayer keeps its original
+// bounded keyframe-retention policy.
 private val backBufferDurationUsFingerprint = Fingerprint(
     definingClass = "Ls3/c;",
     name = "c",
@@ -39,13 +32,13 @@ private val backBufferDurationUsFingerprint = Fingerprint(
 val fixBoostVideoRewindBackBufferPatch = bytecodePatch(
     name = "Fix Boost video rewind back buffer",
     description =
-        "Retains 30 seconds of played video in ExoPlayer so backward seeks can reuse recently played media instead of reloading it.",
+        "Retains 30 seconds of recently played video in ExoPlayer so backward seeks can reuse buffered media instead of reloading it.",
     default = true,
 ) {
     compatibleWith(*BoostCompatible)
 
     execute {
-        check(CONTRACT_MARKER.endsWith("ISSUE188_V1"))
+        check(CONTRACT_MARKER.endsWith("ISSUE188_V2"))
 
         backBufferDurationUsFingerprint.method.apply {
             val instructions = implementation?.instructions
@@ -71,32 +64,6 @@ val fixBoostVideoRewindBackBufferPatch = bytecodePatch(
             addInstruction(
                 returnIndex + 1,
                 "return-wide v$returnRegister",
-            )
-        }
-
-        retainBackBufferFromKeyframeFingerprint.method.apply {
-            val instructions = implementation?.instructions
-                ?: error("DefaultLoadControl retain getter has no implementation")
-
-            val returnIndex = instructions.withIndex()
-                .singleOrNull { (_, instruction) ->
-                    instruction.opcode == Opcode.RETURN
-                }
-                ?.index
-                ?: error("Expected exactly one return in DefaultLoadControl.b()")
-
-            val returnRegister =
-                (instructions[returnIndex] as? OneRegisterInstruction)?.registerA
-                    ?: error("Could not resolve DefaultLoadControl.b() return register")
-
-            // Keep the decoder-safe start of the retained back buffer.
-            replaceInstruction(
-                returnIndex,
-                "const/4 v$returnRegister, 0x1",
-            )
-            addInstruction(
-                returnIndex + 1,
-                "return v$returnRegister",
             )
         }
     }

--- a/patches/src/main/kotlin/app/morphe/patches/reddit/customclients/boostforreddit/fix/media/VideoBackBufferRewindPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/reddit/customclients/boostforreddit/fix/media/VideoBackBufferRewindPatch.kt
@@ -1,0 +1,103 @@
+/*
+ * Modifications Copyright 2026 brealorg.
+ *
+ * See the included NOTICE file for GPLv3 §7(b) and §7(c) terms that apply to this code.
+ */
+
+package app.morphe.patches.reddit.customclients.boostforreddit.fix.media
+
+import app.morphe.patcher.Fingerprint
+import app.morphe.patcher.extensions.InstructionExtensions.addInstruction
+import app.morphe.patcher.extensions.InstructionExtensions.replaceInstruction
+import app.morphe.patcher.patch.bytecodePatch
+import app.morphe.patches.reddit.customclients.boostforreddit.BoostCompatible
+import com.android.tools.smali.dexlib2.Opcode
+import com.android.tools.smali.dexlib2.iface.instruction.OneRegisterInstruction
+
+private const val CONTRACT_MARKER =
+    "MORPHE_BOOST_VIDEO_REWIND_BACKBUFFER_ISSUE188_V1"
+
+// Boost 1.12.12 preserves the ExoPlayer source identity DefaultLoadControl.java
+// at Ls3/c;. Static discovery and the issue contract prove that:
+//   b()Z returns retainBackBufferFromKeyframe
+//   c()J returns backBufferDurationUs
+private val retainBackBufferFromKeyframeFingerprint = Fingerprint(
+    definingClass = "Ls3/c;",
+    name = "b",
+    returnType = "Z",
+    parameters = emptyList(),
+)
+
+private val backBufferDurationUsFingerprint = Fingerprint(
+    definingClass = "Ls3/c;",
+    name = "c",
+    returnType = "J",
+    parameters = emptyList(),
+)
+
+@Suppress("unused")
+val fixBoostVideoRewindBackBufferPatch = bytecodePatch(
+    name = "Fix Boost video rewind back buffer",
+    description =
+        "Retains 30 seconds of played video in ExoPlayer so backward seeks can reuse recently played media instead of reloading it.",
+    default = true,
+) {
+    compatibleWith(*BoostCompatible)
+
+    execute {
+        check(CONTRACT_MARKER.endsWith("ISSUE188_V1"))
+
+        backBufferDurationUsFingerprint.method.apply {
+            val instructions = implementation?.instructions
+                ?: error("DefaultLoadControl back-buffer getter has no implementation")
+
+            val returnIndex = instructions.withIndex()
+                .singleOrNull { (_, instruction) ->
+                    instruction.opcode == Opcode.RETURN_WIDE
+                }
+                ?.index
+                ?: error("Expected exactly one return-wide in DefaultLoadControl.c()")
+
+            val returnRegister =
+                (instructions[returnIndex] as? OneRegisterInstruction)?.registerA
+                    ?: error("Could not resolve DefaultLoadControl.c() return register")
+
+            // ExoPlayer exposes this getter in microseconds.
+            // 30 seconds = 30,000,000 us.
+            replaceInstruction(
+                returnIndex,
+                "const-wide/32 v$returnRegister, 0x1c9c380",
+            )
+            addInstruction(
+                returnIndex + 1,
+                "return-wide v$returnRegister",
+            )
+        }
+
+        retainBackBufferFromKeyframeFingerprint.method.apply {
+            val instructions = implementation?.instructions
+                ?: error("DefaultLoadControl retain getter has no implementation")
+
+            val returnIndex = instructions.withIndex()
+                .singleOrNull { (_, instruction) ->
+                    instruction.opcode == Opcode.RETURN
+                }
+                ?.index
+                ?: error("Expected exactly one return in DefaultLoadControl.b()")
+
+            val returnRegister =
+                (instructions[returnIndex] as? OneRegisterInstruction)?.registerA
+                    ?: error("Could not resolve DefaultLoadControl.b() return register")
+
+            // Keep the decoder-safe start of the retained back buffer.
+            replaceInstruction(
+                returnIndex,
+                "const/4 v$returnRegister, 0x1",
+            )
+            addInstruction(
+                returnIndex + 1,
+                "return v$returnRegister",
+            )
+        }
+    }
+}

--- a/tools/check-boost-video-rewind-backbuffer-issue188.sh
+++ b/tools/check-boost-video-rewind-backbuffer-issue188.sh
@@ -16,43 +16,39 @@ from pathlib import Path
 import re
 import sys
 
-path = Path(sys.argv[1])
-source = path.read_text()
+source = Path(sys.argv[1]).read_text()
 
 checks = {
-    "marker": r'MORPHE_BOOST_VIDEO_REWIND_BACKBUFFER_ISSUE188_V1',
+    "marker": r'MORPHE_BOOST_VIDEO_REWIND_BACKBUFFER_ISSUE188_V2',
     "patch_name": r'name\s*=\s*"Fix Boost video rewind back buffer"',
     "default_enabled": r'default\s*=\s*true',
     "boost_compatibility": r'compatibleWith\(\*BoostCompatible\)',
     "load_control_class": r'definingClass\s*=\s*"Ls3/c;"',
-    "retain_getter": (
-        r'retainBackBufferFromKeyframeFingerprint\s*=\s*Fingerprint\('
-        r'(?s:.*?)name\s*=\s*"b"(?s:.*?)returnType\s*=\s*"Z"'
-    ),
     "duration_getter": (
         r'backBufferDurationUsFingerprint\s*=\s*Fingerprint\('
         r'(?s:.*?)name\s*=\s*"c"(?s:.*?)returnType\s*=\s*"J"'
     ),
     "thirty_seconds_us": r'const-wide/32 v\$returnRegister,\s*0x1c9c380',
-    "retain_true": r'const/4 v\$returnRegister,\s*0x1',
-    "single_wide_return_guard": r'Opcode\.RETURN_WIDE',
-    "single_bool_return_guard": r'Opcode\.RETURN',
+    "wide_return_guard": r'Opcode\.RETURN_WIDE',
 }
 
 for name, pattern in checks.items():
     if not re.search(pattern, source):
         raise SystemExit(f"FAIL={name.upper()}_CONTRACT_MISSING")
 
-if source.count('definingClass = "Ls3/c;"') != 2:
-    raise SystemExit("FAIL=EXPECTED_TWO_LOAD_CONTROL_FINGERPRINTS")
+if source.count('definingClass = "Ls3/c;"') != 1:
+    raise SystemExit("FAIL=EXPECTED_ONE_LOAD_CONTROL_FINGERPRINT")
 
 if source.count('"const-wide/32 v$returnRegister, 0x1c9c380"') != 1:
     raise SystemExit("FAIL=BACK_BUFFER_DURATION_NOT_EXACTLY_ONCE")
 
-if source.count('"const/4 v$returnRegister, 0x1"') != 1:
-    raise SystemExit("FAIL=RETAIN_TRUE_NOT_EXACTLY_ONCE")
-
+# The V9 safety property: do not override retainBackBufferFromKeyframe.
 for forbidden in (
+    'name = "b"',
+    'returnType = "Z"',
+    "retainBackBufferFromKeyframeFingerprint",
+    '"const/4 v$returnRegister, 0x1"',
+    "Opcode.RETURN\n",
     "CacheDataSink",
     "CacheDataSource",
     "OkHttp",
@@ -64,9 +60,8 @@ for forbidden in (
         raise SystemExit(f"FAIL=FORBIDDEN_SCOPE_{forbidden}")
 
 print("ISSUE188_PATCH_IDENTITY=PASS")
-print("ISSUE188_LOADCONTROL_FINGERPRINTS=PASS")
 print("ISSUE188_BACK_BUFFER_30_SECONDS=PASS")
-print("ISSUE188_RETAIN_FROM_KEYFRAME=PASS")
+print("ISSUE188_RETAIN_FROM_KEYFRAME_OVERRIDE=ABSENT")
 print("ISSUE188_NETWORK_AND_CACHE_SCOPE=UNCHANGED")
 print("RESULT=PASS")
 PY

--- a/tools/check-boost-video-rewind-backbuffer-issue188.sh
+++ b/tools/check-boost-video-rewind-backbuffer-issue188.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+PATCH="$ROOT/patches/src/main/kotlin/app/morphe/patches/reddit/customclients/boostforreddit/fix/media/VideoBackBufferRewindPatch.kt"
+
+fail() {
+    printf 'FAIL=%s\n' "$1" >&2
+    exit 1
+}
+
+[ -f "$PATCH" ] || fail "ISSUE188_PATCH_MISSING"
+
+python3 - "$PATCH" <<'PY'
+from pathlib import Path
+import re
+import sys
+
+path = Path(sys.argv[1])
+source = path.read_text()
+
+checks = {
+    "marker": r'MORPHE_BOOST_VIDEO_REWIND_BACKBUFFER_ISSUE188_V1',
+    "patch_name": r'name\s*=\s*"Fix Boost video rewind back buffer"',
+    "default_enabled": r'default\s*=\s*true',
+    "boost_compatibility": r'compatibleWith\(\*BoostCompatible\)',
+    "load_control_class": r'definingClass\s*=\s*"Ls3/c;"',
+    "retain_getter": (
+        r'retainBackBufferFromKeyframeFingerprint\s*=\s*Fingerprint\('
+        r'(?s:.*?)name\s*=\s*"b"(?s:.*?)returnType\s*=\s*"Z"'
+    ),
+    "duration_getter": (
+        r'backBufferDurationUsFingerprint\s*=\s*Fingerprint\('
+        r'(?s:.*?)name\s*=\s*"c"(?s:.*?)returnType\s*=\s*"J"'
+    ),
+    "thirty_seconds_us": r'const-wide/32 v\$returnRegister,\s*0x1c9c380',
+    "retain_true": r'const/4 v\$returnRegister,\s*0x1',
+    "single_wide_return_guard": r'Opcode\.RETURN_WIDE',
+    "single_bool_return_guard": r'Opcode\.RETURN',
+}
+
+for name, pattern in checks.items():
+    if not re.search(pattern, source):
+        raise SystemExit(f"FAIL={name.upper()}_CONTRACT_MISSING")
+
+if source.count('definingClass = "Ls3/c;"') != 2:
+    raise SystemExit("FAIL=EXPECTED_TWO_LOAD_CONTROL_FINGERPRINTS")
+
+if source.count('"const-wide/32 v$returnRegister, 0x1c9c380"') != 1:
+    raise SystemExit("FAIL=BACK_BUFFER_DURATION_NOT_EXACTLY_ONCE")
+
+if source.count('"const/4 v$returnRegister, 0x1"') != 1:
+    raise SystemExit("FAIL=RETAIN_TRUE_NOT_EXACTLY_ONCE")
+
+for forbidden in (
+    "CacheDataSink",
+    "CacheDataSource",
+    "OkHttp",
+    "Interceptor",
+    "Redgifs",
+    "boost_expires",
+):
+    if forbidden in source:
+        raise SystemExit(f"FAIL=FORBIDDEN_SCOPE_{forbidden}")
+
+print("ISSUE188_PATCH_IDENTITY=PASS")
+print("ISSUE188_LOADCONTROL_FINGERPRINTS=PASS")
+print("ISSUE188_BACK_BUFFER_30_SECONDS=PASS")
+print("ISSUE188_RETAIN_FROM_KEYFRAME=PASS")
+print("ISSUE188_NETWORK_AND_CACHE_SCOPE=UNCHANGED")
+print("RESULT=PASS")
+PY


### PR DESCRIPTION
## Summary

- retain a bounded 30-second ExoPlayer back buffer so recently played video can be reused on backward seeks instead of being reloaded
- keep ExoPlayer's original `retainBackBufferFromKeyframe = false` policy to avoid extending retention beyond the configured window
- add a focused issue #188 contract that fences the patch to `DefaultLoadControl.c()J` and excludes network/cache behavior

## Validation

- focused issue #188 contract: PASS
- MPP build: PASS
- clean Boost 1.12.12 patch apply: PASS
- candidate static gate: 14 PASS / 0 FAIL
- bytecode safety gate: PASS
- Boost DEV runtime rewind test: PASS
- repeated 5–20 second backward seeks before first loop: PASS
- process stability under repeated seeking: PASS
- memory growth sanity: PASS
- memory recovery sanity after closing media: PASS
- normal Boost package remained untouched

The initial keyframe-retention variant was rejected after memory review. This PR contains the bounded successor: 30-second back buffer only, with the original keyframe-retention policy unchanged.

Fixes #188
