### PR TITLE
chore(release): prepare Morphe patch bundle 1.4.113

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 
 <!-- MORPHE_MANAGER_CHANGELOG_START -->
+## [1.4.113](https://github.com/brealorg/breal-morphe-patches/compare/morphe-patches-112...morphe-patches-113) (2026-09-09)
+
+* **Boost for Reddit:** Fix video rewind reloading so recently played Boost videos can seek backward without reloading the already played section.
+
 ## [1.4.112](https://github.com/brealorg/breal-morphe-patches/compare/morphe-patches-111...morphe-patches-112) (2026-09-08)
 
 * **Boost for Reddit:** Fix Boost bottom navigation Activity retention discovered while investigating progressive memory growth and OutOfMemoryError crashes.

--- a/README.md
+++ b/README.md
@@ -72,14 +72,14 @@ The repository shorthand shown at the top is the preferred Manager setup. Raw
 
 | Field | Value |
 |---|---|
-| Version | `1.4.112` |
-| Release tag | `morphe-patches-112` |
-| Asset | `patches-1.4.112.mpp` |
-| SHA256 | `f3ba094e0481069eacb816a31983ef27fec8dcff44b433ae88ced852e9285ed1` |
+| Version | `1.4.113` |
+| Release tag | `morphe-patches-113` |
+| Asset | `patches-1.4.113.mpp` |
+| SHA256 | `0b3531bd7187adc39020eb2551b82beee422ccbb5b8ddab9596e1bd56f96819a` |
 | Manager JSON | `https://raw.githubusercontent.com/brealorg/breal-morphe-patches/main/patches-bundle.json` |
-| Download URL | `https://github.com/brealorg/breal-morphe-patches/releases/download/morphe-patches-112/patches-1.4.112.mpp` |
+| Download URL | `https://github.com/brealorg/breal-morphe-patches/releases/download/morphe-patches-113/patches-1.4.113.mpp` |
 
-SHA256: `f3ba094e0481069eacb816a31983ef27fec8dcff44b433ae88ced852e9285ed1`
+SHA256: `0b3531bd7187adc39020eb2551b82beee422ccbb5b8ddab9596e1bd56f96819a`
 ## What this bundle does
 
 The current bundle is focused on practical hotfixes for tested app versions, especially Boost for Reddit behavior on newer Android versions.
@@ -126,10 +126,10 @@ Included Imgur patches:
 ### Patches list
 
 <!-- PATCHES_START -->
-> **Patch source version:** `1.4.112` • `main` • 53 unique patches • 105 package entries
+> **Patch source version:** `1.4.113` • `main` • 54 unique patches • 106 package entries
 
 <details>
-<summary><strong>Boost for Reddit</strong> • 44 patches</summary>
+<summary><strong>Boost for Reddit</strong> • 45 patches</summary>
 
 
 
@@ -159,6 +159,7 @@ Included Imgur patches:
 | [Fix Boost native image upload](#fix-boost-native-image-upload) | Keeps Boost image posts and galleries on Reddit's native uploader and routes images inserted into comments or text posts through Imgur by default, with ImgBB as a manually selected alternative. GIF and video upload behavior is unchanged. |  |
 | [Fix Boost navigation bar overlap](#fix-boost-navigation-bar-overlap) | Adds runtime system bar inset handling for Boost bottom controls and drawer content on Android 15+ target SDK builds. |  |
 | [Fix Boost target SDK 35 compatibility](#fix-boost-target-sdk-35-compatibility) | Sets Boost for Reddit's target SDK to 35 and fixes BillingClient receiver registration for newer Android versions. |  |
+| [Fix Boost video rewind back buffer](#fix-boost-video-rewind-back-buffer) | Retains 30 seconds of recently played video in ExoPlayer so backward seeks can reuse buffered media instead of reloading it. |  |
 | [Fix Boost YouTube playback fallback](#fix-boost-youtube-playback-fallback) | Opens the original YouTube link externally when Boost's legacy embedded YouTube player is unavailable. |  |
 | [Fix download completed notification visibility](#fix-download-completed-notification-visibility) | Moves completed download notifications to a separate default-importance channel so download completion is visible while progress notifications remain low-priority. |  |
 | [Fix Hide crash](#fix-hide-crash) | Stabilizes Boost feed position handling and prevents invalid-index crashes when hiding read posts. |  |
@@ -540,16 +541,16 @@ Compatibility with other app versions is not guaranteed.
 
 ## Verification
 
-Release `1.4.112` is prepared and locally verified with:
+Release `1.4.113` is prepared and locally verified with:
 
-- Release tag `morphe-patches-112`.
+- Release tag `morphe-patches-113`.
 - Local built MPP SHA256 matching README.
-`f3ba094e0481069eacb816a31983ef27fec8dcff44b433ae88ced852e9285ed1`
-- `patches-bundle.json` returning version `1.4.112`.
-- `patches-bundle.json` pointing to the `morphe-patches-112` asset.
+`0b3531bd7187adc39020eb2551b82beee422ccbb5b8ddab9596e1bd56f96819a`
+- `patches-bundle.json` returning version `1.4.113`.
+- `patches-bundle.json` pointing to the `morphe-patches-113` asset.
 - Expected release asset:
-`patches-1.4.112.mpp`
-- `f3ba094e0481069eacb816a31983ef27fec8dcff44b433ae88ced852e9285ed1  patches-1.4.112.mpp`
+`patches-1.4.113.mpp`
+- `0b3531bd7187adc39020eb2551b82beee422ccbb5b8ddab9596e1bd56f96819a  patches-1.4.113.mpp`
 
 ## Development notes
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,4 +3,4 @@ org.gradle.jvmargs = -Xms512M -Xmx2048M
 org.gradle.parallel = true
 android.useAndroidX = true
 kotlin.code.style = official
-version = 1.4.112
+version = 1.4.113

--- a/patches-bundle.json
+++ b/patches-bundle.json
@@ -1,7 +1,7 @@
 {
-  "created_at": "2026-09-08T22:25:53",
-  "description": "Fix Boost bottom navigation Activity retention discovered while investigating progressive memory growth and OutOfMemoryError crashes.\n",
-  "download_url": "https://github.com/brealorg/breal-morphe-patches/releases/download/morphe-patches-112/patches-1.4.112.mpp",
-  "signature_download_url": "https://github.com/brealorg/breal-morphe-patches/releases/download/morphe-patches-112/patches-1.4.112.mpp.asc",
-  "version": "1.4.112"
+  "created_at": "2026-09-09T16:38:17",
+  "description": "Fix video rewind reloading so recently played Boost videos can seek backward without reloading the already played section.\n",
+  "download_url": "https://github.com/brealorg/breal-morphe-patches/releases/download/morphe-patches-113/patches-1.4.113.mpp",
+  "signature_download_url": "https://github.com/brealorg/breal-morphe-patches/releases/download/morphe-patches-113/patches-1.4.113.mpp.asc",
+  "version": "1.4.113"
 }

--- a/patches-list.json
+++ b/patches-list.json
@@ -1,6 +1,6 @@
 {
   "NOTE": "Do NOT manually edit this file. This file is automatically updated when semantic release (release.yml) runs. Manually editing this file can break your releases and break third party tools that use this file.",
-  "version": "1.4.112",
+  "version": "1.4.113",
   "patches": [
     {
       "name": "Add Boost Search bottom navigation",
@@ -831,6 +831,32 @@
         "ResourcePatch",
         "BytecodePatch"
       ],
+      "compatiblePackages": [
+        {
+          "packageName": "com.rubenmayayo.reddit",
+          "name": "Boost for Reddit",
+          "description": null,
+          "apkFileType": "APK_REQUIRED",
+          "appIconColor": "#FF4500",
+          "signatures": null,
+          "targets": [
+            {
+              "version": "1.12.12",
+              "versionCodes": null,
+              "isExperimental": false,
+              "minSdk": 21,
+              "description": null
+            }
+          ]
+        }
+      ],
+      "options": []
+    },
+    {
+      "name": "Fix Boost video rewind back buffer",
+      "description": "Retains 30 seconds of recently played video in ExoPlayer so backward seeks can reuse buffered media instead of reloading it.",
+      "default": true,
+      "dependencies": [],
       "compatiblePackages": [
         {
           "packageName": "com.rubenmayayo.reddit",


### PR DESCRIPTION
## Summary

- prepare Morphe patch bundle `1.4.113` / `morphe-patches-113`
- publish the already qualified Boost video rewind back-buffer fix from #194
- update Manager/feed metadata and bind the clean Java 17 MPP digest

## Validation

- issue #188 focused contract: PASS
- project contracts: PASS
- release notes input validation: PASS
- clean Java 17 MPP build: PASS
- release gate: PASS
- release metadata scope: exactly five generated metadata files
- MPP SHA256: `0b3531bd7187adc39020eb2551b82beee422ccbb5b8ddab9596e1bd56f96819a`

Related to #188 and #194.
